### PR TITLE
circuits: mpc-circuits, zk-circuits: match: Use `FixedPoint` type in match process

### DIFF
--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -3,8 +3,10 @@
 use circuits::{
     mpc_circuits::r#match::compute_match,
     types::{order::Order, r#match::MatchResult},
+    zk_gadgets::fixed_point::FixedPoint,
     Allocate, Open,
 };
+use curve25519_dalek::scalar::Scalar;
 use integration_helpers::types::IntegrationTest;
 use num_bigint::BigInt;
 
@@ -25,7 +27,7 @@ fn check_no_match(res: &MatchResult) -> Result<(), String> {
             quote_amount: 0,
             base_amount: 0,
             direction: 0,
-            execution_price: 0,
+            execution_price: FixedPoint::from(0.),
             max_minus_min_amount: 0,
             min_amount_order_index: 0,
         },
@@ -48,7 +50,7 @@ fn check_match_expected_result(res: &MatchResult, expected: &[u64]) -> Result<()
             quote_amount: expected[2],
             base_amount: expected[3],
             direction: expected[4],
-            execution_price: expected[5],
+            execution_price: FixedPoint::from(Scalar::from(expected[5])),
             max_minus_min_amount: expected[6] as u32,
             min_amount_order_index: expected[7] as u8,
         },

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -57,7 +57,11 @@ fn match_orders<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     my_order: &Order,
     fabric: SharedFabric<N, S>,
 ) -> Result<AuthenticatedMatchResult<N, S>, String> {
-    let my_values = [my_order.side as u64, my_order.price, my_order.amount];
+    let my_values = [
+        my_order.side as u64,
+        my_order.price.clone().into(),
+        my_order.amount,
+    ];
     let party0_values =
         batch_share_plaintext_u64(&my_values, 0 /* owning_party */, fabric.0.clone());
     let party1_values =
@@ -91,7 +95,7 @@ fn match_orders<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
         quote_amount: shared_values[2].to_owned(),
         base_amount: shared_values[3].to_owned(),
         direction: shared_values[4].to_owned(),
-        execution_price: shared_values[5].to_owned(),
+        execution_price: shared_values[5].to_owned().into(),
         max_minus_min_amount: shared_values[6].to_owned(),
         min_amount_order_index: shared_values[7].to_owned(),
     })
@@ -114,7 +118,7 @@ fn setup_witness_and_statement<N: MpcNetwork + Send, S: SharedValueSource<Scalar
         order.quote_mint,
         order.base_mint,
         order.side as u64,
-        order.price,
+        order.price.clone().into(),
         order.amount,
     ]);
     let my_balance_hash = hash_values_arkworks(&[balance.mint, balance.amount]);
@@ -217,7 +221,7 @@ fn test_valid_match_mpc_valid(test_args: &IntegrationTestArgs) -> Result<(), Str
             } else {
                 OrderSide::Sell
             },
-            price: my_order[3],
+            price: FixedPoint::from(Scalar::from(my_order[3])),
             amount: my_order[4],
             timestamp,
         },

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -47,17 +47,42 @@ pub(crate) const TRANSCRIPT_SEED: &str = "merlin seed";
  * Helpers
  */
 
-/// A debug macro used to print the value of a constraint system variable;
-/// used for debugging
+/// A debug macro used for printing wires in a single-prover circuit during execution
 #[allow(unused)]
-macro_rules! print_debug {
-    ($x:expr, $cs:ident) => {
+macro_rules! print_wire {
+    ($x:expr, $cs:ident) => {{
+        use crypto::fields::scalar_to_biguint;
         let x_eval = $cs.eval(&$x.into());
-        println!("{}_eval: {:?}", stringify!($x), scalar_to_biguint(&x_eval));
-    };
+        println!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+    }};
 }
+
+/// A debug macro used for printing wires in a raw MPC circuit during execution
 #[allow(unused)]
-pub(crate) use print_debug;
+macro_rules! print_mpc_wire {
+    ($x:expr) => {{
+        use crypto::fields::scalar_to_biguint;
+        let x_eval = $x.open().unwrap().to_scalar();
+        println!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+    }};
+}
+
+/// A debug macro used for printing wires in an MPC-ZK circuit during execution
+#[allow(unused)]
+macro_rules! print_multiprover_wire {
+    ($x:expr, $cs:ident) => {{
+        use crypto::fields::scalar_to_biguint;
+        let x_eval = $cs.eval(&$x.into()).unwrap().open().unwrap().to_scalar();
+        println!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+    }};
+}
+
+#[allow(unused)]
+pub(crate) use print_mpc_wire;
+#[allow(unused)]
+pub(crate) use print_multiprover_wire;
+#[allow(unused)]
+pub(crate) use print_wire;
 
 /// Represents 2^m as a scalar
 pub fn scalar_2_to_m(m: usize) -> Scalar {

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -13,7 +13,7 @@ use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{LinearCombination, Prover, Variable, Verifier},
-    r1cs_mpc::{MpcProver, MpcVariable},
+    r1cs_mpc::{MpcLinearCombination, MpcProver, MpcVariable},
 };
 use mpc_ristretto::{
     authenticated_ristretto::AuthenticatedCompressedRistretto,
@@ -272,13 +272,13 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone for Authenticated
 }
 
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<AuthenticatedFeeVar<N, S>>
-    for Vec<MpcVariable<N, S>>
+    for Vec<MpcLinearCombination<N, S>>
 {
     fn from(fee: AuthenticatedFeeVar<N, S>) -> Self {
         vec![
-            fee.settle_key,
-            fee.gas_addr,
-            fee.gas_token_amount,
+            fee.settle_key.into(),
+            fee.gas_addr.into(),
+            fee.gas_token_amount.into(),
             fee.percentage_fee.repr,
         ]
     }
@@ -315,7 +315,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 gas_addr: shared_vars[1].to_owned(),
                 gas_token_amount: shared_vars[2].to_owned(),
                 percentage_fee: AuthenticatedFixedPointVar {
-                    repr: shared_vars[3].to_owned(),
+                    repr: shared_vars[3].to_owned().into(),
                 },
             },
             // TODO: implement clone for AuthenticatedCompressedRistretto

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -56,7 +56,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     Scalar::from(order.quote_mint),
                     Scalar::from(order.base_mint),
                     Scalar::from(order.side as u64),
-                    Scalar::from(order.price),
+                    Scalar::from(order.price.to_owned()),
                     Scalar::from(order.amount),
                     Scalar::from(order.timestamp),
                     Scalar::from(balance.mint),
@@ -75,7 +75,9 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 quote_mint: shared_vars[0].to_owned(),
                 base_mint: shared_vars[1].to_owned(),
                 side: shared_vars[2].to_owned(),
-                price: shared_vars[3].to_owned(),
+                price: AuthenticatedFixedPointVar {
+                    repr: shared_vars[3].to_owned().into(),
+                },
                 amount: shared_vars[4].to_owned(),
                 timestamp: shared_vars[5].to_owned(),
             },
@@ -88,7 +90,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 gas_addr: shared_vars[9].to_owned(),
                 gas_token_amount: shared_vars[10].to_owned(),
                 percentage_fee: AuthenticatedFixedPointVar {
-                    repr: shared_vars[11].to_owned(),
+                    repr: shared_vars[11].to_owned().into(),
                 },
             },
         );
@@ -98,7 +100,9 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                 quote_mint: shared_comm[0].to_owned(),
                 base_mint: shared_comm[1].to_owned(),
                 side: shared_comm[2].to_owned(),
-                price: shared_comm[3].to_owned(),
+                price: AuthenticatedCommittedFixedPoint {
+                    repr: shared_comm[3].to_owned(),
+                },
                 amount: shared_comm[4].to_owned(),
                 timestamp: shared_comm[5].to_owned(),
             },

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -49,7 +49,7 @@ mod test_helpers {
                 quote_mint: 1,
                 base_mint: 2,
                 side: OrderSide::Buy,
-                price: 5,
+                price: FixedPoint::from(5.),
                 amount: 1,
                 timestamp: TIMESTAMP,
             },
@@ -57,7 +57,7 @@ mod test_helpers {
                 quote_mint: 1,
                 base_mint: 3,
                 side: OrderSide::Sell,
-                price: 2,
+                price: FixedPoint::from(2.),
                 amount: 10,
                 timestamp: TIMESTAMP,
             }
@@ -110,7 +110,7 @@ mod test_helpers {
                 order.quote_mint,
                 order.base_mint,
                 order.side as u64,
-                order.price,
+                order.price.to_owned().into(),
                 order.amount,
             ]);
         }

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -76,7 +76,7 @@ where
         // Verify that the given balance, order, and fee are all valid members of the wallet
         Self::verify_wallet_contains_balance(witness.balance, &witness.wallet, cs);
         Self::verify_wallet_contains_balance(witness.fee_balance, &witness.wallet, cs);
-        Self::verify_wallet_contains_order(witness.order, &witness.wallet, cs);
+        Self::verify_wallet_contains_order(witness.order.clone(), &witness.wallet, cs);
         Self::verify_wallet_contains_fee(witness.fee.clone(), &witness.wallet, cs);
 
         // Verify that the balance is for the correct mint
@@ -131,8 +131,8 @@ where
         // orders in the wallet
         let mut orders_equal_sum: LinearCombination = Variable::Zero().into();
         for wallet_order in wallet.orders.iter() {
-            let o1_vars: Vec<Variable> = order.into();
-            let o2_vars: Vec<Variable> = (*wallet_order).into();
+            let o1_vars: Vec<LinearCombination> = order.to_owned().into();
+            let o2_vars: Vec<LinearCombination> = wallet_order.clone().into();
 
             orders_equal_sum += EqVecGadget::eq_vec(&o1_vars, &o2_vars, cs);
         }
@@ -423,6 +423,7 @@ mod valid_commitments_test {
             compute_wallet_commitment, compute_wallet_match_nullifier, create_wallet_opening,
             SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
         },
+        zk_gadgets::fixed_point::FixedPoint,
         CommitProver,
     };
 
@@ -619,7 +620,7 @@ mod valid_commitments_test {
             quote_mint: 1,
             base_mint: 3,
             side: OrderSide::Buy,
-            price: 10,
+            price: FixedPoint::from(10.),
             amount: 15,
             timestamp: 0,
         };

--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -859,7 +859,7 @@ mod valid_match_encryption_tests {
             quote_amount: 200,
             base_amount: 100,
             direction: 1,
-            execution_price: 2,
+            execution_price: FixedPoint::from(2.),
             max_minus_min_amount: 10,
             min_amount_order_index: 0
         };

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -228,7 +228,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
             .execution_price
             .mul_integer(&matches.base_amount, cs)
             .map_err(ProverError::Collaborative)?;
-        expected_quote_amount.constraint_equal_integer(&matches.quote_amount, cs);
+        expected_quote_amount.constrain_equal_integer(&matches.quote_amount, cs);
 
         // Ensure the balances cover the orders
         // 1. Mux between the (mint, amount) pairs that the parties are expected to cover by the

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -31,6 +31,7 @@ use crate::{
         comparators::{
             EqGadget, EqVecGadget, EqZeroGadget, GreaterThanEqZeroGadget, NotEqualGadget,
         },
+        fixed_point::FixedPointVar,
         gates::{AndGate, OrGate},
         merkle::PoseidonMerkleHashGadget,
         select::CondSelectGadget,
@@ -356,7 +357,9 @@ where
                 base_mint: Variable::Zero(),
                 side: Variable::Zero(),
                 amount: Variable::Zero(),
-                price: Variable::Zero(),
+                price: FixedPointVar {
+                    repr: Variable::Zero().into(),
+                },
                 timestamp: Variable::Zero(),
             },
             cs,
@@ -371,18 +374,18 @@ where
     ) -> Variable {
         EqVecGadget::eq_vec(
             &[
-                order1.quote_mint,
-                order1.base_mint,
-                order1.side,
-                order1.amount,
-                order1.price,
+                order1.quote_mint.into(),
+                order1.base_mint.into(),
+                order1.side.into(),
+                order1.amount.into(),
+                order1.price.repr.clone(),
             ],
             &[
-                order2.quote_mint,
-                order2.base_mint,
-                order2.side,
-                order2.amount,
-                order2.price,
+                order2.quote_mint.into(),
+                order2.base_mint.into(),
+                order2.side.into(),
+                order2.amount.into(),
+                order2.price.repr.clone(),
             ],
             cs,
         )

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -40,11 +40,11 @@ where
         for order in wallet.orders.iter() {
             hasher.batch_absorb(
                 &[
-                    order.quote_mint,
-                    order.base_mint,
-                    order.side,
-                    order.price,
-                    order.amount,
+                    order.quote_mint.into(),
+                    order.base_mint.into(),
+                    order.side.into(),
+                    order.price.repr.clone(),
+                    order.amount.into(),
                 ],
                 cs,
             )?;

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -53,15 +53,15 @@ pub(super) const HANDSHAKE_INVISIBILITY_WINDOW_MS: u64 = 120_000; // 2 minutes
 pub(super) const HANDSHAKE_CACHE_SIZE: usize = 500;
 /// How frequently a new handshake is initiated from the local peer
 pub(super) const HANDSHAKE_INTERVAL_MS: u64 = 2_000; // 2 seconds
-/// Number of nanoseconds in a millisecond, for convenienc
+/// Number of nanoseconds in a millisecond, for convenience
 const NANOS_PER_MILLI: u64 = 1_000_000;
 
 /// Manages requests to handshake from a peer and sends outbound requests to initiate
 /// a handshake
 pub struct HandshakeManager {
-    /// The hanshake timer; periodically enqueues outbound handshake requests
+    /// The handshake timer; periodically enqueues outbound handshake requests
     pub(super) timer: HandshakeTimer,
-    /// The job realay; provides a shim between the network interface and the manager
+    /// The job relay; provides a shim between the network interface and the manager
     pub(super) relay: HandshakeJobRelay,
 }
 
@@ -508,7 +508,10 @@ impl HandshakeManager {
 
         // The maximum quantity of the mint that the local party will be spending
         let order_amount = match order.side {
-            OrderSide::Buy => order.amount * order.price,
+            OrderSide::Buy => {
+                let res_amount = (order.amount as f64) * order.price.to_f64();
+                res_amount as u64
+            }
             OrderSide::Sell => order.amount,
         };
 
@@ -542,7 +545,7 @@ impl HandshakeManager {
         // Cache the order pair as completed
         handshake_cache
             .write()
-            .expect("handshake_cache lock poiseoned")
+            .expect("handshake_cache lock poisoned")
             .mark_completed(state.local_order_id, state.peer_order_id);
 
         // Write to global state for debugging


### PR DESCRIPTION
### Purpose
This PR converts much of the match process to use the fixed point variable type to represent rational quantities; with a maximum fractional precision of 32 bits. The fields represented as fixed points are essentially prices, fees, and any intra-circuit derivatives of these values.

### Testing
- All unit and integration tests pass, match process functions correctly