### PR TITLE
core: api-server: Bootstrap the API server worker

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ crypto = { path = "../crypto" }
 curve25519-dalek = "2"
 ed25519-dalek = { version = "1.0.1" }
 futures = { version = "0.3.21" }
+hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
 integration-helpers = { path = "../integration-helpers" }
 libp2p = { version = "0.50", features = [
     "async-std",

--- a/core/resources/cluster1.toml
+++ b/core/resources/cluster1.toml
@@ -1,4 +1,5 @@
-port = 8000
+p2p-port = 8000
+http-port = 3000
 version = 0
 debug = true
 wallet-file = "./core/resources/wallets1.json"

--- a/core/resources/cluster2.toml
+++ b/core/resources/cluster2.toml
@@ -1,4 +1,5 @@
-port = 9000
+p2p-port = 8001 
+http-port = 3001
 version = 0
 debug = true
 wallet-file = "./core/resources/wallets2.json"

--- a/core/src/api/http.rs
+++ b/core/src/api/http.rs
@@ -1,0 +1,20 @@
+//! Groups API definitions for the externally facing HTTP API
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::gossip::types::WrappedPeerId;
+
+/// A request to get the replicas of a given wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetReplicasRequest {
+    /// The ID of the wallet requested
+    pub wallet_id: Uuid,
+}
+
+/// A response containing the known replicas for a given wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetReplicasResponse {
+    /// The number of replicas for the wallet
+    pub replicas: Vec<WrappedPeerId>,
+}

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -5,3 +5,4 @@ pub mod cluster_management;
 pub mod gossip;
 pub mod handshake;
 pub mod hearbeat;
+pub mod http;

--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -1,0 +1,10 @@
+//! Defines error types that occur in the ApiServer
+
+/// The error type for errors that occur during ApiServer execution
+#[derive(Clone, Debug)]
+pub enum ApiServerError {
+    /// Error setting up the API server
+    Setup(String),
+    /// HTTP server has failed
+    HttpServerFailure(String),
+}

--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -1,5 +1,7 @@
 //! Defines error types that occur in the ApiServer
 
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 /// The error type for errors that occur during ApiServer execution
 #[derive(Clone, Debug)]
 pub enum ApiServerError {
@@ -7,4 +9,10 @@ pub enum ApiServerError {
     Setup(String),
     /// HTTP server has failed
     HttpServerFailure(String),
+}
+
+impl Display for ApiServerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
 }

--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -1,0 +1,5 @@
+//! Defines the server for the publically facing API (both HTTP and websocket)
+//! that the relayer exposes
+pub mod error;
+pub mod server;
+pub mod worker;

--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -1,4 +1,4 @@
-//! Defines the server for the publically facing API (both HTTP and websocket)
+//! Defines the server for the publicly facing API (both HTTP and websocket)
 //! that the relayer exposes
 pub mod error;
 pub mod server;

--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -1,5 +1,6 @@
 //! Defines the server for the publicly facing API (both HTTP and websocket)
 //! that the relayer exposes
 pub mod error;
+mod routes;
 pub mod server;
 pub mod worker;

--- a/core/src/api_server/routes.rs
+++ b/core/src/api_server/routes.rs
@@ -1,0 +1,128 @@
+//! Abstracts routing logic from the HTTP server
+
+use std::{collections::HashMap, fmt::Display, marker::PhantomData};
+
+use async_trait::async_trait;
+use hyper::{Body, Request, Response, StatusCode};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/**
+ * Helpers
+ */
+
+/// Builds an empty HTTP 400 (Bad Request) response
+fn build_400_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Builds an empty HTTP 404 (Not Found) response
+fn build_404_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Builds an empty HTTP 500 (Internal Server Error) response
+fn build_500_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/**
+ * Trait implementations
+ */
+
+/// A handler is attached to a route and handles the process of translating an
+/// abstract request type into a response
+#[async_trait]
+pub trait Handler {
+    /// The handler method for the request/response on the handler's route
+    async fn handle(&self, req: Request<Body>) -> Response<Body>;
+}
+
+/// A handler that has associated Request/Response type information attached to it.
+/// We implement this as a subtrait so that the router can store trait objects
+/// (associated types are disallowed on trait objects) as Handler that concretely
+/// re-use the default serialization/deserialization logic below
+pub trait TypedHandler: Send + Sync {
+    /// The request type that the handler consumes
+    type Request: DeserializeOwned + for<'de> Deserialize<'de>;
+    /// The response type that the handler returns
+    type Response: Serialize;
+    /// The error type that the handler returns
+    type Error: Display;
+
+    /// The handler logic, translate request into response
+    fn handle_typed(&self, req: Self::Request) -> Result<Self::Response, Self::Error>;
+}
+
+/// Auto-implementation of the Handler trait for a TypedHandler which covers the process
+/// of deserializing the request, reporting errors, and serializing the response into a body
+#[async_trait]
+impl<
+        Req: DeserializeOwned + for<'de> Deserialize<'de>,
+        Resp: Serialize,
+        E: Display,
+        T: TypedHandler<Request = Req, Response = Resp, Error = E>,
+    > Handler for T
+{
+    async fn handle(&self, req: Request<Body>) -> Response<Body> {
+        // Deserialize the request into the request type, return HTTP 400 if deserialization fails
+        let req_body_bytes = hyper::body::to_bytes(req.into_body()).await;
+        if req_body_bytes.is_err() {
+            return build_400_response();
+        }
+
+        let unwrapped: &[u8] = &req_body_bytes.unwrap(); // Necessary to explicitly hold temporary value
+        let deserialized = serde_json::from_reader(unwrapped);
+        if deserialized.is_err() {
+            return build_400_response();
+        }
+
+        let req_body: Req = deserialized.unwrap();
+
+        // Forward to the typed handler
+        if let Ok(resp) = self.handle_typed(req_body) {
+            // Serialize the response into a body
+            Response::new(Body::from(serde_json::to_vec(&resp).unwrap()))
+        } else {
+            build_500_response()
+        }
+    }
+}
+
+/// A router handles the process of serialization/deserialization, and routing
+/// to the appropriate handler
+pub struct Router {
+    /// The routing information, mapping endpoint to handler
+    routes: HashMap<String, Box<dyn Handler>>,
+}
+
+impl Router {
+    /// Create a new router with no routes established
+    fn new() -> Self {
+        Self {
+            routes: HashMap::new(),
+        }
+    }
+
+    /// Add a route to the router
+    fn add_route<H: Handler + 'static>(&mut self, route: String, handler: H) {
+        self.routes.insert(route, Box::new(handler));
+    }
+
+    /// Route a request to a handler
+    async fn handle_req(&self, route: String, req: Request<Body>) -> Response<Body> {
+        if let Some(handler) = self.routes.get(&route) {
+            handler.as_ref().handle(req).await
+        } else {
+            build_404_response()
+        }
+    }
+}

--- a/core/src/api_server/server.rs
+++ b/core/src/api_server/server.rs
@@ -1,0 +1,21 @@
+//! The core logic behind the APIServer's implementation
+
+use hyper::server::{conn::AddrIncoming, Builder};
+use tokio::{runtime::Runtime, task::JoinHandle as TokioJoinHandle};
+
+use super::error::ApiServerError;
+
+/// Accepts inbound HTTP requests and websocket subscriptions and
+/// serves requests from those connections
+///
+/// Clients of this server might be traders looking to manage their
+/// trades, view live execution events, etc
+pub struct ApiServer {
+    /// The builder for the HTTP server before it begins serving; wrapped in
+    /// an option to allow the worker threads to take ownership of the value
+    pub(super) http_server_builder: Option<Builder<AddrIncoming>>,
+    /// The join handle for the http server
+    pub(super) http_server_join_handle: Option<TokioJoinHandle<ApiServerError>>,
+    /// The tokio runtime that the http server runs inside of
+    pub(super) http_server_runtime: Option<Runtime>,
+}

--- a/core/src/api_server/server.rs
+++ b/core/src/api_server/server.rs
@@ -2,11 +2,14 @@
 
 use hyper::{
     server::{conn::AddrIncoming, Builder},
-    Body, Request, Response,
+    Body, Method, Request, Response, StatusCode,
 };
 use tokio::{runtime::Runtime, task::JoinHandle as TokioJoinHandle};
 
-use crate::state::RelayerState;
+use crate::{
+    api::http::{GetReplicasRequest, GetReplicasResponse},
+    state::RelayerState,
+};
 
 use super::{error::ApiServerError, worker::ApiServerConfig};
 
@@ -29,14 +32,58 @@ pub struct ApiServer {
 
 impl ApiServer {
     /// Handles an incoming HTTP request
-    pub(super) fn handle_http_req(
+    pub(super) async fn handle_http_req(
         req: Request<Body>,
         global_state: &RelayerState,
     ) -> Result<Response<Body>, ApiServerError> {
-        println!(
-            "num wallets: {:?}",
-            global_state.read_managed_wallets().len()
-        );
-        Ok(Response::new(Body::from("test response")))
+        match (req.method(), req.uri().path()) {
+            (&Method::POST, "/replicas") => {
+                Ok(Self::handle_get_wallet_info(req, global_state).await)
+            }
+            _ => Ok(Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty())
+                .unwrap()),
+        }
+    }
+
+    /// Handles a request to "/replicas"
+    ///
+    /// Request is of the form { wallet_id: uuid }
+    ///
+    /// Returns the replicas of a wallet with the fields
+    ///     - wallet_id: <uuid>
+    ///     - replicas: [uuid]
+    async fn handle_get_wallet_info(
+        req: Request<Body>,
+        global_state: &RelayerState,
+    ) -> Response<Body> {
+        let body = hyper::body::to_bytes(req.into_body()).await;
+        if body.is_err() {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::empty())
+                .unwrap();
+        }
+
+        let deserialized = serde_json::from_slice(&body.unwrap());
+        if deserialized.is_err() {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::empty())
+                .unwrap();
+        }
+
+        let req_body: GetReplicasRequest = deserialized.unwrap();
+        let replicas = if let Some(wallet_info) =
+            global_state.read_managed_wallets().get(&req_body.wallet_id)
+        {
+            wallet_info.metadata.replicas.clone().into_iter().collect()
+        } else {
+            vec![]
+        };
+
+        let resp = GetReplicasResponse { replicas };
+        Response::new(Body::from(serde_json::to_vec(&resp).unwrap()))
     }
 }

--- a/core/src/api_server/server.rs
+++ b/core/src/api_server/server.rs
@@ -1,9 +1,14 @@
 //! The core logic behind the APIServer's implementation
 
-use hyper::server::{conn::AddrIncoming, Builder};
+use hyper::{
+    server::{conn::AddrIncoming, Builder},
+    Body, Request, Response,
+};
 use tokio::{runtime::Runtime, task::JoinHandle as TokioJoinHandle};
 
-use super::error::ApiServerError;
+use crate::state::RelayerState;
+
+use super::{error::ApiServerError, worker::ApiServerConfig};
 
 /// Accepts inbound HTTP requests and websocket subscriptions and
 /// serves requests from those connections
@@ -11,6 +16,8 @@ use super::error::ApiServerError;
 /// Clients of this server might be traders looking to manage their
 /// trades, view live execution events, etc
 pub struct ApiServer {
+    /// The config passed to the worker
+    pub(super) config: ApiServerConfig,
     /// The builder for the HTTP server before it begins serving; wrapped in
     /// an option to allow the worker threads to take ownership of the value
     pub(super) http_server_builder: Option<Builder<AddrIncoming>>,
@@ -18,4 +25,18 @@ pub struct ApiServer {
     pub(super) http_server_join_handle: Option<TokioJoinHandle<ApiServerError>>,
     /// The tokio runtime that the http server runs inside of
     pub(super) http_server_runtime: Option<Runtime>,
+}
+
+impl ApiServer {
+    /// Handles an incoming HTTP request
+    pub(super) fn handle_http_req(
+        req: Request<Body>,
+        global_state: &RelayerState,
+    ) -> Result<Response<Body>, ApiServerError> {
+        println!(
+            "num wallets: {:?}",
+            global_state.read_managed_wallets().len()
+        );
+        Ok(Response::new(Body::from("test response")))
+    }
 }

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -6,6 +6,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use crossbeam::channel::Receiver;
 use futures::executor::block_on;
 use hyper::{
     server::conn::AddrStream,
@@ -26,6 +27,8 @@ const HTTP_SERVER_NUM_THREADS: usize = 1;
 pub struct ApiServerConfig {
     /// The port that the HTTP server should listen on
     pub http_port: u16,
+    /// The channel to receive cancellation signals on from the coordinator
+    pub cancel_channel: Receiver<()>,
 }
 
 impl Worker for ApiServer {

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -1,0 +1,99 @@
+//! Defines the implementation of the `Worker` trait for the ApiServer
+
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    thread::{self, JoinHandle},
+};
+
+use futures::executor::block_on;
+use hyper::{
+    server::conn::AddrStream,
+    service::{make_service_fn, service_fn},
+    Body, Error, Request, Response, Server,
+};
+use tokio::runtime::Builder as TokioBuilder;
+
+use crate::worker::Worker;
+
+use super::{error::ApiServerError, server::ApiServer};
+
+/// The number of threads backing the HTTP server
+const HTTP_SERVER_NUM_THREADS: usize = 1;
+
+/// The worker config for the ApiServer
+#[derive(Clone, Debug)]
+pub struct ApiServerConfig {
+    /// The port that the HTTP server should listen on
+    pub http_port: u16,
+}
+
+impl Worker for ApiServer {
+    type WorkerConfig = ApiServerConfig;
+    type Error = ApiServerError;
+
+    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        // Build the http server
+        let addr: SocketAddr = format!("127.0.0.1:{}", config.http_port).parse().unwrap();
+        let builder = Server::bind(&addr);
+
+        Ok(Self {
+            http_server_builder: Some(builder),
+            http_server_join_handle: None,
+            http_server_runtime: None,
+        })
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        // Take ownership of the http server, begin listening
+        let server_builder = self.http_server_builder.take().unwrap();
+        let make_service = make_service_fn(|_: &AddrStream| async {
+            Ok::<_, Infallible>(service_fn(|_req: Request<Body>| async move {
+                let response = Response::new(Body::from("Test response"));
+                Ok::<_, Error>(response)
+            }))
+        });
+
+        // Spawn a tokio thread pool to run the server in
+        let tokio_runtime = TokioBuilder::new_multi_thread()
+            .worker_threads(HTTP_SERVER_NUM_THREADS)
+            .enable_io()
+            .enable_time()
+            .build()
+            .map_err(|err| ApiServerError::Setup(err.to_string()))?;
+        let thread_handle = tokio_runtime.spawn_blocking(move || {
+            let server = server_builder.serve(make_service);
+            if let Err(err) = block_on(server) {
+                return ApiServerError::HttpServerFailure(err.to_string());
+            }
+            ApiServerError::HttpServerFailure("http server spuriously shut down".to_string())
+        });
+
+        self.http_server_join_handle = Some(thread_handle);
+        self.http_server_runtime = Some(tokio_runtime);
+
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        "api-server".to_string()
+    }
+
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        // Wrap the Tokio join handle in a wrapper thread
+        let join_handle = self.http_server_join_handle.take().unwrap();
+        let wrapper = thread::spawn(move || block_on(join_handle).unwrap());
+        vec![wrapper]
+    }
+
+    fn is_recoverable(&self) -> bool {
+        true
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("")
+    }
+}

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -66,7 +66,7 @@ impl Worker for ApiServer {
                 Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
                     let global_state = global_state.clone();
                     async move {
-                        Ok::<_, Error>(match Self::handle_http_req(req, &global_state) {
+                        Ok::<_, Error>(match Self::handle_http_req(req, &global_state).await {
                             Ok(resp) => resp,
                             Err(err) => Response::builder()
                                 .status(StatusCode::INTERNAL_SERVER_ERROR)

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -43,9 +43,12 @@ struct Cli {
     #[clap(short, long, value_parser)]
     /// Whether or not to run the relayer in debug mode
     pub debug: bool,
-    #[clap(short, long, value_parser, default_value = "12345")]
-    /// The port to listen on
-    pub port: u32,
+    #[clap(short, long, value_parser, default_value = "8000")]
+    /// The port to listen on for libp2p
+    pub p2p_port: u16,
+    #[clap(short, long, value_parser, default_value = "3000")]
+    /// The port to listen on for the externally facing HTTP API
+    pub http_port: u16,
     #[clap(short, long, value_parser)]
     /// The software version of the relayer
     pub version: Option<String>,
@@ -62,8 +65,10 @@ pub struct RelayerConfig {
     pub version: String,
     /// Bootstrap servers that the peer should connect to
     pub bootstrap_servers: Vec<PeerInfo>,
-    /// The port to listen on
-    pub port: u32,
+    /// The port to listen on for libp2p
+    pub p2p_port: u16,
+    /// The port to listen on for the externally facing HTTP API
+    pub http_port: u16,
     /// The wallet IDs to manage locally
     pub wallets: Vec<Wallet>,
     /// The cluster keypair
@@ -143,7 +148,8 @@ pub fn parse_command_line_args() -> Result<Box<RelayerConfig>, CoordinatorError>
             .version
             .unwrap_or_else(|| String::from(DEFAULT_VERSION)),
         bootstrap_servers: parsed_bootstrap_addrs,
-        port: cli_args.port,
+        p2p_port: cli_args.p2p_port,
+        http_port: cli_args.http_port,
         wallets: parse_wallet_file(cli_args.wallet_file)?,
         cluster_keypair: keypair,
         cluster_id,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (handshake_cancel_sender, handshake_cancel_receiver) =
         channel::bounded(1 /* capacity */);
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
-        global_state,
+        global_state: global_state.clone(),
         network_channel: network_sender,
         job_receiver: handshake_worker_receiver,
         system_bus_sender,
@@ -141,6 +141,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (api_cancel_sender, api_cancel_receiver) = channel::bounded(1 /* capacity */);
     let mut api_server = ApiServer::new(ApiServerConfig {
         http_port: 3000,
+        global_state: global_state.clone(),
         cancel_channel: api_cancel_receiver,
     })
     .expect("failed to build api server");

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -4,6 +4,7 @@
 #![feature(let_chains)]
 
 mod api;
+mod api_server;
 mod config;
 mod error;
 mod gossip;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let args = config::parse_command_line_args().expect("error parsing command line args");
     println!(
         "Relayer running with\n\t version: {}\n\t port: {}\n\t cluster: {:?}",
-        args.version, args.port, args.cluster_id
+        args.version, args.p2p_port, args.cluster_id
     );
 
     // Construct the global state
@@ -74,7 +74,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the network manager
     let (network_cancel_sender, network_cancel_receiver) = channel::bounded(1 /* capacity */);
     let network_manager_config = NetworkManagerConfig {
-        port: args.port,
+        port: args.p2p_port,
         cluster_id: args.cluster_id.clone(),
         cluster_keypair: Some(args.cluster_keypair),
         send_channel: Some(network_receiver),
@@ -140,7 +140,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the API server
     let (api_cancel_sender, api_cancel_receiver) = channel::bounded(1 /* capacity */);
     let mut api_server = ApiServer::new(ApiServerConfig {
-        http_port: 3000,
+        http_port: args.http_port,
         global_state: global_state.clone(),
         cancel_channel: api_cancel_receiver,
     })

--- a/core/src/network_manager/worker.rs
+++ b/core/src/network_manager/worker.rs
@@ -29,7 +29,7 @@ use super::{
 #[derive(Debug)]
 pub struct NetworkManagerConfig {
     /// The port to listen for inbound traffic on
-    pub(crate) port: u32,
+    pub(crate) port: u16,
     /// The cluster ID of the local peer
     pub(crate) cluster_id: ClusterId,
     /// The cluster keypair, wrapped in an option to allow the worker thread to


### PR DESCRIPTION
### Purpose
This PR bootstraps the `api-server` worker run by the coordinator.

The API server will serve externally originating HTTP and websocket requests. In this PR, only an HTTP server with a dummy test endpoint is included. 

### Testing
- Workspace unit tests pass
- API for `/replicas` works properly for external request
- Ad-hoc verified other relayer functionality