### PR TITLE
circuit-macros: `circuit_trace`: Implement circuit tracer procedural macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"circuits",
+	"circuit-macros",
 	"core",
 	"crypto",
     "external-events",

--- a/circuit-macros/Cargo.toml
+++ b/circuit-macros/Cargo.toml
@@ -16,5 +16,8 @@ quote = "1.0.23"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
+curve25519-dalek = "2"
 lazy_static = "1.4"
 merlin = "2.0"
+rand = "0.8"
+rand_core = "0.5"

--- a/circuit-macros/Cargo.toml
+++ b/circuit-macros/Cargo.toml
@@ -11,8 +11,8 @@ bench = []
 
 [dependencies]
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2 = "1.0.50"
+quote = "1.0.23"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/circuit-macros/Cargo.toml
+++ b/circuit-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "circuit-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[features]
+bench = []
+
+[dependencies]
+mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+lazy_static = "1.4"
+merlin = "2.0"

--- a/circuit-macros/src/lib.rs
+++ b/circuit-macros/src/lib.rs
@@ -8,12 +8,19 @@ use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{
+    parse::Parser,
     parse_quote,
     punctuated::Punctuated,
     token::{Comma, Paren},
-    Attribute, Expr, ExprCall, FnArg, ItemFn, Pat, Signature,
+    Attribute, Expr, ExprCall, FnArg, ItemFn, Pat, Result, Signature,
 };
 
+/// The argument given to enable tracing constraint generation latency
+const ARG_CONSTRAINT_LATENCY: &str = "latency";
+/// The argument given to enable tracing the number of constraints
+const ARG_N_CONSTRAINTS: &str = "n_constraints";
+/// The argument given to enable tracing the number of multipliers
+const ARG_N_MULTIPLIERS: &str = "n_multipliers";
 /// The feature flag that enables tracing via these macros
 #[allow(dead_code)]
 const TRACER_FEATURE_FLAG: &str = "bench";
@@ -34,19 +41,66 @@ const TRACE_TARGET_SUFFIX: &str = "impl";
 /// macro to the passthrough and then fold the trampoline into the caller during optimization.
 /// An example of such a conditionally compiled wrapper is: https://godbolt.org/z/jj4fz75Yr
 /// Notice that when the `bench` feature is disabled, the intermediate call is removed
+///
+/// The tracer supports the following metrics:
+///     - Number of constraints generated
+///     - Number of multipliers allocated
+///     - Constraint generation latency
+/// To enable a metric on a target add it to the arguments in the macro, for example, to enable
+/// all metrics one might write the following
+///     #[circuit_trace(n_constraints, n_multipliers, latency)]
+///     fn target() { }
 #[proc_macro_attribute]
-pub fn circuit_trace(_: TokenStream, item: TokenStream) -> TokenStream {
+pub fn circuit_trace(args: TokenStream, item: TokenStream) -> TokenStream {
     let ast: ItemFn = syn::parse(item).unwrap();
-    circuit_trace_impl(ast)
+    let enabled_metrics = parse_macro_args(args).unwrap();
+
+    circuit_trace_impl(ast, enabled_metrics)
+}
+
+/// Stores the macro arguments as to which metrics are enabled for a given tracing target
+#[derive(Clone, Copy, Debug, Default)]
+struct EnabledMetics {
+    /// The number of constraints metric
+    pub n_constraints: bool,
+    /// The number of multiplier metric
+    pub n_multipliers: bool,
+    /// The constraint generation latency metric
+    pub latency: bool,
+}
+
+impl EnabledMetics {
+    /// Returns true if all metrics are disabled for a given target
+    pub fn all_disabled(&self) -> bool {
+        !(self.n_constraints || self.n_multipliers || self.latency)
+    }
+}
+
+/// Parse the arguments into a set of enabled features
+fn parse_macro_args(args: TokenStream) -> Result<EnabledMetics> {
+    let mut enabled = EnabledMetics::default();
+    let parsed_args =
+        Punctuated::<Ident, Comma>::parse_terminated.parse2(TokenStream2::from(args))?;
+
+    for arg in parsed_args.iter() {
+        match arg.to_string().as_str() {
+            ARG_CONSTRAINT_LATENCY => enabled.latency = true,
+            ARG_N_CONSTRAINTS => enabled.n_constraints = true,
+            ARG_N_MULTIPLIERS => enabled.n_multipliers = true,
+            _ => continue,
+        }
+    }
+
+    Ok(enabled)
 }
 
 /// Implementation of the circuit tracer, parses the token stream and defines the two
 /// trampoline function implementation
-fn circuit_trace_impl(target_fn: ItemFn) -> TokenStream {
+fn circuit_trace_impl(target_fn: ItemFn, enabled_metrics: EnabledMetics) -> TokenStream {
     let mut out_tokens = TokenStream2::default();
 
     // Build the trampoline implementations
-    let (inactive_impl, active_impl) = build_trampoline_impls(&target_fn);
+    let (inactive_impl, active_impl) = build_trampoline_impls(&target_fn, enabled_metrics);
     out_tokens.extend(inactive_impl.to_token_stream());
     out_tokens.extend(active_impl.to_token_stream());
 
@@ -58,16 +112,16 @@ fn circuit_trace_impl(target_fn: ItemFn) -> TokenStream {
 
 /// Build both trampoline implementations (active and inactive) and return their parsed
 /// syntax-tree types
-fn build_trampoline_impls(target_fn: &ItemFn) -> (ItemFn, ItemFn) {
+fn build_trampoline_impls(target_fn: &ItemFn, enabled_metrics: EnabledMetics) -> (ItemFn, ItemFn) {
     (
         build_inactive_trampoline(target_fn),
-        build_active_trampoline(target_fn),
+        build_active_trampoline(target_fn, enabled_metrics),
     )
 }
 
 /// Build the trampoline implementation that actively traces the target, gated behind the
 /// "bench" feature flag
-fn build_active_trampoline(target_fn: &ItemFn) -> ItemFn {
+fn build_active_trampoline(target_fn: &ItemFn, enabled_metrics: EnabledMetics) -> ItemFn {
     // In the active trampoline, we keep the signature and visibility of the target the same
     // The changes are to add an attribute #[cfg(feature = "bench")] and change the body to:
     //  1. Add a prelude that sets up trace metrics and scope
@@ -82,8 +136,8 @@ fn build_active_trampoline(target_fn: &ItemFn) -> ItemFn {
     out_fn.attrs.push(attr);
 
     // Build the prelude and epilogue of the tracer
-    let tracer_prelude = build_tracer_prelude(&target_fn.sig.ident);
-    let tracer_epilogue = build_tracer_epilogue();
+    let tracer_prelude = build_tracer_prelude(&target_fn.sig.ident, enabled_metrics);
+    let tracer_epilogue = build_tracer_epilogue(enabled_metrics);
     let call_expr = build_target_invocation(&out_fn.sig);
 
     out_fn.block = parse_quote! {
@@ -100,27 +154,108 @@ fn build_active_trampoline(target_fn: &ItemFn) -> ItemFn {
 
 /// Builds the prelude to the tracer, registers metrics and takes measurements that must happen before
 /// circuit execution (e.g. current timestamp)
-fn build_tracer_prelude(target_fn_name: &Ident) -> TokenStream2 {
+///
+/// TODO: When trace metrics involving the constraint system are enabled (e.g. n_constraints) the macro
+/// assumes the existence of a local binding `cs: ConstraintSystem` that can be used to query the
+/// constraint system metrics. In the future, we should remove this brittle assumption or allow rebinding
+/// the name as a macro argument
+fn build_tracer_prelude(target_fn_name: &Ident, enabled_metrics: EnabledMetics) -> TokenStream2 {
     // Scope into the target fn
     let fn_name_string = target_fn_name.to_string();
-    quote! {
-        CURR_SCOPE.lock().unwrap().scope_in(#fn_name_string.to_string())
+
+    let mut tokens = TokenStream2::default();
+
+    // Scope into the target function
+    tokens.extend(quote! {
+        CURR_SCOPE.lock().unwrap().scope_in(#fn_name_string.to_string());
+    });
+
+    // Setup enabled metrics, we intentionally obfuscate the names of the trace variables to ensure
+    // they don't alias with any (well named) local bindings
+    if enabled_metrics.n_constraints {
+        tokens.extend(quote! {
+            let __n_constraint_pre = cs.num_constraints() as u64;
+        });
     }
+
+    if enabled_metrics.n_multipliers {
+        tokens.extend(quote! {
+            let __n_multipliers_pre = cs.num_multipliers() as u64;
+        });
+    }
+
+    if enabled_metrics.latency {
+        tokens.extend(quote! {
+            let __time_pre = std::time::Instant::now();
+        })
+    }
+
+    tokens
 }
 
 /// Builds the epilogue after the tracer, records metrics into global `MetricsCapture` for analysis
 /// and closes the current scope
-fn build_tracer_epilogue() -> TokenStream2 {
-    // Record a dummy metric for now and scope out of the fn body
-    quote! {
-        SCOPED_METRICS.lock().unwrap().record_metric(
-            CURR_SCOPE.lock().unwrap().clone(),
-            "n_constraints".to_string(),
-            42,
-        );
+fn build_tracer_epilogue(enabled_metrics: EnabledMetics) -> TokenStream2 {
+    // Record dummy metrics and scope out of the method
+    let mut tokens = TokenStream2::default();
 
-        CURR_SCOPE.lock().unwrap().scope_out();
+    // Record timing first before performing any other operations, including locking the metrics
+    if enabled_metrics.latency {
+        tokens.extend(quote! {
+            let __latency = __time_pre.elapsed().as_millis();
+        });
     }
+
+    tokens.extend(quote! {
+        let mut __locked_scope = CURR_SCOPE.lock().unwrap().clone();
+    });
+
+    // Now, if any metrics are to be collected, lock the global metrics store
+    if !enabled_metrics.all_disabled() {
+        tokens.extend(quote! {
+            let mut __locked_metrics = SCOPED_METRICS.lock().unwrap();
+        });
+    }
+
+    // Record any enabled metrics
+    if enabled_metrics.n_constraints {
+        tokens.extend(quote! {
+            let __new_constraints = cs.num_constraints() as u64;
+            __locked_metrics.record_metric(
+                __locked_scope.clone(),
+                #ARG_N_CONSTRAINTS.to_string(),
+                __new_constraints - __n_constraint_pre
+            );
+        })
+    }
+
+    if enabled_metrics.n_multipliers {
+        tokens.extend(quote! {
+            let __new_multipliers = cs.num_multipliers() as u64;
+            __locked_metrics.record_metric(
+                __locked_scope.clone(),
+                #ARG_N_MULTIPLIERS.to_string(),
+                __new_multipliers - __n_multipliers_pre
+            );
+        })
+    }
+
+    if enabled_metrics.latency {
+        tokens.extend(quote! {
+            __locked_metrics.record_metric(
+                __locked_scope.clone(),
+                #ARG_CONSTRAINT_LATENCY.to_string(),
+                __latency.try_into().unwrap()
+            );
+        })
+    }
+
+    // Close the current scope
+    tokens.extend(quote! {
+        __locked_scope.scope_out();
+    });
+
+    tokens
 }
 
 /// Build the trampoline implementation that does not trace and simply passes through to
@@ -139,7 +274,7 @@ fn build_inactive_trampoline(target_fn: &ItemFn) -> ItemFn {
 
     // Modify the body to pass-through to the trace target
     let call_expr = build_target_invocation(&out_fn.sig);
-    out_fn.block = parse_quote!({println!("inactive trampoline"); #call_expr});
+    out_fn.block = parse_quote!({ #call_expr });
 
     out_fn
 }

--- a/circuit-macros/src/lib.rs
+++ b/circuit-macros/src/lib.rs
@@ -1,0 +1,170 @@
+//! Groups proc-macro macro definitions used in the circuits crate
+
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(unsafe_code)]
+
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use quote::ToTokens;
+use syn::{
+    parse_quote,
+    punctuated::Punctuated,
+    token::{Comma, Paren},
+    Attribute, Expr, ExprCall, FnArg, ItemFn, Pat, Signature,
+};
+
+/// The feature flag that enables tracing via these macros
+#[allow(dead_code)]
+const TRACER_FEATURE_FLAG: &str = "bench";
+/// The suffix appended to the trace target implementation to give it a different signature
+/// from its trampoline
+const TRACE_TARGET_SUFFIX: &str = "impl";
+
+/// A macro that wraps the target function in a kretprobe inspired trampoline function
+/// and traces statistics through the target's execution
+///
+/// This macro expands to two implementations of the trampoline which are conditionally
+/// compiled between. When the `bench` feature flag is active, the full-fledged tracing
+/// implementation is compiled into the trampoline. This implementation collects circuit
+/// statistics at the gadget scope.
+///
+/// When the `bench` feature flag is not active, the trampoline implementation is a simple
+/// passthrough -- calling the target function directly. Concretely, `rustc` will expand this
+/// macro to the passthrough and then fold the trampoline into the caller during optimization.
+/// An example of such a conditionally compiled wrapper is: https://godbolt.org/z/jj4fz75Yr
+/// Notice that when the `bench` feature is disabled, the intermediate call is removed
+#[proc_macro_attribute]
+pub fn circuit_trace(_: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = syn::parse(item).unwrap();
+    circuit_trace_impl(ast)
+}
+
+/// Implementation of the circuit tracer, parses the token stream and defines the two
+/// trampoline function implementation
+fn circuit_trace_impl(target_fn: ItemFn) -> TokenStream {
+    let mut out_tokens = TokenStream2::default();
+
+    // Build the trampoline implementations
+    let (inactive_impl, active_impl) = build_trampoline_impls(&target_fn);
+    out_tokens.extend(inactive_impl.to_token_stream());
+    out_tokens.extend(active_impl.to_token_stream());
+
+    // Modify the target function to have a different signature from the trampoline
+    out_tokens.extend(modify_target_fn(&target_fn).to_token_stream());
+
+    out_tokens.into()
+}
+
+/// Build both trampoline implementations (active and inactive) and return their parsed
+/// syntax-tree types
+fn build_trampoline_impls(target_fn: &ItemFn) -> (ItemFn, ItemFn) {
+    (
+        build_inactive_trampoline(target_fn),
+        build_active_trampoline(target_fn),
+    )
+}
+
+/// Build the trampoline implementation that actively traces the target, gated behind the
+/// "bench" feature flag
+fn build_active_trampoline(target_fn: &ItemFn) -> ItemFn {
+    // In the active trampoline, we keep the signature and visibility of the target the same
+    // The changes are to add an attribute #[cfg(feature = "bench")] and change the body to:
+    //  1. Add a prelude that sets up trace metrics and scope
+    //  2. Call the target method
+    //  3. Add an epilog to close trace metrics and scope
+    let mut out_fn = target_fn.clone();
+
+    // Add the conditional compilation attr
+    let attr: Attribute = parse_quote! {
+        #[cfg(feature = #TRACER_FEATURE_FLAG)]
+    };
+    out_fn.attrs.push(attr);
+
+    // Modify the body to pass-through to the trace target
+    let call_expr = build_target_invocation(&out_fn.sig);
+    out_fn.block = parse_quote!({println!("active trampoline"); #call_expr});
+
+    out_fn
+}
+
+/// Build the trampoline implementation that does not trace and simply passes through to
+/// the target function. This implementation is active when the `bench` feature flag is disabled
+fn build_inactive_trampoline(target_fn: &ItemFn) -> ItemFn {
+    // In the inactive trampoline, we keep the signature and visibility of the target the same
+    // The changes are to add an attribute #[cfg(not(feature = "bench"))] and change the body to call
+    // the target
+    let mut out_fn = target_fn.clone();
+
+    // Add the conditional compilation attr
+    let attr: Attribute = parse_quote! {
+        #[cfg(not(feature = #TRACER_FEATURE_FLAG))]
+    };
+    out_fn.attrs.push(attr);
+
+    // Modify the body to pass-through to the trace target
+    let call_expr = build_target_invocation(&out_fn.sig);
+    out_fn.block = parse_quote!({println!("inactive trampoline"); #call_expr});
+
+    out_fn
+}
+
+/// Build the argument list for the target function from the trampoline function's signature
+fn build_target_invocation(trampoline_sig: &Signature) -> ExprCall {
+    let mut args = Vec::new();
+    let mut parsed_receiver = None;
+
+    for input_arg in trampoline_sig.inputs.clone().into_iter() {
+        match input_arg {
+            FnArg::Typed(type_pattern) => {
+                match *type_pattern.pat {
+                    Pat::Ident(pattern) => args.push(pattern.ident),
+                    _ => {}
+                };
+            }
+            FnArg::Receiver(receiver) => parsed_receiver = Some(receiver),
+        }
+    }
+
+    // Build the expression resolving to the function; using Self:: prelude if the
+    let target_fn_name = get_modified_target_name(trampoline_sig);
+    let function = if parsed_receiver.is_some() {
+        // If a receiver was found (i.e. this is a call with &self) expand the macro to
+        // a MethodCallExpr
+        Expr::Path(parse_quote!(Self::#target_fn_name))
+    } else {
+        Expr::Path(parse_quote!(#target_fn_name))
+    };
+
+    // Build the argument expression passed to the function call
+    let mut punctuated_args: Punctuated<Expr, Comma> = Punctuated::new();
+    if let Some(receiver) = parsed_receiver {
+        punctuated_args.push(parse_quote!(#receiver))
+    }
+    for arg in args.into_iter() {
+        punctuated_args.push(parse_quote!(#arg))
+    }
+
+    ExprCall {
+        attrs: Vec::new(),
+        func: Box::new(function),
+        paren_token: Paren::default(),
+        args: punctuated_args,
+    }
+}
+
+/// Build the modified target function
+///
+/// The tracing target needs to be renamed so that calls to `fn_name` will route through the
+fn modify_target_fn(target_fn: &ItemFn) -> ItemFn {
+    let mut modified_target = target_fn.clone();
+    modified_target.sig.ident = get_modified_target_name(&target_fn.sig);
+
+    modified_target
+}
+
+/// Get the name of the modified target fn given the unmodified signature
+fn get_modified_target_name(sig: &Signature) -> Ident {
+    let modified_name = format!("{}_{}", sig.ident.to_string(), TRACE_TARGET_SUFFIX);
+    Ident::new(&modified_name, Span::call_site())
+}

--- a/circuit-macros/tests/test_macros.rs
+++ b/circuit-macros/tests/test_macros.rs
@@ -1,0 +1,71 @@
+use circuit_macros::circuit_trace;
+use lazy_static::lazy_static;
+use merlin::Transcript;
+use mpc_bulletproof::{
+    r1cs::{Prover, RandomizableConstraintSystem},
+    PedersenGens,
+};
+use std::collections::HashMap;
+
+/// A type used for scop
+#[derive(Clone, Debug)]
+pub struct Scope {
+    pub path: Vec<String>,
+}
+
+/// Represents a list of metrics collected via a trace
+#[derive(Clone, Debug)]
+pub struct Metrics {
+    /// A list of metrics, represented as named tuples
+    metrics_list: Vec<(String, u64)>,
+}
+
+lazy_static! {
+    static ref SCOPED_METRICS: HashMap<Scope, Metrics> = HashMap::new();
+}
+
+struct Temp {
+    x: u64,
+}
+
+impl Temp {
+    pub fn new(x: u64) -> Self {
+        Temp { x }
+    }
+
+    fn test2(&self) {
+        println!("testing")
+    }
+
+    // #[circuit_trace]
+    pub fn test(&self, y: u64) -> u64 {
+        Self::test2(&self);
+        self.x + y
+    }
+}
+
+fn helper(x: u64) -> u64 {
+    x + 1
+}
+
+/// A dummy target for the macro
+#[circuit_trace]
+fn dummy(x: u64) -> u64 {
+    // let temp = Temp::new(1);
+    // let y = 5;
+    // temp.test(y);
+    let new_x = helper(x);
+    println!("Tests abc: {:?}", new_x);
+    new_x
+}
+
+#[test]
+fn test_macro() {
+    let mut transcript = Transcript::new("test".as_bytes());
+    let pc_gens = PedersenGens::default();
+    let prover = Prover::new(&pc_gens, &mut transcript);
+
+    let res = dummy(1);
+    assert_eq!(res, 2);
+    assert_eq!(1, 2);
+}

--- a/circuit-macros/tests/test_macros.rs
+++ b/circuit-macros/tests/test_macros.rs
@@ -1,13 +1,20 @@
 use circuit_macros::circuit_trace;
+use curve25519_dalek::scalar::Scalar;
 use lazy_static::lazy_static;
 use merlin::Transcript;
-use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+use mpc_bulletproof::{
+    r1cs::{ConstraintSystem, Prover, Variable},
+    PedersenGens,
+};
+use rand_core::OsRng;
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Mutex,
+    thread,
+    time::Duration,
 };
 
-/// A type used for scop
+/// A type used for scoping trace metrics
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Scope {
     pub path: Vec<String>,
@@ -17,6 +24,10 @@ impl Scope {
     /// Build a new scope
     pub fn new() -> Self {
         Self { path: vec![] }
+    }
+
+    pub fn from_path(path: Vec<String>) -> Self {
+        Self { path }
     }
 
     /// Append a value to the scope
@@ -84,6 +95,11 @@ impl MetricsCapture {
             .unwrap()
             .add_metric(metric_name, value);
     }
+
+    /// Get the metric for the given scope and metric name
+    pub fn get_metric(&mut self, scope: Scope, metric_name: String) -> Option<u64> {
+        self.metrics.get(&scope)?.data.get(&metric_name).cloned()
+    }
 }
 
 lazy_static! {
@@ -91,24 +107,160 @@ lazy_static! {
     static ref CURR_SCOPE: Mutex<Scope> = Mutex::new(Scope::new());
 }
 
-fn helper(x: u64) -> u64 {
-    x + 1
+/// A dummy gadget whose constraint generation is done through an associated function, used to
+/// test the trace macro on an associated function
+pub struct Gadget {}
+impl Gadget {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[circuit_trace(n_constraints, n_multipliers, latency)]
+    pub fn apply_constraints(cs: &mut Prover) {
+        // Apply dummy constraints
+        let mut rng = OsRng {};
+        let (_, var) = cs.commit(Scalar::one(), Scalar::random(&mut rng));
+        let (_, _, mul_out) = cs.multiply(var.into(), Variable::Zero().into());
+        cs.constrain(mul_out.into());
+
+        // Add some latency to test the latency metric
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
-/// A dummy target for the macro
-#[circuit_trace(n_constraints, n_multipliers, latency)]
+/// A dummy macro target that is not an associated function of any abstract gadget, used to
+/// test the non-associated macro arg
+#[circuit_trace(non_associated, n_constraints, n_multipliers, latency)]
 #[allow(unused)]
-fn dummy(x: u64, cs: &mut Prover) -> u64 {
-    let new_x = helper(x);
-    new_x
+fn non_associated_gadget(cs: &mut Prover) {
+    // Apply dummy constraints
+    let mut rng = OsRng {};
+    let (_, var) = cs.commit(Scalar::one(), Scalar::random(&mut rng));
+    let (_, _, mul_out) = cs.multiply(var.into(), Variable::Zero().into());
+    cs.constrain(mul_out.into());
+
+    // Add some latency to test the latency metric
+    thread::sleep(Duration::from_millis(100));
 }
 
+/// Tests the tracer macro on an associated function when the tracer is enabled
+#[cfg(feature = "bench")]
 #[test]
-fn test_macro() {
+fn test_macro_associated() {
+    // Build a dummy constraint system and apply a few constraints
     let mut prover_transcript = Transcript::new("test".as_bytes());
     let pc_gens = PedersenGens::default();
     let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
-    dummy(1, &mut prover);
-    println!("SCOPED METRICS: {:?}", SCOPED_METRICS.lock().unwrap());
+    Gadget::apply_constraints(&mut prover);
+
+    // Read the values from the tracer, this test is gated behind the same feature flag
+    // as the tracer, so metrics should have been recorded
+    let gadget_scope = Scope::from_path(vec!["apply_constraints".to_string()]);
+    let mut locked_metrics = SCOPED_METRICS.lock().unwrap();
+
+    let latency_metric = locked_metrics
+        .get_metric(gadget_scope.clone(), "latency".to_string())
+        .unwrap();
+    assert!(latency_metric > 100);
+
+    let n_constraints_metric = locked_metrics
+        .get_metric(gadget_scope.clone(), "n_constraints".to_string())
+        .unwrap();
+    assert_eq!(3, n_constraints_metric);
+
+    let n_multipliers_metric = locked_metrics
+        .get_metric(gadget_scope, "n_multipliers".to_string())
+        .unwrap();
+    assert_eq!(1, n_multipliers_metric);
+}
+
+/// Tests the tracer macro on a non-associated function when the tracer is enabled
+#[cfg(feature = "bench")]
+#[test]
+fn test_macro_non_associated() {
+    // Build a dummy constraint system and apply a few constraints
+    let mut prover_transcript = Transcript::new("test".as_bytes());
+    let pc_gens = PedersenGens::default();
+    let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
+    non_associated_gadget(&mut prover);
+
+    // Read the values from the tracer, this test is gated behind the same feature flag
+    // as the tracer, so metrics should have been recorded
+    let gadget_scope = Scope::from_path(vec!["non_associated_gadget".to_string()]);
+    let mut locked_metrics = SCOPED_METRICS.lock().unwrap();
+
+    let latency_metric = locked_metrics
+        .get_metric(gadget_scope.clone(), "latency".to_string())
+        .unwrap();
+    assert!(latency_metric > 100);
+
+    let n_constraints_metric = locked_metrics
+        .get_metric(gadget_scope.clone(), "n_constraints".to_string())
+        .unwrap();
+    assert_eq!(3, n_constraints_metric);
+
+    let n_multipliers_metric = locked_metrics
+        .get_metric(gadget_scope, "n_multipliers".to_string())
+        .unwrap();
+    assert_eq!(1, n_multipliers_metric);
+}
+
+/// Tests the tracer macro on an associated function when the tracer is disabled
+#[cfg(not(feature = "bench"))]
+#[test]
+fn test_macro_associated() {
+    // Build a dummy constraint system and apply a few constraints
+    let mut prover_transcript = Transcript::new("test".as_bytes());
+    let pc_gens = PedersenGens::default();
+    let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
+    Gadget::apply_constraints(&mut prover);
+
+    // Read the values from the tracer, this test is gated behind the same feature flag
+    // as the tracer, so metrics should have been recorded
+    let gadget_scope = Scope::from_path(vec!["apply_constraints".to_string()]);
+    let mut locked_metrics = SCOPED_METRICS.lock().unwrap();
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope.clone(), "latency".to_string())
+        .is_none());
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope.clone(), "n_constraints".to_string())
+        .is_none());
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope, "n_multipliers".to_string())
+        .is_none());
+}
+
+/// Tests the tracer macro on a non-associated function when the tracer is disabled
+#[cfg(not(feature = "bench"))]
+#[test]
+fn test_macro_non_associated() {
+    // Build a dummy constraint system and apply a few constraints
+    let mut prover_transcript = Transcript::new("test".as_bytes());
+    let pc_gens = PedersenGens::default();
+    let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
+    non_associated_gadget(&mut prover);
+
+    // Read the values from the tracer, this test is gated behind the same feature flag
+    // as the tracer, so metrics should have been recorded
+    let gadget_scope = Scope::from_path(vec!["non_associated_gadget".to_string()]);
+    let mut locked_metrics = SCOPED_METRICS.lock().unwrap();
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope.clone(), "latency".to_string())
+        .is_none());
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope.clone(), "n_constraints".to_string())
+        .is_none());
+
+    assert!(locked_metrics
+        .get_metric(gadget_scope, "n_multipliers".to_string())
+        .is_none());
 }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "6e3e804" }
 ark-sponge = { git = "https://github.com/arkworks-rs/sponge", rev = "2d5f91b" }
 bitvec = "1.0"
+circuit-macros = { path = "../circuit-macros" }
 crypto = { path = "../crypto" }
 curve25519-dalek = "2"
 itertools = "0.10"

--- a/circuits/src/tracing.rs
+++ b/circuits/src/tracing.rs
@@ -1,0 +1,104 @@
+//! Groups the global static data structures used for tracing circuit execution
+//!
+//! The types used here are copied over from the circuit-macros crate. Due to the restriction
+//! on procedural macros to own their crate, these two crates cannot share these types.
+#![cfg(feature = "bench")]
+
+use lazy_static::lazy_static;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Mutex,
+};
+
+/// A type used for scoping trace metrics
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Scope {
+    pub path: Vec<String>,
+}
+
+impl Scope {
+    /// Build a new scope
+    pub fn new() -> Self {
+        Self { path: vec![] }
+    }
+
+    pub fn from_path(path: Vec<String>) -> Self {
+        Self { path }
+    }
+
+    /// Append a value to the scope
+    pub fn scope_in(&mut self, scope: String) {
+        self.path.push(scope)
+    }
+
+    /// Pop the latest scope from the path
+    pub fn scope_out(&mut self) -> String {
+        self.path.pop().unwrap()
+    }
+}
+
+/// Represents a list of metrics collected via a trace
+#[derive(Clone, Debug)]
+pub struct ScopedMetrics {
+    /// A list of metrics, represented as named tuples
+    pub(crate) data: HashMap<String, u64>,
+}
+
+impl ScopedMetrics {
+    /// Create a new, empty list of metrics
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    /// Add a metric to the list, aggregating if the metric already exists
+    ///
+    /// Returns the value if a previous value existed
+    pub fn add_metric(&mut self, name: String, value: u64) -> Option<u64> {
+        if let Some(curr_val) = self.data.get(&name) {
+            self.data.insert(name, curr_val + value)
+        } else {
+            self.data.insert(name, value);
+            None
+        }
+    }
+}
+
+/// A set of metrics captured by the execution of the tracer on a circuit
+#[derive(Clone, Debug)]
+pub struct MetricsCapture {
+    /// A mapping from scope to the metrics captured at that scope
+    pub(crate) metrics: HashMap<Scope, ScopedMetrics>,
+}
+
+impl MetricsCapture {
+    /// Create a new MetricsCapture instance
+    pub fn new() -> Self {
+        Self {
+            metrics: HashMap::new(),
+        }
+    }
+
+    /// Record a scoped metric, if the metric already exists for the scope, aggregate it
+    pub fn record_metric(&mut self, scope: Scope, metric_name: String, value: u64) {
+        if let Entry::Vacant(e) = self.metrics.entry(scope.clone()) {
+            e.insert(ScopedMetrics::new());
+        }
+
+        self.metrics
+            .get_mut(&scope)
+            .unwrap()
+            .add_metric(metric_name, value);
+    }
+
+    /// Get the metric for the given scope and metric name
+    pub fn get_metric(&mut self, scope: Scope, metric_name: String) -> Option<u64> {
+        self.metrics.get(&scope)?.data.get(&metric_name).cloned()
+    }
+}
+
+lazy_static! {
+    pub(crate) static ref SCOPED_METRICS: Mutex<MetricsCapture> = Mutex::new(MetricsCapture::new());
+    pub(crate) static ref CURR_SCOPE: Mutex<Scope> = Mutex::new(Scope::new());
+}

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -2,6 +2,7 @@
 
 use std::marker::PhantomData;
 
+use circuit_macros::circuit_trace;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::r1cs::{
@@ -35,6 +36,7 @@ impl ExpGadget {
     ///
     /// Provides a functional interface for composing this gadget into a larger
     /// circuit.
+    #[circuit_trace(latency)]
     pub fn gadget<L, CS>(cs: &mut CS, x: L, alpha: u64) -> LinearCombination
     where
         L: Into<LinearCombination>,
@@ -58,6 +60,7 @@ impl ExpGadget {
     }
 
     /// Generate the constraints for the ExpGadget statement
+    #[circuit_trace(latency)]
     fn generate_constraints<CS: RandomizableConstraintSystem>(
         cs: &mut CS,
         x_var: Variable,
@@ -301,7 +304,7 @@ mod arithmetic_tests {
     /// Tests that a single prover exp does not verify for incorrect values
     #[test]
     fn test_single_prover_exp_failure() {
-        // Gerneate a random input
+        // Generate a random input
         let mut rng = OsRng {};
         let alpha = rng.next_u32();
         let random_value = Scalar::random(&mut rng);

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -31,7 +31,7 @@ pub struct EqZeroGadget {}
 impl EqZeroGadget {
     /// Computes whether the given input is equal to zero
     ///
-    /// Relies on the fact that modulo a prime field, all elements (execept zero)
+    /// Relies on the fact that modulo a prime field, all elements (except zero)
     /// have a valid multiplicative inverse
     pub fn eq_zero<L, CS>(cs: &mut CS, val: L) -> Variable
     where


### PR DESCRIPTION
### Purpose
This PR adds the `circuit_trace` attribute-like procedural macro in the `circuit-macros` crate. This macro is attached to gadgets that allocate constraints in the constraint system and modifies the gadget code to trace metrics through the circuit's execution.

This will enable us to write benchmarks with constraint system specific metrics and optimize around those at a fine granularity.

### Technical Overview
The tracer is implemented as a procedural macro that takes as input a function and produces three functions as a result:
- The original function, with `_impl` appended and visibility erased (e.g. public methods now private) so that the associated function interface of the target object does not change.
- A dummy "trampoline" implementation that simply calls the `_impl` method. This is conditionally compiled into the source on the flag `#[cfg(not(feature = "bench"))]`, i.e. when the "bench" feature is not active.
- A tracing trampoline (enabled by `#[cfg(feature = "bench")]`) implementation that is divided into:
    1. A prelude; which sets up trace metrics (e.g. sampling a start timestamp for latency metrics) and specifies the target function as the current trace scope.
    2. The delegated function call to the `_impl` method.
    3. An epilogue; which closes metrics (e.g. recording an end timestamp), records them into a global metrics store, and closes the target function's trace scope.

Note that in the first case (the passthrough trampoline), `rustc` will fold the trampoline into the caller function; so the tracer incurs no overhead when disabled. To see this concretely, check out this [godbolt example](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:13,fontUsePx:'0',j:1,lang:rust,selection:(endColumn:1,endLineNumber:33,positionColumn:1,positionLineNumber:33,selectionStartColumn:1,selectionStartLineNumber:33,startColumn:1,startLineNumber:33),source:'%0A//+Test+main%0Apub+fn+main()+%7B%0A++++//+Black+box+a+with+a+volatile+read+so+that+rustc+doesn!'t+fold%0A++++//+a+into+the+computation%0A++++let+a+%3D+1%3B%0A++++let+mut+b+%3D+unsafe+%7B%0A++++++++let+ret+%3D+std::ptr::read_volatile(%26a)%3B%0A++++++++std::mem::forget(a)%3B%0A++++++++ret%0A++++%7D%3B%0A++++trampoline(%26mut+b,+target)%3B%0A++++println!!(%22a:+%7B:%3F%7D%22,+b)%3B%0A%7D%0A%0A%23%5Binline(never)%5D%0Afn+target(a:+%26mut+i32)+%7B%0A++++*a+*%3D+2%3B%0A%7D%0A%0A%23%5Bcfg(feature+%3D+%22bench%22)%5D%0Afn+trampoline(a:+%26mut+i32,+target:+fn+(%26mut+i32))+%7B%0A++++*a+%2B%3D+1%3B%0A++++target(a)%3B%0A++++*a+%2B%3D+1%3B%0A%7D%0A%0A%23%5Bcfg(not(feature+%3D+%22bench%22))%5D%0Afn+trampoline(a:+%26mut+i32,+target:+fn+(%26mut+i32))+%7B%0A++++target(a)%3B%0A%7D%0A%0A'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1460,deviceViewOpen:'1',filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,libs:!(),options:'-C+opt-level%3D2',selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+rustc+1.46.0+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

The tracer also enables scoped metrics that effectively track the call-stack between gadgets. This allows us to view fine-grained trace information (like a flame graph) to determine which gadgets are doing the bulk of the allocation.

### Testing
- Tested the macro on dummy gadgets
- Applied the macro to an existing gadget, verified the gadget still worked properly.