### PR TITLE
circuits: zk-circuits: `VALID MATCH ENCRYPTION`: Add tests for note structure

### DIFF
--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -129,7 +129,7 @@ impl EqGadget {
     /// Computes a == b
     pub fn eq<L, CS>(a: L, b: L, cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination>,
+        L: Into<LinearCombination> + Clone,
         CS: RandomizableConstraintSystem,
     {
         EqZeroGadget::eq_zero(a.into() - b.into(), cs)


### PR DESCRIPTION
### Purpose
This PR adds additional tests for note structure validity; asserting that the notes have the proper fees applies and receive the proper amounts of each token. These tests are done with modified ciphertext to isolate the note-construction constraints.

### Testing
- Added tests for each volume computed for parties, relayers, and protocol.
- All tests pass.