### PR TITLE
core: handshake: Add proof of `VALID MATCH MPC` to handshake

### DIFF
--- a/circuits/src/types/match.rs
+++ b/circuits/src/types/match.rs
@@ -160,7 +160,7 @@ impl CommitVerifier for CommittedMatchResult {
 
 /// Represents a single match on a pair of overlapping orders
 /// with values authenticated in an MPC network
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AuthenticatedMatchResult<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
     /// The mint of the order token in the asset pair being matched
     pub quote_mint: AuthenticatedScalar<N, S>,
@@ -183,6 +183,23 @@ pub struct AuthenticatedMatchResult<N: MpcNetwork + Send, S: SharedValueSource<S
     /// The index of the order (0 or 1) that has the minimum amount, i.e. the order that is
     /// completely filled by this match
     pub min_amount_order_index: AuthenticatedScalar<N, S>,
+}
+
+/// A custom clone implementation; necessary because the MpcNetwork will not generally implement
+/// clone
+impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone for AuthenticatedMatchResult<N, S> {
+    fn clone(&self) -> Self {
+        Self {
+            quote_mint: self.quote_mint.clone(),
+            base_mint: self.base_mint.clone(),
+            quote_amount: self.quote_amount.clone(),
+            base_amount: self.base_amount.clone(),
+            direction: self.direction.clone(),
+            execution_price: self.execution_price.clone(),
+            max_minus_min_amount: self.max_minus_min_amount.clone(),
+            min_amount_order_index: self.min_amount_order_index.clone(),
+        }
+    }
 }
 
 /// Serialization to a vector of authenticated scalars

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -5,11 +5,15 @@ use std::fmt::Display;
 /// The core error type for the handshake manager
 #[derive(Clone, Debug)]
 pub enum HandshakeManagerError {
+    /// An error while collaboratively proving a statement
+    Multiprover(String),
     /// An invalid request ID was passed in a message; i.e. the request ID is not known
     /// to the local state machine
     InvalidRequest(String),
     /// Error in MPC networking
     MpcNetwork(String),
+    /// Error verifying a proof
+    VerificationError(String),
     /// Error sending a message to the network
     SendMessage(String),
     /// Error while setting up the handshake manager

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -396,7 +396,6 @@ impl HandshakeManager {
         handshake_cache: SharedHandshakeCache<OrderIdentifier>,
         global_state: &RelayerState,
     ) -> Option<(OrderIdentifier, Order, Balance, Fee)> {
-        println!("Choosing balance and fee");
         let mut rng = thread_rng();
         let mut proposed_order = None;
 


### PR DESCRIPTION
### Purpose
This PR adds the final component of the handshake MPC; in which the two parties collaboratively prove `VALID MATCH MPC` and locally verify its correctness.

At this point, both parties have the ability to encumber one another's wallets, and may proceed with settlement.

### Testing
- Workspace wide unit tests
- Validated the full workflow of relayer execution from bootstrap -> handshake negotiation -> match computation -> collaborative proof -> verification