### PR TITLE
core: handshake: scheduler: Refactor order scheduling and fix a few bugs

### DIFF
--- a/core/src/api/gossip.rs
+++ b/core/src/api/gossip.rs
@@ -13,9 +13,7 @@ use crate::{
 };
 
 use super::{
-    cluster_management::{
-        ClusterAuthRequest, ClusterAuthResponse, ClusterManagementMessage, ReplicateRequestBody,
-    },
+    cluster_management::{ClusterManagementMessage, ReplicateRequestBody},
     handshake::HandshakeMessage,
     heartbeat::{BootstrapRequest, HeartbeatMessage},
     orderbook_management::{OrderBookManagementMessage, OrderInfoRequest, OrderInfoResponse},
@@ -112,8 +110,6 @@ impl AuthenticatedGossipRequest {
 pub enum GossipRequest {
     /// A request from a peer to bootstrap the network state from the recipient
     Bootstrap(BootstrapRequest),
-    /// A request from a peer to prove that the local peer is part of the given cluster
-    ClusterAuth(ClusterAuthRequest),
     /// A request from a peer initiating a heartbeat
     Heartbeat(HeartbeatMessage),
     /// A request from a peer initiating a handshake
@@ -145,7 +141,6 @@ impl GossipRequest {
     pub fn requires_cluster_auth(&self) -> bool {
         match self {
             GossipRequest::Bootstrap(..) => false,
-            GossipRequest::ClusterAuth(..) => true,
             GossipRequest::Heartbeat(..) => false,
             GossipRequest::Handshake { .. } => false,
             GossipRequest::OrderInfo(..) => false,
@@ -223,8 +218,6 @@ pub enum GossipResponse {
     /// A simple Ack response, libp2p sometimes closes connections if no response is
     /// sent, so we can send an empty ack in place for requests that need no response
     Ack,
-    /// A response from a peer proving that they are authorized to join a given cluster
-    ClusterAuth(ClusterAuthResponse),
     /// A response from a peer to a sender's heartbeat request
     Heartbeat(HeartbeatMessage),
     /// A response from a peer to a sender's handshake request
@@ -246,7 +239,6 @@ impl GossipResponse {
     pub fn requires_cluster_auth(&self) -> bool {
         match self {
             GossipResponse::Ack => false,
-            GossipResponse::ClusterAuth(..) => true,
             GossipResponse::Heartbeat(..) => false,
             GossipResponse::Handshake { .. } => false,
             GossipResponse::OrderInfo(..) => false,

--- a/core/src/api/heartbeat.rs
+++ b/core/src/api/heartbeat.rs
@@ -8,7 +8,7 @@ use crate::{
     gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
     state::{
         wallet::{WalletIdentifier, WalletMetadata},
-        ClusterMetadata, OrderIdentifier,
+        OrderIdentifier,
     },
 };
 
@@ -23,8 +23,6 @@ pub struct HeartbeatMessage {
     pub known_peers: HashMap<String, PeerInfo>,
     /// The local peer's orderbook
     pub orders: Vec<(OrderIdentifier, ClusterId)>,
-    /// The metadata that the local peer has about its own cluster
-    pub cluster_metadata: ClusterMetadata,
 }
 
 /// Defines a request to bootstrap the cluster state from the recipient

--- a/core/src/api/heartbeat.rs
+++ b/core/src/api/heartbeat.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
+    gossip::types::{ClusterId, PeerInfo},
     state::{
         wallet::{WalletIdentifier, WalletMetadata},
         OrderIdentifier,
@@ -29,5 +29,5 @@ pub struct HeartbeatMessage {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BootstrapRequest {
     /// The requester's peer ID
-    pub peer_id: WrappedPeerId,
+    pub peer_info: PeerInfo,
 }

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -99,11 +99,6 @@ impl GossipProtocolExecutor {
         // Add the peer to the known peers index
         self.global_state.add_single_peer(peer_id, peer_info);
 
-        // The cluster join request is authenticated at the network layer
-        // by the `NetworkManager`, so no authentication needs to be done.
-        // Simply update the local cluster metadata to reflect the new node's membership
-        self.global_state.add_cluster_peer(peer_id);
-
         // Request that the peer replicate all locally replicated wallets
         let wallets = self.global_state.read_wallet_index().get_all_wallets();
         self.send_replicate_request(peer_id, wallets)
@@ -137,11 +132,7 @@ impl GossipProtocolExecutor {
         self.global_state.add_wallets(req.wallets.clone());
 
         // Update cluster management bookkeeping
-        let topic = self
-            .global_state
-            .read_cluster_metadata()
-            .id
-            .get_management_topic();
+        let topic = self.global_state.local_cluster_id.get_management_topic();
 
         // Broadcast a message to the network indicating that the wallet is now replicated
         let replicated_message = PubsubMessage::ClusterManagement {

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -30,10 +30,6 @@ impl GossipProtocolExecutor {
         job: ClusterManagementJob,
     ) -> Result<(), GossipError> {
         match job {
-            ClusterManagementJob::ClusterAuthSuccess(cluster_id, peer_id, peer_info) => {
-                self.add_peer_to_cluster(peer_id, peer_info, cluster_id)?;
-            }
-
             ClusterManagementJob::ClusterJoinRequest(cluster_id, req) => {
                 self.handle_cluster_join_job(cluster_id, req)?;
             }
@@ -71,13 +67,7 @@ impl GossipProtocolExecutor {
 
         // Add the peer to the cluster metadata
         // Move out of message to avoid clones
-        let peer_id = message.peer_id;
-        let peer_info = message.peer_info;
-
-        self.add_peer_to_cluster(peer_id, peer_info.clone(), cluster_id)?;
-
-        // Add the peer to the known peers index
-        self.global_state.add_single_peer(peer_id, peer_info);
+        self.add_peer_to_cluster(message.peer_id, message.peer_info, cluster_id)?;
 
         // Request that the peer replicate all locally replicated wallets
         let wallets = self.global_state.read_wallet_index().get_all_wallets();

--- a/core/src/gossip/heartbeat.rs
+++ b/core/src/gossip/heartbeat.rs
@@ -195,7 +195,7 @@ impl GossipProtocolExecutor {
     /// Returns a boolean indicating whether the peer is now indexed in the peer info
     /// state. This value may be false if the peer has been recently expired and its
     /// invisibility window has not elapsed
-    fn add_new_peers(
+    pub(super) fn add_new_peers(
         &self,
         new_peer_ids: &[WrappedPeerId],
         new_peer_info: &HashMap<WrappedPeerId, PeerInfo>,

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -13,7 +13,7 @@ use crate::{
     state::{wallet::WalletIdentifier, NetworkOrder, OrderIdentifier},
 };
 
-use super::types::{ClusterId, PeerInfo, WrappedPeerId};
+use super::types::{ClusterId, WrappedPeerId};
 
 /// Defines a heartbeat job that can be enqueued by other workers in a relayer
 #[derive(Debug)]
@@ -60,9 +60,6 @@ pub enum ClusterManagementJob {
         /// The ID of the peer that has just replicated the wallet
         peer_id: WrappedPeerId,
     },
-    /// A job indicating that a peer has successfully authenticated into the cluster
-    /// from a previous outbound cluster auth request
-    ClusterAuthSuccess(ClusterId, WrappedPeerId, PeerInfo),
     /// A request from a peer to join the local peer's cluster
     ClusterJoinRequest(ClusterId, ClusterJoinMessage),
     /// Replicate a set of wallets forwarded from a peer

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -3,7 +3,6 @@
 
 use circuits::verify_singleprover_proof;
 use libp2p::request_response::ResponseChannel;
-use tracing::log;
 
 use crate::{
     api::{
@@ -32,8 +31,7 @@ impl GossipProtocolExecutor {
                 response_channel,
             } => self.handle_order_info_request(order_id, response_channel),
 
-            OrderBookManagementJob::OrderInfoResponse { info, order_id } => {
-                log::info!("got order info response for order {order_id}");
+            OrderBookManagementJob::OrderInfoResponse { info, .. } => {
                 if let Some(order_info) = info {
                     self.handle_order_info_response(order_info)?;
                 }
@@ -60,7 +58,6 @@ impl GossipProtocolExecutor {
         order_id: OrderIdentifier,
         response_channel: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Result<(), GossipError> {
-        log::info!("got order info request");
         let order_info = self
             .global_state
             .read_order_book()

--- a/core/src/gossip/worker.rs
+++ b/core/src/gossip/worker.rs
@@ -107,7 +107,7 @@ impl Worker for GossipServer {
         }
 
         let req = BootstrapRequest {
-            peer_id: self.config.local_peer_id,
+            peer_info: self.config.global_state.local_peer_info(),
         };
         for (peer_id, _) in self.config.bootstrap_servers.iter() {
             self.config

--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -4,6 +4,7 @@ use std::thread::{Builder, JoinHandle};
 
 use crossbeam::channel::{Receiver, Sender};
 use tokio::sync::mpsc::UnboundedSender;
+use tracing::log;
 
 use crate::{
     api::gossip::GossipOutbound,
@@ -40,8 +41,6 @@ impl Worker for HandshakeManager {
     type Error = HandshakeManagerError;
 
     fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
-        // Build a thread pool to handle handshake operations
-        println!("Starting execution loop for handshake protocol executor...");
         // Start a timer thread, periodically asks workers to begin handshakes with peers
         let scheduler = HandshakeScheduler::new(
             config.job_sender.clone(),
@@ -81,6 +80,8 @@ impl Worker for HandshakeManager {
     }
 
     fn start(&mut self) -> Result<(), Self::Error> {
+        log::info!("Starting executor loop for handshake protocol executor...");
+
         // Spawn both the executor and the scheduler in a thread
         let executor = self.executor.take().unwrap();
         let executor_handle = Builder::new()

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -112,11 +112,6 @@ impl NetworkManager {
                 self.config.cluster_keypair.as_ref().unwrap(),
             ),
         );
-
-        // Add self to cluster metadata
-        self.config
-            .global_state
-            .add_cluster_peer(self.local_peer_id);
     }
 
     /// Setup pubsub subscriptions for the network manager
@@ -535,6 +530,7 @@ impl NetworkManagerExecutor {
                         .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string())),
 
                     GossipRequest::Replicate(replicate_message) => {
+                        log::info!("replicate request");
                         self.gossip_work_queue
                             .send(GossipServerJob::Cluster(
                                 ClusterManagementJob::ReplicateRequest(replicate_message),

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -266,12 +266,27 @@ impl NetworkOrderBook {
     }
 
     /// Fetch all the locally managed, verified orders
+    ///
+    /// Used to choose a match candidate for a scheduled remote order handshake
     pub fn get_local_verified_orders(&self) -> Vec<OrderIdentifier> {
         let locked_verified_orders = self.read_verified_orders();
         let locked_local_orders = self.read_local_orders();
 
         locked_verified_orders
             .intersection(&locked_local_orders)
+            .cloned()
+            .collect_vec()
+    }
+
+    /// Fetch all the non-locally managed, verified orders
+    ///
+    /// Used for choosing orders to schedule handshakes on
+    pub fn get_nonlocal_verified_orders(&self) -> Vec<OrderIdentifier> {
+        let locked_verified_orders = self.read_verified_orders();
+        let locked_local_orders = self.read_local_orders();
+
+        locked_verified_orders
+            .difference(&locked_local_orders)
             .cloned()
             .collect_vec()
     }

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -88,6 +88,13 @@ impl PeerIndex {
         self.peer_map.len()
     }
 
+    /// Returns the info for a given peer
+    pub fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
+        self.peer_map
+            .get(peer_id)
+            .map(|info| info.read().expect(ERR_PEER_POISONED).clone())
+    }
+
     /// Returns whether the given peer is already indexed by the peer index
     pub fn contains_peer(&self, peer_id: &WrappedPeerId) -> bool {
         self.peer_map.contains_key(peer_id)

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -98,8 +98,15 @@ impl PeerIndex {
         self.peer_map.contains_key(peer_id)
     }
 
+    /// Returns a list of all cluster peers
+    pub fn get_all_cluster_peers(&self, cluster_id: &ClusterId) -> Vec<WrappedPeerId> {
+        self.read_cluster_peers(cluster_id)
+            .map(|peers| peers.iter().cloned().collect_vec())
+            .unwrap_or_default()
+    }
+
     /// Returns a random cluster peer for the given cluster
-    pub fn get_cluster_peer(&self, cluster_id: &ClusterId) -> Option<WrappedPeerId> {
+    pub fn sample_cluster_peer(&self, cluster_id: &ClusterId) -> Option<WrappedPeerId> {
         let mut rng = thread_rng();
         let cluster_peers = self.read_cluster_peers(cluster_id)?;
 

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -88,11 +88,6 @@ impl PeerIndex {
         self.peer_map.len()
     }
 
-    /// Returns the info for a given peer if it is indexed
-    pub fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
-        self.read_peer(peer_id).map(|info| info.clone())
-    }
-
     /// Returns whether the given peer is already indexed by the peer index
     pub fn contains_peer(&self, peer_id: &WrappedPeerId) -> bool {
         self.peer_map.contains_key(peer_id)

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -256,9 +256,7 @@ impl RelayerState {
 
             // Update the local orderbook state
             self.read_order_book()
-                .write_order(&order_id)
-                .unwrap()
-                .attach_commitment_proof(proof_bundle.clone());
+                .update_order_validity_proof(&order_id, proof_bundle.clone());
 
             // Gossip about the updated proof to the network
             let message = GossipOutbound::Pubsub {

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -286,7 +286,7 @@ impl RelayerState {
     /// Sample an order for handshake
     pub fn choose_handshake_order(&self) -> Option<OrderIdentifier> {
         // Read the set of orders that are verified and thereby ready for batch
-        let verified_orders = { self.read_order_book().get_verified_orders() };
+        let verified_orders = { self.read_order_book().get_nonlocal_verified_orders() };
         if verified_orders.is_empty() {
             return None;
         }

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -271,9 +271,16 @@ impl RelayerState {
     // | Getters |
     // -----------
 
-    /// Acquire a read lock on `local_peer_id`
+    /// Get the local peer's ID
     pub fn local_peer_id(&self) -> WrappedPeerId {
         self.local_peer_id
+    }
+
+    /// Get the peer info for the local peer
+    pub fn local_peer_info(&self) -> PeerInfo {
+        self.read_peer_index()
+            .get_peer_info(&self.local_peer_id)
+            .unwrap()
     }
 
     /// Sample an order for handshake

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -271,13 +271,6 @@ impl RelayerState {
     // | Getters |
     // -----------
 
-    /// Get the local peer's info
-    pub fn get_local_peer_info(&self) -> PeerInfo {
-        self.read_peer_index()
-            .get_peer_info(&self.local_peer_id)
-            .unwrap()
-    }
-
     /// Acquire a read lock on `local_peer_id`
     pub fn local_peer_id(&self) -> WrappedPeerId {
         self.local_peer_id

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -22,7 +22,6 @@ use crypto::fields::{biguint_to_scalar, prime_field_to_scalar, scalar_to_biguint
 use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use num_bigint::BigUint;
-use rand::{Rng, RngCore};
 use serde::{
     de::{Error as SerdeErr, SeqAccess, Visitor},
     ser::SerializeSeq,
@@ -245,26 +244,9 @@ impl WalletIndex {
     // | Getters |
     // -----------
 
-    /// Returns true if there are no wallets in the locally managed wallet index
-    pub fn is_empty(&self) -> bool {
-        self.wallet_map.is_empty()
-    }
-
     /// Get the wallet that an order is allocated in
     pub fn get_wallet_for_order(&self, order_id: &OrderIdentifier) -> Option<WalletIdentifier> {
         self.order_to_wallet.get(order_id).cloned()
-    }
-
-    /// Return a random wallet, used for sampling wallets to match with
-    pub fn get_random_wallet<R: RngCore>(&self, rng: &mut R) -> Wallet {
-        let key_index = rng.gen_range(0..self.wallet_map.len());
-        self.wallet_map
-            .values()
-            .nth(key_index)
-            .unwrap()
-            .read()
-            .expect(ERR_WALLET_POISONED)
-            .clone()
     }
 
     /// Returns a list of all wallets

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -374,12 +374,10 @@ impl WalletIndex {
     /// This method is called when a cluster peer is determined to have failed; we should
     /// update the replication state and take any steps necessary to get the wallet replicated
     /// on a safe number of peers
-    pub fn remove_peer_replicas(&self, peers: &[WrappedPeerId]) {
+    pub fn remove_peer_replicas(&self, peer: &WrappedPeerId) {
         for (_, wallet) in self.wallet_map.iter() {
             let mut locked_wallet = wallet.write().expect("wallet lock poisoned");
-            for peer in peers.iter() {
-                locked_wallet.metadata.replicas.remove(peer);
-            }
+            locked_wallet.metadata.replicas.remove(peer);
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR makes another (smaller) refactor to the handshake scheduling flow that chooses a match candidate order from a set of locally managed, verified orders; rather than round robin on managed wallets.

As well this PR makes a few small improvements and fixes a few small gossip bugs along the way:
1. Peers need not authenticate into their cluster explicitly through a `ClusterAuth` message. The `PeerInfo` struct passed between nodes via heartbeat contains a signature of the peer's ID with the cluster private key. When a new peer is discovered, this signature is verified, authenticating the peer into their cluster in the `PeerIndex` (regardless of whether the local peer is in this cluster).
2. When a peer uses a node to bootstrap into the network, the bootstrap node should index the new peer.
3. Locally managed orders should be ignored when scheduling handshakes, this avoid unnecessary message passing and synchronization

### Testing
- Unit tests
- Verified the cluster auth, join, management flows
- Verified the match flows, verified that matches are correctly scheduled and cached, and that they wait for validity proofs.