### PR TITLE
circuits: zk-circuits: `VALID COMMITMENTS`: Add initial implementation

### DIFF
--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -55,7 +55,7 @@ impl From<&Balance> for Vec<u64> {
 
 /// Represents the constraint system allocated type of a balance in tuple holding a
 /// reference to the ERC-20 token and its amount
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct BalanceVar {
     /// the mint (erc-20 token address) of the token in the balance
     pub mint: Variable,

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -67,7 +67,7 @@ impl From<&Fee> for Vec<u64> {
 }
 
 /// A fee with values allocated in a single-prover constraint system
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct FeeVar {
     /// The public settle key of the cluster collecting fees
     pub settle_key: Variable,

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -112,7 +112,7 @@ impl From<OrderSide> for u64 {
 }
 
 /// An order with values allocated in a single-prover constraint system
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct OrderVar {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: Variable,

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -4,3 +4,194 @@ pub mod valid_commitments;
 pub mod valid_match_mpc;
 pub mod valid_wallet_create;
 pub mod valid_wallet_update;
+
+#[cfg(test)]
+mod test_helpers {
+    use ark_sponge::{poseidon::PoseidonSponge, CryptographicSponge};
+    use crypto::{
+        fields::{
+            biguint_to_prime_field, prime_field_to_scalar, scalar_to_prime_field,
+            DalekRistrettoField,
+        },
+        hash::default_poseidon_params,
+    };
+    use curve25519_dalek::scalar::Scalar;
+    use itertools::Itertools;
+    use lazy_static::lazy_static;
+    use num_bigint::BigUint;
+    use rand_core::{CryptoRng, RngCore};
+
+    use crate::{
+        types::{
+            balance::Balance,
+            fee::Fee,
+            order::{Order, OrderSide},
+            wallet::{Wallet, NUM_KEYS},
+        },
+        zk_gadgets::merkle::merkle_test::get_opening_indices,
+    };
+
+    // --------------
+    // | Dummy Data |
+    // --------------
+
+    lazy_static! {
+        pub(crate) static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
+            Balance { mint: 1, amount: 5 },
+            Balance {
+                mint: 2,
+                amount: 10
+            }
+        ];
+        pub(crate) static ref INITIAL_ORDERS: [Order; MAX_ORDERS] = [
+            Order {
+                quote_mint: 1,
+                base_mint: 2,
+                side: OrderSide::Buy,
+                price: 5,
+                amount: 1,
+                timestamp: TIMESTAMP,
+            },
+            Order {
+                quote_mint: 1,
+                base_mint: 3,
+                side: OrderSide::Sell,
+                price: 2,
+                amount: 10,
+                timestamp: TIMESTAMP,
+            }
+        ];
+        pub(crate) static ref INITIAL_FEES: [Fee; MAX_FEES] = [Fee {
+            settle_key: BigUint::from(11u8),
+            gas_addr: BigUint::from(1u8),
+            percentage_fee: 1,
+            gas_token_amount: 3,
+        }];
+        pub(crate) static ref INITIAL_WALLET: SizedWallet = Wallet {
+            balances: INITIAL_BALANCES.clone(),
+            orders: INITIAL_ORDERS.clone(),
+            fees: INITIAL_FEES.clone(),
+            keys: vec![Scalar::from(1u64); NUM_KEYS].try_into().unwrap(),
+            randomness: Scalar::from(42u64)
+        };
+    }
+
+    // -------------
+    // | Constants |
+    // -------------
+
+    /// The maximum number of balances allowed in a wallet for tests
+    pub(crate) const MAX_BALANCES: usize = 2;
+    /// The maximum number of orders allowed in a wallet for tests
+    pub(crate) const MAX_ORDERS: usize = 2;
+    /// The maximum number of fees allowed in a wallet for tests
+    pub(crate) const MAX_FEES: usize = 1;
+    /// The initial timestamp used in testing
+    pub(crate) const TIMESTAMP: u64 = 3; // dummy value
+
+    pub type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+    // -----------
+    // | Helpers |
+    // -----------
+    /// Compute the commitment to a wallet
+    pub(crate) fn compute_wallet_commitment(wallet: &SizedWallet) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+
+        // Hash the balances into the state
+        for balance in wallet.balances.iter() {
+            hasher.absorb(&vec![balance.mint, balance.amount]);
+        }
+
+        // Hash the orders into the state
+        for order in wallet.orders.iter() {
+            hasher.absorb(&vec![
+                order.quote_mint,
+                order.base_mint,
+                order.side as u64,
+                order.price,
+                order.amount,
+            ]);
+        }
+
+        // Hash the fees into the state
+        for fee in wallet.fees.iter() {
+            hasher.absorb(&vec![
+                biguint_to_prime_field(&fee.settle_key),
+                biguint_to_prime_field(&fee.gas_addr),
+            ]);
+
+            hasher.absorb(&vec![fee.gas_token_amount, fee.percentage_fee]);
+        }
+
+        // Hash the keys into the state
+        hasher.absorb(&wallet.keys.iter().map(scalar_to_prime_field).collect_vec());
+
+        // Hash the randomness into the state
+        hasher.absorb(&scalar_to_prime_field(&wallet.randomness));
+
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+
+    /// Given a wallet, create a dummy opening to a dummy root
+    ///
+    /// Returns a scalar and two vectors representing:
+    ///     - The root of the Merkle tree
+    ///     - The opening values (sister nodes)
+    ///     - The opening indices (left or right)
+    pub(crate) fn create_wallet_opening<R: RngCore + CryptoRng>(
+        wallet: &SizedWallet,
+        height: usize,
+        index: usize,
+        rng: &mut R,
+    ) -> (Scalar, Vec<Scalar>, Vec<Scalar>) {
+        // Create random sister nodes for the opening
+        let random_opening = (0..height - 1).map(|_| Scalar::random(rng)).collect_vec();
+        let opening_indices = get_opening_indices(index, height);
+
+        // Compute the root of the mock Merkle tree
+        let mut curr_root = compute_wallet_commitment(wallet);
+        for (path_index, sister_node) in opening_indices.iter().zip(random_opening.iter()) {
+            let mut sponge = PoseidonSponge::new(&default_poseidon_params());
+
+            // Left hand child
+            let left_right = if path_index.eq(&Scalar::zero()) {
+                vec![curr_root, scalar_to_prime_field(sister_node)]
+            } else {
+                vec![scalar_to_prime_field(sister_node), curr_root]
+            };
+
+            sponge.absorb(&left_right);
+            curr_root = sponge.squeeze_field_elements(1 /* num_elements */)[0];
+        }
+
+        (
+            prime_field_to_scalar(&curr_root),
+            random_opening,
+            opening_indices,
+        )
+    }
+
+    /// Given a wallet and its commitment, compute the wallet spend nullifier
+    pub(crate) fn compute_wallet_spend_nullifier(
+        wallet: &SizedWallet,
+        commitment: DalekRistrettoField,
+    ) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+        hasher.absorb(&vec![commitment, scalar_to_prime_field(&wallet.randomness)]);
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+
+    /// Given a wallet and its commitment, compute the wallet match nullifier
+    pub(crate) fn compute_wallet_match_nullifier(
+        wallet: &SizedWallet,
+        commitment: DalekRistrettoField,
+    ) -> DalekRistrettoField {
+        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
+        hasher.absorb(&vec![
+            commitment,
+            scalar_to_prime_field(&(wallet.randomness + Scalar::one())),
+        ]);
+        hasher.squeeze_field_elements(1 /* num_elements */)[0]
+    }
+}

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -1,5 +1,6 @@
 //! Groups circuitry for full zero knowledge circuits that we are interested
 //! in proving knowledge of witness for throughout the network
+pub mod valid_commitments;
 pub mod valid_match_mpc;
 pub mod valid_wallet_create;
 pub mod valid_wallet_update;

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -1,0 +1,277 @@
+//! Defines the VALID COMMITMENTS circuit which proves knowledge of a balance
+//! order and fee inside of a wallet that can be matched against
+//!
+//! A node in the relayer network will prove this statement for each order and
+//! use it as part of the handshake process
+//!
+//! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.3
+//! for a formal specification
+
+use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use itertools::Itertools;
+use mpc_bulletproof::{
+    r1cs::{ConstraintSystem, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
+    r1cs_mpc::R1CSError,
+    BulletproofGens,
+};
+use rand_core::OsRng;
+
+use crate::{
+    errors::{ProverError, VerifierError},
+    types::{
+        balance::{Balance, BalanceVar, CommittedBalance},
+        fee::{CommittedFee, Fee, FeeVar},
+        order::{CommittedOrder, Order, OrderVar},
+        wallet::{CommittedWallet, Wallet, WalletVar},
+    },
+    CommitProver, CommitVerifier, SingleProverCircuit,
+};
+
+/// The circuitry for the VALID COMMITMENTS statement
+#[derive(Clone, Debug)]
+pub struct ValidCommitments<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// Apply the constraints for the VALID COMMITMENTS circuitry
+    pub fn circuit<CS: RandomizableConstraintSystem>(
+        witness: ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        merkle_root: Variable,
+        match_nullifier: Variable,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        Ok(())
+    }
+}
+
+/// The witness type for VALID COMMITMENTS
+#[derive(Clone, Debug)]
+pub struct ValidCommitmentsWitness<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The wallet that the committed values come from
+    pub wallet: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The selected order to commit to
+    pub order: Order,
+    /// The selected balance to commit to
+    pub balance: Balance,
+    /// The selected fee to commit to
+    pub fee: Fee,
+    /// The merkle proof that the wallet is valid within the state tree
+    pub wallet_opening: Vec<Scalar>,
+    /// The indices of the merkle proof that the wallet is valid
+    pub wallet_opening_indices: Vec<Scalar>,
+}
+
+/// The witness type for VALID COMMITMENTS, allocated in a constraint system
+#[derive(Clone, Debug)]
+pub struct ValidCommitmentsWitnessVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The wallet that the committed values come from
+    pub wallet: WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The selected order to commit to
+    pub order: OrderVar,
+    /// The selected balance to commit to
+    pub balance: BalanceVar,
+    /// The selected fee to commit to
+    pub fee: FeeVar,
+    /// The merkle proof that the wallet is valid within the state tree
+    pub wallet_opening: Vec<Variable>,
+    /// The indices of the merkle proof that the wallet is valid
+    pub wallet_opening_indices: Vec<Variable>,
+}
+
+/// The witness type for VALID COMMITMENTS, committed to by a prover
+#[derive(Clone, Debug)]
+pub struct ValidCommitmentsWitnessCommitment<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// The wallet that the committed values come from
+    pub wallet: CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The selected order to commit to
+    pub order: CommittedOrder,
+    /// The selected balance to commit to
+    pub balance: CommittedBalance,
+    /// The selected fee to commit to
+    pub fee: CommittedFee,
+    /// The merkle proof that the wallet is valid within the state tree
+    pub wallet_opening: Vec<CompressedRistretto>,
+    /// The indices of the merkle proof that the wallet is valid
+    pub wallet_opening_indices: Vec<CompressedRistretto>,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitProver
+    for ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type VarType = ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type CommitType = ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_prover<R: rand_core::RngCore + rand_core::CryptoRng>(
+        &self,
+        rng: &mut R,
+        prover: &mut Prover,
+    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
+        // Commit to the variables individually
+        let (wallet_var, wallet_commit) = self.wallet.commit_prover(rng, prover).unwrap();
+        let (order_var, order_commit) = self.order.commit_prover(rng, prover).unwrap();
+        let (balance_var, balance_commit) = self.balance.commit_prover(rng, prover).unwrap();
+        let (fee_var, fee_commit) = self.fee.commit_prover(rng, prover).unwrap();
+
+        // Commit to the Merkle proof
+        let (merkle_opening_comms, merkle_opening_vars): (Vec<CompressedRistretto>, Vec<Variable>) =
+            self.wallet_opening
+                .iter()
+                .map(|opening_elem| prover.commit(*opening_elem, Scalar::random(rng)))
+                .unzip();
+        let (merkle_index_comms, merkle_index_vars): (Vec<CompressedRistretto>, Vec<Variable>) =
+            self.wallet_opening_indices
+                .iter()
+                .map(|opening_index| prover.commit(*opening_index, Scalar::random(rng)))
+                .unzip();
+
+        Ok((
+            ValidCommitmentsWitnessVar {
+                wallet: wallet_var,
+                order: order_var,
+                balance: balance_var,
+                fee: fee_var,
+                wallet_opening: merkle_opening_vars,
+                wallet_opening_indices: merkle_index_vars,
+            },
+            ValidCommitmentsWitnessCommitment {
+                wallet: wallet_commit,
+                order: order_commit,
+                balance: balance_commit,
+                fee: fee_commit,
+                wallet_opening: merkle_opening_comms,
+                wallet_opening_indices: merkle_index_comms,
+            },
+        ))
+    }
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
+    for ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type VarType = ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = ();
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        let wallet_var = self.wallet.commit_verifier(verifier).unwrap();
+        let order_var = self.order.commit_verifier(verifier).unwrap();
+        let balance_var = self.balance.commit_verifier(verifier).unwrap();
+        let fee_var = self.fee.commit_verifier(verifier).unwrap();
+
+        let merkle_opening_vars = self
+            .wallet_opening
+            .iter()
+            .map(|opening_val| verifier.commit(*opening_val))
+            .collect_vec();
+        let merkle_index_vars = self
+            .wallet_opening_indices
+            .iter()
+            .map(|opening_indices| verifier.commit(*opening_indices))
+            .collect_vec();
+
+        Ok(ValidCommitmentsWitnessVar {
+            wallet: wallet_var,
+            order: order_var,
+            balance: balance_var,
+            fee: fee_var,
+            wallet_opening: merkle_opening_vars,
+            wallet_opening_indices: merkle_index_vars,
+        })
+    }
+}
+
+/// The statement type for VALID COMMITMENTS
+#[derive(Clone, Debug)]
+pub struct ValidCommitmentsStatement {
+    /// The wallet match nullifier of the wallet committed to
+    pub nullifier: Scalar,
+    /// The global merkle root being proved against
+    pub merkle_root: Scalar,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> SingleProverCircuit
+    for ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    type Witness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type WitnessCommitment = ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type Statement = ValidCommitmentsStatement;
+
+    const BP_GENS_CAPACITY: usize = 32768;
+
+    fn prove(
+        witness: Self::Witness,
+        statement: Self::Statement,
+        mut prover: Prover,
+    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
+        // Commit to the witness
+        let mut rng = OsRng {};
+        let (witness_var, witness_commit) = witness.commit_prover(&mut rng, &mut prover).unwrap();
+
+        let nullifier_var = prover.commit_public(statement.nullifier);
+        let merkle_root_var = prover.commit_public(statement.merkle_root);
+
+        // Apply the constraints
+        ValidCommitments::circuit(witness_var, merkle_root_var, nullifier_var, &mut prover)
+            .map_err(ProverError::R1CS)?;
+
+        // Prove the statement
+        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
+        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
+
+        Ok((witness_commit, proof))
+    }
+
+    fn verify(
+        witness_commitment: Self::WitnessCommitment,
+        statement: Self::Statement,
+        proof: R1CSProof,
+        mut verifier: Verifier,
+    ) -> Result<(), VerifierError> {
+        // Commit to the witness
+        let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
+
+        let nullifier_var = verifier.commit_public(statement.nullifier);
+        let merkle_root_var = verifier.commit_public(statement.merkle_root);
+
+        // Apply the constraints
+        ValidCommitments::circuit(witness_var, merkle_root_var, nullifier_var, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
+
+        // Verify the proof
+        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
+        verifier
+            .verify(&proof, &bp_gens)
+            .map_err(VerifierError::R1CS)
+    }
+}

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -773,13 +773,13 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
         // Apply constraints to the verifier
         Self::input_consistency_single_prover(
             &mut verifier,
-            &Into::<Vec<Variable>>::into(party0_order.clone()),
+            &Into::<Vec<Variable>>::into(party0_order),
             &hash_o1_var,
         )
         .map_err(VerifierError::R1CS)?;
         Self::input_consistency_single_prover(
             &mut verifier,
-            &Into::<Vec<Variable>>::into(party0_balance.clone()),
+            &Into::<Vec<Variable>>::into(party0_balance),
             &hash_b1_var,
         )
         .map_err(VerifierError::R1CS)?;
@@ -791,13 +791,13 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
         .map_err(VerifierError::R1CS)?;
         Self::input_consistency_single_prover(
             &mut verifier,
-            &Into::<Vec<Variable>>::into(party1_order.clone()),
+            &Into::<Vec<Variable>>::into(party1_order),
             &hash_o2_var,
         )
         .map_err(VerifierError::R1CS)?;
         Self::input_consistency_single_prover(
             &mut verifier,
-            &Into::<Vec<Variable>>::into(party1_balance.clone()),
+            &Into::<Vec<Variable>>::into(party1_balance),
             &hash_b2_var,
         )
         .map_err(VerifierError::R1CS)?;

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -676,34 +676,22 @@ where
 mod valid_wallet_update_tests {
     use std::ops::Neg;
 
-    use ark_sponge::{poseidon::PoseidonSponge, CryptographicSponge};
-    use crypto::{
-        fields::{
-            biguint_to_prime_field, prime_field_to_scalar, scalar_to_prime_field,
-            DalekRistrettoField,
-        },
-        hash::default_poseidon_params,
-    };
+    use crypto::fields::prime_field_to_scalar;
     use curve25519_dalek::scalar::Scalar;
-    use itertools::Itertools;
-    use lazy_static::lazy_static;
     use merlin::Transcript;
     use mpc_bulletproof::{
         r1cs::{ConstraintSystem, Prover, Variable},
         PedersenGens,
     };
-    use num_bigint::BigUint;
-    use rand_core::{CryptoRng, OsRng, RngCore};
+    use rand_core::{OsRng, RngCore};
 
     use crate::{
         test_helpers::bulletproof_prove_and_verify,
-        types::{
-            balance::Balance,
-            fee::Fee,
-            order::{Order, OrderSide},
-            wallet::{Wallet, NUM_KEYS},
+        types::order::Order,
+        zk_circuits::test_helpers::{
+            compute_wallet_commitment, compute_wallet_match_nullifier,
+            compute_wallet_spend_nullifier, create_wallet_opening, INITIAL_WALLET,
         },
-        zk_gadgets::merkle::merkle_test::get_opening_indices,
         CommitProver,
     };
 
@@ -726,158 +714,6 @@ mod valid_wallet_update_tests {
     const TIMESTAMP: u64 = 3; // dummy value
     /// The height of the Merkle state tree
     const MERKLE_HEIGHT: usize = 3;
-
-    type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-
-    // --------------
-    // | Dummy Data |
-    // --------------
-
-    lazy_static! {
-        static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
-            Balance { mint: 1, amount: 5 },
-            Balance {
-                mint: 2,
-                amount: 10
-            }
-        ];
-        static ref INITIAL_ORDERS: [Order; MAX_ORDERS] = [
-            Order {
-                quote_mint: 1,
-                base_mint: 2,
-                side: OrderSide::Buy,
-                price: 5,
-                amount: 1,
-                timestamp: TIMESTAMP,
-            },
-            Order {
-                quote_mint: 1,
-                base_mint: 3,
-                side: OrderSide::Sell,
-                price: 2,
-                amount: 10,
-                timestamp: TIMESTAMP,
-            }
-        ];
-        static ref INITIAL_FEES: [Fee; MAX_FEES] = [Fee {
-            settle_key: BigUint::from(11u8),
-            gas_addr: BigUint::from(13u8),
-            percentage_fee: 1,
-            gas_token_amount: 5,
-        }];
-        static ref INITIAL_WALLET: SizedWallet = Wallet {
-            balances: INITIAL_BALANCES.clone(),
-            orders: INITIAL_ORDERS.clone(),
-            fees: INITIAL_FEES.clone(),
-            keys: vec![Scalar::from(1u64); NUM_KEYS].try_into().unwrap(),
-            randomness: Scalar::from(42u64)
-        };
-    }
-
-    // -----------
-    // | Helpers |
-    // -----------
-
-    /// Compute the commitment to a wallet
-    pub(crate) fn compute_wallet_commitment(wallet: &SizedWallet) -> DalekRistrettoField {
-        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
-
-        // Hash the balances into the state
-        for balance in wallet.balances.iter() {
-            hasher.absorb(&vec![balance.mint, balance.amount]);
-        }
-
-        // Hash the orders into the state
-        for order in wallet.orders.iter() {
-            hasher.absorb(&vec![
-                order.quote_mint,
-                order.base_mint,
-                order.side as u64,
-                order.price,
-                order.amount,
-            ]);
-        }
-
-        // Hash the fees into the state
-        for fee in wallet.fees.iter() {
-            hasher.absorb(&vec![
-                biguint_to_prime_field(&fee.settle_key),
-                biguint_to_prime_field(&fee.gas_addr),
-            ]);
-
-            hasher.absorb(&vec![fee.gas_token_amount, fee.percentage_fee]);
-        }
-
-        // Hash the keys into the state
-        hasher.absorb(&wallet.keys.iter().map(scalar_to_prime_field).collect_vec());
-
-        // Hash the randomness into the state
-        hasher.absorb(&scalar_to_prime_field(&wallet.randomness));
-
-        hasher.squeeze_field_elements(1 /* num_elements */)[0]
-    }
-
-    /// Given a wallet, create a dummy opening to a dummy root
-    ///
-    /// Returns a scalar and two vectors representing:
-    ///     - The root of the Merkle tree
-    ///     - The opening values (sister nodes)
-    ///     - The opening indices (left or right)
-    fn create_wallet_opening<R: RngCore + CryptoRng>(
-        wallet: &SizedWallet,
-        height: usize,
-        index: usize,
-        rng: &mut R,
-    ) -> (Scalar, Vec<Scalar>, Vec<Scalar>) {
-        // Create random sister nodes for the opening
-        let random_opening = (0..height - 1).map(|_| Scalar::random(rng)).collect_vec();
-        let opening_indices = get_opening_indices(index, height);
-
-        // Compute the root of the mock Merkle tree
-        let mut curr_root = compute_wallet_commitment(wallet);
-        for (path_index, sister_node) in opening_indices.iter().zip(random_opening.iter()) {
-            let mut sponge = PoseidonSponge::new(&default_poseidon_params());
-
-            // Left hand child
-            let left_right = if path_index.eq(&Scalar::zero()) {
-                vec![curr_root, scalar_to_prime_field(sister_node)]
-            } else {
-                vec![scalar_to_prime_field(sister_node), curr_root]
-            };
-
-            sponge.absorb(&left_right);
-            curr_root = sponge.squeeze_field_elements(1 /* num_elements */)[0];
-        }
-
-        (
-            prime_field_to_scalar(&curr_root),
-            random_opening,
-            opening_indices,
-        )
-    }
-
-    /// Given a wallet and its commitment, compute the wallet spend nullifier
-    fn compute_wallet_spend_nullifier(
-        wallet: &SizedWallet,
-        commitment: DalekRistrettoField,
-    ) -> DalekRistrettoField {
-        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
-        hasher.absorb(&vec![commitment, scalar_to_prime_field(&wallet.randomness)]);
-        hasher.squeeze_field_elements(1 /* num_elements */)[0]
-    }
-
-    /// Given a wallet and its commitment, compute the wallet match nullifier
-    fn compute_wallet_match_nullifier(
-        wallet: &SizedWallet,
-        commitment: DalekRistrettoField,
-    ) -> DalekRistrettoField {
-        let mut hasher = PoseidonSponge::new(&default_poseidon_params());
-        hasher.absorb(&vec![
-            commitment,
-            scalar_to_prime_field(&(wallet.randomness + Scalar::one())),
-        ]);
-        hasher.squeeze_field_elements(1 /* num_elements */)[0]
-    }
 
     /// Applies the constraints to a constraint system and verifies that they are
     /// all satisfied

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -1,0 +1,106 @@
+//! Groups logic for computing wallet commitments and nullifiers inside of a circuit
+
+use curve25519_dalek::scalar::Scalar;
+use mpc_bulletproof::{
+    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
+    r1cs_mpc::R1CSError,
+};
+
+use crate::{mpc_gadgets::poseidon::PoseidonSpongeParameters, types::wallet::WalletVar};
+
+use super::poseidon::PoseidonHashGadget;
+
+/// A gadget for computing wallet commitments
+#[derive(Clone, Debug)]
+pub struct WalletCommitGadget<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {}
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    WalletCommitGadget<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    /// Compute the commitment to a wallet
+    pub fn wallet_commit<CS: RandomizableConstraintSystem>(
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        // Create a new hash gadget
+        let hash_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hash_params);
+
+        // Hash the balances into the state
+        for balance in wallet.balances.iter() {
+            hasher.batch_absorb(&[balance.mint, balance.amount], cs)?;
+        }
+
+        // Hash the orders into the state
+        for order in wallet.orders.iter() {
+            hasher.batch_absorb(
+                &[
+                    order.quote_mint,
+                    order.base_mint,
+                    order.side,
+                    order.price,
+                    order.amount,
+                ],
+                cs,
+            )?;
+        }
+
+        // Hash the fees into the state
+        for fee in wallet.fees.iter() {
+            hasher.batch_absorb(
+                &[
+                    fee.settle_key,
+                    fee.gas_addr,
+                    fee.gas_token_amount,
+                    fee.percentage_fee,
+                ],
+                cs,
+            )?;
+        }
+
+        // Hash the keys into the state
+        hasher.batch_absorb(&wallet.keys, cs)?;
+
+        // Hash the randomness into the state
+        hasher.absorb(wallet.randomness, cs)?;
+
+        // Squeeze an element out of the state
+        hasher.squeeze(cs)
+    }
+}
+
+/// A gadget for computing the nullifier of a wallet
+#[derive(Clone, Debug)]
+pub struct NullifierGadget {}
+impl NullifierGadget {
+    /// Compute the spend nullifier of a wallet from a commitment to the wallet
+    pub fn spend_nullifier<CS: RandomizableConstraintSystem>(
+        wallet_randomness: Variable,
+        wallet_commit: LinearCombination,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        let hasher_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hasher_params);
+
+        hasher.batch_absorb(&[wallet_commit, wallet_randomness.into()], cs)?;
+        hasher.squeeze(cs)
+    }
+
+    /// Compute the match nullifier of a wallet from a commitment to the wallet
+    pub fn match_nullifier<CS: RandomizableConstraintSystem>(
+        wallet_randomness: Variable,
+        wallet_commit: LinearCombination,
+        cs: &mut CS,
+    ) -> Result<LinearCombination, R1CSError> {
+        let hasher_params = PoseidonSpongeParameters::default();
+        let mut hasher = PoseidonHashGadget::new(hasher_params);
+
+        hasher.batch_absorb(&[wallet_commit, wallet_randomness + Scalar::one()], cs)?;
+        hasher.squeeze(cs)
+    }
+}

--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! Groups gadgets used in zero knowledge circuits
 pub mod arithmetic;
 pub mod bits;
+pub mod commitments;
 pub mod comparators;
 pub mod edwards;
 pub mod elgamal;


### PR DESCRIPTION
### Purpose
This PR adds the initial implementation of the `VALID COMMITMENTS` circuit from the [whitepaper](https://whitepaper.renegade.fi) section A.3.

This proof is used to being the match process. Both parties commit to their inputs to the match and prove that these commitments are valid elements of the state tree.

Left to do:
- More tests around edge cases of fee balances

### Testing
- All unit tests pass
- Tested various circuit constraints and edge cases from an adversarial prover.