### PR TITLE
core: handshake: Place in-flight match order pairs in invisibility window

### DIFF
--- a/core/src/api/cluster_management.rs
+++ b/core/src/api/cluster_management.rs
@@ -23,6 +23,13 @@ pub enum ClusterManagementMessage {
     /// A message indicating that the publisher has replicated the wallets contained
     /// in the message body
     Replicated(ReplicatedMessage),
+    /// A message to cluster peers indicating that the publisher has begun a handshake
+    /// on the given order pair
+    ///
+    /// Recipients should place this order pair in an invisibility window and not schedule
+    /// it for handshake until the invisibility period has elapsed and either resulted in
+    /// a match or an error
+    MatchInProgress(OrderIdentifier, OrderIdentifier),
     /// A cache synchronization update wherein the sender informs its cluster peers that
     /// it has run the match computation on a given pair of orders
     ///

--- a/core/src/handshake/handshake_cache.rs
+++ b/core/src/handshake/handshake_cache.rs
@@ -12,6 +12,7 @@ use std::{
     cmp::{max, min},
     hash::Hash,
     num::NonZeroUsize,
+    time::{Duration, Instant},
 };
 
 use lru::LruCache;
@@ -33,7 +34,29 @@ pub struct HandshakeCache<O> {
     /// The underlying LRU cache controlling evication from the HandshakeCache
     ///
     /// Entries are cached with the lower (abstract ordering) identifier stored first
-    lru_cache: LruCache<(O, O), ()>,
+    lru_cache: LruCache<(O, O), HandshakeCacheState>,
+}
+
+/// Represents the state of an entry in the handshake cache for various types of caching
+#[derive(Clone, Copy, Debug)]
+pub enum HandshakeCacheState {
+    /// A completed match, either by the local peer or a cluster replica;
+    /// this order pair should not be scheduled again
+    Completed,
+    /// A match that a remote peer has initiated; the local peer places this
+    /// order pair in an invisibility window to avoid duplicating the remote
+    /// peer's work.
+    ///
+    /// There are two transitions out of this state:
+    ///     1. The remote peer completes a match on the pair; in which case it
+    ///        will broadcast a message to complete the pair, moving it to the
+    ///        completed state
+    ///     2. The remote peer fails to complete a math; the invisibility window
+    ///        elapses, and this entry if removed from the cache
+    Invisibile {
+        /// The `Instant` at which the invisibility window expires
+        until: Instant,
+    },
 }
 
 impl<O: Clone + Eq + Hash + Ord> HandshakeCache<O> {
@@ -63,13 +86,40 @@ impl<O: Clone + Eq + Hash + Ord> HandshakeCache<O> {
     }
 
     /// Caches an entry
-    pub fn push(&mut self, o1: O, o2: O) {
-        self.lru_cache.push(Self::cache_tuple(o1, o2), ());
+    pub fn mark_completed(&mut self, o1: O, o2: O) {
+        self.lru_cache
+            .push(Self::cache_tuple(o1, o2), HandshakeCacheState::Completed);
+    }
+
+    /// Mark the given pair as invisible for a duration
+    ///
+    /// Window represents the amount of time this order pair is invisible for
+    pub fn mark_invisible(&mut self, o1: O, o2: O, window: Duration) {
+        self.lru_cache.push(
+            Self::cache_tuple(o1, o2),
+            HandshakeCacheState::Invisibile {
+                until: Instant::now() + window,
+            },
+        );
     }
 
     /// Checks whether a given pair is cached
     pub fn contains(&self, o1: O, o2: O) -> bool {
-        self.lru_cache.contains(&Self::cache_tuple(o1, o2))
+        // If the cache contains the entry in the `Invisible` state and the invisibility window
+        // has expired, return false
+        if let Some(entry) = self.lru_cache.peek(&Self::cache_tuple(o1, o2)) {
+            match entry {
+                HandshakeCacheState::Completed => true,
+                HandshakeCacheState::Invisibile { until } => {
+                    // checked_duration_since will return none if the arg is later than
+                    // `Instant::now()`. If `is_none() == true` then the invisibility
+                    // window has not elapsed and the entry is considered cached
+                    Instant::now().checked_duration_since(*until).is_none()
+                }
+            }
+        } else {
+            false
+        }
     }
 }
 
@@ -81,9 +131,9 @@ mod handshake_cache_tests {
     #[test]
     fn test_lru_policy() {
         let mut cache = HandshakeCache::new(2 /* max_size */);
-        cache.push(1, 1);
-        cache.push(2, 2);
-        cache.push(3, 3);
+        cache.mark_completed(1, 1);
+        cache.mark_completed(2, 2);
+        cache.mark_completed(3, 3);
 
         assert!(!cache.contains(1, 1));
         assert!(cache.contains(2, 2));
@@ -95,12 +145,12 @@ mod handshake_cache_tests {
     fn test_cache_ordering() {
         let mut cache = HandshakeCache::new(1 /* max_size */);
         // Try the smaller value first
-        cache.push(4, 5);
+        cache.mark_completed(4, 5);
         assert!(cache.contains(4, 5));
         assert!(cache.contains(5, 4));
 
         // Try the larger value first
-        cache.push(7, 6);
+        cache.mark_completed(7, 6);
         assert!(!cache.contains(4, 5));
         assert!(cache.contains(6, 7));
         assert!(cache.contains(7, 6));

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -40,6 +40,14 @@ pub enum HandshakeExecutionJob {
         /// The net that was setup for the party
         net: QuicTwoPartyNet,
     },
+    /// Indicates that a cluster replica has initiated a match on the given order pair.
+    /// The local peer should not schedule this order pair for a match for some duration
+    PeerMatchInProgress {
+        /// The first of the orders in the pair
+        order1: OrderIdentifier,
+        /// The second of the orderes in the pair
+        order2: OrderIdentifier,
+    },
     /// Update the handshake cache with an entry from an order pair that a cluster
     /// peer has executed
     CacheEntry {

--- a/core/src/handshake/match.rs
+++ b/core/src/handshake/match.rs
@@ -108,6 +108,7 @@ impl HandshakeManager {
         local_order: &Order,
         fabric: SharedFabric<N, S>,
     ) -> Result<AuthenticatedMatchResult<N, S>, HandshakeManagerError> {
+        // Allocate the orders in the MPC fabric
         let shared_order1 = local_order
             .allocate(0 /* owning_party */, fabric.clone())
             .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
@@ -115,6 +116,7 @@ impl HandshakeManager {
             .allocate(1 /* owning_party */, fabric.clone())
             .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))?;
 
+        // Run the circuit
         compute_match(&shared_order1, &shared_order2, fabric)
             .map_err(|err| HandshakeManagerError::MpcNetwork(err.to_string()))
     }

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -554,6 +554,14 @@ impl NetworkManager {
                     ClusterManagementMessage::CacheSync(order1, order2) => handshake_work_queue
                         .send(HandshakeExecutionJob::CacheEntry { order1, order2 })
                         .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?,
+
+                    // Forward the match in progress message to the handshake manager so that it can avoid
+                    // scheduling a duplicate handshake for the given order pair
+                    ClusterManagementMessage::MatchInProgress(order1, order2) => {
+                        handshake_work_queue
+                            .send(HandshakeExecutionJob::PeerMatchInProgress { order1, order2 })
+                            .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Purpose
Within a cluster; when one peer begins a match on two orders, its cluster peers should not schedule that match for some time -- this avoids duplicating in-progress work. However, if a peer commits to trying a match and then fails, its cluster peers should try that order pair again after some time. 

To support this, we add cache states to the `HandshakeCache`; one of which is `Invisible`. In the `Invisible` state, an order pair is considered cached until some timeout has elapsed. This allows cluster peers to avoid scheduling an order pair while one peer attempts a match.

### Testing
- Workspace unit tests pass
- Tested the behavior by spinning up multiple peers in a cluster and having them match with a peer in a separate cluster.