### PR TITLE
Add `crypto` crate to monorepo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
 	"circuits",
 	"core",
+	"crypto",
 	"integration-helpers"
 ]
 

--- a/circuits/Dockerfile
+++ b/circuits/Dockerfile
@@ -4,6 +4,7 @@ FROM rust:1.63-slim-buster AS builder
 # Create a build dir and add local dependencies
 WORKDIR /build
 COPY ./rust-toolchain ./circuits/rust-toolchain
+COPY ./crypto ./crypto
 COPY ./integration-helpers ./integration-helpers
 
 # Place a set of dummy sources in the path, build the dummy executable

--- a/circuits/integration/mpc_gadgets/arithmetic.rs
+++ b/circuits/integration/mpc_gadgets/arithmetic.rs
@@ -1,9 +1,7 @@
 //! Groups integration tests for arithmetic gadets used in the MPC circuits
 
-use circuits::{
-    mpc_gadgets::arithmetic::{pow, prefix_mul, product},
-    scalar_to_biguint,
-};
+use circuits::mpc_gadgets::arithmetic::{pow, prefix_mul, product};
+use crypto::fields::scalar_to_biguint;
 use integration_helpers::{
     mpc_network::field::get_ristretto_group_modulus, types::IntegrationTest,
 };

--- a/circuits/integration/mpc_gadgets/mod.rs
+++ b/circuits/integration/mpc_gadgets/mod.rs
@@ -1,11 +1,11 @@
-use ark_ff::fields::{Fp256, MontBackend, MontConfig};
-use circuits::{bigint_to_scalar, scalar_to_bigint, scalar_to_biguint};
+use crypto::fields::{
+    prime_field_to_bigint, scalar_to_bigint, scalar_to_prime_field, DalekRistrettoField,
+};
 use curve25519_dalek::scalar::Scalar;
 use mpc_ristretto::{
     authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource,
     mpc_scalar::scalar_to_u64, network::MpcNetwork,
 };
-use num_bigint::{BigInt, BigUint};
 
 pub mod arithmetic;
 pub mod bits;
@@ -13,30 +13,12 @@ pub mod comparators;
 pub mod modulo;
 pub mod poseidon;
 
-/// Defines a custom Arkworks field with the same modulus as the Dalek Ristretto group
-///
-/// This is necessary for testing against Arkworks, otherwise the values will not be directly comparable
-#[derive(MontConfig)]
-#[modulus = "7237005577332262213973186563042994240857116359379907606001950938285454250989"]
-#[generator = "2"]
-pub(crate) struct TestFieldConfig;
-pub(crate) type TestField = Fp256<MontBackend<TestFieldConfig, 4>>;
-
 /**
  * Helpers
  */
 
-/// Converts a dalek scalar to an arkworks ff element
-pub(crate) fn scalar_to_prime_field(a: &Scalar) -> TestField {
-    Fp256::from(scalar_to_biguint(a))
-}
-
-pub(crate) fn prime_field_to_scalar(a: &TestField) -> Scalar {
-    bigint_to_scalar(&felt_to_bigint(a))
-}
-
 /// Converts a nested vector of Dalek scalars to arkworks field elements
-pub(crate) fn convert_scalars_nested_vec(a: &Vec<Vec<Scalar>>) -> Vec<Vec<TestField>> {
+pub(crate) fn convert_scalars_nested_vec(a: &Vec<Vec<Scalar>>) -> Vec<Vec<DalekRistrettoField>> {
     let mut res = Vec::with_capacity(a.len());
     for row in a.iter() {
         let mut row_res = Vec::with_capacity(row.len());
@@ -50,15 +32,9 @@ pub(crate) fn convert_scalars_nested_vec(a: &Vec<Vec<Scalar>>) -> Vec<Vec<TestFi
     res
 }
 
-/// Convert an arkworks prime field element to a bigint
-pub(crate) fn felt_to_bigint(element: &TestField) -> BigInt {
-    let felt_biguint = Into::<BigUint>::into(*element);
-    felt_biguint.into()
-}
-
 /// Compares a Dalek Scalar to an Arkworks field element
-pub(crate) fn compare_scalar_to_felt(scalar: &Scalar, felt: &TestField) -> bool {
-    scalar_to_bigint(scalar).eq(&felt_to_bigint(felt))
+pub(crate) fn compare_scalar_to_felt(scalar: &Scalar, felt: &DalekRistrettoField) -> bool {
+    scalar_to_bigint(scalar).eq(&prime_field_to_bigint(felt))
 }
 
 pub(crate) fn check_equal<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(

--- a/circuits/integration/mpc_gadgets/modulo.rs
+++ b/circuits/integration/mpc_gadgets/modulo.rs
@@ -1,9 +1,6 @@
 //! Groups integration tests for modulo MPC gadgets
-use circuits::{
-    bigint_to_scalar,
-    mpc_gadgets::modulo::{mod_2m, shift_right, truncate},
-    scalar_to_bigint,
-};
+use circuits::mpc_gadgets::modulo::{mod_2m, shift_right, truncate};
+use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
 use integration_helpers::types::IntegrationTest;
 use mpc_ristretto::mpc_scalar::scalar_to_u64;
 use num_bigint::{BigInt, RandomBits};

--- a/circuits/integration/mpc_gadgets/poseidon.rs
+++ b/circuits/integration/mpc_gadgets/poseidon.rs
@@ -4,10 +4,8 @@ use ark_sponge::{
     poseidon::{PoseidonConfig, PoseidonSponge},
     CryptographicSponge,
 };
-use circuits::{
-    mpc_gadgets::poseidon::{AuthenticatedPoseidonHasher, PoseidonSpongeParameters},
-    scalar_to_bigint,
-};
+use circuits::mpc_gadgets::poseidon::{AuthenticatedPoseidonHasher, PoseidonSpongeParameters};
+use crypto::fields::{prime_field_to_bigint, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::types::IntegrationTest;
 use mpc_ristretto::{
@@ -18,8 +16,7 @@ use rand::{thread_rng, RngCore};
 use crate::{IntegrationTestArgs, TestWrapper};
 
 use super::{
-    compare_scalar_to_felt, convert_scalars_nested_vec, felt_to_bigint, scalar_to_prime_field,
-    TestField,
+    compare_scalar_to_felt, convert_scalars_nested_vec, scalar_to_prime_field, DalekRistrettoField,
 };
 
 /**
@@ -29,7 +26,7 @@ use super::{
 /// Converts a set of Poseidon parameters encoded as scalars to parameters encoded as field elements
 pub(crate) fn convert_params(
     native_params: &PoseidonSpongeParameters,
-) -> PoseidonConfig<TestField> {
+) -> PoseidonConfig<DalekRistrettoField> {
     PoseidonConfig::new(
         native_params.full_rounds,
         native_params.parital_rounds,
@@ -63,7 +60,7 @@ fn check_against_arkworks_hash<N: MpcNetwork + Send, S: SharedValueSource<Scalar
         arkworks_poseidon.absorb(input_elem);
     }
 
-    let arkworks_squeezed: TestField =
+    let arkworks_squeezed: DalekRistrettoField =
         arkworks_poseidon.squeeze_field_elements(1 /* num_elements */)[0];
 
     // Open the given result and compare to the computed result
@@ -75,7 +72,7 @@ fn check_against_arkworks_hash<N: MpcNetwork + Send, S: SharedValueSource<Scalar
         return Err(format!(
             "Expected {:?}, got {:?}",
             scalar_to_bigint(&result_open.to_scalar()),
-            felt_to_bigint(&arkworks_squeezed)
+            prime_field_to_bigint(&arkworks_squeezed)
         ));
     }
 

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -16,6 +16,7 @@ use circuits::{
         ValidMatchMpcCircuit, ValidMatchMpcStatement, ValidMatchMpcWitness,
     },
 };
+use crypto::fields::{prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{
     mpc_network::{batch_share_plaintext_scalar, batch_share_plaintext_u64},
@@ -27,8 +28,7 @@ use num_bigint::BigInt;
 use rand_core::{OsRng, RngCore};
 
 use crate::{
-    mpc_gadgets::{poseidon::convert_params, prime_field_to_scalar, scalar_to_prime_field},
-    zk_gadgets::multiprover_prove_and_verify,
+    mpc_gadgets::poseidon::convert_params, zk_gadgets::multiprover_prove_and_verify,
     IntegrationTestArgs, TestWrapper,
 };
 
@@ -46,7 +46,9 @@ fn hash_values_arkworks(values: &[u64]) -> Scalar {
         arkworks_hasher.absorb(val)
     }
 
-    prime_field_to_scalar(&arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0])
+    prime_field_to_scalar(
+        &arkworks_hasher.squeeze_field_elements::<DalekRistrettoField>(1 /* num_elements */)[0],
+    )
 }
 
 /// Creates an authenticated match from an order in each relayer

--- a/circuits/integration/zk_gadgets/arithmetic.rs
+++ b/circuits/integration/zk_gadgets/arithmetic.rs
@@ -1,8 +1,8 @@
 //! Groups gadgets around arithemtic integration tests
-use circuits::{
-    bigint_to_scalar, scalar_to_bigint,
-    zk_gadgets::arithmetic::{ExpGadgetStatement, MultiproverExpGadget, MultiproverExpWitness},
+use circuits::zk_gadgets::arithmetic::{
+    ExpGadgetStatement, MultiproverExpGadget, MultiproverExpWitness,
 };
+use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{
     mpc_network::field::get_ristretto_group_modulus, types::IntegrationTest,

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -1,10 +1,8 @@
 //! Groups integration tests for the circuitry that converts between scalars and their
 //! bit representations
 
-use circuits::{
-    bigint_to_scalar_bits, scalar_to_bigint,
-    zk_gadgets::bits::{MultiproverToBitsGadget, ToBitsStatement},
-};
+use circuits::zk_gadgets::bits::{MultiproverToBitsGadget, ToBitsStatement};
+use crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{mpc_network::batch_share_plaintext_scalar, types::IntegrationTest};
 use rand_core::{OsRng, RngCore};

--- a/circuits/integration/zk_gadgets/poseidon.rs
+++ b/circuits/integration/zk_gadgets/poseidon.rs
@@ -8,6 +8,7 @@ use circuits::{
     },
 };
 
+use crypto::fields::{prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::types::IntegrationTest;
 use itertools::Itertools;
@@ -15,10 +16,7 @@ use mpc_bulletproof::r1cs_mpc::{MultiproverError, R1CSError};
 use mpc_ristretto::authenticated_scalar::AuthenticatedScalar;
 use rand_core::{OsRng, RngCore};
 
-use crate::{
-    mpc_gadgets::{poseidon::convert_params, prime_field_to_scalar, scalar_to_prime_field},
-    IntegrationTestArgs, TestWrapper,
-};
+use crate::{mpc_gadgets::poseidon::convert_params, IntegrationTestArgs, TestWrapper};
 
 use super::multiprover_prove_and_verify;
 
@@ -63,8 +61,9 @@ fn test_poseidon_multiprover(test_args: &IntegrationTestArgs) -> Result<(), Stri
     for input in arkworks_input {
         arkworks_hasher.absorb(&input);
     }
-    let expected_scalar =
-        prime_field_to_scalar(&arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0]);
+    let expected_scalar = prime_field_to_scalar(
+        &arkworks_hasher.squeeze_field_elements::<DalekRistrettoField>(1 /* num_elements */)[0],
+    );
 
     // Prove the statement
     let witness = MultiproverPoseidonWitness {

--- a/circuits/src/mpc_gadgets/bits.rs
+++ b/circuits/src/mpc_gadgets/bits.rs
@@ -230,13 +230,12 @@ pub fn bit_lt<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 mod tests {
     use std::iter;
 
+    use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
     use curve25519_dalek::scalar::Scalar;
     use integration_helpers::mpc_network::mock_mpc_fabric;
     use mpc_ristretto::mpc_scalar::scalar_to_u64;
     use num_bigint::BigInt;
     use rand::{thread_rng, Rng, RngCore};
-
-    use crate::{bigint_to_scalar, scalar_to_bigint};
 
     use super::{scalar_from_bits_le, scalar_to_bits_le};
 

--- a/circuits/src/mpc_gadgets/modulo.rs
+++ b/circuits/src/mpc_gadgets/modulo.rs
@@ -1,5 +1,6 @@
 //! Groups logic for computing modulo and truncation operators
 
+use crypto::fields::{bigint_to_scalar, bigint_to_scalar_bits, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use mpc_ristretto::{
     authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
@@ -7,8 +8,7 @@ use mpc_ristretto::{
 use num_bigint::BigInt;
 
 use crate::{
-    bigint_to_scalar, bigint_to_scalar_bits, errors::MpcError, mpc::SharedFabric,
-    mpc_gadgets::bits::bit_lt, scalar_2_to_m, scalar_to_bigint, SCALAR_MAX_BITS,
+    errors::MpcError, mpc::SharedFabric, mpc_gadgets::bits::bit_lt, scalar_2_to_m, SCALAR_MAX_BITS,
 };
 
 use super::bits::scalar_from_bits_le;

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -1,10 +1,10 @@
 //! Groups the base type and derived types for the `Fee` entity
 use crate::{
-    bigint_to_scalar,
     errors::{MpcError, TypeConversionError},
     mpc::SharedFabric,
     Allocate, CommitProver, CommitSharedProver, CommitVerifier,
 };
+use crypto::fields::bigint_to_scalar;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -1,6 +1,7 @@
 //! Groups trait and type definitions for the handshake tuple
 
-use crate::{bigint_to_scalar, errors::MpcError, CommitSharedProver};
+use crate::{errors::MpcError, CommitSharedProver};
+use crypto::fields::bigint_to_scalar;
 use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use mpc_bulletproof::r1cs_mpc::MpcProver;

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -263,12 +263,13 @@ impl<'a, N: MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCircuit<
 
 #[cfg(test)]
 mod arithmetic_tests {
+    use crypto::fields::{bigint_to_scalar, scalar_to_biguint};
     use curve25519_dalek::scalar::Scalar;
     use integration_helpers::mpc_network::field::get_ristretto_group_modulus;
     use num_bigint::BigUint;
     use rand_core::{OsRng, RngCore};
 
-    use crate::{bigint_to_scalar, scalar_to_biguint, test_helpers::bulletproof_prove_and_verify};
+    use crate::test_helpers::bulletproof_prove_and_verify;
 
     use super::{ExpGadget, ExpGadgetStatement, ExpGadgetWitness};
 

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -1,6 +1,7 @@
 //! Groups gadgets for going from scalar -> bits and from bits -> scalar
 use std::marker::PhantomData;
 
+use crypto::fields::bigint_to_scalar;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
@@ -22,7 +23,6 @@ use num_bigint::BigInt;
 use rand_core::OsRng;
 
 use crate::{
-    bigint_to_scalar,
     errors::{MpcError, ProverError, VerifierError},
     mpc::SharedFabric,
     mpc_gadgets::bits::{scalar_to_bits_le, to_bits_le},
@@ -234,12 +234,11 @@ impl<'a, const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>
 
 #[cfg(test)]
 mod bits_test {
+    use crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
     use curve25519_dalek::scalar::Scalar;
     use rand_core::{OsRng, RngCore};
 
-    use crate::{
-        bigint_to_scalar_bits, scalar_to_bigint, test_helpers::bulletproof_prove_and_verify,
-    };
+    use crate::test_helpers::bulletproof_prove_and_verify;
 
     use super::{ToBitsGadget, ToBitsStatement};
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,39 +1,20 @@
 [package]
-name = "circuits"
+name = "crypto"
 version = "0.1.0"
 edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
 ark-sponge = { git = "https://github.com/arkworks-rs/sponge" }
-bitvec = "1.0"
-crypto = { path = "../crypto" }
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
 curve25519-dalek = "2"
 itertools = "0.10"
-merlin = "2.0"
-mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
-mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = { version = "0.8" }
 rand_core = "0.5"
-serde = { version = "1.0.139", features = ["serde_derive"] }
 
-[dev-dependencies]
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
-clap = { version = "4.0", features = ["derive"] }
-colored = "2"
-ctor = "0.1"
-criterion = { version = "0.4" } 
-dns-lookup = "1.0"
-integration-helpers = { path = "../integration-helpers" }
-inventory = "0.3"
-rand = "0.8"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
-
-[[test]]
-name = "integration"
-path = "integration/main.rs"
-harness = false
 
 # Patches normally only belong in the workspace root. However, we run integration
 # tests outside the context of a workspace (i.e. as a standalone crate), so these

--- a/crypto/src/constants.rs
+++ b/crypto/src/constants.rs
@@ -1,8 +1,8 @@
 //! Defines important constants used in the
-use curve25519_dalek::scalar::Scalar;
-use num_bigint::BigInt;
 
-use crate::bigint_to_scalar;
+use num_bigint::BigUint;
+
+use crate::fields::DalekRistrettoField;
 
 /// The maximum number of orders allowed in a wallet
 pub const MAX_ORDERS: usize = 2;
@@ -25,7 +25,7 @@ pub const MAX_BALANCES: usize = 2;
  * from the scripts above and taking the output for t = 3, \alpha = 5
  */
 #[allow(non_snake_case)]
-pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<Scalar>> {
+pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<DalekRistrettoField>> {
     vec![
         vec![
             field_element_from_hex_string(
@@ -65,7 +65,7 @@ pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<Scalar>> {
 
 /// Round constants for t = 3 (2-1 hash)
 #[allow(non_snake_case)]
-pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<Scalar>> {
+pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<DalekRistrettoField>> {
     vec![
         vec![
             field_element_from_hex_string(
@@ -777,8 +777,8 @@ pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<Scalar>> {
 /// Converts a literal hexidecimal string to a field element through BigUint
 /// this function should only ever be called on the constants above, so we panic
 /// if parsing fails
-fn field_element_from_hex_string(byte_string: &[u8]) -> Scalar {
-    bigint_to_scalar(&BigInt::parse_bytes(byte_string, 16 /* radix */).unwrap())
+fn field_element_from_hex_string(byte_string: &[u8]) -> DalekRistrettoField {
+    DalekRistrettoField::from(BigUint::parse_bytes(byte_string, 16 /* radix */).unwrap())
 }
 
 #[cfg(test)]

--- a/crypto/src/fields.rs
+++ b/crypto/src/fields.rs
@@ -1,0 +1,127 @@
+//! Helpers for manipulating values within a field and translating between fields
+
+use std::ops::Neg;
+
+use ark_ff::{Fp256, MontBackend, MontConfig, PrimeField};
+use curve25519_dalek::scalar::Scalar;
+use num_bigint::{BigInt, BigUint, Sign};
+
+/// Defines a custom Arkworks field with the same modulus as the Dalek Ristretto group
+///
+/// This is necessary for testing against Arkworks, otherwise the values will not be directly comparable
+#[derive(MontConfig)]
+#[modulus = "7237005577332262213973186563042994240857116359379907606001950938285454250989"]
+#[generator = "2"]
+pub struct DalekRistrettoFieldConfig;
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
+pub type DalekRistrettoField = Fp256<MontBackend<DalekRistrettoFieldConfig, 4>>;
+
+/// Convert a scalar to a BigInt
+pub fn scalar_to_bigint(a: &Scalar) -> BigInt {
+    BigInt::from_signed_bytes_le(&a.to_bytes())
+}
+
+/// Convert a scalar to a BigUint
+pub fn scalar_to_biguint(a: &Scalar) -> BigUint {
+    BigUint::from_bytes_le(&a.to_bytes())
+}
+
+/// Convert a bigint to a scalar
+pub fn bigint_to_scalar(a: &BigInt) -> Scalar {
+    let (sign, mut bytes) = a.to_bytes_le();
+    if bytes.len() < 32 {
+        zero_pad_bytes(&mut bytes, 32)
+    }
+
+    let scalar = Scalar::from_bytes_mod_order(bytes[..32].try_into().unwrap());
+
+    match sign {
+        Sign::Minus => scalar.neg(),
+        _ => scalar,
+    }
+}
+
+/// Pad an array up to the desired length with zeros
+fn zero_pad_bytes(unpadded_buf: &mut Vec<u8>, n: usize) {
+    unpadded_buf.append(&mut vec![0u8; n - unpadded_buf.len()])
+}
+
+/// Convert a bigint to a vector of bits, encoded as scalars
+pub fn bigint_to_scalar_bits<const D: usize>(a: &BigInt) -> Vec<Scalar> {
+    let mut res = Vec::with_capacity(D);
+    // Reverse the iterator; BigInt::bits expects big endian
+    for i in 0..D {
+        res.push(if a.bit(i as u64) {
+            Scalar::one()
+        } else {
+            Scalar::zero()
+        })
+    }
+
+    res
+}
+
+/// Converts a dalek scalar to an arkworks ff element
+pub fn scalar_to_prime_field(a: &Scalar) -> DalekRistrettoField {
+    Fp256::from(scalar_to_biguint(a))
+}
+
+/// Convert an Arkworks field element to a Dalek scalar
+pub fn prime_field_to_scalar<F: PrimeField>(a: &F) -> Scalar {
+    bigint_to_scalar(&prime_field_to_bigint(a))
+}
+
+/// Convert an arkworks prime field element to a bigint
+pub fn prime_field_to_bigint<F: PrimeField>(element: &F) -> BigInt {
+    let felt_biguint = Into::<BigUint>::into(*element);
+    felt_biguint.into()
+}
+
+#[cfg(test)]
+mod field_helper_test {
+    use curve25519_dalek::scalar::Scalar;
+    use num_bigint::BigInt;
+    use rand::{thread_rng, Rng, RngCore};
+
+    use crate::fields::{bigint_to_scalar, bigint_to_scalar_bits, scalar_to_bigint};
+
+    #[test]
+    fn test_scalar_to_bigint() {
+        let rand_val = thread_rng().next_u64();
+        let res = scalar_to_bigint(&Scalar::from(rand_val));
+
+        assert_eq!(res, BigInt::from(rand_val));
+    }
+
+    #[test]
+    fn test_bigint_to_scalar() {
+        let rand_val = thread_rng().next_u64();
+        let res = bigint_to_scalar(&BigInt::from(rand_val));
+
+        assert_eq!(res, Scalar::from(rand_val));
+    }
+
+    #[test]
+    fn test_bigint_to_scalar_bits() {
+        let mut rng = thread_rng();
+        let random_scalar_bits = (0..256)
+            .map(|_| rng.gen_bool(0.5 /* p */) as u64)
+            .collect::<Vec<_>>();
+
+        let random_bigint = random_scalar_bits
+            .iter()
+            .rev()
+            .cloned()
+            .map(BigInt::from)
+            .fold(BigInt::from(0u64), |acc, val| acc * 2 + val);
+        let scalar_bits = random_scalar_bits
+            .into_iter()
+            .map(Scalar::from)
+            .collect::<Vec<_>>();
+
+        let res = bigint_to_scalar_bits::<256 /* bits */>(&random_bigint);
+
+        assert_eq!(res.len(), scalar_bits.len());
+        assert_eq!(res, scalar_bits);
+    }
+}

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,0 +1,55 @@
+//! Implementations of cryptographic hash functions
+
+use ark_sponge::poseidon::PoseidonConfig;
+use curve25519_dalek::scalar::Scalar;
+
+use crate::{
+    constants::{POSEIDON_MDS_MATRIX_T_3, POSEIDON_ROUND_CONSTANTS_T_3},
+    fields::DalekRistrettoField,
+};
+
+/// Hash the input using a Poseidon hash with default parameters
+///
+/// Uses defaults from the `circuits` package to ensure that hashes are
+/// consistent with those produced by the proof system
+///
+/// We require that the input be castable to a vector of u64s; this is to
+/// match the hashes defined in the ZK circuitry
+pub fn poseidon_hash_default_params<T: Into<Vec<u64>>>(val: T) -> Scalar {
+    unimplemented!("")
+}
+
+/// Returns a default set of arkworks params
+///
+/// We use the Poseidon permutation with the following default parameters:
+///     \alpha = 5; i.e. the s-box is x^5 \mod p. This was chosen because:
+///     for the prime field used in Ristretto, gcd(3, p-1) = 3
+///     whereas gcd(5, p-1) = 1, making x^5 (mod p) invertible.
+pub fn default_poseidon_params() -> PoseidonConfig<DalekRistrettoField> {
+    PoseidonConfig::new(
+        8,                              /* full_rounds */
+        56,                             /* partial_rounds */
+        5,                              /* alpha */
+        POSEIDON_MDS_MATRIX_T_3(),      /* mds matrix */
+        POSEIDON_ROUND_CONSTANTS_T_3(), /* round constants */
+        2,                              /* rate */
+        1,                              /* capacity */
+    )
+}
+
+// /// Hashes the payload of `Scalar`s via the Arkworks Poseidon sponge implementation
+// /// Returns the result, re-cast into the Dalek Ristretto scalar field
+// fn hash_values_arkworks(values: &[u64]) -> Scalar {
+//     let arkworks_input = values
+//         .iter()
+//         .map(|val| scalar_to_prime_field(&Scalar::from(*val)))
+//         .collect_vec();
+//     let arkworks_params = convert_params(&PoseidonSpongeParameters::default());
+
+//     let mut arkworks_hasher = PoseidonSponge::new(&arkworks_params);
+//     for val in arkworks_input.iter() {
+//         arkworks_hasher.absorb(val)
+//     }
+
+//     prime_field_to_scalar(&arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0])
+// }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,0 +1,7 @@
+//! Cryptography helpers and primitives useful throughout the relayer
+#![deny(unsafe_code)]
+#![deny(clippy::missing_docs_in_private_items)]
+
+pub mod constants;
+pub mod fields;
+pub mod hash;


### PR DESCRIPTION
### Purpose
This PR:
1. Adds the `crypto` crate to the monorepo. This crate will contain reusable cryptographic primitives that can be depended on by other crates in a symmetric way. I.e. we can be sure that the `circuits` crate and `core` are hashing values in the same Poseidon configuration.
2. Refactors the `circuits` crate to move many of the helpers into the new `crypto` crate. This includes field translation, Poseidon constants, arkworks hashing, etc.

### Testing
- `cargo-integrate circuits`: all integration tests pass
- Ran two clusters locally; verified high level execution