### PR TITLE
circuits: zk-circuits: `VALID WALLET UPDATE`: Constrain bounds checks on balances

### DIFF
--- a/circuit-macros/tests/test_macros.rs
+++ b/circuit-macros/tests/test_macros.rs
@@ -15,17 +15,12 @@ use std::{
 };
 
 /// A type used for scoping trace metrics
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Scope {
     pub path: Vec<String>,
 }
 
 impl Scope {
-    /// Build a new scope
-    pub fn new() -> Self {
-        Self { path: vec![] }
-    }
-
     pub fn from_path(path: Vec<String>) -> Self {
         Self { path }
     }
@@ -42,20 +37,13 @@ impl Scope {
 }
 
 /// Represents a list of metrics collected via a trace
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ScopedMetrics {
     /// A list of metrics, represented as named tuples
     pub(crate) data: HashMap<String, u64>,
 }
 
 impl ScopedMetrics {
-    /// Create a new, empty list of metrics
-    pub fn new() -> Self {
-        Self {
-            data: HashMap::new(),
-        }
-    }
-
     /// Add a metric to the list, aggregating if the metric already exists
     ///
     /// Returns the value if a previous value existed
@@ -70,24 +58,17 @@ impl ScopedMetrics {
 }
 
 /// A set of metrics captured by the execution of the tracer on a circuit
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MetricsCapture {
     /// A mapping from scope to the metrics captured at that scope
     pub(crate) metrics: HashMap<Scope, ScopedMetrics>,
 }
 
 impl MetricsCapture {
-    /// Create a new MetricsCapture instance
-    pub fn new() -> Self {
-        Self {
-            metrics: HashMap::new(),
-        }
-    }
-
     /// Record a scoped metric, if the metric already exists for the scope, aggregate it
     pub fn record_metric(&mut self, scope: Scope, metric_name: String, value: u64) {
         if let Entry::Vacant(e) = self.metrics.entry(scope.clone()) {
-            e.insert(ScopedMetrics::new());
+            e.insert(ScopedMetrics::default());
         }
 
         self.metrics
@@ -103,8 +84,8 @@ impl MetricsCapture {
 }
 
 lazy_static! {
-    static ref SCOPED_METRICS: Mutex<MetricsCapture> = Mutex::new(MetricsCapture::new());
-    static ref CURR_SCOPE: Mutex<Scope> = Mutex::new(Scope::new());
+    static ref SCOPED_METRICS: Mutex<MetricsCapture> = Mutex::new(MetricsCapture::default());
+    static ref CURR_SCOPE: Mutex<Scope> = Mutex::new(Scope::default());
     /// Used to synchronize the tests in this module in specific, because the tracer does not
     /// allow concurrent access to these global state elements
     static ref TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -114,10 +95,6 @@ lazy_static! {
 /// test the trace macro on an associated function
 pub struct Gadget {}
 impl Gadget {
-    pub fn new() -> Self {
-        Self {}
-    }
-
     #[circuit_trace(n_constraints, n_multipliers, latency)]
     pub fn apply_constraints(cs: &mut Prover) {
         // Apply dummy constraints

--- a/circuits/src/zk_gadgets/edwards.rs
+++ b/circuits/src/zk_gadgets/edwards.rs
@@ -363,7 +363,7 @@ pub(crate) mod edwards_tests {
         let mut rng = OsRng {};
 
         // Create a constraint system to allocate the points within
-        let mut prover_transcript = Transcript::new(&TRANSCRIPT_SEED.as_bytes());
+        let mut prover_transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
         let pc_gens = PedersenGens::default();
         let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
@@ -392,13 +392,13 @@ pub(crate) mod edwards_tests {
         let mut rng = OsRng {};
 
         // Create a constraint system to allocate the points within
-        let mut prover_transcript = Transcript::new(&TRANSCRIPT_SEED.as_bytes());
+        let mut prover_transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
         let pc_gens = PedersenGens::default();
         let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
         // Construct the curve
         let curve = create_ed25519_repr();
-        let field_mod = FieldMod::new(BigUint::from(1u8) << 255 - 19u8, true /* is_prime */);
+        let field_mod = FieldMod::new((BigUint::from(1u8) << 255) - 19u8, true /* is_prime */);
 
         // Generate a random point and a random scalar
         let random_point = ed25519_random_point(&mut rng);
@@ -411,11 +411,10 @@ pub(crate) mod edwards_tests {
 
         // Perform the multiplication in the constraint system
         let basepoint = ed25519_to_nonnative_edwards(random_point, &mut prover);
-        let alloc_scalar =
-            NonNativeElementVar::from_bigint(random_bigint, field_mod.clone(), &mut prover);
+        let alloc_scalar = NonNativeElementVar::from_bigint(random_bigint, field_mod, &mut prover);
 
         let res =
             curve.scalar_mul::<32 /* SCALAR_BITS */, _>(&alloc_scalar, &basepoint, &mut prover);
-        assert_points_equal(expected, res, &mut prover);
+        assert_points_equal(expected, res, &prover);
     }
 }

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -1310,7 +1310,7 @@ mod nonnative_tests {
         let n_bits = 256;
         let mut rng = thread_rng();
 
-        let mut prover_transcript = Transcript::new(&TRANSCRIPT_SEED.as_bytes());
+        let mut prover_transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
         let pc_gens = PedersenGens::default();
         let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
@@ -1376,7 +1376,7 @@ mod nonnative_tests {
 
             let res =
                 NonNativeElementVar::cond_select(selector, &nonnative1, &nonnative2, &mut prover);
-            assert_eq!(expected, res.as_bigint(&mut prover));
+            assert_eq!(expected, res.as_bigint(&prover));
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR adds the two final checks necessary to complete the initial write of `VALID WALLET UPDATE`. These are:
1. That for an external withdraw, or an internal transfer, the now-nullified wallet has a balance covering this transfer. This is implicitly done by first checking that all existing balances were updated correctly, and then checking that a balance previously existed for the transferred mint.
2. After the balances are updated; they should be non-negative. This is done efficiently by bounding the balances by a power of 2 (in our case $2^{64}$), taking the bit decomposition of only the first $n = 64$ bits, and then reconstructing the value from the balance `Scalar` from these bits. If the value is non-negative, it can be reconstructed from 64 bits; if it is negative it cannot be reconstructed without its highest bit.

### Testing
- All unit tests pass
- Added tests for invalid withdraws with no matching mint, and for over-drafting a balance.