### PR TITLE
core: gossip: Gossip about proofs of `VALID COMMITMENTS`

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -22,6 +22,7 @@ num-integer = "0.1"
 rand = { version = "0.8" }
 rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }
+serde_arrays = "0.1"
 
 [dev-dependencies]
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", rev = "bd44745" }

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -97,7 +97,7 @@ impl CommitProver for Balance {
 }
 
 /// Represents the committed type of the balance tuple
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedBalance {
     /// the mint (erc-20 token address) of the token in the balance
     pub mint: CompressedRistretto,

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -137,7 +137,7 @@ impl CommitProver for Fee {
 }
 
 /// A fee that has been committed to in a single-prover constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedFee {
     /// The public settle key of the cluster collecting fees
     pub settle_key: CompressedRistretto,

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -152,7 +152,7 @@ pub struct KeyChainVar {
 }
 
 /// Represents a commitment to a keychain that has been allocated in a single-prover constraint system
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedKeyChain {
     /// The public root key
     pub pk_root: CompressedRistretto,

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -192,7 +192,7 @@ impl CommitProver for Order {
 }
 
 /// An order that has been committed to by a prover
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedOrder {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: CompressedRistretto,

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -5,6 +5,7 @@ use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::r1cs::{Prover, Variable, Verifier};
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
 use crate::{CommitProver, CommitVerifier};
 
@@ -110,7 +111,7 @@ where
 }
 
 /// Represents a commitment to a wallet in the constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedWallet<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
@@ -119,10 +120,13 @@ pub struct CommittedWallet<
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// The list of balances in the wallet
+    #[serde(with = "serde_arrays")]
     pub balances: [CommittedBalance; MAX_BALANCES],
     /// The list of open orders in the wallet
+    #[serde(with = "serde_arrays")]
     pub orders: [CommittedOrder; MAX_ORDERS],
     /// The list of payable fees in the wallet
+    #[serde(with = "serde_arrays")]
     pub fees: [CommittedFee; MAX_FEES],
     /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
     pub keys: CommittedKeyChain,

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -17,6 +17,7 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
@@ -233,7 +234,7 @@ pub struct ValidCommitmentsWitnessVar<
 }
 
 /// The witness type for VALID COMMITMENTS, committed to by a prover
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidCommitmentsWitnessCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
@@ -344,7 +345,7 @@ where
 }
 
 /// The statement type for VALID COMMITMENTS
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ValidCommitmentsStatement {
     /// The wallet match nullifier of the wallet committed to
     pub nullifier: Scalar,

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -239,7 +239,7 @@ pub struct FixedPointVar {
 }
 
 /// A commitment to a fixed-precision variable
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedFixedPoint {
     /// The underlying scalar representing the fixed point variable
     pub(crate) repr: CompressedRistretto,

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -12,6 +12,7 @@ use mpc_bulletproof::{
 };
 
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 use std::ops::Neg;
 
 use crate::{
@@ -198,7 +199,7 @@ pub struct MerkleOpeningVar {
 }
 
 /// A commitment to a Merkle opening in a constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MerkleOpeningCommitment {
     /// The opening from the leaf node to the root, i.e. the set of sister nodes
     /// that hash together with the input from the leaf to the root

--- a/core/resources/cluster1_no_wallet.toml
+++ b/core/resources/cluster1_no_wallet.toml
@@ -1,6 +1,7 @@
-port = 9000
+p2p-port = 8001
+http-port = 3001
+websocket-port = 4001
 version = 0
-debug = true
 
 # A base64 encoded dummy keypair
 cluster-public-key = "ksPP4AJGbB1bUj5acbZ8Ngzy7mCSM3xvE9FDwb5zH0c="

--- a/core/src/api/cluster_management.rs
+++ b/core/src/api/cluster_management.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
-    state::{orderbook::OrderIdentifier, wallet::{Wallet, WalletIdentifier}},
+    state::{
+        orderbook::OrderIdentifier,
+        wallet::{Wallet, WalletIdentifier},
+    },
 };
 
 /// The topic prefix for the cluster management pubsub topic

--- a/core/src/api/gossip.rs
+++ b/core/src/api/gossip.rs
@@ -126,6 +126,10 @@ pub enum GossipResponse {
 }
 
 /// Represents a pubsub message flooded through the network
+///
+/// Practically, enum variants listed at this scope should be published on
+/// a unique topic per variant; i.e. this is the granularity at which we
+/// specify a topic.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PubsubMessage {
     /// A message broadcast to indicate an even relevant to cluster management

--- a/core/src/api/gossip.rs
+++ b/core/src/api/gossip.rs
@@ -106,6 +106,9 @@ pub enum GossipRequest {
 /// Represents the possible response types for a request-response message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GossipResponse {
+    /// A simple Ack response, libp2p sometimes closes connections if no response is
+    /// sent, so we can send an empty ack in place for requests that need no response
+    Ack,
     /// A response from a peer proving that they are authorized to join a given cluster
     ClusterAuth(ClusterAuthResponse),
     /// A response from a peer to a sender's heartbeat request

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -10,7 +10,9 @@ use crate::{
         },
         gossip::{GossipOutbound, GossipRequest, PubsubMessage},
     },
+    proof_generation::jobs::ValidCommitmentsBundle,
     state::{
+        orderbook::OrderIdentifier,
         wallet::{Wallet, WalletIdentifier},
         RelayerState,
     },
@@ -56,6 +58,10 @@ impl GossipProtocolExecutor {
 
             ClusterManagementJob::ShareValidityProofs(req) => {
                 Self::handle_share_validity_proofs_job(req, global_state, network_channel)?;
+            }
+
+            ClusterManagementJob::UpdateValidityProof(order_id, proof) => {
+                Self::handle_updated_validity_proof(order_id, proof, global_state);
             }
         }
 
@@ -247,5 +253,16 @@ impl GossipProtocolExecutor {
         }
 
         Ok(())
+    }
+
+    /// Handle a message from a cluster peer that sends a proof of `VALID COMMITMENTS` for an order
+    fn handle_updated_validity_proof(
+        order_id: OrderIdentifier,
+        proof: ValidCommitmentsBundle,
+        global_state: &RelayerState,
+    ) {
+        global_state
+            .read_order_book()
+            .update_order_validity_proof(&order_id, proof);
     }
 }

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -222,7 +222,6 @@ impl GossipProtocolExecutor {
         global_state: &RelayerState,
         network_channel: UnboundedSender<GossipOutbound>,
     ) -> Result<(), GossipError> {
-        println!("Got share validity proofs job");
         // Check the local order book for any requested proofs that the local peer has stored
         let mut outbound_messages = Vec::new();
         {
@@ -237,7 +236,6 @@ impl GossipProtocolExecutor {
             }
         } // locked_order_book released
 
-        println!("Sharing {} order proofs", outbound_messages.len());
         // Forward outbound proof messages to the network manager
         for message in outbound_messages.into_iter() {
             network_channel

--- a/core/src/gossip/heartbeat.rs
+++ b/core/src/gossip/heartbeat.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     api::{
         cluster_management::ClusterAuthRequest,
-        gossip::{GossipOutbound, GossipRequest},
+        gossip::{GossipOutbound, GossipRequest, ManagerControlDirective},
         heartbeat::HeartbeatMessage,
     },
     state::{
@@ -305,10 +305,12 @@ impl GossipProtocolExecutor {
     ) -> Result<(), GossipError> {
         for peer in peer_ids.iter() {
             network_channel
-                .send(GossipOutbound::NewAddr {
-                    peer_id: *peer,
-                    address: peer_info.get(peer).unwrap().get_addr(),
-                })
+                .send(GossipOutbound::ManagementMessage(
+                    ManagerControlDirective::NewAddr {
+                        peer_id: *peer,
+                        address: peer_info.get(peer).unwrap().get_addr(),
+                    },
+                ))
                 .map_err(|err| GossipError::SendMessage(err.to_string()))?;
         }
 

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -9,13 +9,15 @@ use crate::{
         gossip::GossipResponse,
         heartbeat::{BootstrapRequest, HeartbeatMessage},
     },
-    state::wallet::WalletIdentifier,
+    proof_generation::jobs::ValidCommitmentsBundle,
+    state::{orderbook::OrderIdentifier, wallet::WalletIdentifier},
 };
 
 use super::types::{ClusterId, PeerInfo, WrappedPeerId};
 
 /// Defines a heartbeat job that can be enqueued by other workers in a relayer
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum GossipServerJob {
     /// Handle a job to bootstrap a newly added peer
     Bootstrap(BootstrapRequest, ResponseChannel<GossipResponse>),
@@ -43,6 +45,7 @@ pub enum GossipServerJob {
 
 /// Defines a job schedule for a cluster management task
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ClusterManagementJob {
     /// Add a replica for a given wallet to the state and begin gossip operations
     /// for that wallet
@@ -61,4 +64,6 @@ pub enum ClusterManagementJob {
     ReplicateRequest(ReplicateRequestBody),
     /// Forward any known proofs of order validity to the sending cluster peer
     ShareValidityProofs(ValidityProofRequest),
+    /// A proof has been shared by a cluster peer
+    UpdateValidityProof(OrderIdentifier, ValidCommitmentsBundle),
 }

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -5,7 +5,7 @@ use libp2p::request_response::ResponseChannel;
 
 use crate::{
     api::{
-        cluster_management::{ClusterJoinMessage, ReplicateRequestBody},
+        cluster_management::{ClusterJoinMessage, ReplicateRequestBody, ValidityProofRequest},
         gossip::GossipResponse,
         heartbeat::{BootstrapRequest, HeartbeatMessage},
     },
@@ -59,4 +59,6 @@ pub enum ClusterManagementJob {
     ClusterJoinRequest(ClusterId, ClusterJoinMessage),
     /// Replicate a set of wallets forwarded from a peer
     ReplicateRequest(ReplicateRequestBody),
+    /// Forward any known proofs of order validity to the sending cluster peer
+    ShareValidityProofs(ValidityProofRequest),
 }

--- a/core/src/gossip/worker.rs
+++ b/core/src/gossip/worker.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::UnboundedSender as TokioSender;
 
 use crate::{
     api::{
-        gossip::{GossipOutbound, GossipRequest},
+        gossip::{GossipOutbound, GossipRequest, ManagerControlDirective},
         heartbeat::BootstrapRequest,
     },
     state::RelayerState,
@@ -91,10 +91,12 @@ impl Worker for GossipServer {
         for bootstrap_peer in self.config.bootstrap_servers.iter() {
             self.config
                 .network_sender
-                .send(GossipOutbound::NewAddr {
-                    peer_id: bootstrap_peer.get_peer_id(),
-                    address: bootstrap_peer.get_addr(),
-                })
+                .send(GossipOutbound::ManagementMessage(
+                    ManagerControlDirective::NewAddr {
+                        peer_id: bootstrap_peer.get_peer_id(),
+                        address: bootstrap_peer.get_addr(),
+                    },
+                ))
                 .map_err(|err| GossipError::SendMessage(err.to_string()))?;
         }
 

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -558,7 +558,7 @@ impl HandshakeManager {
             .send(GossipOutbound::Pubsub {
                 topic: locked_cluster_id.get_management_topic(),
                 message: PubsubMessage::new_cluster_management_unsigned(
-                    locked_cluster_id.clone(),
+                    locked_cluster_id,
                     ClusterManagementMessage::CacheSync(state.local_order_id, state.peer_order_id),
                 ),
             })

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,6 +1,7 @@
 //! The entrypoint to the relayer, starts the coordinator thread which manages all other worker threads
 #![feature(let_chains)]
 #![feature(generic_const_exprs)]
+#![feature(const_likely)]
 #![allow(incomplete_features)]
 #![deny(unsafe_code)]
 #![deny(clippy::missing_docs_in_private_items)]

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -99,20 +99,19 @@ impl NetworkManager {
     /// Setup global state after peer_id and address have been assigned
     pub(super) fn update_global_state_after_startup(&self) {
         // Add self to peer info index
-        self.config
-            .global_state
-            .write_peer_index()
-            .add_peer(PeerInfo::new(
+        self.config.global_state.add_single_peer(
+            self.local_peer_id,
+            PeerInfo::new(
                 self.local_peer_id,
                 self.cluster_id.clone(),
                 self.local_addr.clone(),
-            ));
+            ),
+        );
 
         // Add self to cluster metadata
         self.config
             .global_state
-            .write_cluster_metadata()
-            .add_member(self.local_peer_id);
+            .add_cluster_peer(self.local_peer_id);
     }
 
     /// Setup pubsub subscriptions for the network manager
@@ -378,7 +377,7 @@ impl NetworkManager {
                 // access to the private key
                 GossipRequest::ClusterAuth(auth_message) => {
                     // If the auth message is not for the local peer's cluster, ignore it
-                    let local_cluster_id = { global_state.read_cluster_id().clone() };
+                    let local_cluster_id = { global_state.local_cluster_id.clone() };
                     if auth_message.cluster_id != local_cluster_id {
                         return Err(NetworkManagerError::Authentication(
                             ERR_WRONG_CLUSTER.to_string(),

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -231,7 +231,7 @@ impl NetworkManagerExecutor {
                             println!("Listening on {}/p2p/{}\n", address, self.local_peer_id);
                         },
                         // This catchall may be enabled for fine-grained libp2p introspection
-                        x => { println!("Got x: {:?}", x) }
+                        _ => {  }
                     }
                 }
 
@@ -344,7 +344,6 @@ impl NetworkManagerExecutor {
             .pubsub
             .publish(topic, message)
             .map_err(|err| NetworkManagerError::Network(err.to_string()))?;
-        println!("message sent\n");
         Ok(())
     }
 
@@ -530,8 +529,12 @@ impl NetworkManagerExecutor {
                 }
 
                 GossipRequest::ValidityProof { order_id, proof } => {
-                    println!("got bundle for order {:?}: {:?}", order_id, proof);
-                    Ok(())
+                    // TODO: Authenticate this
+                    self.gossip_work_queue
+                        .send(GossipServerJob::Cluster(
+                            ClusterManagementJob::UpdateValidityProof(order_id, proof),
+                        ))
+                        .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))
                 }
             },
 

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -536,13 +536,10 @@ impl NetworkManager {
                         peer_id,
                     }) => {
                         // Forward one job per replicated wallet; makes gossip server implementation cleaner
-                        for wallet in wallets.into_iter() {
+                        for wallet_id in wallets.into_iter() {
                             gossip_work_queue
                                 .send(GossipServerJob::Cluster(
-                                    ClusterManagementJob::AddWalletReplica {
-                                        wallet_id: wallet.wallet_id,
-                                        peer_id,
-                                    },
+                                    ClusterManagementJob::AddWalletReplica { wallet_id, peer_id },
                                 ))
                                 .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?;
                         }
@@ -560,6 +557,10 @@ impl NetworkManager {
                         handshake_work_queue
                             .send(HandshakeExecutionJob::PeerMatchInProgress { order1, order2 })
                             .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?
+                    }
+
+                    _ => {
+                        unimplemented!("TODO: Implement handler for proof request")
                     }
                 }
             }

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -155,7 +155,11 @@ impl ProofManager {
         >(witness, statement)
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidWalletCreateBundle(commitment, statement, proof))
+        Ok(ValidWalletCreateBundle {
+            commitment,
+            statement,
+            proof,
+        })
     }
 
     /// Create a proof of `VALID COMMITMENTS`
@@ -197,6 +201,10 @@ impl ProofManager {
         >(witness, statement)
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidCommitmentsBundle(witness_comm, statement, proof))
+        Ok(ValidCommitmentsBundle {
+            commitment: witness_comm,
+            statement,
+            proof,
+        })
     }
 }

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -93,6 +93,7 @@ impl NetworkOrder {
     /// Transitions the state of an order from `Received` to `Verified` by
     /// attaching a proof of `VALID COMMITMENTS` to the order
     pub fn attach_commitment_proof(&mut self, proof: ValidCommitmentsBundle) {
+        println!("new proof");
         assert_eq!(
             self.state,
             NetworkOrderState::Received,
@@ -174,6 +175,12 @@ impl NetworkOrderBook {
         }
 
         false
+    }
+
+    /// Fetch a copy of the validity proof for the given order, or `None` if a proof
+    /// is not locally stored
+    pub fn get_validity_proof(&self, order_id: &OrderIdentifier) -> Option<ValidCommitmentsBundle> {
+        self.read_order(order_id)?.valid_commit_proof.clone()
     }
 
     // -----------

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -166,6 +166,16 @@ impl NetworkOrderBook {
     // | Getters |
     // -----------
 
+    /// Returns whether or not the local node holds a proof of `VALID COMMITMENTS`
+    /// for the given order
+    pub fn has_validity_proof(&self, order_id: &OrderIdentifier) -> bool {
+        if let Some(order_info) = self.read_order(order_id) {
+            return order_info.valid_commit_proof.is_some();
+        }
+
+        false
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -33,7 +33,11 @@ use uuid::Uuid;
 
 use crate::{gossip::types::WrappedPeerId, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 
-use super::{new_shared, orderbook::OrderIdentifier, Shared};
+use super::{
+    new_shared,
+    orderbook::{NetworkOrderBook, OrderIdentifier},
+    Shared,
+};
 
 /// A type that attaches default size parameters to a circuit allocated wallet
 type SizedCircuitWallet = CircuitWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -33,11 +33,7 @@ use uuid::Uuid;
 
 use crate::{gossip::types::WrappedPeerId, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 
-use super::{
-    new_shared,
-    orderbook::{NetworkOrderBook, OrderIdentifier},
-    Shared,
-};
+use super::{new_shared, orderbook::OrderIdentifier, Shared};
 
 /// A type that attaches default size parameters to a circuit allocated wallet
 type SizedCircuitWallet = CircuitWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;


### PR DESCRIPTION
### Purpose
This PR adds logic around gossiping proofs between cluster peers. Specifically, when a peer joins their cluster, they are asked by existing cluster peers to replicate managed wallets locally.

When a peer receives a `Replicate` request, it enters all orders into the locally maintained order book in the `Received` state, and publishes a Gossipsub message onto the network requesting a proof of `VALID COMMITMENTS` from a peer who has one.

Any peer may respond; and the newly added cluster peer updates the order's state with the proof.

Todo:
- Authenticate proof responses with the cluster key. This will come as part of a broader todo around how we manage cluster signatures. The current approach is good, but needs some refactoring to fit in requests like this.

### Testing
- Unit tests
- Tested the case in which a peer bootstraps into an existing cluster; verified that the new peer requested and received a validity proof, and transitioned the order into the `Verified` state.