### PR TITLE
circuits: Update `mpc-bulletproof` usage after interface change

### DIFF
--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -9,7 +9,10 @@ use std::{borrow::Borrow, marker::PhantomData};
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{LinearCombination, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
+    r1cs::{
+        ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem, Variable,
+        Verifier,
+    },
     r1cs_mpc::{
         MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable, R1CSError,
         SharedR1CSProof,

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -11,7 +11,7 @@
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
+    r1cs::{ConstraintSystem, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
     r1cs_mpc::R1CSError,
     BulletproofGens,
 };
@@ -315,12 +315,12 @@ where
         let (witness_var, witness_comm) = witness.commit_prover(&mut rng, &mut prover).unwrap();
 
         // Commit to the statement
-        let (_, wallet_commitment_var) = prover.commit_public(statement.wallet_commitment);
-        let (_, wallet_ciphertext_vars): (Vec<CompressedRistretto>, Vec<Variable>) = statement
+        let wallet_commitment_var = prover.commit_public(statement.wallet_commitment);
+        let wallet_ciphertext_vars = statement
             .wallet_ciphertext
             .iter()
             .map(|felt| prover.commit_public(*felt))
-            .unzip();
+            .collect_vec();
 
         // Apply the constraints
         Self::apply_constraints(

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -5,7 +5,8 @@ use std::marker::PhantomData;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::r1cs::{
-    LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+    ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable,
+    Verifier,
 };
 use mpc_bulletproof::r1cs_mpc::{
     MpcConstraintSystem, MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem,
@@ -111,7 +112,7 @@ impl SingleProverCircuit for ExpGadget {
         let blinding_factor = Scalar::random(&mut rng);
 
         let (x_commit, x_var) = prover.commit(witness.x, blinding_factor);
-        let (_, out_var) = prover.commit_public(statement.expected_out);
+        let out_var = prover.commit_public(statement.expected_out);
 
         // Generate the constraints for the circuit
         Self::generate_constraints(&mut prover, x_var, out_var, statement.alpha);

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -85,11 +85,11 @@ impl<const D: usize> SingleProverCircuit for ToBitsGadget<D> {
         let (witness_comm, witness_var) = prover.commit(witness, Scalar::random(&mut rng));
 
         // Commit to the statement
-        let (_, statement_vars): (Vec<_>, Vec<_>) = statement
+        let statement_vars = statement
             .bits
             .iter()
             .map(|bit| prover.commit_public(*bit))
-            .unzip();
+            .collect_vec();
 
         // Get the bits result and constrain the output
         let res_bits = Self::to_bits(&mut prover, witness_var).map_err(ProverError::R1CS)?;

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -85,7 +85,7 @@ impl SingleProverCircuit for EqZeroGadget {
         let (witness_comm, witness_var) = prover.commit(witness, Scalar::random(&mut rng));
 
         // Commit to the statement
-        let (_, expected_var) = prover.commit_public(Scalar::from(statement as u8));
+        let expected_var = prover.commit_public(Scalar::from(statement as u8));
 
         // Test equality to zero and constrain this to be expected
         let eq_zero = EqZeroGadget::eq_zero(&mut prover, witness_var);

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -4,7 +4,8 @@ use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{
-        LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
+        Variable, Verifier,
     },
     r1cs_mpc::{
         MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable, R1CSError,
@@ -210,7 +211,7 @@ impl SingleProverCircuit for PoseidonMerkleHashGadget {
             .unzip();
 
         // Commit to the expected root
-        let (_, root_var) = prover.commit_public(statement.expected_root);
+        let root_var = prover.commit_public(statement.expected_root);
 
         // Apply the constraints
         PoseidonMerkleHashGadget::compute_and_constrain_root(

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -925,10 +925,10 @@ mod nonnative_tests {
 
             // Commit to the statement variable
             let expected_words = bigint_to_scalar_words(statement);
-            let (_, statement_word_vars): (Vec<_>, Vec<Variable>) = expected_words
+            let statement_word_vars = expected_words
                 .iter()
                 .map(|word| prover.commit_public(*word))
-                .unzip();
+                .collect_vec();
 
             let statement_word_lcs: Vec<LinearCombination> = statement_word_vars
                 .into_iter()
@@ -1015,10 +1015,10 @@ mod nonnative_tests {
 
             // Commit to the statement variable
             let expected_words = bigint_to_scalar_words(statement);
-            let (_, statement_word_vars): (Vec<_>, Vec<Variable>) = expected_words
+            let statement_word_vars = expected_words
                 .iter()
                 .map(|word| prover.commit_public(*word))
-                .unzip();
+                .collect_vec();
 
             let statement_word_lcs: Vec<LinearCombination> = statement_word_vars
                 .into_iter()
@@ -1094,10 +1094,10 @@ mod nonnative_tests {
 
             // Commit to the statement variable
             let expected_words = bigint_to_scalar_words(statement);
-            let (_, statement_word_vars): (Vec<_>, Vec<Variable>) = expected_words
+            let statement_word_vars = expected_words
                 .iter()
                 .map(|word| prover.commit_public(*word))
-                .unzip();
+                .collect_vec();
 
             let statement_word_lcs: Vec<LinearCombination> = statement_word_vars
                 .into_iter()
@@ -1347,7 +1347,7 @@ mod nonnative_tests {
             let words = bigint_to_scalar_words(random_val);
             let allocated_words = words
                 .iter()
-                .map(|word| prover.commit_public(*word).1.into())
+                .map(|word| prover.commit_public(*word).into())
                 .collect_vec();
 
             let mut val =

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -7,7 +7,8 @@ use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{
-        LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
+        Variable, Verifier,
     },
     r1cs_mpc::{
         MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable, R1CSError,
@@ -300,7 +301,7 @@ impl SingleProverCircuit for PoseidonHashGadget {
             .unzip();
 
         // Commit publically to the expected result
-        let (_, out_var) = prover.commit_public(statement.expected_out);
+        let out_var = prover.commit_public(statement.expected_out);
 
         // Apply the constraints to the proof system
         let mut hasher = PoseidonHashGadget::new(statement.params);

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -75,7 +75,7 @@ impl SingleProverCircuit for CondSelectGadget {
         let (b_comm, b_var) = prover.commit(witness.b, Scalar::random(&mut rng));
         let (sel_comm, sel_var) = prover.commit(witness.selector, Scalar::random(&mut rng));
 
-        let (_, expected_var) = prover.commit_public(statement.expected);
+        let expected_var = prover.commit_public(statement.expected);
 
         // Apply the constraints
         let res = Self::select(&mut prover, a_var, b_var, sel_var);
@@ -227,11 +227,11 @@ impl SingleProverCircuit for CondSelectVectorGadget {
         let (sel_comm, sel_var) = prover.commit(witness.selector, Scalar::random(&mut rng));
 
         // Commit to the statement
-        let (_, expected_vars): (Vec<_>, Vec<_>) = statement
+        let expected_vars = statement
             .expected
             .into_iter()
             .map(|expected_val| prover.commit_public(expected_val))
-            .unzip();
+            .collect_vec();
 
         // Apply the constraints
         let res = Self::select(&mut prover, &a_vars, &b_vars, sel_var);


### PR DESCRIPTION
### Purpose
I removed the `CompressedRistretto` return type in the `mpc-bulletproof` package because it's useless. This commit reflects this change applies to the consumer side of the library.

### Testing
- All tests pass