### PR TITLE
core: network-manager: Refactor cluster auth signatures for safety

### DIFF
--- a/core/resources/wallets2.json
+++ b/core/resources/wallets2.json
@@ -27,6 +27,21 @@
                 "percentage_fee": 0.01
             }
         ],
+        "public_keys": [
+            [],
+            [],
+            [],
+            []
+        ],
+        "secret_keys": [
+            [],
+            [],
+            [],
+            []
+        ],
+        "randomness": [
+            42
+        ],
         "metadata": {
             "replicas": []
         }

--- a/core/src/api/cluster_management.rs
+++ b/core/src/api/cluster_management.rs
@@ -99,28 +99,12 @@ pub struct ClusterAuthRequest {
 /// cluster private key
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClusterAuthResponse {
-    /// The body of the response, the signature of which is attached
-    pub body: ClusterAuthResponseBody,
-    /// The signature of the two former attributes under the cluster private key
-    pub signature: Vec<u8>,
-}
-
-/// The body of a cluster auth response; signed with the cluster private key
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ClusterAuthResponseBody {
     /// The cluster ID
     pub cluster_id: ClusterId,
     /// The ID of the peer proving authorization
     pub peer_id: WrappedPeerId,
     /// The peer info of the peer authenticating into the cluster
     pub peer_info: PeerInfo,
-}
-
-// Explicit byte serialization for hashing and signing
-impl From<&ClusterAuthResponseBody> for Vec<u8> {
-    fn from(body: &ClusterAuthResponseBody) -> Self {
-        serde_json::to_vec(&body).unwrap()
-    }
 }
 
 /// The body of a proof request message published to a cluster

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -166,13 +166,13 @@ impl GossipProtocolExecutor {
             .get_management_topic();
 
         // Broadcast a message to the network indicating that the wallet is now replicated
-        let replicated_message = PubsubMessage::new_cluster_management_unsigned(
-            global_state.local_cluster_id.clone(),
-            ClusterManagementMessage::Replicated(ReplicatedMessage {
+        let replicated_message = PubsubMessage::ClusterManagement {
+            cluster_id: global_state.local_cluster_id.clone(),
+            message: ClusterManagementMessage::Replicated(ReplicatedMessage {
                 wallets: req.wallets.iter().map(|wallet| wallet.wallet_id).collect(),
                 peer_id: global_state.local_peer_id(),
             }),
-        );
+        };
         network_channel
             .send(GossipOutbound::Pubsub {
                 topic: topic.clone(),
@@ -192,15 +192,14 @@ impl GossipProtocolExecutor {
                 }
             }
         } // locked_order_state released
-        println!("Replicated orders, {:?} need proofs", orders_needing_proofs);
 
-        let proof_request = PubsubMessage::new_cluster_management_unsigned(
-            global_state.local_cluster_id.clone(),
-            ClusterManagementMessage::RequestOrderValidityProof(ValidityProofRequest {
+        let proof_request = PubsubMessage::ClusterManagement {
+            cluster_id: global_state.local_cluster_id.clone(),
+            message: ClusterManagementMessage::RequestOrderValidityProof(ValidityProofRequest {
                 order_ids: orders_needing_proofs,
                 sender: global_state.local_peer_id,
             }),
-        );
+        };
         network_channel
             .send(GossipOutbound::Pubsub {
                 topic,

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -6,7 +6,7 @@ use libp2p::request_response::ResponseChannel;
 use crate::{
     api::{
         cluster_management::{ClusterJoinMessage, ReplicateRequestBody, ValidityProofRequest},
-        gossip::GossipResponse,
+        gossip::AuthenticatedGossipResponse,
         heartbeat::{BootstrapRequest, HeartbeatMessage},
     },
     proof_generation::jobs::ValidCommitmentsBundle,
@@ -20,7 +20,10 @@ use super::types::{ClusterId, PeerInfo, WrappedPeerId};
 #[allow(clippy::large_enum_variant)]
 pub enum GossipServerJob {
     /// Handle a job to bootstrap a newly added peer
-    Bootstrap(BootstrapRequest, ResponseChannel<GossipResponse>),
+    Bootstrap(
+        BootstrapRequest,
+        ResponseChannel<AuthenticatedGossipResponse>,
+    ),
     /// Handle an incoming cluster management job
     Cluster(ClusterManagementJob),
     /// Job type for the heartbeat executor to send an outbound heartbeat request
@@ -32,7 +35,7 @@ pub enum GossipServerJob {
         /// The message contents
         message: HeartbeatMessage,
         /// A channel on which to send the response
-        channel: ResponseChannel<GossipResponse>,
+        channel: ResponseChannel<AuthenticatedGossipResponse>,
     },
     /// Handle an incoming heartbeat response from a peer
     HandleHeartbeatResp {

--- a/core/src/gossip/server.rs
+++ b/core/src/gossip/server.rs
@@ -82,10 +82,10 @@ impl GossipServer {
             .network_sender
             .send(GossipOutbound::Pubsub {
                 topic: self.config.cluster_id.get_management_topic(),
-                message: PubsubMessage::new_cluster_management_unsigned(
-                    self.config.cluster_id.clone(),
-                    ClusterManagementMessage::Join(message_body),
-                ),
+                message: PubsubMessage::ClusterManagement {
+                    cluster_id: self.config.cluster_id.clone(),
+                    message: ClusterManagementMessage::Join(message_body),
+                },
             })
             .map_err(|err| GossipError::SendMessage(err.to_string()))?;
 

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -5,7 +5,7 @@ use mpc_ristretto::network::QuicTwoPartyNet;
 use uuid::Uuid;
 
 use crate::{
-    api::{gossip::GossipResponse, handshake::HandshakeMessage},
+    api::{gossip::AuthenticatedGossipResponse, handshake::HandshakeMessage},
     gossip::types::WrappedPeerId,
     state::orderbook::OrderIdentifier,
 };
@@ -27,7 +27,7 @@ pub enum HandshakeExecutionJob {
         ///
         /// If the channel is `None`, the response should be forwarded
         /// as a new gossip request to the network manager directly
-        response_channel: Option<ResponseChannel<GossipResponse>>,
+        response_channel: Option<ResponseChannel<AuthenticatedGossipResponse>>,
     },
     /// Indicates that the network manager has setup an MPC net and the receiving thread
     /// may begin executing a match over this network

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -310,10 +310,12 @@ impl HandshakeManager {
                     network_channel
                         .send(GossipOutbound::Pubsub {
                             topic: cluster_id.get_management_topic(),
-                            message: PubsubMessage::new_cluster_management_unsigned(
+                            message: PubsubMessage::ClusterManagement {
                                 cluster_id,
-                                ClusterManagementMessage::MatchInProgress(order_id, peer_order),
-                            ),
+                                message: ClusterManagementMessage::MatchInProgress(
+                                    order_id, peer_order,
+                                ),
+                            },
                         })
                         .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
 
@@ -397,10 +399,12 @@ impl HandshakeManager {
                     network_channel
                         .send(GossipOutbound::Pubsub {
                             topic: cluster_id.get_management_topic(),
-                            message: PubsubMessage::new_cluster_management_unsigned(
+                            message: PubsubMessage::ClusterManagement {
                                 cluster_id,
-                                ClusterManagementMessage::MatchInProgress(my_order, peer_order),
-                            ),
+                                message: ClusterManagementMessage::MatchInProgress(
+                                    my_order, peer_order,
+                                ),
+                            },
                         })
                         .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
 
@@ -564,10 +568,13 @@ impl HandshakeManager {
         network_channel
             .send(GossipOutbound::Pubsub {
                 topic: locked_cluster_id.get_management_topic(),
-                message: PubsubMessage::new_cluster_management_unsigned(
-                    locked_cluster_id,
-                    ClusterManagementMessage::CacheSync(state.local_order_id, state.peer_order_id),
-                ),
+                message: PubsubMessage::ClusterManagement {
+                    cluster_id: locked_cluster_id,
+                    message: ClusterManagementMessage::CacheSync(
+                        state.local_order_id,
+                        state.peer_order_id,
+                    ),
+                },
             })
             .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
 

--- a/core/src/network_manager/composed_protocol.rs
+++ b/core/src/network_manager/composed_protocol.rs
@@ -25,7 +25,7 @@ use std::{
     iter,
 };
 
-use crate::api::gossip::{GossipRequest, GossipResponse};
+use crate::api::gossip::{AuthenticatedGossipRequest, AuthenticatedGossipResponse};
 
 use super::error::NetworkManagerError;
 
@@ -104,7 +104,7 @@ impl ComposedNetworkBehavior {
 #[allow(clippy::large_enum_variant)]
 pub enum ComposedProtocolEvent {
     /// An event from the request/response behavior, point-to-point
-    RequestResponse(RequestResponseEvent<GossipRequest, GossipResponse>),
+    RequestResponse(RequestResponseEvent<AuthenticatedGossipRequest, AuthenticatedGossipResponse>),
     /// An event from the KDHT behavior; e.g. new address
     Kademlia(KademliaEvent),
     /// An event from the pubsub behavior; broadcast
@@ -120,8 +120,12 @@ impl From<KademliaEvent> for ComposedProtocolEvent {
     }
 }
 
-impl From<RequestResponseEvent<GossipRequest, GossipResponse>> for ComposedProtocolEvent {
-    fn from(e: RequestResponseEvent<GossipRequest, GossipResponse>) -> Self {
+impl From<RequestResponseEvent<AuthenticatedGossipRequest, AuthenticatedGossipResponse>>
+    for ComposedProtocolEvent
+{
+    fn from(
+        e: RequestResponseEvent<AuthenticatedGossipRequest, AuthenticatedGossipResponse>,
+    ) -> Self {
         ComposedProtocolEvent::RequestResponse(e)
     }
 }
@@ -193,8 +197,8 @@ impl RelayerGossipCodec {
 #[async_trait]
 impl RequestResponseCodec for RelayerGossipCodec {
     type Protocol = RelayerGossipProtocol;
-    type Request = GossipRequest;
-    type Response = GossipResponse;
+    type Request = AuthenticatedGossipRequest;
+    type Response = AuthenticatedGossipResponse;
 
     /// Deserializes a read request
     async fn read_request<T>(
@@ -210,7 +214,7 @@ impl RequestResponseCodec for RelayerGossipCodec {
             return Err(IoError::new(ErrorKind::InvalidData, "empty request"));
         }
 
-        let deserialized: GossipRequest = serde_json::from_slice(&req_data).unwrap();
+        let deserialized: AuthenticatedGossipRequest = serde_json::from_slice(&req_data).unwrap();
         Ok(deserialized)
     }
 
@@ -228,7 +232,7 @@ impl RequestResponseCodec for RelayerGossipCodec {
             return Err(IoError::new(ErrorKind::InvalidData, "empty response"));
         }
 
-        let deserialized: GossipResponse = serde_json::from_slice(&resp_data).unwrap();
+        let deserialized: AuthenticatedGossipResponse = serde_json::from_slice(&resp_data).unwrap();
         Ok(deserialized)
     }
 

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -188,7 +188,6 @@ impl NetworkOrderBook {
         if self.order_map.contains_key(&order.id) {
             return;
         }
-        println!("Adding order");
 
         // If the order is local, add it to the local order list
         order.state = NetworkOrderState::Received;


### PR DESCRIPTION
### Purpose
This PR refactors how we handle cluster authentication at the network level. The previous implementation was likely to cause bugs for two reasons:
- The signature verification logic was repeated and handled in each request handler.
- Nothing in the code enforced a request/response type to explicitly require a signature.

This PR refactors these issues to avoid future bugs such that:
- Signature generation and verification is centralized in the gossip and pubsub types directly.
- This relies on a method `requires_cluster_signature` that explicitly requires each enum variant to return `true` or `false` -- future additions to the request/response and pubsub APIs will require the author to explicitly decide whether a message type requires a cluster authenticated link.

### Testing
- Ad-hoc verified that the high level functionality of the relayer works