### PR TITLE
core: handshake: Add hashes to handshake messages and state

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ark-serialize = "0.3"
 async-trait = "0.1.56"
 base64 = { version = "0.13" }
 circuits = { path = "../circuits" }
 clap = { version = "3.2.8", features = ["derive"] }
 crossbeam = { version = "0.8.1" }
+crypto = { path = "../crypto" }
 ed25519-dalek = { version = "1.0.1" }
 futures = { version = "0.3.21" }
 integration-helpers = { path = "../integration-helpers" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ circuits = { path = "../circuits" }
 clap = { version = "3.2.8", features = ["derive"] }
 crossbeam = { version = "0.8.1" }
 crypto = { path = "../crypto" }
+curve25519-dalek = "2"
 ed25519-dalek = { version = "1.0.1" }
 futures = { version = "0.3.21" }
 integration-helpers = { path = "../integration-helpers" }

--- a/core/src/api/cluster_management.rs
+++ b/core/src/api/cluster_management.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
-    handshake::manager::OrderIdentifier,
+    handshake::types::OrderIdentifier,
     state::Wallet,
 };
 

--- a/core/src/api/handshake.rs
+++ b/core/src/api/handshake.rs
@@ -41,6 +41,14 @@ pub enum HandshakeMessage {
         /// Set to `None` by the sender if all locally held orders are cached
         /// as already matched with the `peer_order`
         sender_order: Option<OrderIdentifier>,
+        /// A hash commitment to the sender's order
+        order_hash: Option<HashOutput>,
+        /// A hash commitment to the sender's balance
+        balance_hash: Option<HashOutput>,
+        /// A hash commitment to the sender's fee
+        fee_hash: Option<HashOutput>,
+        /// A hash commitment to the sender's randomness
+        randomness_hash: Option<HashOutput>,
     },
     /// Go forward with a handshake after a proposed order pair is setup
     ExecuteMatch {

--- a/core/src/api/handshake.rs
+++ b/core/src/api/handshake.rs
@@ -2,7 +2,10 @@
 use portpicker::Port;
 use serde::{Deserialize, Serialize};
 
-use crate::{gossip::types::WrappedPeerId, handshake::manager::OrderIdentifier};
+use crate::{
+    gossip::types::WrappedPeerId,
+    handshake::types::{HashOutput, OrderIdentifier},
+};
 
 /// Enumerates the different operations possible via handshake
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -15,6 +18,14 @@ pub enum HandshakeMessage {
         peer_id: WrappedPeerId,
         /// An order local to the sender, that the sender wants to computed matches for
         sender_order: OrderIdentifier,
+        /// A hash commitment to the sender's order
+        order_hash: HashOutput,
+        /// A hash commitment to the sender's balance
+        balance_hash: HashOutput,
+        /// A hash commitment to the sender's fee
+        fee_hash: HashOutput,
+        /// A hash commitment to the sender's randomness
+        randomness_hash: HashOutput,
     },
     /// Propose an order to match with an order sent in InitiateMatch
     ///

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -9,10 +9,11 @@ use crate::{
     gossip::types::WrappedPeerId,
 };
 
-use super::manager::OrderIdentifier;
+use super::types::OrderIdentifier;
 
 /// Represents a job for the handshake manager's thread pool to execute
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum HandshakeExecutionJob {
     /// Process a handshake request
     ProcessHandshakeMessage {

--- a/core/src/handshake/match.rs
+++ b/core/src/handshake/match.rs
@@ -15,6 +15,9 @@ use mpc_ristretto::{fabric::AuthenticatedMpcFabric, network::QuicTwoPartyNet};
 
 use super::{error::HandshakeManagerError, manager::HandshakeManager};
 
+/// The party_id of the leader (aka dialer/king) in the MPC computation
+pub(crate) const KING: u64 = 0;
+
 /// Match-centric implementations for the handshake manager
 impl HandshakeManager {
     /// Execute the match MPC over the provisioned QUIC stream
@@ -64,6 +67,7 @@ impl HandshakeManager {
         fee: Fee,
         match_res: MatchResult,
     ) -> Result<(), HandshakeManagerError> {
+        // Build the statement of VALID MATCH MPC
         unimplemented!("")
     }
 }

--- a/core/src/handshake/match.rs
+++ b/core/src/handshake/match.rs
@@ -1,31 +1,65 @@
 //! Groups the handshake manager definitions necessary to run the MPC match computation
 //! and collaboratively generate a proof of `VALID MATCH MPC`
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, thread};
 
 use circuits::{
     mpc::SharedFabric,
     mpc_circuits::r#match::compute_match,
-    types::{balance::Balance, fee::Fee, order::Order, r#match::MatchResult},
+    types::{balance::Balance, fee::Fee, order::Order, r#match::AuthenticatedMatchResult},
     Allocate, Open,
 };
+use curve25519_dalek::scalar::Scalar;
 use futures::executor::block_on;
 use integration_helpers::mpc_network::mocks::PartyIDBeaverSource;
-use mpc_ristretto::{fabric::AuthenticatedMpcFabric, network::QuicTwoPartyNet};
+use mpc_ristretto::{
+    beaver::SharedValueSource,
+    fabric::AuthenticatedMpcFabric,
+    network::{MpcNetwork, QuicTwoPartyNet},
+};
+use tokio::runtime::Builder as TokioBuilder;
 
-use super::{error::HandshakeManagerError, manager::HandshakeManager};
+use super::{error::HandshakeManagerError, manager::HandshakeManager, state::HandshakeState};
 
 /// The party_id of the leader (aka dialer/king) in the MPC computation
 pub(crate) const KING: u64 = 0;
 
 /// Match-centric implementations for the handshake manager
 impl HandshakeManager {
-    /// Execute the match MPC over the provisioned QUIC stream
-    pub(super) fn execute_match_mpc(
+    /// Execute the MPC and collaborative proof for a match computation
+    ///
+    /// Spawns the match computation in a separate thread wrapped by a custom
+    /// Tokio runtime. The QUIC implementation in quinn is async and expects
+    /// to be run inside of a Tokio runtime
+    pub(super) fn execute_match(
         party_id: u64,
-        local_order: Order,
-        local_balance: Balance,
-        local_fee: Fee,
+        handshake_state: HandshakeState,
+        mpc_net: QuicTwoPartyNet,
+    ) -> Result<(), HandshakeManagerError> {
+        // Build a tokio runtime in the current thread for the MPC to run inside of
+        let tid = thread::current().id();
+        let tokio_runtime = TokioBuilder::new_multi_thread()
+            .thread_name(format!("handshake-mpc-{:?}", tid))
+            .enable_io()
+            .enable_time()
+            .build()
+            .map_err(|err| HandshakeManagerError::SetupError(err.to_string()))?;
+
+        // Wrap the current thread's execution in a Tokio blocking thread
+        let join_handle = tokio_runtime.spawn_blocking(move || {
+            Self::execute_match_impl(party_id, handshake_state.to_owned(), mpc_net)
+        });
+
+        block_on(join_handle)
+            .unwrap()
+            .map_err(|err| HandshakeManagerError::SetupError(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Implementation of the execute_match method that is wrapped in a Tokio runtime
+    fn execute_match_impl(
+        party_id: u64,
+        handshake_state: HandshakeState,
         mut mpc_net: QuicTwoPartyNet,
     ) -> Result<(), HandshakeManagerError> {
         println!("Matching order...\n");
@@ -41,31 +75,43 @@ impl HandshakeManager {
             Rc::new(RefCell::new(mpc_net)),
             Rc::new(RefCell::new(beaver_source)),
         );
+
         let shared_fabric = SharedFabric::new(fabric);
 
-        let shared_order1 = local_order
-            .allocate(0 /* owning_party */, shared_fabric.clone())
-            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
-        let shared_order2 = local_order
-            .allocate(1 /* owning_party */, shared_fabric.clone())
-            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
-
-        let match_res = compute_match(&shared_order1, &shared_order2, shared_fabric)
-            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?
+        // Run the mpc to get a match result
+        let match_res = Self::execute_match_mpc(&handshake_state.order, shared_fabric)?;
+        let match_res_open = match_res
             .open_and_authenticate()
             .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
 
-        println!("Got MPC res: {:?}", match_res);
-        Self::prove_valid_match(local_order, local_balance, local_fee, match_res)
+        println!("Got MPC res: {:?}", match_res_open);
+        Ok(())
+    }
+
+    /// Execute the match MPC over the provisioned QUIC stream
+    fn execute_match_mpc<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
+        local_order: &Order,
+        fabric: SharedFabric<N, S>,
+    ) -> Result<AuthenticatedMatchResult<N, S>, HandshakeManagerError> {
+        let shared_order1 = local_order
+            .allocate(0 /* owning_party */, fabric.clone())
+            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
+        let shared_order2 = local_order
+            .allocate(1 /* owning_party */, fabric.clone())
+            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
+
+        compute_match(&shared_order1, &shared_order2, fabric)
+            .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))
     }
 
     /// Generates a collaborative proof of the validity of a given match result
+    #[allow(unused)]
     #[allow(unused_variables)]
-    fn prove_valid_match(
-        order: Order,
-        balance: Balance,
-        fee: Fee,
-        match_res: MatchResult,
+    fn prove_valid_match<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
+        order: &Order,
+        balance: &Balance,
+        fee: &Fee,
+        match_res: AuthenticatedMatchResult<N, S>,
     ) -> Result<(), HandshakeManagerError> {
         // Build the statement of VALID MATCH MPC
         unimplemented!("")

--- a/core/src/handshake/mod.rs
+++ b/core/src/handshake/mod.rs
@@ -5,4 +5,5 @@ pub mod jobs;
 pub mod manager;
 pub mod r#match;
 pub mod state;
+pub mod types;
 pub mod worker;

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -9,8 +9,16 @@ use std::{
 
 use crate::state::Shared;
 
-use super::{error::HandshakeManagerError, manager::OrderIdentifier};
-use circuits::types::{balance::Balance, fee::Fee, order::Order};
+use super::{
+    error::HandshakeManagerError,
+    r#match::KING,
+    types::{HashOutput, OrderIdentifier},
+};
+use circuits::{
+    types::{balance::Balance, fee::Fee, order::Order},
+    zk_circuits::valid_match_mpc::ValidMatchMpcStatement,
+};
+use crypto::fields::prime_field_to_scalar;
 use uuid::Uuid;
 
 /// Holds state information for all in-flight handshake correspondences
@@ -32,6 +40,7 @@ impl HandshakeStateIndex {
     }
 
     /// Adds a new handshake to the state
+    #[allow(clippy::too_many_arguments)]
     pub fn new_handshake(
         &self,
         request_id: Uuid,
@@ -39,20 +48,35 @@ impl HandshakeStateIndex {
         order: Order,
         balance: Balance,
         fee: Fee,
+        order_hash: HashOutput,
+        balance_hash: HashOutput,
+        fee_hash: HashOutput,
+        randomness_hash: HashOutput,
     ) {
-        // Use a dummy value for the peer order until it is negotiated
-        self.new_handshake_with_peer_order(
+        // Use dummy values until peer negotiates an order, balance, fee tuple
+        self.new_handshake_with_peer_info(
             request_id,
+            // Dummy value for peer_order_id
             Uuid::default(),
             local_order_id,
             order,
             balance,
             fee,
+            order_hash,
+            balance_hash,
+            fee_hash,
+            randomness_hash,
+            // Use dummy values for peer hashes
+            HashOutput::from(0),
+            HashOutput::from(0),
+            HashOutput::from(0),
+            HashOutput::from(0),
         )
     }
 
     /// Adds a new handshake to the state where the peer's order is already known (e.g. the peer initiated the handshake)
-    pub fn new_handshake_with_peer_order(
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_handshake_with_peer_info(
         &self,
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
@@ -60,6 +84,14 @@ impl HandshakeStateIndex {
         order: Order,
         balance: Balance,
         fee: Fee,
+        order_hash: HashOutput,
+        balance_hash: HashOutput,
+        fee_hash: HashOutput,
+        randomness_hash: HashOutput,
+        peer_order_hash: HashOutput,
+        peer_balance_hash: HashOutput,
+        peer_fee_hash: HashOutput,
+        peer_randomness_hash: HashOutput,
     ) {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         locked_state.insert(
@@ -71,21 +103,42 @@ impl HandshakeStateIndex {
                 order,
                 balance,
                 fee,
+                order_hash,
+                balance_hash,
+                fee_hash,
+                randomness_hash,
+                peer_order_hash,
+                peer_balance_hash,
+                peer_fee_hash,
+                peer_randomness_hash,
             ),
         );
     }
 
     /// Update a request to fill in a peer's order_id that has been decided on
-    pub fn update_peer_order_id(
+    ///
+    /// This is decoupled from the constructor because the peer that initiates
+    /// a handshake will not know the peer's handshake information ahead of time
+    /// when the state is created
+    pub fn update_peer_info(
         &self,
         request_id: &Uuid,
         order_id: OrderIdentifier,
+        order_hash: HashOutput,
+        balance_hash: HashOutput,
+        fee_hash: HashOutput,
+        randomness_hash: HashOutput,
     ) -> Result<(), HandshakeManagerError> {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         let state_entry = locked_state.get_mut(request_id).ok_or_else(|| {
             HandshakeManagerError::InvalidRequest(format!("request_id {:?}", request_id))
         })?;
+
         state_entry.peer_order_id = order_id;
+        state_entry.peer_order_hash = order_hash;
+        state_entry.peer_balance_hash = balance_hash;
+        state_entry.peer_fee_hash = fee_hash;
+        state_entry.peer_randomness_hash = randomness_hash;
 
         Ok(())
     }
@@ -143,6 +196,22 @@ pub struct HandshakeState {
     pub balance: Balance,
     /// The local peer's fee, paid out to the contract and the executing node
     pub fee: Fee,
+    /// The local peer's order hash
+    pub order_hash: HashOutput,
+    /// The local peer's balance hash
+    pub balance_hash: HashOutput,
+    /// The local peer's fee hash
+    pub fee_hash: HashOutput,
+    /// The local peer's randomness hash
+    pub randomness_hash: HashOutput,
+    /// The local peer's order hash
+    pub peer_order_hash: HashOutput,
+    /// The remote peer's balance hash
+    pub peer_balance_hash: HashOutput,
+    /// The remote peer's fee hash
+    pub peer_fee_hash: HashOutput,
+    /// The remote peer's randomness hash
+    pub peer_randomness_hash: HashOutput,
     /// The current state information of the
     pub state: State,
 }
@@ -168,6 +237,7 @@ pub enum State {
 
 impl HandshakeState {
     /// Create a new handshake in the order negotiation state
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
@@ -175,6 +245,14 @@ impl HandshakeState {
         order: Order,
         balance: Balance,
         fee: Fee,
+        order_hash: HashOutput,
+        balance_hash: HashOutput,
+        fee_hash: HashOutput,
+        randomness_hash: HashOutput,
+        peer_order_hash: HashOutput,
+        peer_balance_hash: HashOutput,
+        peer_fee_hash: HashOutput,
+        peer_randomness_hash: HashOutput,
     ) -> Self {
         Self {
             request_id,
@@ -183,6 +261,14 @@ impl HandshakeState {
             order,
             balance,
             fee,
+            order_hash,
+            balance_hash,
+            fee_hash,
+            randomness_hash,
+            peer_order_hash,
+            peer_balance_hash,
+            peer_fee_hash,
+            peer_randomness_hash,
             state: State::OrderNegotiation,
         }
     }
@@ -212,5 +298,57 @@ impl HandshakeState {
     /// Transition the state to Error
     pub fn error(&mut self, err: HandshakeManagerError) {
         self.state = State::Error(err);
+    }
+
+    /// Build a VALID MATCH MPC statement from the state of a given handshake
+    pub fn build_valid_match_statement(&self, party_id: u64) -> ValidMatchMpcStatement {
+        // Reorder the hashes depending on the party_id; the king's order (party_id 0) should
+        // come first in the statement
+        let mut hashes = Vec::new();
+        if party_id == KING {
+            hashes.append(&mut vec![
+                self.order_hash,
+                self.balance_hash,
+                self.fee_hash,
+                self.randomness_hash,
+            ]);
+            hashes.append(&mut vec![
+                self.peer_order_hash,
+                self.peer_balance_hash,
+                self.peer_fee_hash,
+                self.peer_randomness_hash,
+            ]);
+        } else {
+            // Swap order
+            hashes.append(&mut vec![
+                self.peer_order_hash,
+                self.peer_balance_hash,
+                self.peer_fee_hash,
+                self.peer_randomness_hash,
+            ]);
+            hashes.append(&mut vec![
+                self.order_hash,
+                self.balance_hash,
+                self.fee_hash,
+                self.randomness_hash,
+            ]);
+        }
+
+        // The hashes are done natively via Arkworks and must be converted to the Dalek scalar representation
+        let hashes_scalar = hashes
+            .iter()
+            .map(|hash| prime_field_to_scalar(&hash.0))
+            .collect::<Vec<_>>();
+
+        ValidMatchMpcStatement {
+            hash_order1: hashes_scalar[0].to_owned(),
+            hash_balance1: hashes_scalar[1].to_owned(),
+            hash_fee1: hashes_scalar[2].to_owned(),
+            hash_randomness1: hashes_scalar[3].to_owned(),
+            hash_order2: hashes_scalar[4].to_owned(),
+            hash_balance2: hashes_scalar[5].to_owned(),
+            hash_fee2: hashes_scalar[6].to_owned(),
+            hash_randomness2: hashes_scalar[7].to_owned(),
+        }
     }
 }

--- a/core/src/handshake/types.rs
+++ b/core/src/handshake/types.rs
@@ -1,0 +1,82 @@
+//! Groups type definitions relevant to the handshake process
+
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use crypto::fields::DalekRistrettoField;
+use serde::{
+    de::{Error as DeserializeError, Visitor},
+    ser::Error as SerializeError,
+    Deserialize, Serialize,
+};
+use std::fmt::{Formatter, Result as FmtResult};
+use uuid::Uuid;
+
+/// An identifier of an order used for caching
+/// TODO: Update this with a commitment to an order, UUID for testing
+pub type OrderIdentifier = Uuid;
+
+/// A wrapper around a hasher's output that both:
+///     1. Abstracts the underlying field details
+///     2. Allos us to implement serialization/deserialization traits
+#[derive(Copy, Clone, Debug)]
+pub struct HashOutput(pub DalekRistrettoField);
+
+impl From<u64> for HashOutput {
+    fn from(x: u64) -> Self {
+        Self(DalekRistrettoField::from(x))
+    }
+}
+
+impl Serialize for HashOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Use the Arkworks compression/serialization implementation
+        let mut buf = Vec::new();
+        self.0.serialize_compressed(&mut buf).map_err(|err| {
+            SerializeError::custom(format!("error serializing HashOutput: {}", err))
+        })?;
+
+        serializer.serialize_bytes(&buf)
+    }
+}
+
+impl<'de> Deserialize<'de> for HashOutput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(HashOutputVisitor)
+    }
+}
+
+/// Serde visitor implementation for deserializing arkworks field elements
+/// wrapped in the HashOutput abstraction
+struct HashOutputVisitor;
+impl<'de> Visitor<'de> for HashOutputVisitor {
+    type Value = HashOutput;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str("a HashOutput encoded as a byte array")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut bytes_vec = Vec::new();
+        while let Some(value) = seq.next_element()? {
+            bytes_vec.push(value);
+        }
+
+        let res =
+            DalekRistrettoField::deserialize_compressed(bytes_vec.as_slice()).map_err(|err| {
+                DeserializeError::custom(format!(
+                    "deserializing byte array to HashOutput: {:?}",
+                    err
+                ))
+            })?;
+
+        Ok(HashOutput(res))
+    }
+}

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::{
     gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
-    handshake::manager::{OrderIdentifier, DEFAULT_HANDSHAKE_PRIORITY},
+    handshake::{manager::DEFAULT_HANDSHAKE_PRIORITY, types::OrderIdentifier},
 };
 
 /**


### PR DESCRIPTION
### Purpose
This PR includes hashes of orders, balances, fees, and wallet randomness throughout the match process; including in the state machine, the messages passed between peers, etc. These hashes form the statement that is proven (the witness of course being the inputs to the matching engine); and are used for input consistency checks across proofs.

### Testing
- Workspace unit tests
- Verified basic relayer execution