### PR TITLE
circuits: zk-circuits: `VALID MATCH ENCRYPTION`: Implement fixed-point arithmetic

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -18,6 +18,7 @@ miller_rabin = "1.1.1"
 mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
+num-integer = "0.1"
 rand = { version = "0.8" }
 rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -57,11 +57,7 @@ fn match_orders<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     my_order: &Order,
     fabric: SharedFabric<N, S>,
 ) -> Result<AuthenticatedMatchResult<N, S>, String> {
-    let my_values = [
-        my_order.side as u64,
-        my_order.price.clone().into(),
-        my_order.amount,
-    ];
+    let my_values = [my_order.side as u64, my_order.price.into(), my_order.amount];
     let party0_values =
         batch_share_plaintext_u64(&my_values, 0 /* owning_party */, fabric.0.clone());
     let party1_values =
@@ -122,7 +118,7 @@ fn setup_witness_and_statement<N: MpcNetwork + Send, S: SharedValueSource<Scalar
         order.quote_mint,
         order.base_mint,
         order.side as u64,
-        order.price.clone().into(),
+        order.price.into(),
         order.amount,
     ]);
     let my_balance_hash = hash_values_arkworks(&[balance.mint, balance.amount]);
@@ -130,7 +126,7 @@ fn setup_witness_and_statement<N: MpcNetwork + Send, S: SharedValueSource<Scalar
         fee.settle_key.clone().try_into().unwrap(),
         fee.gas_addr.clone().try_into().unwrap(),
         fee.gas_token_amount,
-        fee.percentage_fee.clone().into(),
+        fee.percentage_fee.into(),
     ]);
     let my_randomness_hash = hash_values_arkworks(&[wallet_randomness]);
 

--- a/circuits/src/mpc_gadgets/comparators.rs
+++ b/circuits/src/mpc_gadgets/comparators.rs
@@ -1,4 +1,4 @@
-//! Groups logic around arithemtic comparator circuits
+//! Groups logic around arithmetic comparator circuits
 
 use std::iter;
 
@@ -172,7 +172,7 @@ pub fn kary_or<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     constant_round_or_impl(&unblinded_shared_bits, fabric)
 }
 
-// TODO: Optimize this into parallel blocks for larger lenth inputs
+// TODO: Optimize this into parallel blocks for larger length inputs
 /// Computes the "OR" of all input bits using a public polynomial.
 ///
 /// Specifically, the method evaluates the polynomial:

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -228,7 +228,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Allocate<N, S> for Fee 
                     biguint_to_scalar(&self.settle_key),
                     biguint_to_scalar(&self.gas_addr),
                     Scalar::from(self.gas_token_amount),
-                    Scalar::from(self.percentage_fee.clone()),
+                    Scalar::from(self.percentage_fee),
                 ],
             )
             .map_err(|err| MpcError::SharingError(err.to_string()))?;
@@ -303,7 +303,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     biguint_to_scalar(&self.settle_key),
                     biguint_to_scalar(&self.gas_addr),
                     Scalar::from(self.gas_token_amount),
-                    Scalar::from(self.percentage_fee.clone()),
+                    Scalar::from(self.percentage_fee),
                 ],
                 &blinders,
             )

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -64,7 +64,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
                     biguint_to_scalar(&fee.settle_key),
                     biguint_to_scalar(&fee.gas_addr),
                     Scalar::from(fee.gas_token_amount),
-                    Scalar::from(fee.percentage_fee.clone()),
+                    Scalar::from(fee.percentage_fee),
                 ],
                 &blinders,
             )

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -122,10 +122,7 @@ mod test_helpers {
                 biguint_to_prime_field(&fee.gas_addr),
             ]);
 
-            hasher.absorb(&vec![
-                fee.gas_token_amount,
-                fee.percentage_fee.clone().into(),
-            ]);
+            hasher.absorb(&vec![fee.gas_token_amount, fee.percentage_fee.into()]);
         }
 
         // Hash the keys into the state

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -405,7 +405,7 @@ mod test_valid_wallet_create {
             arkworks_hasher.absorb(&scalar_to_prime_field(&biguint_to_scalar(&fee.gas_addr)));
             arkworks_hasher.absorb(&DalekRistrettoField::from(fee.gas_token_amount));
             arkworks_hasher.absorb(&DalekRistrettoField::from(Into::<u64>::into(
-                fee.percentage_fee.clone(),
+                fee.percentage_fee,
             )));
         }
 

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -57,7 +57,7 @@ lazy_static! {
 ///
 /// This is useful for centralizing conversion logic to provide an abstract to_scalar,
 /// from_scalar interface to modules that commit to this value
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FixedPoint {
     /// The underlying scalar representing the fixed point variable
     pub(crate) repr: Scalar,
@@ -106,6 +106,7 @@ impl From<f32> for FixedPoint {
         }
     }
 }
+
 impl From<Scalar> for FixedPoint {
     fn from(scalar: Scalar) -> Self {
         Self { repr: scalar }
@@ -129,6 +130,74 @@ impl From<u64> for FixedPoint {
 impl From<FixedPoint> for u64 {
     fn from(fp: FixedPoint) -> Self {
         scalar_to_u64(&fp.repr)
+    }
+}
+
+impl Add<FixedPoint> for FixedPoint {
+    type Output = FixedPoint;
+    fn add(self, rhs: FixedPoint) -> Self::Output {
+        Self {
+            repr: self.repr + rhs.repr,
+        }
+    }
+}
+
+impl Add<Scalar> for FixedPoint {
+    type Output = FixedPoint;
+    fn add(self, rhs: Scalar) -> Self::Output {
+        Self {
+            repr: self.repr + *TWO_TO_M_SCALAR * rhs,
+        }
+    }
+}
+
+impl Add<FixedPoint> for Scalar {
+    type Output = FixedPoint;
+    fn add(self, rhs: FixedPoint) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl Mul<Scalar> for FixedPoint {
+    type Output = FixedPoint;
+    fn mul(self, rhs: Scalar) -> Self::Output {
+        Self {
+            repr: self.repr * rhs,
+        }
+    }
+}
+
+impl Neg for FixedPoint {
+    type Output = FixedPoint;
+    fn neg(self) -> Self::Output {
+        Self {
+            repr: self.repr.neg(),
+        }
+    }
+}
+
+impl Sub<FixedPoint> for FixedPoint {
+    type Output = FixedPoint;
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: FixedPoint) -> Self::Output {
+        self + rhs.neg()
+    }
+}
+
+impl Sub<Scalar> for FixedPoint {
+    type Output = FixedPoint;
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: Scalar) -> Self::Output {
+        self + rhs.neg()
+    }
+}
+
+impl Sub<FixedPoint> for Scalar {
+    type Output = FixedPoint;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: FixedPoint) -> Self::Output {
+        self + rhs.neg()
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR makes updates to the existing `VALID MATCH ENCRYPTION` circuit structure after the match process was refactored to use `FixedPoint` variables instead of direct integers. As a result, much of the note validation had to change; including defining how rounding is done in the case of fixed-point imprecision.

A follow up PR will add more test cases for invalid witness types; largely around note structure. This PR already includes invalid ciphertext tests.

### Testing
- All unit tests pass
- Added invalid witness tests for all encrypted fields