### PR TITLE
core: handshake: Refactor handshake scheduling and gate on `VALID COMMITMENTS`

### DIFF
--- a/core/resources/cluster2.toml
+++ b/core/resources/cluster2.toml
@@ -1,6 +1,6 @@
-p2p-port = 8001 
-http-port = 3001
-websocket-port = 4001
+p2p-port = 8002 
+http-port = 3002
+websocket-port = 4002
 version = 0
 wallet-file = "./core/resources/wallets2.json"
 

--- a/core/src/api/heartbeat.rs
+++ b/core/src/api/heartbeat.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    gossip::types::{PeerInfo, WrappedPeerId},
+    gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
     state::{
         wallet::{WalletIdentifier, WalletMetadata},
         ClusterMetadata, OrderIdentifier,
@@ -22,7 +22,7 @@ pub struct HeartbeatMessage {
     /// PeerID is converted to string for serialization
     pub known_peers: HashMap<String, PeerInfo>,
     /// The local peer's orderbook
-    pub orders: Vec<(OrderIdentifier, WrappedPeerId)>,
+    pub orders: Vec<(OrderIdentifier, ClusterId)>,
     /// The metadata that the local peer has about its own cluster
     pub cluster_metadata: ClusterMetadata,
 }

--- a/core/src/api/orderbook_management.rs
+++ b/core/src/api/orderbook_management.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    gossip::types::{ClusterId},
+    gossip::types::ClusterId,
     proof_generation::jobs::ValidCommitmentsBundle,
     state::{NetworkOrder, OrderIdentifier},
 };

--- a/core/src/api/orderbook_management.rs
+++ b/core/src/api/orderbook_management.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    gossip::types::WrappedPeerId,
+    gossip::types::{ClusterId},
     proof_generation::jobs::ValidCommitmentsBundle,
     state::{NetworkOrder, OrderIdentifier},
 };
@@ -38,16 +38,16 @@ pub enum OrderBookManagementMessage {
     OrderReceived {
         /// The identifier of the new order
         order_id: OrderIdentifier,
-        /// The peer that originated the message
-        owner: WrappedPeerId,
+        /// The cluster that manages this order
+        cluster: ClusterId,
     },
     /// A new validity proof has been generated for an order, it should be placed in
     /// the `Verified` state after local peers verify the proof
     OrderProofUpdated {
         /// The identifier of the now updated order
         order_id: OrderIdentifier,
-        /// The owner of the order
-        owner: WrappedPeerId,
+        /// The cluster that manages this order
+        cluster: ClusterId,
         /// The new proof of `VALID COMMITMENTS`
         proof: ValidCommitmentsBundle,
     },

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -73,13 +73,11 @@ impl GossipProtocolExecutor {
         // Move out of message to avoid clones
         let peer_id = message.peer_id;
         let peer_info = message.peer_info;
-        let peer_addr = message.addr;
 
-        self.add_peer_to_cluster(peer_id, peer_info, cluster_id.clone())?;
+        self.add_peer_to_cluster(peer_id, peer_info.clone(), cluster_id)?;
 
         // Add the peer to the known peers index
-        self.global_state
-            .add_single_peer(peer_id, PeerInfo::new(peer_id, cluster_id, peer_addr));
+        self.global_state.add_single_peer(peer_id, peer_info);
 
         // Request that the peer replicate all locally replicated wallets
         let wallets = self.global_state.read_wallet_index().get_all_wallets();

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -97,16 +97,16 @@ pub enum OrderBookManagementJob {
     OrderReceived {
         /// The identifier of the new order
         order_id: OrderIdentifier,
-        /// The peer that originated the message
-        owner: WrappedPeerId,
+        /// The cluster that manages this order
+        cluster: ClusterId,
     },
     /// A new validity proof has been generated for an order, it should be placed in
     /// the `Verified` state after local peers verify the proof
     OrderProofUpdated {
         /// The identifier of the now updated order
         order_id: OrderIdentifier,
-        /// The owner of the order
-        owner: WrappedPeerId,
+        /// The cluster that manages this order
+        cluster: ClusterId,
         /// The new proof of `VALID COMMITMENTS`
         proof: ValidCommitmentsBundle,
     },

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     errors::GossipError, jobs::OrderBookManagementJob, server::GossipProtocolExecutor,
-    types::WrappedPeerId,
+    types::ClusterId,
 };
 
 impl GossipProtocolExecutor {
@@ -41,16 +41,16 @@ impl GossipProtocolExecutor {
                 Ok(())
             }
 
-            OrderBookManagementJob::OrderReceived { order_id, owner } => {
-                self.handle_new_order(order_id, owner);
+            OrderBookManagementJob::OrderReceived { order_id, cluster } => {
+                self.handle_new_order(order_id, cluster);
                 Ok(())
             }
 
             OrderBookManagementJob::OrderProofUpdated {
                 order_id,
-                owner,
+                cluster,
                 proof,
-            } => self.handle_new_validity_proof(order_id, owner, proof),
+            } => self.handle_new_validity_proof(order_id, cluster, proof),
         }
     }
 
@@ -97,9 +97,9 @@ impl GossipProtocolExecutor {
     }
 
     /// Handles a newly discovered order added to the book
-    fn handle_new_order(&self, order_id: OrderIdentifier, owner: WrappedPeerId) {
+    fn handle_new_order(&self, order_id: OrderIdentifier, cluster: ClusterId) {
         self.global_state
-            .add_order(NetworkOrder::new(order_id, owner, false /* local */))
+            .add_order(NetworkOrder::new(order_id, cluster, false /* local */))
     }
 
     /// Handles a new validity proof attached to an order
@@ -109,7 +109,7 @@ impl GossipProtocolExecutor {
     fn handle_new_validity_proof(
         &self,
         order_id: OrderIdentifier,
-        owner: WrappedPeerId,
+        cluster: ClusterId,
         proof_bundle: ValidCommitmentsBundle,
     ) -> Result<(), GossipError> {
         // Verify the proof
@@ -128,7 +128,7 @@ impl GossipProtocolExecutor {
             .contains_order(&order_id)
         {
             self.global_state
-                .add_order(NetworkOrder::new(order_id, owner, false /* local */));
+                .add_order(NetworkOrder::new(order_id, cluster, false /* local */));
         }
 
         self.global_state

--- a/core/src/gossip/types.rs
+++ b/core/src/gossip/types.rs
@@ -24,7 +24,7 @@ pub struct PeerInfo {
     peer_id: WrappedPeerId,
     /// The multiaddr of the peer
     addr: Multiaddr,
-    /// Last time a successful hearbeat was received from this peer
+    /// Last time a successful heartbeat was received from this peer
     #[serde(skip)]
     last_heartbeat: AtomicU64,
     /// The ID of the cluster the peer belongs to
@@ -173,7 +173,7 @@ impl<'de> Visitor<'de> for PeerIDVisitor {
     }
 }
 /// A type alias for the cluster identifier
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterId(String);
 
 impl ClusterId {
@@ -184,7 +184,7 @@ impl ClusterId {
         Self(encoded_key)
     }
 
-    /// Get the cluster management pubsub topic name for the cluster idenified
+    /// Get the cluster management pubsub topic name for the cluster identified
     pub fn get_management_topic(&self) -> String {
         format!("{}-{}", CLUSTER_MANAGEMENT_TOPIC_PREFIX, self.0)
     }

--- a/core/src/handshake/handshake_cache.rs
+++ b/core/src/handshake/handshake_cache.rs
@@ -31,7 +31,7 @@ pub struct HandshakeCache<O> {
     size: usize,
     /// The maximum number of elements in the cache
     max_size: usize,
-    /// The underlying LRU cache controlling evication from the HandshakeCache
+    /// The underlying LRU cache controlling eviction from the HandshakeCache
     ///
     /// Entries are cached with the lower (abstract ordering) identifier stored first
     lru_cache: LruCache<(O, O), HandshakeCacheState>,

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -16,8 +16,8 @@ use crate::{
 pub enum HandshakeExecutionJob {
     /// A request to initiate a handshake with a scheduled peer
     PerformHandshake {
-        /// The peer to handshake with
-        peer: WrappedPeerId,
+        /// The order to attempt a handshake on
+        order: OrderIdentifier,
     },
     /// Process a handshake request
     ProcessHandshakeMessage {

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -693,23 +693,23 @@ impl NetworkManagerExecutor {
                 }
             }
             PubsubMessage::OrderBookManagement(msg) => match msg {
-                OrderBookManagementMessage::OrderReceived { order_id, owner } => self
+                OrderBookManagementMessage::OrderReceived { order_id, cluster } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
-                        OrderBookManagementJob::OrderReceived { order_id, owner },
+                        OrderBookManagementJob::OrderReceived { order_id, cluster },
                     ))
                     .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?,
 
                 OrderBookManagementMessage::OrderProofUpdated {
                     order_id,
-                    owner,
+                    cluster,
                     proof,
                 } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
                         OrderBookManagementJob::OrderProofUpdated {
                             order_id,
-                            owner,
+                            cluster,
                             proof,
                         },
                     ))

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -105,10 +105,11 @@ impl NetworkManager {
         // Add self to peer info index
         self.config.global_state.add_single_peer(
             self.local_peer_id,
-            PeerInfo::new(
+            PeerInfo::new_with_cluster_secret_key(
                 self.local_peer_id,
                 self.cluster_id.clone(),
                 self.local_addr.clone(),
+                self.config.cluster_keypair.as_ref().unwrap(),
             ),
         );
 

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -2,6 +2,7 @@
 //! global state elements
 mod orderbook;
 pub mod peers;
+mod priority;
 #[allow(clippy::module_inception)]
 mod state;
 pub mod wallet;

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -88,6 +88,11 @@ impl PeerIndex {
         self.peer_map.len()
     }
 
+    /// Returns the info for a given peer if it is indexed
+    pub fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
+        self.read_peer(peer_id).map(|info| info.clone())
+    }
+
     /// Returns whether the given peer is already indexed by the peer index
     pub fn contains_peer(&self, peer_id: &WrappedPeerId) -> bool {
         self.peer_map.contains_key(peer_id)

--- a/core/src/state/priority.rs
+++ b/core/src/state/priority.rs
@@ -1,15 +1,53 @@
 //! Groups state primitives, type definitions, and synchronization logic for
 //! the state object that stores order and cluster priorities for handshakes
 
-use std::{collections::HashMap, sync::atomic::AtomicU32};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        RwLockReadGuard,
+    },
+};
 
 use crate::gossip::types::ClusterId;
 
-use super::OrderIdentifier;
+use super::{new_shared, OrderIdentifier, Shared};
+
+/// The error emitted when an order's priority lock is poisoned
+const ERR_ORDER_PRIORITY_POISONED: &str = "order priority lock poisoned";
+
+/// The default priority for a cluster
+const CLUSTER_DEFAULT_PRIORITY: u32 = 1;
+/// The default priority for an order
+const ORDER_DEFAULT_PRIORITY: u32 = 1;
 
 /// A type alias for the abstract priority implementation
-pub type Priority = AtomicU32;
-/// The default priority for an order
+pub type ClusterPriority = AtomicU32;
+/// A type that represents the priority for an order, including its cluster
+/// priority
+#[derive(Clone, Debug)]
+pub struct OrderPriority {
+    /// The priority of the cluster that the order is managed by
+    cluster_priority: u32,
+    /// The priority of the order itself
+    order_priority: u32,
+}
+
+impl Default for OrderPriority {
+    fn default() -> Self {
+        OrderPriority {
+            cluster_priority: CLUSTER_DEFAULT_PRIORITY,
+            order_priority: ORDER_DEFAULT_PRIORITY,
+        }
+    }
+}
+
+impl OrderPriority {
+    /// Compute the effective scheduling priority for an order
+    pub fn get_effective_priority(&self) -> u32 {
+        self.cluster_priority * self.order_priority
+    }
+}
 
 /// Stores handshake priority information at multiple granularities; i.e.
 /// cluster and order granularity
@@ -20,9 +58,9 @@ pub type Priority = AtomicU32;
 #[derive(Debug)]
 pub struct HandshakePriorityStore {
     /// A mapping from cluster ID to priority
-    cluster_priorities: HashMap<ClusterId, Priority>,
+    cluster_priorities: HashMap<ClusterId, ClusterPriority>,
     /// A mapping from order ID to priority
-    order_priorities: HashMap<OrderIdentifier, Priority>,
+    order_priorities: HashMap<OrderIdentifier, Shared<OrderPriority>>,
 }
 
 impl HandshakePriorityStore {
@@ -32,5 +70,59 @@ impl HandshakePriorityStore {
             cluster_priorities: HashMap::new(),
             order_priorities: HashMap::new(),
         }
+    }
+
+    // -----------
+    // | Locking |
+    // -----------
+
+    /// Acquire a read lock on an order's priority
+    pub fn read_order_priority(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Option<RwLockReadGuard<OrderPriority>> {
+        self.order_priorities
+            .get(order_id)
+            .map(|order| order.read().expect(ERR_ORDER_PRIORITY_POISONED))
+    }
+
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Read an order's priority
+    pub fn get_order_priority(&self, order_id: &OrderIdentifier) -> OrderPriority {
+        self.read_order_priority(order_id)
+            .map(|order| order.clone())
+            .unwrap_or_default()
+    }
+
+    /// Read a cluster's priority, returns default if not indexed
+    pub fn get_cluster_priority(&self, cluster_id: &ClusterId) -> u32 {
+        self.cluster_priorities
+            .get(cluster_id)
+            .map(|priority| priority.load(Ordering::Relaxed))
+            .unwrap_or(CLUSTER_DEFAULT_PRIORITY)
+    }
+
+    // -----------
+    // | Setters |
+    // -----------
+
+    /// Add a new order to the priority list
+    pub fn new_order(&mut self, order_id: OrderIdentifier, cluster_id: ClusterId) {
+        let cluster_priority = self.get_cluster_priority(&cluster_id);
+        self.order_priorities.insert(
+            order_id,
+            new_shared(OrderPriority {
+                cluster_priority,
+                order_priority: ORDER_DEFAULT_PRIORITY,
+            }),
+        );
+    }
+
+    /// Remove the order from the priority list
+    pub fn remove_order(&mut self, order_id: &OrderIdentifier) {
+        self.order_priorities.remove(order_id);
     }
 }

--- a/core/src/state/priority.rs
+++ b/core/src/state/priority.rs
@@ -1,0 +1,36 @@
+//! Groups state primitives, type definitions, and synchronization logic for
+//! the state object that stores order and cluster priorities for handshakes
+
+use std::{collections::HashMap, sync::atomic::AtomicU32};
+
+use crate::gossip::types::ClusterId;
+
+use super::OrderIdentifier;
+
+/// A type alias for the abstract priority implementation
+pub type Priority = AtomicU32;
+/// The default priority for an order
+
+/// Stores handshake priority information at multiple granularities; i.e.
+/// cluster and order granularity
+///
+/// A cluster can have its priority lowered from the default for toxic behavior
+/// (dropping MPCs, unreliable heartbeats, faulty proofs, etc). An order may have
+/// its priority raised as a result of known IoIs on the order
+#[derive(Debug)]
+pub struct HandshakePriorityStore {
+    /// A mapping from cluster ID to priority
+    cluster_priorities: HashMap<ClusterId, Priority>,
+    /// A mapping from order ID to priority
+    order_priorities: HashMap<OrderIdentifier, Priority>,
+}
+
+impl HandshakePriorityStore {
+    /// Create a new priority store for handshakes
+    pub fn new() -> Self {
+        HandshakePriorityStore {
+            cluster_priorities: HashMap::new(),
+            order_priorities: HashMap::new(),
+        }
+    }
+}

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -206,7 +206,7 @@ impl RelayerState {
                     {
                         self.write_order_book().add_order(NetworkOrder::new(
                             *order_id,
-                            self.local_peer_id,
+                            self.local_cluster_id.clone(),
                             true, /* local */
                         ));
                     } // order_book lock released
@@ -265,7 +265,7 @@ impl RelayerState {
                 message: PubsubMessage::OrderBookManagement(
                     OrderBookManagementMessage::OrderProofUpdated {
                         order_id,
-                        owner: self.local_peer_id,
+                        cluster: self.local_cluster_id.clone(),
                         proof: proof_bundle,
                     },
                 ),
@@ -434,7 +434,7 @@ impl RelayerState {
         for order_id in new_orders.into_iter() {
             locked_order_book.add_order(NetworkOrder::new(
                 order_id,
-                self.local_peer_id,
+                self.local_cluster_id.clone(),
                 true, /* local */
             ));
         }

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -242,6 +242,11 @@ impl WalletIndex {
     // | Getters |
     // -----------
 
+    /// Returns true if there are no wallets in the locally managed wallet index
+    pub fn is_empty(&self) -> bool {
+        self.wallet_map.is_empty()
+    }
+
     /// Return a random wallet, used for sampling wallets to match with
     pub fn get_random_wallet<R: RngCore>(&self, rng: &mut R) -> Wallet {
         let key_index = rng.gen_range(0..self.wallet_map.len());


### PR DESCRIPTION
### Purpose
This PR makes a few modifications to the handshake scheduler:
1. The scheduler scores are assessed at multiple granularities:
    - Each cluster has a handshake score that is decremented when toxic behavior (hangups, invalid commitment proofs, spam) are detected
    - Each order has a handshake score that can be adjusted based on locality, IoIs, etc
2. To support this form of scheduling I denormalized much of the state wrt wallets and handshake scores
3. The scheduler awaits a proof of `VALID COMMITMENTS` for both orders before scheduling a handshake on an order pair

### Testing
- Unit tests pass
- Tested the handshake flow, verified that a peer did not accept or initiate a handshake on an order pair until it had proved and/or verified each proof of `VALID COMMITMENTS`.
- Verified that state was broadly still tracked correctly after refactor