### PR TITLE
core: api-server: Create websocket API and forward internal events

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,6 @@ crypto = { path = "../crypto" }
 curve25519-dalek = "2"
 ed25519-dalek = { version = "1.0.1" }
 futures = { version = "0.3.21" }
-futures-sink = { version = "0.3" }
 futures-util = { version = "0.3" }
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
 integration-helpers = { path = "../integration-helpers" }
@@ -52,6 +51,7 @@ termion = "2.0"
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.5.9" }
 tracing = { version = "0.1", features = ["log"] }
+tokio-stream = { version = "0.1" }
 tokio-tungstenite = { version = "0.18" }
 tungstenite = { version = "0.18" }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,8 @@ crypto = { path = "../crypto" }
 curve25519-dalek = "2"
 ed25519-dalek = { version = "1.0.1" }
 futures = { version = "0.3.21" }
+futures-sink = { version = "0.3" }
+futures-util = { version = "0.3" }
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
 integration-helpers = { path = "../integration-helpers" }
 libp2p = { version = "0.50", features = [
@@ -51,4 +53,5 @@ tokio = { version = "1", features = ["full"] }
 toml = { version = "0.5.9" }
 tracing = { version = "0.1", features = ["log"] }
 tokio-tungstenite = { version = "0.18" }
+tungstenite = { version = "0.18" }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,4 +50,5 @@ termion = "2.0"
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.5.9" }
 tracing = { version = "0.1", features = ["log"] }
+tokio-tungstenite = { version = "0.18" }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/core/resources/cluster1.toml
+++ b/core/resources/cluster1.toml
@@ -1,5 +1,6 @@
 p2p-port = 8000
 http-port = 3000
+websocket-port = 4000
 version = 0
 debug = true
 wallet-file = "./core/resources/wallets1.json"

--- a/core/resources/cluster2.toml
+++ b/core/resources/cluster2.toml
@@ -1,5 +1,6 @@
 p2p-port = 8001 
 http-port = 3001
+websocket-port = 4001
 version = 0
 debug = true
 wallet-file = "./core/resources/wallets2.json"

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -6,3 +6,4 @@ pub mod gossip;
 pub mod handshake;
 pub mod hearbeat;
 pub mod http;
+pub mod websocket;

--- a/core/src/api/websocket.rs
+++ b/core/src/api/websocket.rs
@@ -18,3 +18,11 @@ pub enum SubscriptionMessage {
         topic: String,
     },
 }
+
+/// A message that is sent in response to a SubscriptionMessage, notifies the client
+/// of the now active subscriptions after a subscribe/unsubscripe message is applied
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubscriptionResponse {
+    /// The subscriptions that remain after applying the requested update
+    pub subscriptions: Vec<String>,
+}

--- a/core/src/api/websocket.rs
+++ b/core/src/api/websocket.rs
@@ -1,0 +1,20 @@
+//! Groups API definitions for the websocket API
+
+use serde::{Deserialize, Serialize};
+
+/// A message type that indicates the client would like to either subscribe or unsubscribe
+/// from a given topic
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SubscriptionMessage {
+    /// Indicates that the client would like to subscribe to the given topic
+    Subscribe {
+        /// The topic being subscribed to
+        topic: String,
+    },
+    /// Indicates that the client would like to unsubscribe to the given topic
+    Unsubscribe {
+        /// The topic being unsubscribed from
+        topic: String,
+    },
+}

--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -9,6 +9,8 @@ pub enum ApiServerError {
     Setup(String),
     /// HTTP server has failed
     HttpServerFailure(String),
+    /// Websocket server has failed
+    WebsocketServerFailure(String),
 }
 
 impl Display for ApiServerError {

--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -9,6 +9,8 @@ pub enum ApiServerError {
     Setup(String),
     /// HTTP server has failed
     HttpServerFailure(String),
+    /// A failure while handling a websocket connection
+    WebsocketHandlerFailure(String),
     /// Websocket server has failed
     WebsocketServerFailure(String),
 }

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -28,6 +28,8 @@ const HTTP_SERVER_NUM_THREADS: usize = 1;
 pub struct ApiServerConfig {
     /// The port that the HTTP server should listen on
     pub http_port: u16,
+    /// The port that the websocket server should listen on
+    pub websocket_port: u16,
     /// The relayer-global state
     pub global_state: RelayerState,
     /// The channel to receive cancellation signals on from the coordinator

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -43,16 +43,19 @@ struct Cli {
     #[clap(short, long, value_parser)]
     /// Whether or not to run the relayer in debug mode
     pub debug: bool,
-    #[clap(short, long, value_parser, default_value = "8000")]
+    #[clap(short = 'p', long, value_parser, default_value = "8000")]
     /// The port to listen on for libp2p
     pub p2p_port: u16,
-    #[clap(short, long, value_parser, default_value = "3000")]
+    #[clap(long, value_parser, default_value = "3000")]
     /// The port to listen on for the externally facing HTTP API
     pub http_port: u16,
+    /// The port to listen on for the externally facing websocket API
+    #[clap(long, value_parser, default_value = "4000")]
+    pub websocket_port: u16,
     #[clap(short, long, value_parser)]
     /// The software version of the relayer
     pub version: Option<String>,
-    #[clap(short, long, value_parser)]
+    #[clap(long, value_parser)]
     /// A file holding a json representation of the wallets the local node
     /// should manage
     pub wallet_file: Option<String>,
@@ -69,6 +72,8 @@ pub struct RelayerConfig {
     pub p2p_port: u16,
     /// The port to listen on for the externally facing HTTP API
     pub http_port: u16,
+    /// The port to listen on for the externally facing websocket API
+    pub websocket_port: u16,
     /// The wallet IDs to manage locally
     pub wallets: Vec<Wallet>,
     /// The cluster keypair
@@ -150,6 +155,7 @@ pub fn parse_command_line_args() -> Result<Box<RelayerConfig>, CoordinatorError>
         bootstrap_servers: parsed_bootstrap_addrs,
         p2p_port: cli_args.p2p_port,
         http_port: cli_args.http_port,
+        websocket_port: cli_args.websocket_port,
         wallets: parse_wallet_file(cli_args.wallet_file)?,
         cluster_keypair: keypair,
         cluster_id,

--- a/core/src/gossip/worker.rs
+++ b/core/src/gossip/worker.rs
@@ -12,7 +12,6 @@ use crate::{
         hearbeat::BootstrapRequest,
     },
     state::RelayerState,
-    types::SystemBusMessage,
     worker::Worker,
     CancelChannel,
 };
@@ -43,13 +42,6 @@ pub struct GossipServerConfig {
     pub(crate) heartbeat_worker_receiver: Receiver<GossipServerJob>,
     /// A job queue to send outbound network requests on
     pub(crate) network_sender: TokioSender<GossipOutbound>,
-    /// The system bus to which all workers have access
-    /// Sender
-    #[allow(dead_code)]
-    pub(crate) system_bus_sender: Sender<SystemBusMessage>,
-    /// Receiver
-    #[allow(dead_code)]
-    pub(crate) system_bus_receiver: Receiver<SystemBusMessage>,
     /// The channel on which the coordinator may mandate that the
     /// gossip server cancel its execution
     pub(crate) cancel_channel: CancelChannel,

--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -81,6 +81,7 @@ impl Worker for HandshakeManager {
             config.job_receiver,
             config.network_channel,
             config.global_state,
+            config.system_bus,
             config.cancel_channel,
         )?;
 

--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -5,7 +5,7 @@ use std::{
     thread::JoinHandle,
 };
 
-use crossbeam::channel::{Receiver, Sender};
+use crossbeam::channel::Receiver;
 use rayon::ThreadPoolBuilder;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -17,6 +17,7 @@ use crate::{
         state::HandshakeStateIndex,
     },
     state::RelayerState,
+    system_bus::SystemBus,
     types::SystemBusMessage,
     worker::Worker,
 };
@@ -36,12 +37,7 @@ pub struct HandshakeManagerConfig {
     /// The job queue on which to receive handshake requrests
     pub job_receiver: Receiver<HandshakeExecutionJob>,
     /// The system bus to which all workers have access
-    /// Sender
-    #[allow(dead_code)]
-    pub(crate) system_bus_sender: Sender<SystemBusMessage>,
-    /// Receiver
-    #[allow(dead_code)]
-    pub(crate) system_bus_receiver: Receiver<SystemBusMessage>,
+    pub system_bus: SystemBus<SystemBusMessage>,
     /// The channel on which the coordinator may mandate that the
     /// handshake manager cancel its execution
     pub(crate) cancel_channel: Receiver<()>,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -142,6 +142,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (api_cancel_sender, api_cancel_receiver) = channel::bounded(1 /* capacity */);
     let mut api_server = ApiServer::new(ApiServerConfig {
         http_port: args.http_port,
+        websocket_port: args.websocket_port,
         global_state: global_state.clone(),
         cancel_channel: api_cancel_receiver,
     })

--- a/core/src/network_manager/worker.rs
+++ b/core/src/network_manager/worker.rs
@@ -17,7 +17,6 @@ use crate::{
     handshake::jobs::HandshakeExecutionJob,
     network_manager::composed_protocol::ComposedNetworkBehavior,
     state::RelayerState,
-    types::SystemBusMessage,
     worker::Worker,
 };
 
@@ -45,13 +44,6 @@ pub struct NetworkManagerConfig {
     pub(crate) heartbeat_work_queue: Sender<GossipServerJob>,
     /// The work queue to forward inbound handshake requests to
     pub(crate) handshake_work_queue: Sender<HandshakeExecutionJob>,
-    /// The system bus to which all workers have access
-    /// Sender
-    #[allow(dead_code)]
-    pub(crate) system_bus_sender: Sender<SystemBusMessage>,
-    /// Receiver
-    #[allow(dead_code)]
-    pub(crate) system_bus_receiver: Receiver<SystemBusMessage>,
     /// The global shared state of the local relayer
     pub(crate) global_state: RelayerState,
     /// The channel on which the coordinator can send a cancel signal to

--- a/core/src/system_bus.rs
+++ b/core/src/system_bus.rs
@@ -186,7 +186,7 @@ impl<M: Clone + Sync> TopicFabric<M> {
 /// The system bus abstracts over an embedded pubsub functionality
 ///
 /// Note that publishing to a topic with no subscribers is a no-op
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SystemBus<M> {
     /// The topic mesh connects publishers to subscribers, it is concretely implemented
     /// as a mapping from topic name (String) to a bus (single-producer, multi-consumer)

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,5 +1,33 @@
 //! Groups type definitions relevant to all modules and at the top level
 
+use serde::{Deserialize, Serialize};
+
+use crate::handshake::types::OrderIdentifier;
+
+/**
+ * Topic names
+ */
+
+/// The topic published to when the handshake manager begins a new
+/// match computation with a peer
+pub const HANDSHAKE_STATUS_TOPIC: &str = "handshakes";
+
 /// A message type for generic system bus messages, broadcast to all modules
-#[derive(Clone, Debug)]
-pub enum SystemBusMessage {}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SystemBusMessage {
+    /// A message indicating that a handshake with a peer has started
+    HandshakeInProgress {
+        /// The order_id of the local party
+        local_order_id: OrderIdentifier,
+        /// The order_id of the remote peer
+        peer_order_id: OrderIdentifier,
+    },
+    /// A message indicating that a handshake with a peer has completed
+    HandshakeCompleted {
+        /// The order_id of the local party
+        local_order_id: OrderIdentifier,
+        /// The order_id of the remote peer
+        peer_order_id: OrderIdentifier,
+    },
+}


### PR DESCRIPTION
### Purpose
This PR adds the initial external facing websocket API and connects it to the system bus. The websocket server accepts connections on the configurable port and waits for two types of messages:
1. Messages from the websocket client indicating that the client would like to subscribe or unsubscribe from a websocket topic.
2. Messages from the internal system bus indicating that some event has occurred (e.g. a handshake completes). The websocket handler will only listen on topics that the client has explicitly subscribed to.

### Testing
- Workspace unit tests pass
- Produced events from a handshake between two peers, verified that the client received the message.