### PR TITLE
core: system-bus: Bootstrap the `system-bus` module

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 ark-serialize = "0.3"
 async-trait = "0.1.56"
 base64 = { version = "0.13" }
+bus = { version = "2.3" }
 circuits = { path = "../circuits" }
 clap = { version = "3.2.8", features = ["derive"] }
 crossbeam = { version = "0.8.1" }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -11,6 +11,7 @@ mod gossip;
 mod handshake;
 mod network_manager;
 mod state;
+mod system_bus;
 mod types;
 mod worker;
 

--- a/core/src/system_bus.rs
+++ b/core/src/system_bus.rs
@@ -6,11 +6,17 @@
 //! a given topic; a publish action is a no-op. Consequently, a new subscriber
 //! will not see historical messages
 
+// TODO: Remove this lint allowance
+#![allow(dead_code)]
+
 use bus::{Bus, BusReader};
 use std::{
     cell::RefCell,
     collections::HashMap,
-    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{
+        atomic::{AtomicU16, Ordering},
+        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    },
     task::{Context, Poll},
 };
 use tokio::macros::support::poll_fn;
@@ -26,18 +32,36 @@ const BUS_BUFFER_SIZE: usize = 10;
 /// The trait bounds on the message (Clone + Sync) are required by the Bus implementation
 #[derive(Debug)]
 pub struct TopicReader<M> {
+    /// The name of the topic that this reader listens to
+    topic_name: String,
     /// The underlying bus reader for the topic's bus
     reader: BusReader<M>,
     /// A buffered message; used when a call to has_next returns a value
     buffered_message: RefCell<Option<M>>,
+    /// When the reader is dropped we decrement this value in the parent struct so that
+    /// the topic may be deallocated if we are the last reader
+    num_readers: Arc<AtomicU16>,
+    /// A reference to the system bus's topic mesh; readers hold this reference so that they
+    /// may deallocate the topic when dropped if they are the last reader on the topic
+    topic_mesh: Shared<HashMap<String, Shared<TopicFabric<M>>>>,
 }
 
 impl<M: Clone + Sync> TopicReader<M> {
     /// Construct a new reader for a topic
-    pub fn new(bus_reader: BusReader<M>) -> Self {
+    pub fn new(
+        topic_name: String,
+        bus_reader: BusReader<M>,
+        num_readers: Arc<AtomicU16>,
+        topic_mesh: Shared<HashMap<String, Shared<TopicFabric<M>>>>,
+    ) -> Self {
+        // Increment num_readers in the topic mesh now that the local thread is reading
+        num_readers.fetch_add(1 /* val */, Ordering::Relaxed);
         Self {
+            topic_name,
             reader: bus_reader,
             buffered_message: RefCell::new(None),
+            num_readers,
+            topic_mesh,
         }
     }
 
@@ -85,29 +109,77 @@ impl<M: Clone + Sync> TopicReader<M> {
     }
 }
 
+/// A reference counting `Drop` implementation for the reader; if the reader is the last
+/// reader on a given topic, it should clean up the topic from the system bus's mesh
+impl<M> Drop for TopicReader<M> {
+    fn drop(&mut self) {
+        // If there was only one reader (local thread) before this reader was dropped, deallocate the
+        // topic in the pubsub mesh
+        let prev_num_readers = self.num_readers.fetch_sub(1 /* val */, Ordering::Relaxed);
+        if prev_num_readers == 1 {
+            let mut locked_mesh = self.topic_mesh.write().expect("topic_mesh lock poisoned");
+
+            // Ensure that no new subscriptions have come in since we acquired the lock
+            // If so, abort the deallocation of the topic, otherewise zombie readers will
+            // exist for the deallocated topic
+            let new_num_readers = self.num_readers.load(Ordering::Relaxed);
+            if new_num_readers > 0 {
+                return;
+            }
+
+            locked_mesh.remove(&self.topic_name);
+        } // locked_mesh released here
+    }
+}
+
 /// An implementation of a single-producer, multi-consumer topic specific bus
 #[derive(Debug)]
 pub struct TopicFabric<M> {
+    /// The name of the topic that this fabric is allocated for
+    topic_name: String,
     /// The broadcast primitive underlying a shared bus
     bus: Bus<M>,
+    /// The number of readers on the given topic
+    num_readers: Arc<AtomicU16>,
+    /// A reference to the parent mesh that this topic is stored in
+    ///
+    /// Topics store these references so that they may deallocate themselves
+    /// when the last listener is dropped
+    topic_mesh: Shared<HashMap<String, Shared<TopicFabric<M>>>>,
 }
 
 impl<M: Clone + Sync> TopicFabric<M> {
     /// Construct a new fabric for a registered topic
-    pub fn new() -> Self {
+    pub fn new(
+        topic_name: String,
+        topic_mesh: Shared<HashMap<String, Shared<TopicFabric<M>>>>,
+    ) -> Self {
         Self {
+            topic_name,
             bus: Bus::new(BUS_BUFFER_SIZE),
+            num_readers: Arc::new(AtomicU16::new(0 /* val */)),
+            topic_mesh,
         }
     }
 
     /// Add a new reader to the fabric
     pub fn new_reader(&mut self) -> TopicReader<M> {
-        TopicReader::new(self.bus.add_rx())
+        TopicReader::new(
+            self.topic_name.clone(),
+            self.bus.add_rx(),
+            self.num_readers.clone(),
+            self.topic_mesh.clone(),
+        )
     }
 
     /// Write a message onto the topic bus
     pub fn write_message(&mut self, message: M) {
         self.bus.broadcast(message)
+    }
+
+    /// Get the number of readers of the topic
+    pub fn num_readers(&self) -> u16 {
+        self.num_readers.load(Ordering::Relaxed)
     }
 }
 
@@ -163,7 +235,13 @@ impl<M: Clone + Sync> SystemBus<M> {
         let contains_topic = { self.read_topic_mesh().contains_key(&topic) };
         if !contains_topic {
             let mut locked_mesh = self.write_topic_mesh();
-            locked_mesh.insert(topic.clone(), Arc::new(RwLock::new(TopicFabric::new())));
+            locked_mesh.insert(
+                topic.clone(),
+                Arc::new(RwLock::new(TopicFabric::new(
+                    topic.clone(),
+                    self.topic_mesh.clone(),
+                ))),
+            );
         } // locked_mesh released
 
         // Build a reader on the topic of interest and return it as a pollable to the subscriber
@@ -177,7 +255,20 @@ impl<M: Clone + Sync> SystemBus<M> {
         locked_topic.new_reader()
     }
 
+    /// Returns the number of listeners on a topic
+    pub fn num_listeners(&self, topic: &String) -> u16 {
+        if let Some(topic_entry) = self.read_topic_mesh().get(topic) {
+            let locked_topic = topic_entry.write().expect("topic_entry lock poisoned");
+            locked_topic.num_readers()
+        } else {
+            0
+        }
+    }
+
     /// Returns whether or not the given topic has been subscribed to by any readers
+    ///
+    /// This method is implemented mostly for testing purposes, i.e. to give us an idea of
+    /// whether the topic is allocated in the underlying mesh
     pub fn has_listeners(&self, topic: &String) -> bool {
         self.read_topic_mesh().contains_key(topic)
     }
@@ -277,5 +368,49 @@ mod system_bus_tests {
         assert_eq!(message1, reader1.next_message().await);
         assert_eq!(message2, reader1.next_message().await);
         assert_eq!(message2, reader2.next_message().await);
+    }
+
+    /// Tests the num_listeners method
+    #[tokio::test]
+    #[allow(unused)]
+    async fn test_num_listeners() {
+        // Start out with no listeners
+        let pubsub = SystemBus::<()>::new();
+        assert_eq!(0, pubsub.num_listeners(&TEST_TOPIC.to_string()));
+
+        let reader1 = pubsub.subscribe(TEST_TOPIC.to_string());
+        assert_eq!(1, pubsub.num_listeners(&TEST_TOPIC.to_string()));
+
+        let reader2 = pubsub.subscribe(TEST_TOPIC.to_string());
+        assert_eq!(2, pubsub.num_listeners(&TEST_TOPIC.to_string()));
+    }
+
+    /// Tests that topics are deallocated from the pubsub mesh when the last reader is dropped
+    #[tokio::test]
+    async fn test_dealloc_topic() {
+        // Setup the pubsub mesh; there are no listeners to any topic to begin, so `has_listeners`
+        // should return false
+        let pubsub = SystemBus::<u64>::new();
+        assert!(!pubsub.has_listeners(&TEST_TOPIC.to_string()));
+
+        // Add one reader, `has_listeners` should now be true
+        let reader1 = pubsub.subscribe(TEST_TOPIC.to_string());
+        assert!(pubsub.has_listeners(&TEST_TOPIC.to_string()));
+
+        // Drop the reader, `has_listeners` should be false
+        drop(reader1);
+        assert!(!pubsub.has_listeners(&TEST_TOPIC.to_string()));
+
+        // Add two readers, drop them one by one
+        let reader2 = pubsub.subscribe(TEST_TOPIC.to_string());
+        let reader3 = pubsub.subscribe(TEST_TOPIC.to_string());
+        assert!(pubsub.has_listeners(&TEST_TOPIC.to_string()));
+
+        drop(reader3);
+        assert!(pubsub.has_listeners(&TEST_TOPIC.to_string()));
+
+        // Drop the last reader, `has_listeners` should now be returning false
+        drop(reader2);
+        assert!(!pubsub.has_listeners(&TEST_TOPIC.to_string()));
     }
 }

--- a/core/src/system_bus.rs
+++ b/core/src/system_bus.rs
@@ -1,0 +1,131 @@
+//! The system bus defines an embedded pubsub architecture in which
+//! consumers may subscribe to a topic and producers may publish to the topics
+//! with broadcast semantics
+//!
+//! The implementation of the bus is such that if there are no subscribers to
+//! a given topic; a publish action is a no-op. Consequently, a new subscriber
+//! will not see historical messages
+
+use bus::{Bus, BusReader};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+use tokio::macros::support::poll_fn;
+
+use crate::state::Shared;
+
+/// The number of messages to buffer inside a single topic's bus
+const BUS_BUFFER_SIZE: usize = 10;
+
+/// A wrapper around `BusReader` that allows us to store topic-relevant information,
+/// add reference counts, and build pollable methods around reading
+#[derive(Debug)]
+pub struct TopicReader<M> {
+    /// The underlying bus reader for the topic's bus
+    reader: BusReader<M>,
+}
+
+impl<M> TopicReader<M> {
+    /// Construct a new reader for a topic
+    pub fn new(bus_reader: BusReader<M>) -> Self {
+        Self { reader: bus_reader }
+    }
+}
+
+/// An implementation of a single-producer, multi-consumer topic specific bus
+#[derive(Debug)]
+pub struct TopicFabric<M> {
+    /// The broadcast primitive underlying a shared bus
+    bus: Bus<M>,
+}
+
+impl<M> TopicFabric<M> {
+    /// Construct a new fabric for a registered topic
+    pub fn new() -> Self {
+        Self {
+            bus: Bus::new(BUS_BUFFER_SIZE),
+        }
+    }
+
+    /// Add a new reader to the fabric
+    pub fn new_reader(&mut self) -> TopicReader<M> {
+        TopicReader::new(self.bus.add_rx())
+    }
+
+    /// Write a message onto the topic bus
+    pub fn write_message(&mut self, message: M) {
+        self.bus.broadcast(message)
+    }
+}
+
+/// The system bus abstracts over an embedded pubsub functionality
+///
+/// Note that publishing to a topic with no subscribers is a no-op
+#[derive(Debug)]
+pub struct SystemBus<M> {
+    /// The topic mesh connects publishers to subscribers, it is concretely implemented
+    /// as a mapping from topic name (String) to a bus (single-producer, multi-consumer)
+    topic_mesh: Shared<HashMap<String, Shared<TopicFabric<M>>>>,
+}
+
+impl<M> SystemBus<M> {
+    /// Construct a new system bus
+    pub fn new() -> Self {
+        Self {
+            topic_mesh: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Acquire a read lock on the topic mesh
+    fn read_topic_mesh(&self) -> RwLockReadGuard<HashMap<String, Shared<TopicFabric<M>>>> {
+        self.topic_mesh.read().expect("topic_mesh lock poisoned")
+    }
+
+    /// Acquire a write lock on the topic mesh
+    fn write_topic_mesh(&self) -> RwLockWriteGuard<HashMap<String, Shared<TopicFabric<M>>>> {
+        self.topic_mesh.write().expect("topic_mesh lock poisoned")
+    }
+
+    /// Publish a message onto a topic; blocks if the buffer is full
+    pub fn publish(&self, topic: String, message: M) {
+        let locked_mesh = self.read_topic_mesh();
+        let topic_entry = locked_mesh.get(&topic);
+
+        // If the topic is not registered, there are no listeners, short circuit
+        if topic_entry.is_none() {
+            return;
+        }
+
+        // Otherwise, lock the topic and push a message onto it
+        let mut locked_topic = topic_entry
+            .unwrap()
+            .write()
+            .expect("topic_entry lock poisoned");
+        locked_topic.write_message(message)
+    }
+
+    /// Subscribe to a topic, returns a pollable future
+    pub fn subscribe(&self, topic: String) {
+        // If the topic is not yet registered, create one
+        let contains_topic = { self.read_topic_mesh().contains_key(&topic) };
+        if !contains_topic {
+            let mut locked_mesh = self.write_topic_mesh();
+            locked_mesh.insert(topic.clone(), Arc::new(RwLock::new(TopicFabric::new())));
+        } // locked_mesh released
+
+        // Build a reader on the topic of interest and return it as a pollable to the subscriber
+        let locked_mesh = self.read_topic_mesh();
+        let mut locked_topic = locked_mesh
+            .get(&topic)
+            .unwrap()
+            .write()
+            .expect("topic_entry lock poisoned");
+        let reader = locked_topic.new_reader();
+    }
+
+    /// Returns whether or not the given topic has been subscribed to by any readers
+    pub fn has_listeners(&self, topic: &String) -> bool {
+        self.read_topic_mesh().contains_key(topic)
+    }
+}


### PR DESCRIPTION
## Purpose
The `system-bus` module exposes an embedded Pub/Sub functionality to the node. This will allow workers to push messages onto the bus to be consumed elsewhere (i.e. by a listener managing a websocket connection to a front end). In the long run, we will use these events to display status updates in the FE.

## Technical Notes
There are three abstractions of interest here:
### `TopicReader`
The `TopicReader` is the lowest level of encapsulation. It holds the underlying [`bus::BusReader`](https://docs.rs/bus/latest/bus/struct.BusReader.html#) that is used to receive a multi-consumer message. As well, the `TopicReader` provides two additional functionalities:
1. Wraps the `BusReader` in an `async` interface by using [`tokio::future::poll_fn`](https://docs.rs/tokio/0.2.0-alpha.4/tokio/future/fn.poll_fn.html). 
2. Holds a reference to the topic mesh and an `AtomicU16` representing the number of readers (itself included) on its topic. When a `TopicReader` is dropped; it updates the reader count, and deallocates the topic in the `SystemBus` if it was the last reader. This allows publishers to skip publishing to topics that are no longer listened to.

### `TopicFabric`
The `TopicFabric` provides a one-to-many encapsulation in which many `TopicReader`s are derives from the `TopicFabric`. The fabric holds the underlying [`bus::Bus`](https://docs.rs/bus/latest/bus/struct.Bus.html) and stores the reader reference counts.

### `SystemBus`
The `SystemBus` exposes a pubsub functionality over the above encapsulations. It does so by mapping the topic name to a `TopicFabric` and dispatching relevant publish/subscribe requests to the fabrics.

## Testing
- Workspace unit tests pass
- Ad-hoc verified that relayer functionality still works