### PR TITLE
circuits: zk-circuits: valid-wallet-update: Implement `VALID WALLET UPDATE`

### DIFF
--- a/circuits/Dockerfile
+++ b/circuits/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /build
 COPY ./rust-toolchain ./circuits/rust-toolchain
 COPY ./crypto ./crypto
 COPY ./integration-helpers ./integration-helpers
+COPY ./circuit-macros ./circuit-macros
 
 # Place a set of dummy sources in the path, build the dummy executable
 # to cache built dependencies, then bulid the full executable

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -84,7 +84,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
         };
     }
 
-    let test_cases: Vec<Vec<u64>> = vec![
+    let mut test_cases: Vec<Vec<u64>> = vec![
         // Quote mints different
         vec![
             sel!(0, 1),   /* quote_mint */
@@ -119,9 +119,12 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
         ],
     ];
 
-    for case in test_cases.iter() {
+    let timestamp = 0;
+    for case in test_cases.iter_mut() {
         // Marshal into an order
+        case.push(timestamp);
         let my_order: Order = (case as &[u64]).try_into().unwrap();
+
         // Allocate the orders in the network
         let order1 = my_order
             .allocate(0 /* owning_party */, test_args.mpc_fabric.clone())
@@ -136,7 +139,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
             .open_and_authenticate()
             .map_err(|err| format!("Error opening match result: {:?}", err))?;
 
-        // Assert that no match occured
+        // Assert that no match occurred
         check_no_match(&res)?;
     }
 
@@ -158,7 +161,7 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
         };
     }
 
-    let test_cases: Vec<Vec<u64>> = vec![
+    let mut test_cases: Vec<Vec<u64>> = vec![
         // Different prices and amounts
         vec![
             1,            /* quote_mint */
@@ -220,9 +223,12 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
         ],
     ];
 
-    for (case, expected_res) in test_cases.iter().zip(expected_results.iter()) {
+    let timestamp = 0; // dummy value
+    for (case, expected_res) in test_cases.iter_mut().zip(expected_results.iter()) {
         // Marshal into an order
+        case.push(timestamp);
         let my_order: Order = (case as &[u64]).try_into().unwrap();
+
         // Allocate the orders in the network
         let order1 = my_order
             .allocate(0 /* owning_party */, test_args.mpc_fabric.clone())
@@ -237,7 +243,7 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
             .open_and_authenticate()
             .map_err(|err| format!("Error opening match result: {:?}", err))?;
 
-        // Assert that no match occured
+        // Assert that no match occurred
         check_match_expected_result(&res, expected_res)?;
     }
 

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -1,6 +1,6 @@
 //! Groups integration tests for the VALID MATCH MPC circuit
 
-use std::cmp;
+use std::{cmp, time::SystemTime};
 
 use ark_sponge::{poseidon::PoseidonSponge, CryptographicSponge};
 use circuits::{
@@ -64,7 +64,7 @@ fn match_orders<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 
     // Match the values
     let min_amount = cmp::min(party0_values[2], party1_values[2]);
-    // Discritize the price in the same way the circuit does, i.e. with shr
+    // Discretize the price in the same way the circuit does, i.e. with shr
     let price = (party0_values[1] + party1_values[1]) >> 1;
 
     let shared_values = fabric
@@ -201,6 +201,13 @@ fn test_valid_match_mpc_valid(test_args: &IntegrationTestArgs) -> Result<(), Str
         1, // percentage fee
     ];
 
+    let timestamp: u64 = SystemTime::now()
+        .elapsed()
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap();
+
     let (witness, statement) = setup_witness_and_statement(
         Order {
             quote_mint: my_order[0],
@@ -212,6 +219,7 @@ fn test_valid_match_mpc_valid(test_args: &IntegrationTestArgs) -> Result<(), Str
             },
             price: my_order[3],
             amount: my_order[4],
+            timestamp,
         },
         Balance {
             mint: my_balance[0],

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -24,7 +24,7 @@ use integration_helpers::{
 };
 use itertools::Itertools;
 use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use rand_core::{OsRng, RngCore};
 
 use crate::{
@@ -226,8 +226,8 @@ fn test_valid_match_mpc_valid(test_args: &IntegrationTestArgs) -> Result<(), Str
             amount: my_balance[1],
         },
         Fee {
-            settle_key: BigInt::from(my_fee[0]),
-            gas_addr: BigInt::from(my_fee[1]),
+            settle_key: BigUint::from(my_fee[0]),
+            gas_addr: BigUint::from(my_fee[1]),
             gas_token_amount: my_fee[2],
             percentage_fee: my_fee[3],
         },

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -231,7 +231,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitVerifier
     type ErrorType = MpcError;
 
     fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
-        // Open the committments
+        // Open the commitments
         let opened_commit = AuthenticatedCompressedRistretto::batch_open_and_authenticate(&[
             self.mint.clone(),
             self.amount.clone(),

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -4,7 +4,7 @@ use crate::{
     mpc::SharedFabric,
     Allocate, CommitProver, CommitSharedProver, CommitVerifier,
 };
-use crypto::fields::bigint_to_scalar;
+use crypto::fields::biguint_to_scalar;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
@@ -15,7 +15,7 @@ use mpc_ristretto::{
     authenticated_ristretto::AuthenticatedCompressedRistretto,
     authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
 };
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -24,9 +24,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fee {
     /// The public settle key of the cluster collecting fees
-    pub settle_key: BigInt,
+    pub settle_key: BigUint,
     /// The mint (ERC-20 Address) of the token used to pay gas
-    pub gas_addr: BigInt,
+    pub gas_addr: BigUint,
     /// The amount of the mint token to use for gas
     pub gas_token_amount: u64,
     /// The percentage fee that the cluster may take upon match
@@ -47,8 +47,8 @@ impl TryFrom<&[u64]> for Fee {
         }
 
         Ok(Self {
-            settle_key: BigInt::from(values[0]),
-            gas_addr: BigInt::from(values[1]),
+            settle_key: BigUint::from(values[0]),
+            gas_addr: BigUint::from(values[1]),
             gas_token_amount: values[2],
             percentage_fee: values[3],
         })
@@ -103,9 +103,9 @@ impl CommitProver for Fee {
         prover: &mut Prover,
     ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
         let (settle_comm, settle_var) =
-            prover.commit(bigint_to_scalar(&self.settle_key), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.settle_key), Scalar::random(rng));
         let (addr_comm, addr_var) =
-            prover.commit(bigint_to_scalar(&self.gas_addr), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.gas_addr), Scalar::random(rng));
         let (amount_comm, amount_var) =
             prover.commit(Scalar::from(self.gas_token_amount), Scalar::random(rng));
         let (percent_comm, percent_var) =
@@ -217,8 +217,8 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Allocate<N, S> for Fee 
             .batch_allocate_private_scalars(
                 owning_party,
                 &[
-                    bigint_to_scalar(&self.settle_key),
-                    bigint_to_scalar(&self.gas_addr),
+                    biguint_to_scalar(&self.settle_key),
+                    biguint_to_scalar(&self.gas_addr),
                     Scalar::from(self.gas_token_amount),
                     Scalar::from(self.percentage_fee),
                 ],
@@ -290,8 +290,8 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
             .batch_commit(
                 owning_party,
                 &[
-                    bigint_to_scalar(&self.settle_key),
-                    bigint_to_scalar(&self.gas_addr),
+                    biguint_to_scalar(&self.settle_key),
+                    biguint_to_scalar(&self.gas_addr),
                     Scalar::from(self.gas_token_amount),
                     Scalar::from(self.percentage_fee),
                 ],

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -1,7 +1,7 @@
 //! Groups trait and type definitions for the handshake tuple
 
 use crate::{errors::MpcError, CommitSharedProver};
-use crypto::fields::bigint_to_scalar;
+use crypto::fields::biguint_to_scalar;
 use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use mpc_bulletproof::r1cs_mpc::MpcProver;
@@ -56,8 +56,8 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     Scalar::from(order.amount),
                     Scalar::from(balance.mint),
                     Scalar::from(balance.amount),
-                    bigint_to_scalar(&fee.settle_key),
-                    bigint_to_scalar(&fee.gas_addr),
+                    biguint_to_scalar(&fee.settle_key),
+                    biguint_to_scalar(&fee.gas_addr),
                     Scalar::from(fee.gas_token_amount),
                     Scalar::from(fee.percentage_fee),
                 ],

--- a/circuits/src/types/mod.rs
+++ b/circuits/src/types/mod.rs
@@ -4,3 +4,4 @@ pub mod fee;
 pub mod handshake_tuple;
 pub mod r#match;
 pub mod order;
+pub mod wallet;

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Represents the base type of an open order, including the asset pair, the amount, price,
 /// and direction
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Order {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: u64,

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -1,0 +1,177 @@
+//! Groups type definitions for a wallet and implements traits to allocate
+//! the wallet
+
+use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use itertools::Itertools;
+use mpc_bulletproof::r1cs::{Prover, Variable, Verifier};
+use rand_core::{CryptoRng, RngCore};
+
+use crate::{CommitProver, CommitVerifier};
+
+use super::{
+    balance::{Balance, BalanceVar, CommittedBalance},
+    fee::{CommittedFee, Fee, FeeVar},
+    order::{CommittedOrder, Order, OrderVar},
+};
+
+/// The number of keys in the key hierarchy stored in the wallet
+const NUM_KEYS: usize = 4;
+
+/// Represents the base type of a wallet holding orders, balances, fees, keys
+/// and cryptographic randomness
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Wallet<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The list of balances in the wallet
+    pub balances: [Balance; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [Order; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [Fee; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: [Scalar; NUM_KEYS],
+    /// The wallet randomness used to blind commitments, nullifiers, etc
+    pub randomness: Scalar,
+}
+
+/// Represents a wallet that has been allocated in a constraint system
+#[derive(Clone, Debug)]
+pub struct WalletVar<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The list of balances in the wallet
+    pub balances: [BalanceVar; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [OrderVar; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [FeeVar; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: [Variable; NUM_KEYS],
+    /// The wallet randomness used to blind commitments, nullifiers, etc
+    pub randomness: Variable,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitProver
+    for Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type CommitType = CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_prover<R: RngCore + CryptoRng>(
+        &self,
+        rng: &mut R,
+        prover: &mut Prover,
+    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
+        let (balance_vars, committed_balances): (Vec<BalanceVar>, Vec<CommittedBalance>) = self
+            .balances
+            .iter()
+            .map(|balance| balance.commit_prover(rng, prover).unwrap())
+            .unzip();
+
+        let (order_vars, committed_orders): (Vec<OrderVar>, Vec<CommittedOrder>) = self
+            .orders
+            .iter()
+            .map(|order| order.commit_prover(rng, prover).unwrap())
+            .unzip();
+
+        let (fee_vars, committed_fees): (Vec<FeeVar>, Vec<CommittedFee>) = self
+            .fees
+            .iter()
+            .map(|fee| fee.commit_prover(rng, prover).unwrap())
+            .unzip();
+
+        let (key_comms, key_vars): (Vec<CompressedRistretto>, Vec<Variable>) = self
+            .keys
+            .iter()
+            .map(|key| prover.commit(*key, Scalar::random(rng)))
+            .unzip();
+
+        let (randomness_comm, randomness_var) = prover.commit(self.randomness, Scalar::random(rng));
+
+        Ok((
+            WalletVar {
+                balances: balance_vars.try_into().unwrap(),
+                orders: order_vars.try_into().unwrap(),
+                fees: fee_vars.try_into().unwrap(),
+                keys: key_vars.try_into().unwrap(),
+                randomness: randomness_var,
+            },
+            CommittedWallet {
+                balances: committed_balances.try_into().unwrap(),
+                orders: committed_orders.try_into().unwrap(),
+                fees: committed_fees.try_into().unwrap(),
+                keys: key_comms.try_into().unwrap(),
+                randomness: randomness_comm,
+            },
+        ))
+    }
+}
+
+/// Represents a commitment to a wallet in the constraint system
+#[derive(Clone, Debug)]
+pub struct CommittedWallet<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The list of balances in the wallet
+    pub balances: [CommittedBalance; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [CommittedOrder; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [CommittedFee; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: [CompressedRistretto; NUM_KEYS],
+    /// The wallet randomness used to blind commitments, nullifiers, etc
+    pub randomness: CompressedRistretto,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
+    for CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        let balance_vars = self
+            .balances
+            .iter()
+            .map(|balance| balance.commit_verifier(verifier).unwrap())
+            .collect_vec();
+        let order_vars = self
+            .orders
+            .iter()
+            .map(|order| order.commit_verifier(verifier).unwrap())
+            .collect_vec();
+        let fee_vars = self
+            .fees
+            .iter()
+            .map(|fee| fee.commit_verifier(verifier).unwrap())
+            .collect_vec();
+
+        let key_vars = self
+            .keys
+            .iter()
+            .map(|key| verifier.commit(*key))
+            .collect_vec();
+        let randomness_var = verifier.commit(self.randomness);
+
+        Ok(WalletVar {
+            balances: balance_vars.try_into().unwrap(),
+            orders: order_vars.try_into().unwrap(),
+            fees: fee_vars.try_into().unwrap(),
+            keys: key_vars.try_into().unwrap(),
+            randomness: randomness_var,
+        })
+    }
+}

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The number of keys in the key hierarchy stored in the wallet
-const NUM_KEYS: usize = 4;
+pub(crate) const NUM_KEYS: usize = 4;
 
 /// Represents the base type of a wallet holding orders, balances, fees, keys
 /// and cryptographic randomness

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -2,3 +2,4 @@
 //! in proving knowledge of witness for throughout the network
 pub mod valid_match_mpc;
 pub mod valid_wallet_create;
+pub mod valid_wallet_update;

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -6,7 +6,11 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use curve25519_dalek::{
+    ristretto::{CompressedRistretto, RistrettoPoint},
+    scalar::Scalar,
+    traits::Identity,
+};
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{
@@ -511,6 +515,7 @@ impl From<&[CompressedRistretto]> for ValidMatchCommitment {
                 side: commitments[2],
                 price: commitments[3],
                 amount: commitments[4],
+                timestamp: RistrettoPoint::identity().compress(),
             },
             balance1: CommittedBalance {
                 mint: commitments[5],
@@ -528,6 +533,7 @@ impl From<&[CompressedRistretto]> for ValidMatchCommitment {
                 side: commitments[13],
                 price: commitments[14],
                 amount: commitments[15],
+                timestamp: RistrettoPoint::identity().compress(),
             },
             balance2: CommittedBalance {
                 mint: commitments[16],

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -352,13 +352,13 @@ mod test_valid_wallet_create {
     use ark_sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use crypto::{
         fields::{
-            bigint_to_scalar, prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField,
+            biguint_to_scalar, prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField,
         },
         hash::default_poseidon_params,
     };
     use curve25519_dalek::scalar::Scalar;
     use itertools::Itertools;
-    use num_bigint::BigInt;
+    use num_bigint::BigUint;
     use rand_core::{CryptoRng, OsRng, RngCore};
 
     use crate::{test_helpers::bulletproof_prove_and_verify, types::fee::Fee};
@@ -379,8 +379,8 @@ mod test_valid_wallet_create {
     /// Generates a random fee for testing
     fn random_fee<R: RngCore + CryptoRng>(rng: &mut R) -> Fee {
         Fee {
-            settle_key: BigInt::from(rng.next_u64()),
-            gas_addr: BigInt::from(rng.next_u64()),
+            settle_key: BigUint::from(rng.next_u64()),
+            gas_addr: BigUint::from(rng.next_u64()),
             gas_token_amount: rng.next_u64(),
             percentage_fee: rng.next_u64(),
         }
@@ -398,8 +398,8 @@ mod test_valid_wallet_create {
 
         // Absorb the fees into the hasher state
         for fee in witness.fees.iter() {
-            arkworks_hasher.absorb(&scalar_to_prime_field(&bigint_to_scalar(&fee.settle_key)));
-            arkworks_hasher.absorb(&scalar_to_prime_field(&bigint_to_scalar(&fee.gas_addr)));
+            arkworks_hasher.absorb(&scalar_to_prime_field(&biguint_to_scalar(&fee.settle_key)));
+            arkworks_hasher.absorb(&scalar_to_prime_field(&biguint_to_scalar(&fee.gas_addr)));
             arkworks_hasher.absorb(&DalekRistrettoField::from(fee.gas_token_amount));
             arkworks_hasher.absorb(&DalekRistrettoField::from(fee.percentage_fee));
         }

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -38,6 +38,8 @@ use crate::{
 };
 
 /// The circuitry for the VALID WALLET UPDATE statement
+///
+/// TODO: bounds checks everywhere
 #[derive(Clone, Debug)]
 pub struct ValidWalletUpdate<
     const MAX_BALANCES: usize,
@@ -116,7 +118,6 @@ where
         );
 
         Self::validate_wallet_orders(&witness.wallet2, &witness.wallet1, timestamp, cs);
-
         Ok(())
     }
 
@@ -163,6 +164,9 @@ where
 
         // Hash the keys into the state
         hasher.batch_absorb(cs, &wallet.keys)?;
+
+        // Hash the randomness into the state
+        hasher.absorb(cs, wallet.randomness)?;
 
         // Squeeze an element out of the state
         hasher.squeeze(cs)
@@ -688,5 +692,265 @@ where
         verifier
             .verify(&proof, &bp_gens)
             .map_err(VerifierError::R1CS)
+    }
+}
+
+#[cfg(test)]
+mod valid_wallet_update_tests {
+    use ark_sponge::{poseidon::PoseidonSponge, CryptographicSponge};
+    use crypto::{
+        fields::{
+            biguint_to_prime_field, prime_field_to_scalar, scalar_to_prime_field,
+            DalekRistrettoField,
+        },
+        hash::default_poseidon_params,
+    };
+    use curve25519_dalek::scalar::Scalar;
+    use itertools::Itertools;
+    use lazy_static::lazy_static;
+    use num_bigint::BigUint;
+    use rand_core::{CryptoRng, OsRng, RngCore};
+
+    use crate::{
+        test_helpers::bulletproof_prove_and_verify,
+        types::{
+            balance::Balance,
+            fee::Fee,
+            order::{Order, OrderSide},
+            wallet::{Wallet, NUM_KEYS},
+        },
+        zk_gadgets::merkle::merkle_test::get_opening_indices,
+    };
+
+    use super::{ValidWalletUpdate, ValidWalletUpdateStatement, ValidWalletUpdateWitness};
+
+    // -------------
+    // | Constants |
+    // -------------
+
+    /// The maximum number of balances allowed in a wallet for tests
+    const MAX_BALANCES: usize = 2;
+    /// The maximum number of orders allowed in a wallet for tests
+    const MAX_ORDERS: usize = 2;
+    /// The maximum number of fees allowed in a wallet for tests
+    const MAX_FEES: usize = 1;
+    /// The initial timestamp used in testing
+    const TIMESTAMP: u64 = 3; // dummy value
+    /// The height of the Merkle state tree
+    const MERKLE_HEIGHT: usize = 5;
+
+    type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+    // --------------
+    // | Dummy Data |
+    // --------------
+
+    lazy_static! {
+        static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
+            Balance { mint: 1, amount: 5 },
+            Balance {
+                mint: 2,
+                amount: 10
+            }
+        ];
+        static ref INITIAL_ORDERS: [Order; MAX_ORDERS] = [
+            Order {
+                quote_mint: 1,
+                base_mint: 2,
+                side: OrderSide::Buy,
+                price: 5,
+                amount: 1,
+                timestamp: TIMESTAMP,
+            },
+            Order {
+                quote_mint: 1,
+                base_mint: 3,
+                side: OrderSide::Sell,
+                price: 2,
+                amount: 10,
+                timestamp: TIMESTAMP,
+            }
+        ];
+        static ref INITIAL_FEES: [Fee; MAX_FEES] = [Fee {
+            settle_key: BigUint::from(11u8),
+            gas_addr: BigUint::from(13u8),
+            percentage_fee: 1,
+            gas_token_amount: 5,
+        }];
+        static ref INITIAL_WALLET: SizedWallet = Wallet {
+            balances: INITIAL_BALANCES.clone(),
+            orders: INITIAL_ORDERS.clone(),
+            fees: INITIAL_FEES.clone(),
+            keys: vec![Scalar::from(1u64); NUM_KEYS].try_into().unwrap(),
+            randomness: Scalar::from(42u64)
+        };
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Compute the commitment to a wallet
+    pub(crate) fn compute_wallet_commitment(wallet: &SizedWallet) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+
+        // Hash the balances into the state
+        for balance in wallet.balances.iter() {
+            hasher.absorb(&vec![balance.mint, balance.amount]);
+        }
+
+        // Hash the orders into the state
+        for order in wallet.orders.iter() {
+            hasher.absorb(&vec![
+                order.quote_mint,
+                order.base_mint,
+                order.side as u64,
+                order.price,
+                order.amount,
+            ]);
+        }
+
+        // Hash the fees into the state
+        for fee in wallet.fees.iter() {
+            hasher.absorb(&vec![
+                biguint_to_prime_field(&fee.settle_key),
+                biguint_to_prime_field(&fee.gas_addr),
+            ]);
+
+            hasher.absorb(&vec![fee.gas_token_amount, fee.percentage_fee]);
+        }
+
+        // Hash the keys into the state
+        hasher.absorb(&wallet.keys.iter().map(scalar_to_prime_field).collect_vec());
+
+        // Hash the randomness into the state
+        hasher.absorb(&scalar_to_prime_field(&wallet.randomness));
+
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+
+    /// Given a wallet, create a dummy opening to a dummy root
+    ///
+    /// Returns a scalar and two vectors representing:
+    ///     - The root of the Merkle tree
+    ///     - The opening values (sister nodes)
+    ///     - The opening indices (left or right)
+    fn create_wallet_opening<R: RngCore + CryptoRng>(
+        wallet: &SizedWallet,
+        height: usize,
+        index: usize,
+        rng: &mut R,
+    ) -> (Scalar, Vec<Scalar>, Vec<Scalar>) {
+        // Create random sister nodes for the opening
+        let random_opening = (0..height - 1).map(|_| Scalar::random(rng)).collect_vec();
+        let opening_indices = get_opening_indices(index, height);
+
+        // Compute the root of the mock Merkle tree
+        let mut curr_root = compute_wallet_commitment(wallet);
+        for (path_index, sister_node) in opening_indices.iter().zip(random_opening.iter()) {
+            let mut sponge = PoseidonSponge::new(&default_poseidon_params());
+
+            // Left hand child
+            let left_right = if path_index.eq(&Scalar::zero()) {
+                vec![curr_root, scalar_to_prime_field(sister_node)]
+            } else {
+                vec![scalar_to_prime_field(sister_node), curr_root]
+            };
+
+            sponge.absorb(&left_right);
+            curr_root = sponge.squeeze_field_elements(1 /* num_elements */)[0];
+        }
+
+        (
+            prime_field_to_scalar(&curr_root),
+            random_opening,
+            opening_indices,
+        )
+    }
+
+    /// Given a wallet and its commitment, compute the wallet spend nullifier
+    fn compute_wallet_spend_nullifier(
+        wallet: &SizedWallet,
+        commitment: DalekRistrettoField,
+    ) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+        hasher.absorb(&vec![commitment, scalar_to_prime_field(&wallet.randomness)]);
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+
+    /// Given a wallet and its commitment, compute the wallet match nullifier
+    fn compute_wallet_match_nullifier(
+        wallet: &SizedWallet,
+        commitment: DalekRistrettoField,
+    ) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+        hasher.absorb(&vec![
+            commitment,
+            scalar_to_prime_field(&(wallet.randomness + Scalar::one())),
+        ]);
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// Tests that updating a wallet with a valid witness/statement pair
+    ///
+    /// TODO: Add more tests in follow up
+    #[test]
+    fn test_place_order() {
+        let mut rng = OsRng {};
+
+        // Setup the initial wallet to have a single order, the updated wallet with a
+        // new order
+        let timestamp = TIMESTAMP + 1;
+        let mut initial_wallet = INITIAL_WALLET.clone();
+        let mut new_wallet = initial_wallet.clone();
+
+        // Make changes to the initial and new wallet
+        new_wallet.orders[1].timestamp = timestamp;
+        new_wallet.randomness = initial_wallet.randomness + Scalar::from(2u32);
+        initial_wallet.orders[1] = Order::default();
+
+        // Create a mock Merkle opening for the old wallet
+        let random_index = rng.next_u32() % (2u32.pow(MERKLE_HEIGHT.try_into().unwrap()));
+        let (mock_root, mock_opening, mock_opening_indices) = create_wallet_opening(
+            &initial_wallet,
+            MERKLE_HEIGHT,
+            random_index as usize,
+            &mut rng,
+        );
+
+        let witness = ValidWalletUpdateWitness {
+            wallet1: initial_wallet.clone(),
+            wallet2: new_wallet.clone(),
+            wallet1_opening: mock_opening,
+            wallet1_opening_indices: mock_opening_indices,
+            internal_transfer: (Scalar::zero(), Scalar::zero()),
+        };
+
+        let new_wallet_commit = compute_wallet_commitment(&new_wallet);
+        let old_wallet_commit = compute_wallet_commitment(&initial_wallet);
+
+        let old_wallet_spend_nullifier =
+            compute_wallet_spend_nullifier(&initial_wallet, old_wallet_commit);
+        let old_wallet_match_nullifier =
+            compute_wallet_match_nullifier(&initial_wallet, old_wallet_commit);
+
+        let statement = ValidWalletUpdateStatement {
+            timestamp: Scalar::from(timestamp),
+            pk_root: new_wallet.keys[0],
+            new_wallet_commitment: prime_field_to_scalar(&new_wallet_commit),
+            wallet_spend_nullifier: prime_field_to_scalar(&old_wallet_spend_nullifier),
+            wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
+            merkle_root: mock_root,
+            external_transfer: (Scalar::zero(), Scalar::zero(), Scalar::zero()),
+        };
+
+        let res = bulletproof_prove_and_verify::<
+            ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        >(witness, statement);
+        assert!(res.is_ok());
     }
 }

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -1,0 +1,488 @@
+//! Defines the VALID WALLET UPDATE circuit which proves that a valid
+//! transition exists between a pair of wallets, and nullifies the old
+//! wallet.
+//!
+//! The user proves this statement to create new orders, deposit and withdraw
+//! funds, and transfer funds internally.
+//!
+//! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.2
+//! for a formal specification
+
+use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use itertools::Itertools;
+use mpc_bulletproof::{
+    r1cs::{
+        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
+        Variable, Verifier,
+    },
+    r1cs_mpc::R1CSError,
+    BulletproofGens,
+};
+use rand_core::OsRng;
+
+use crate::{
+    errors::{ProverError, VerifierError},
+    mpc_gadgets::poseidon::PoseidonSpongeParameters,
+    types::wallet::{CommittedWallet, Wallet, WalletVar},
+    zk_gadgets::{
+        comparators::NotEqualGadget, merkle::PoseidonMerkleHashGadget, poseidon::PoseidonHashGadget,
+    },
+    CommitProver, CommitVerifier, SingleProverCircuit,
+};
+
+/// The circuitry for the VALID WALLET UPDATE statement
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdate<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized, {}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// Applies the constraints of the VALID WALLET UPDATE statement
+    pub fn circuit<CS: RandomizableConstraintSystem>(
+        witness: ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        pk_root: Variable,
+        merkle_root: Variable,
+        match_nullifier: Variable,
+        spend_nullifier: Variable,
+        new_wallet_commit: Variable,
+        external_transfer: (Variable, Variable, Variable),
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        // Commit to the new wallet and constrain it to equal the public variable
+        let new_wallet_commit_res = Self::wallet_commit(&witness.wallet2, cs)?;
+        cs.constrain(new_wallet_commit - new_wallet_commit_res);
+
+        // Commit to the old wallet, use this as a leaf in the Merkle opening
+        let old_wallet_commit = Self::wallet_commit(&witness.wallet1, cs)?;
+        PoseidonMerkleHashGadget::compute_and_constrain_root_prehashed(
+            cs,
+            old_wallet_commit.clone(),
+            witness.wallet1_opening,
+            witness.wallet1_opening_indices,
+            merkle_root.into(),
+        )?;
+
+        // Verify that the nullifiers are properly computed
+        let spend_nullifier_res =
+            Self::compute_spend_nullifier(&witness.wallet1, old_wallet_commit.clone(), cs)?;
+        let match_nullifier_res =
+            Self::compute_match_nullifier(&witness.wallet1, old_wallet_commit.clone(), cs)?;
+
+        cs.constrain(spend_nullifier - spend_nullifier_res);
+        cs.constrain(match_nullifier - match_nullifier_res);
+
+        // Verify that the given pk_root key is the same as the wallet
+        cs.constrain(pk_root - witness.wallet1.keys[0]);
+
+        // Verify that the keys are unchanged between the two wallets
+        Self::constrain_keys_equal(&witness.wallet1, &witness.wallet2, cs);
+
+        // The randomness of the new wallet should equal the randomness of the old wallet, twice incremented
+        cs.constrain(witness.wallet1.randomness + Scalar::from(2u64) - witness.wallet2.randomness);
+
+        // Validate the balances of the new wallet
+        Self::validate_wallet_balances(&witness.wallet2, cs);
+
+        Ok(())
+    }
+
+    /// Compute the commitment to a wallet
+    fn wallet_commit<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        // Create a new hash gadget
+        let hash_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hash_params);
+
+        // Hash the balances into the state
+        for balance in wallet.balances.iter() {
+            hasher.batch_absorb(cs, &[balance.mint, balance.amount])?;
+        }
+
+        // Hash the orders into the state
+        for order in wallet.orders.iter() {
+            hasher.batch_absorb(
+                cs,
+                &[
+                    order.quote_mint,
+                    order.base_mint,
+                    order.side,
+                    order.price,
+                    order.amount,
+                ],
+            )?;
+        }
+
+        // Hash the fees into the state
+        for fee in wallet.fees.iter() {
+            hasher.batch_absorb(
+                cs,
+                &[
+                    fee.settle_key,
+                    fee.gas_addr,
+                    fee.gas_token_amount,
+                    fee.percentage_fee,
+                ],
+            )?;
+        }
+
+        // Hash the keys into the state
+        hasher.batch_absorb(cs, &wallet.keys)?;
+
+        // Squeeze an element out of the state
+        hasher.squeeze(cs)
+    }
+
+    /// Compute the wallet spend nullifier, defined as the poseidon hash:
+    ///     H(C(W) || r)
+    fn compute_spend_nullifier<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        wallet_commit: LinearCombination,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        let hasher_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hasher_params);
+
+        hasher.batch_absorb(cs, &[wallet_commit, wallet.randomness.into()])?;
+        hasher.squeeze(cs)
+    }
+
+    /// Compute the wallet match nullifier, defined as the poseidon hash:
+    ///     H(C(W) || r + 1)
+    fn compute_match_nullifier<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        wallet_commit: LinearCombination,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        let hasher_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hasher_params);
+
+        hasher.batch_absorb(cs, &[wallet_commit, wallet.randomness + Scalar::one()])?;
+        hasher.squeeze(cs)
+    }
+
+    /// Constrain the keys of two wallets to be equal
+    fn constrain_keys_equal<CS: RandomizableConstraintSystem>(
+        wallet1: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        wallet2: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) {
+        for (key1, key2) in wallet1.keys.iter().zip(wallet2.keys.iter()) {
+            cs.constrain(*key1 - *key2);
+        }
+    }
+
+    /// Validate the balances of the new wallet
+    fn validate_wallet_balances<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) {
+        // All balances of the new order should have unique mint or mint zero
+        Self::constrain_unique_balance_mints(wallet, cs);
+    }
+
+    /// Constrains all balance mints to be unique or zero
+    fn constrain_unique_balance_mints<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) {
+        for i in 0..wallet.balances.len() {
+            for j in (i + 1)..wallet.balances.len() {
+                // Check whether balance[i] != balance[j]
+                let ij_unique =
+                    NotEqualGadget::not_equal(wallet.balances[i].mint, wallet.balances[j].mint, cs);
+
+                // Evaluate the polynomial mint * (1 - ij_unique) which is 0 iff
+                // the mint is zero, or balance[i] != balance[j]
+                let (_, _, constraint_poly) =
+                    cs.multiply(wallet.balances[i].mint.into(), Variable::One() - ij_unique);
+                cs.constrain(constraint_poly.into());
+            }
+        }
+    }
+}
+
+/// The witness type for VALID WALLET UPDATE
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateWitness<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The old wallet; that being updated
+    pub wallet1: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The new wallet; after the update is complete
+    pub wallet2: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The opening from the old wallet's commitment to the global
+    /// Merkle root
+    pub wallet1_opening: Vec<Scalar>,
+    /// The indices of the opening, i.e. 0 indicating that the next index in
+    /// the opening is a left node, 1 indicating that it's a right hand node
+    pub wallet1_opening_indices: Vec<Scalar>,
+    /// The internal transfer tuple, a pair of (mint, volume); used to transfer
+    /// funds out of a wallet to a settle-able note
+    pub internal_transfer: (Scalar, Scalar),
+}
+
+/// The witness type for VALID WALLET UPDATE that has been allocated
+/// in a constraint system
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateWitnessVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The old wallet; that being updated
+    pub wallet1: WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The new wallet; after the update is complete
+    pub wallet2: WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The opening from the old wallet's commitment to the global
+    /// Merkle root
+    pub wallet1_opening: Vec<Variable>,
+    /// The indices of the opening, i.e. 0 indicating that the next index in
+    /// the opening is a left node, 1 indicating that it's a right hand node
+    pub wallet1_opening_indices: Vec<Variable>,
+    /// The internal transfer tuple, a pair of (mint, volume); used to transfer
+    /// funds out of a wallet to a settle-able note
+    pub internal_transfer: (Variable, Variable),
+}
+
+/// A commitment to the witness of VALID WALLET UPDATE
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateWitnessCommitment<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The old wallet; that being updated
+    pub wallet1: CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The new wallet; after the update is complete
+    pub wallet2: CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The opening from the old wallet's commitment to the global
+    /// Merkle root
+    pub wallet1_opening: Vec<CompressedRistretto>,
+    /// The indices of the opening, i.e. 0 indicating that the next index in
+    /// the opening is a left node, 1 indicating that it's a right hand node
+    pub wallet1_opening_indices: Vec<CompressedRistretto>,
+    /// The internal transfer tuple, a pair of (mint, volume); used to transfer
+    /// funds out of a wallet to a settle-able note
+    pub internal_transfer: (CompressedRistretto, CompressedRistretto),
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitProver
+    for ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type VarType = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type CommitType = ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_prover<R: rand_core::RngCore + rand_core::CryptoRng>(
+        &self,
+        rng: &mut R,
+        prover: &mut Prover,
+    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
+        let (wallet1_var, wallet1_comm) = self.wallet1.commit_prover(rng, prover).unwrap();
+        let (wallet2_var, wallet2_comm) = self.wallet2.commit_prover(rng, prover).unwrap();
+
+        let (opening_comms, opening_vars): (Vec<CompressedRistretto>, Vec<Variable>) = self
+            .wallet1_opening
+            .iter()
+            .map(|opening_elem| prover.commit(*opening_elem, Scalar::random(rng)))
+            .unzip();
+        let (opening_index_comms, opening_index_vars): (Vec<CompressedRistretto>, Vec<Variable>) =
+            self.wallet1_opening_indices
+                .iter()
+                .map(|opening_index| prover.commit(*opening_index, Scalar::random(rng)))
+                .unzip();
+
+        let (internal_transfer_mint_comm, internal_transfer_mint_var) =
+            prover.commit(self.internal_transfer.0, Scalar::random(rng));
+        let (internal_transfer_volume_comm, internal_transfer_volume_var) =
+            prover.commit(self.internal_transfer.1, Scalar::random(rng));
+
+        Ok((
+            ValidWalletUpdateWitnessVar {
+                wallet1: wallet1_var,
+                wallet2: wallet2_var,
+                wallet1_opening: opening_vars,
+                wallet1_opening_indices: opening_index_vars,
+                internal_transfer: (internal_transfer_mint_var, internal_transfer_volume_var),
+            },
+            ValidWalletUpdateWitnessCommitment {
+                wallet1: wallet1_comm,
+                wallet2: wallet2_comm,
+                wallet1_opening: opening_comms,
+                wallet1_opening_indices: opening_index_comms,
+                internal_transfer: (internal_transfer_mint_comm, internal_transfer_volume_comm),
+            },
+        ))
+    }
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
+    for ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type VarType = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        let wallet1_var = self.wallet1.commit_verifier(verifier).unwrap();
+        let wallet2_var = self.wallet2.commit_verifier(verifier).unwrap();
+
+        let opening_vars = self
+            .wallet1_opening
+            .iter()
+            .map(|opening_elem| verifier.commit(*opening_elem))
+            .collect_vec();
+        let opening_index_vars = self
+            .wallet1_opening_indices
+            .iter()
+            .map(|opening_index| verifier.commit(*opening_index))
+            .collect_vec();
+
+        let internal_transfer_mint = verifier.commit(self.internal_transfer.0);
+        let internal_transfer_volume = verifier.commit(self.internal_transfer.1);
+
+        Ok(ValidWalletUpdateWitnessVar {
+            wallet1: wallet1_var,
+            wallet2: wallet2_var,
+            wallet1_opening: opening_vars,
+            wallet1_opening_indices: opening_index_vars,
+            internal_transfer: (internal_transfer_mint, internal_transfer_volume),
+        })
+    }
+}
+
+/// The statement type for VALID WALLET UPDATE
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateStatement {
+    /// The root public key of the wallet being updated
+    pub pk_root: Scalar,
+    /// The commitment to the new wallet
+    pub new_wallet_commitment: Scalar,
+    /// The wallet spend nullifier of the old wallet
+    pub wallet_spend_nullifier: Scalar,
+    /// The wallet match nullifier of the old wallet
+    pub wallet_match_nullifier: Scalar,
+    /// The global state tree root used to prove opening
+    pub merkle_root: Scalar,
+    /// The external transfer tuple, used to deposit or withdraw funds
+    /// of the form (mint, volume, direction)
+    pub external_transfer: (Scalar, Scalar, Scalar),
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> SingleProverCircuit
+    for ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type Witness = ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type WitnessCommitment = ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type Statement = ValidWalletUpdateStatement;
+
+    const BP_GENS_CAPACITY: usize = 32768;
+
+    fn prove(
+        witness: Self::Witness,
+        statement: Self::Statement,
+        mut prover: Prover,
+    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
+        // Commit to the witness
+        let mut rng = OsRng {};
+        let (witness_var, witness_comm) = witness.commit_prover(&mut rng, &mut prover).unwrap();
+
+        // Commit to the statement
+        let pk_root_var = prover.commit_public(statement.pk_root);
+        let new_wallet_commit_var = prover.commit_public(statement.new_wallet_commitment);
+        let match_nullifier_var = prover.commit_public(statement.wallet_match_nullifier);
+        let spend_nullifier_var = prover.commit_public(statement.wallet_spend_nullifier);
+        let merkle_root_var = prover.commit_public(statement.merkle_root);
+        let external_transfer_mint = prover.commit_public(statement.external_transfer.0);
+        let external_transfer_volume = prover.commit_public(statement.external_transfer.1);
+        let external_transfer_direction = prover.commit_public(statement.external_transfer.2);
+
+        // Apply the constraints
+        Self::circuit(
+            witness_var,
+            pk_root_var,
+            merkle_root_var,
+            match_nullifier_var,
+            spend_nullifier_var,
+            new_wallet_commit_var,
+            (
+                external_transfer_mint,
+                external_transfer_volume,
+                external_transfer_direction,
+            ),
+            &mut prover,
+        )
+        .map_err(ProverError::R1CS)?;
+
+        // Prove the statement
+        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
+        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
+
+        Ok((witness_comm, proof))
+    }
+
+    fn verify(
+        witness_commitment: Self::WitnessCommitment,
+        statement: Self::Statement,
+        proof: R1CSProof,
+        mut verifier: Verifier,
+    ) -> Result<(), VerifierError> {
+        // Commit to the witness
+        let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
+
+        // Commit to the statement
+        let pk_root_var = verifier.commit_public(statement.pk_root);
+        let new_wallet_commit_var = verifier.commit_public(statement.new_wallet_commitment);
+        let match_nullifier_var = verifier.commit_public(statement.wallet_match_nullifier);
+        let spend_nullifier_var = verifier.commit_public(statement.wallet_spend_nullifier);
+        let merkle_root_var = verifier.commit_public(statement.merkle_root);
+        let external_transfer_mint = verifier.commit_public(statement.external_transfer.0);
+        let external_transfer_volume = verifier.commit_public(statement.external_transfer.1);
+        let external_transfer_direction = verifier.commit_public(statement.external_transfer.2);
+
+        // Apply the constraints
+        Self::circuit(
+            witness_var,
+            pk_root_var,
+            merkle_root_var,
+            match_nullifier_var,
+            spend_nullifier_var,
+            new_wallet_commit_var,
+            (
+                external_transfer_mint,
+                external_transfer_volume,
+                external_transfer_direction,
+            ),
+            &mut verifier,
+        )
+        .map_err(VerifierError::R1CS)?;
+
+        // Verify the proof
+        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
+        verifier
+            .verify(&proof, &bp_gens)
+            .map_err(VerifierError::R1CS)
+    }
+}

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -349,6 +349,7 @@ where
                 side: Variable::Zero(),
                 amount: Variable::Zero(),
                 price: Variable::Zero(),
+                timestamp: Variable::Zero(),
             },
             cs,
         )

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -122,6 +122,22 @@ impl SingleProverCircuit for EqZeroGadget {
     }
 }
 
+/// Returns a boolean representing a != b where 1 is true and 0 is false
+#[derive(Debug)]
+pub struct NotEqualGadget {}
+
+impl NotEqualGadget {
+    /// Computes a != b
+    pub fn not_equal<L, CS>(a: L, b: L, cs: &mut CS) -> LinearCombination
+    where
+        L: Into<LinearCombination> + Clone,
+        CS: RandomizableConstraintSystem,
+    {
+        let eq_zero = EqZeroGadget::eq_zero(cs, a.into() - b.into());
+        Variable::One() - eq_zero
+    }
+}
+
 /// A gadget that enforces a value of a given bitlength is positive
 #[derive(Clone, Debug)]
 pub struct GreaterThanEqZeroGadget<const D: usize> {}

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem},
+    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem},
 };
 use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
@@ -19,7 +19,7 @@ impl OrGate {
     ///
     /// The arguments are assumed to be binary (0 or 1), but this assumption should be
     /// constrained elsewhere in the calling circuit
-    pub fn or<L, CS>(cs: &mut CS, a: L, b: L) -> LinearCombination
+    pub fn or<L, CS>(a: L, b: L, cs: &mut CS) -> LinearCombination
     where
         L: Into<LinearCombination> + Clone,
         CS: RandomizableConstraintSystem,
@@ -36,7 +36,7 @@ pub struct MultiproverOrGate<'a, N: MpcNetwork + Send, S: SharedValueSource<Scal
 }
 
 impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> MultiproverOrGate<'a, N, S> {
-    /// Return the logical OR of the two arguemnts
+    /// Return the logical OR of the two arguments
     ///
     /// The arguments are assumed to be binary (0 or 1), but this assumption should be
     /// constrained elsewhere in the calling circuit
@@ -49,5 +49,24 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> Multiprov
             .multiply(&a.into(), &b.into())
             .map_err(ProverError::Collaborative)?;
         Ok(&a + &b - a_times_b)
+    }
+}
+
+/// Represents an AND gate in the constraint system
+#[derive(Clone, Debug)]
+pub struct AndGate {}
+impl AndGate {
+    /// Computes the logical AND of the two inputs: out = a & b
+    ///
+    /// The arguments are assumed to be binary (0 or 1), but this assumption should be
+    /// constrained elsewhere in the calling circuit
+    pub fn and<L, CS>(a: L, b: L, cs: &mut CS) -> Variable
+    where
+        L: Into<LinearCombination> + Clone,
+        CS: RandomizableConstraintSystem,
+    {
+        // For binary values, and is reduced to multiplication
+        // Multiply the values and return their output wire
+        cs.multiply(a.into(), b.into()).2
     }
 }

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -549,7 +549,7 @@ impl<'a, N: MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCircuit<
 }
 
 #[cfg(test)]
-mod merkle_test {
+pub(crate) mod merkle_test {
     use ark_crypto_primitives::{
         crh::poseidon::{TwoToOneCRH, CRH},
         merkle_tree::{Config, IdentityDigestConverter},
@@ -595,7 +595,7 @@ mod merkle_test {
     /// determine incrementally which subtree a given index should be a part of.
     ///
     /// The tree indices from leaf to root are exactly the LSB decomposition of the scalar
-    fn get_opening_indices(leaf_index: usize, tree_height: usize) -> Vec<Scalar> {
+    pub(crate) fn get_opening_indices(leaf_index: usize, tree_height: usize) -> Vec<Scalar> {
         if tree_height == 0 {
             vec![]
         } else {

--- a/crypto/src/fields.rs
+++ b/crypto/src/fields.rs
@@ -41,9 +41,14 @@ pub fn bigint_to_scalar(a: &BigInt) -> Scalar {
     }
 }
 
-/// Conver a BigUint to a scalar
+/// Convert a BigUint to a scalar
 pub fn biguint_to_scalar(a: &BigUint) -> Scalar {
     bigint_to_scalar(&a.clone().into())
+}
+
+/// Convert a BigUint to an Arkworks representation of the Ristretto scalar field
+pub fn biguint_to_prime_field(a: &BigUint) -> DalekRistrettoField {
+    scalar_to_prime_field(&biguint_to_scalar(a))
 }
 
 /// Pad an array up to the desired length with zeros


### PR DESCRIPTION
### Purpose
This PR gives the initial implementation of the statement `VALID WALLET UPDATE` from Appendix A.2 of the [whitepaper](https://renegade.fi/whitepaper.pdf).

This essentially states that any deposits, withdraws, new order placements, and internal transfers have correctly updated the wallet state. The commitment to the new wallet is passed as a public variable so that it is verified before being entered into the state tree.

Left to a subsequent PR are bounds checks (where appropriate) and a more comprehensive test suite for the various functionalities of this circuit.

### Testing
- Unit tests pass
- Tested a proof in which a user creates a new order