### PR TITLE
circuits: zk-circuits: Cleanup interfaces and fix integration test bugs

### DIFF
--- a/circuits/Dockerfile
+++ b/circuits/Dockerfile
@@ -3,7 +3,13 @@ FROM rust:1.63-slim-buster AS builder
 
 # Create a build dir and add local dependencies
 WORKDIR /build
+
+# Build the rust toolchain before adding any dependencies; this is the slowest
+# step and we would like to cache it before anything else
 COPY ./rust-toolchain ./circuits/rust-toolchain
+RUN cat circuits/rust-toolchain | xargs rustup toolchain install
+
+# Copy in dependencies from the same repo
 COPY ./crypto ./crypto
 COPY ./integration-helpers ./integration-helpers
 COPY ./circuit-macros ./circuit-macros

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -40,7 +40,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
         let balance = &self.1;
         let fee = &self.2;
 
-        let num_committed_elements = 5 /* order */ + 2 /* balance */ + 4 /* fee */;
+        let num_committed_elements = 6 /* order */ + 2 /* balance */ + 4 /* fee */;
         let blinders = (0..num_committed_elements)
             .map(|_| Scalar::random(rng))
             .collect_vec();
@@ -54,6 +54,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     Scalar::from(order.side as u64),
                     Scalar::from(order.price),
                     Scalar::from(order.amount),
+                    Scalar::from(order.timestamp),
                     Scalar::from(balance.mint),
                     Scalar::from(balance.amount),
                     biguint_to_scalar(&fee.settle_key),
@@ -72,16 +73,17 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 side: shared_vars[2].to_owned(),
                 price: shared_vars[3].to_owned(),
                 amount: shared_vars[4].to_owned(),
+                timestamp: shared_vars[5].to_owned(),
             },
             AuthenticatedBalanceVar {
-                mint: shared_vars[5].to_owned(),
-                amount: shared_vars[6].to_owned(),
+                mint: shared_vars[6].to_owned(),
+                amount: shared_vars[7].to_owned(),
             },
             AuthenticatedFeeVar {
-                settle_key: shared_vars[7].to_owned(),
-                gas_addr: shared_vars[8].to_owned(),
-                gas_token_amount: shared_vars[9].to_owned(),
-                percentage_fee: shared_vars[10].to_owned(),
+                settle_key: shared_vars[8].to_owned(),
+                gas_addr: shared_vars[9].to_owned(),
+                gas_token_amount: shared_vars[10].to_owned(),
+                percentage_fee: shared_vars[11].to_owned(),
             },
         );
 
@@ -92,16 +94,17 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 side: shared_comm[2].to_owned(),
                 price: shared_comm[3].to_owned(),
                 amount: shared_comm[4].to_owned(),
+                timestamp: shared_comm[5].to_owned(),
             },
             AuthenticatedCommittedBalance {
-                mint: shared_comm[5].to_owned(),
-                amount: shared_comm[6].to_owned(),
+                mint: shared_comm[6].to_owned(),
+                amount: shared_comm[7].to_owned(),
             },
             AuthenticatedCommittedFee {
-                settle_key: shared_comm[7].to_owned(),
-                gas_addr: shared_comm[8].to_owned(),
-                gas_token_amount: shared_comm[9].to_owned(),
-                percentage_fee: shared_comm[10].to_owned(),
+                settle_key: shared_comm[8].to_owned(),
+                gas_addr: shared_comm[9].to_owned(),
+                gas_token_amount: shared_comm[10].to_owned(),
+                percentage_fee: shared_comm[11].to_owned(),
             },
         );
 

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -237,6 +237,8 @@ pub struct AuthenticatedOrder<N: MpcNetwork + Send, S: SharedValueSource<Scalar>
     pub price: AuthenticatedScalar<N, S>,
     /// The amount of base currency to buy or sell
     pub amount: AuthenticatedScalar<N, S>,
+    /// A timestamp indicating when the order was placed, set by the user
+    pub timestamp: AuthenticatedScalar<N, S>,
 }
 
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Allocate<N, S> for Order {
@@ -258,6 +260,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Allocate<N, S> for Orde
                     self.side.into(),
                     self.price,
                     self.amount,
+                    self.timestamp,
                 ],
             )
             .map_err(|err| MpcError::SharingError(err.to_string()))?;
@@ -268,6 +271,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Allocate<N, S> for Orde
             side: shared_values[2].to_owned(),
             price: shared_values[3].to_owned(),
             amount: shared_values[4].to_owned(),
+            timestamp: shared_values[5].to_owned(),
         })
     }
 }
@@ -286,6 +290,8 @@ pub struct AuthenticatedOrderVar<N: MpcNetwork + Send, S: SharedValueSource<Scal
     pub price: MpcVariable<N, S>,
     /// The amount of base currency to buy or sell
     pub amount: MpcVariable<N, S>,
+    /// A timestamp indicating when the order was placed, set by the user
+    pub timestamp: MpcVariable<N, S>,
 }
 
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone for AuthenticatedOrderVar<N, S> {
@@ -296,6 +302,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone for Authenticated
             side: self.side.clone(),
             price: self.price.clone(),
             amount: self.amount.clone(),
+            timestamp: self.timestamp.clone(),
         }
     }
 }
@@ -325,7 +332,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
         rng: &mut R,
         prover: &mut MpcProver<N, S>,
     ) -> Result<(Self::SharedVarType, Self::CommitType), Self::ErrorType> {
-        let blinders = (0..5).map(|_| Scalar::random(rng)).collect_vec();
+        let blinders = (0..6).map(|_| Scalar::random(rng)).collect_vec();
         let (shared_comm, shared_vars) = prover
             .batch_commit(
                 owning_party,
@@ -335,6 +342,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     Scalar::from(self.side as u64),
                     Scalar::from(self.price),
                     Scalar::from(self.amount),
+                    Scalar::from(self.timestamp),
                 ],
                 &blinders,
             )
@@ -347,6 +355,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 side: shared_vars[2].to_owned(),
                 price: shared_vars[3].to_owned(),
                 amount: shared_vars[4].to_owned(),
+                timestamp: shared_vars[5].to_owned(),
             },
             AuthenticatedCommittedOrder {
                 quote_mint: shared_comm[0].to_owned(),
@@ -354,6 +363,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 side: shared_comm[2].to_owned(),
                 price: shared_comm[3].to_owned(),
                 amount: shared_comm[4].to_owned(),
+                timestamp: shared_comm[5].to_owned(),
             },
         ))
     }
@@ -372,6 +382,8 @@ pub struct AuthenticatedCommittedOrder<N: MpcNetwork + Send, S: SharedValueSourc
     pub price: AuthenticatedCompressedRistretto<N, S>,
     /// The amount of base currency to buy or sell
     pub amount: AuthenticatedCompressedRistretto<N, S>,
+    /// A timestamp indicating when the order was placed, set by the user
+    pub timestamp: AuthenticatedCompressedRistretto<N, S>,
 }
 
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone
@@ -384,6 +396,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone
             side: self.side.clone(),
             price: self.price.clone(),
             amount: self.amount.clone(),
+            timestamp: self.timestamp.clone(),
         }
     }
 }
@@ -398,6 +411,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<AuthenticatedCommi
             order.side,
             order.price,
             order.amount,
+            order.timestamp,
         ]
     }
 }
@@ -421,6 +435,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitVerifier
         let side_var = verifier.commit(opened_commit[2].value());
         let price_var = verifier.commit(opened_commit[3].value());
         let amount_var = verifier.commit(opened_commit[4].value());
+        let timestamp_var = verifier.commit(opened_commit[5].value());
 
         Ok(OrderVar {
             quote_mint: quote_var,
@@ -428,7 +443,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitVerifier
             side: side_var,
             price: price_var,
             amount: amount_var,
-            timestamp: Variable::Zero(), // unused in ZK-MPC path
+            timestamp: timestamp_var,
         })
     }
 }

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -6,11 +6,7 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use curve25519_dalek::{
-    ristretto::{CompressedRistretto, RistrettoPoint},
-    scalar::Scalar,
-    traits::Identity,
-};
+use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{
@@ -515,45 +511,45 @@ impl From<&[CompressedRistretto]> for ValidMatchCommitment {
                 side: commitments[2],
                 price: commitments[3],
                 amount: commitments[4],
-                timestamp: RistrettoPoint::identity().compress(),
+                timestamp: commitments[5],
             },
             balance1: CommittedBalance {
-                mint: commitments[5],
-                amount: commitments[6],
+                mint: commitments[6],
+                amount: commitments[7],
             },
             fee1: CommittedFee {
-                settle_key: commitments[7],
-                gas_addr: commitments[8],
-                gas_token_amount: commitments[9],
-                percentage_fee: commitments[10],
+                settle_key: commitments[8],
+                gas_addr: commitments[9],
+                gas_token_amount: commitments[10],
+                percentage_fee: commitments[11],
             },
             order2: CommittedOrder {
-                quote_mint: commitments[11],
-                base_mint: commitments[12],
-                side: commitments[13],
-                price: commitments[14],
-                amount: commitments[15],
-                timestamp: RistrettoPoint::identity().compress(),
+                quote_mint: commitments[12],
+                base_mint: commitments[13],
+                side: commitments[14],
+                price: commitments[15],
+                amount: commitments[16],
+                timestamp: commitments[17],
             },
             balance2: CommittedBalance {
-                mint: commitments[16],
-                amount: commitments[17],
+                mint: commitments[18],
+                amount: commitments[19],
             },
             fee2: CommittedFee {
-                settle_key: commitments[18],
-                gas_addr: commitments[19],
-                gas_token_amount: commitments[20],
-                percentage_fee: commitments[21],
+                settle_key: commitments[20],
+                gas_addr: commitments[21],
+                gas_token_amount: commitments[22],
+                percentage_fee: commitments[23],
             },
             match_result: CommittedMatchResult {
-                quote_mint: commitments[22],
-                base_mint: commitments[23],
-                quote_amount: commitments[24],
-                base_amount: commitments[25],
-                direction: commitments[26],
-                execution_price: commitments[27],
-                max_minus_min_amount: commitments[28],
-                min_amount_order_index: commitments[29],
+                quote_mint: commitments[24],
+                base_mint: commitments[25],
+                quote_amount: commitments[26],
+                base_amount: commitments[27],
+                direction: commitments[28],
+                execution_price: commitments[29],
+                max_minus_min_amount: commitments[30],
+                min_amount_order_index: commitments[31],
             },
         }
     }
@@ -711,7 +707,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
             fabric,
         )?;
 
-        // Prover the statement
+        // Prove the statement
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
 

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -79,35 +79,35 @@ where
         // This wallet should have empty orders and balances, hash zeros into the state
         // to represent an empty orders list
         let zeros = [Scalar::zero(); MAX_BALANCES * BALANCE_ZEROS + MAX_ORDERS * ORDER_ZEROS];
-        hasher.batch_absorb(cs, &zeros)?;
+        hasher.batch_absorb(&zeros, cs)?;
 
         // Hash the fees into the state
         for fee in witness.fees.iter() {
             hasher.batch_absorb(
-                cs,
                 &[
                     fee.settle_key,
                     fee.gas_addr,
                     fee.gas_token_amount,
                     fee.percentage_fee,
                 ],
+                cs,
             )?;
         }
 
         // Hash the keys into the state
         hasher.batch_absorb(
-            cs,
             &[
                 witness.root_public_key,
                 witness.match_public_key,
                 witness.settle_public_key,
                 witness.view_public_key,
             ],
+            cs,
         )?;
-        hasher.absorb(cs, witness.wallet_randomness)?;
+        hasher.absorb(witness.wallet_randomness, cs)?;
 
         // Enforce that the result is equal to the expected commitment
-        hasher.constrained_squeeze(cs, expected_commit)?;
+        hasher.constrained_squeeze(expected_commit, cs)?;
         Ok(())
     }
 }

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -248,7 +248,6 @@ pub struct GreaterThanEqZeroWitness {
     /// The value attested to that must be greater than zero
     val: Scalar,
 }
-
 impl<const D: usize> SingleProverCircuit for GreaterThanEqZeroGadget<D> {
     type Statement = ();
     type Witness = GreaterThanEqZeroWitness;

--- a/circuits/src/zk_gadgets/edwards.rs
+++ b/circuits/src/zk_gadgets/edwards.rs
@@ -265,7 +265,7 @@ impl TwistedEdwardsCurve {
         }
 
         // Evaluate whether the sum is zero
-        EqZeroGadget::eq_zero(cs, bit_sum)
+        EqZeroGadget::eq_zero(bit_sum, cs)
     }
 }
 

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -405,10 +405,10 @@ impl NonNativeElementVar {
 
         let selector_lc: LinearCombination = selector.into();
         let selected_words = CondSelectVectorGadget::select(
-            cs,
             &lhs_words.take(max_len).collect_vec(),
             &rhs_words.take(max_len).collect_vec(),
             selector_lc,
+            cs,
         );
 
         Self::new(selected_words, lhs.field_mod.clone())

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -32,8 +32,8 @@ impl CondSelectGadget {
         CS: RandomizableConstraintSystem,
     {
         // Computes selector * a + (1 - selector) * b
-        let (_, selector_var, mul1_out) = cs.multiply(a.into(), selector.into());
-        let (_, _, mul2_out) = cs.multiply(b.into(), Variable::One() - selector_var);
+        let (_, _, mul1_out) = cs.multiply(a.into(), selector.clone().into());
+        let (_, _, mul2_out) = cs.multiply(b.into(), Variable::One() - selector);
 
         mul1_out + mul2_out
     }


### PR DESCRIPTION
### Purpose
This PR is a few small cleanups that:
1. Make the gadget interfaces more consistent and tracer-friendly
2. Fixes a broken integration test that stemmed from adding timestamps to the order type.

### Testing
- All unit and integration tests pass