### PR TITLE
core: handshake: Setup initial code structure for post-match encryption

### DIFF
--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -7,7 +7,7 @@ use circuits::{
     Allocate, Open,
 };
 use integration_helpers::types::IntegrationTest;
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 
 use crate::{IntegrationTestArgs, TestWrapper};
 
@@ -21,8 +21,8 @@ fn check_no_match(res: &MatchResult) -> Result<(), String> {
     check_single_match(
         res,
         &MatchResult {
-            quote_mint: BigInt::from(0u64),
-            base_mint: BigInt::from(0u64),
+            quote_mint: BigUint::from(0u64),
+            base_mint: BigUint::from(0u64),
             quote_amount: 0,
             base_amount: 0,
             direction: 0,
@@ -170,8 +170,8 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
     //      [party1_buy_mint, party1_buy_amount, party2_buy_mint, party2_buy_amount]
     let expected_results = vec![
         MatchResult {
-            quote_mint: BigInt::from(1),
-            base_mint: BigInt::from(2),
+            quote_mint: BigUint::from(1u8),
+            base_mint: BigUint::from(2u8),
             quote_amount: 150,
             base_amount: 20,
             direction: 0,
@@ -180,8 +180,8 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
             min_amount_order_index: 0,
         },
         MatchResult {
-            quote_mint: BigInt::from(1),
-            base_mint: BigInt::from(2),
+            quote_mint: BigUint::from(1u8),
+            base_mint: BigUint::from(2u8),
             quote_amount: 100,
             base_amount: 10,
             direction: 1,
@@ -190,8 +190,8 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
             min_amount_order_index: 0,
         },
         MatchResult {
-            quote_mint: BigInt::from(1),
-            base_mint: BigInt::from(2),
+            quote_mint: BigUint::from(1u8),
+            base_mint: BigUint::from(2u8),
             quote_amount: 200,
             base_amount: 20,
             direction: 1,

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -557,8 +557,8 @@ pub mod native_helpers {
             note.fee_volume,
             note.fee_direction as u64,
             note.type_ as u64,
-            note.randomness,
         ]);
+        hasher.absorb(&biguint_to_prime_field(&note.randomness));
         hasher.absorb(&scalar_to_prime_field(&pk_settle_receiver));
         hasher.squeeze_field_elements(1 /* num_elements */)[0]
     }

--- a/circuits/src/mpc.rs
+++ b/circuits/src/mpc.rs
@@ -30,7 +30,7 @@ pub struct SharedFabric<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 );
 
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> SharedFabric<N, S> {
-    /// Wrap an existing fabric in a shared mutibility struct
+    /// Wrap an existing fabric in a shared mutability struct
     pub fn new(fabric: AuthenticatedMpcFabric<N, S>) -> Self {
         Self(Rc::new(RefCell::new(fabric)))
     }

--- a/circuits/src/types/handshake_tuple.rs
+++ b/circuits/src/types/handshake_tuple.rs
@@ -5,6 +5,7 @@ use crate::{
     zk_gadgets::fixed_point::{AuthenticatedCommittedFixedPoint, AuthenticatedFixedPointVar},
     CommitSharedProver,
 };
+use crypto::fields::biguint_to_scalar;
 use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use mpc_bulletproof::r1cs_mpc::MpcProver;
@@ -45,13 +46,13 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
             .batch_commit(
                 owning_party,
                 &[
-                    Scalar::from(order.quote_mint),
-                    Scalar::from(order.base_mint),
+                    biguint_to_scalar(&order.quote_mint),
+                    biguint_to_scalar(&order.base_mint),
                     Scalar::from(order.side as u64),
                     Scalar::from(order.price.to_owned()),
                     Scalar::from(order.amount),
                     Scalar::from(order.timestamp),
-                    Scalar::from(balance.mint),
+                    biguint_to_scalar(&balance.mint),
                     Scalar::from(balance.amount),
                 ],
                 &blinders,

--- a/circuits/src/types/match.rs
+++ b/circuits/src/types/match.rs
@@ -23,6 +23,7 @@ use mpc_ristretto::{
 };
 use num_bigint::BigInt;
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
 /// The number of scalars in a match tuple for serialization/deserialization
 pub(crate) const MATCH_SIZE_SCALARS: usize = 8;
@@ -114,7 +115,7 @@ pub struct MatchResultVar {
 }
 
 /// A commitment to the match result in a single-prover constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedMatchResult {
     /// The mint of the order token in the asset pair being matched
     pub quote_mint: CompressedRistretto,

--- a/circuits/src/types/match.rs
+++ b/circuits/src/types/match.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     CommitProver, CommitSharedProver, CommitVerifier, Open,
 };
-use crypto::fields::bigint_to_scalar;
+use crypto::fields::biguint_to_scalar;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 
 use itertools::Itertools;
@@ -21,7 +21,7 @@ use mpc_ristretto::{
     authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource,
     mpc_scalar::scalar_to_u64, network::MpcNetwork,
 };
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -35,9 +35,9 @@ pub(crate) const MATCH_SIZE_SCALARS: usize = 8;
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct MatchResult {
     /// The mint of the order token in the asset pair being matched
-    pub quote_mint: BigInt,
+    pub quote_mint: BigUint,
     /// The mint of the base token in the asset pair being matched
-    pub base_mint: BigInt,
+    pub base_mint: BigUint,
     /// The amount of the quote token exchanged by this match
     pub quote_amount: u64,
     /// The amount of the base token exchanged by this match
@@ -76,8 +76,8 @@ impl TryFrom<&[u64]> for MatchResult {
         }
 
         Ok(MatchResult {
-            quote_mint: BigInt::from(values[0]),
-            base_mint: BigInt::from(values[1]),
+            quote_mint: BigUint::from(values[0]),
+            base_mint: BigUint::from(values[1]),
             quote_amount: values[2],
             base_amount: values[3],
             direction: values[4],
@@ -151,9 +151,9 @@ impl CommitProver for MatchResult {
         prover: &mut mpc_bulletproof::r1cs::Prover,
     ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
         let (quote_mint_comm, quote_mint_var) =
-            prover.commit(bigint_to_scalar(&self.quote_mint), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.quote_mint), Scalar::random(rng));
         let (base_mint_comm, base_mint_var) =
-            prover.commit(bigint_to_scalar(&self.base_mint), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.base_mint), Scalar::random(rng));
         let (quote_amount_comm, quote_amount_var) =
             prover.commit(Scalar::from(self.quote_amount), Scalar::random(rng));
         let (base_amount_comm, base_amount_var) =

--- a/circuits/src/types/note.rs
+++ b/circuits/src/types/note.rs
@@ -3,6 +3,7 @@
 
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use mpc_bulletproof::r1cs::{Prover, Variable, Verifier};
+use serde::{Deserialize, Serialize};
 
 use crate::{CommitProver, CommitVerifier};
 
@@ -92,7 +93,7 @@ impl From<NoteVar> for Vec<Variable> {
 }
 
 /// Represents a note that has been allocated in a constraint system
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CommittedNote {
     /// The first mint exchanged via the note
     pub mint1: CompressedRistretto,

--- a/circuits/src/types/note.rs
+++ b/circuits/src/types/note.rs
@@ -45,7 +45,7 @@ pub struct Note {
     /// or by match
     pub type_: NoteType,
     /// The randomness included with the note, used to authenticate notes
-    pub randomness: u64,
+    pub randomness: BigUint,
 }
 
 /// Represents a note that has been allocated in a constraint system
@@ -153,7 +153,7 @@ impl CommitProver for Note {
         let (type_comm, type_var) =
             prover.commit(Scalar::from(self.type_ as u8), Scalar::random(rng));
         let (randomness_comm, randomness_var) =
-            prover.commit(Scalar::from(self.randomness), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.randomness), Scalar::random(rng));
 
         Ok((
             NoteVar {

--- a/circuits/src/types/note.rs
+++ b/circuits/src/types/note.rs
@@ -1,8 +1,10 @@
 //! Groups type definitions for protocol notes: a state primitive which is created upon a transfer
 //! or a successful match. Notes are redeemed into the balances of a wallet and nullified.
 
+use crypto::fields::biguint_to_scalar;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use mpc_bulletproof::r1cs::{Prover, Variable, Verifier};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use crate::{CommitProver, CommitVerifier};
@@ -22,19 +24,19 @@ pub enum NoteType {
 #[derive(Clone, Debug)]
 pub struct Note {
     /// The first mint exchanged via the note
-    pub mint1: u64,
+    pub mint1: BigUint,
     /// The volume of the first mint exchanged  
     pub volume1: u64,
     /// The direction of the first mint
     pub direction1: OrderSide,
     /// The second mint exchanged via the note
-    pub mint2: u64,
+    pub mint2: BigUint,
     /// The volume of the second mint exchanged
     pub volume2: u64,
     /// The direction of the second mint
     pub direction2: OrderSide,
     /// The mint of the relayer fee paid on contract interaction
-    pub fee_mint: u64,
+    pub fee_mint: BigUint,
     /// The volume of the relayer fee paid on contract interaction
     pub fee_volume: u64,
     /// The direction of the relayer fee, will be Buy for the relayer's note
@@ -130,18 +132,20 @@ impl CommitProver for Note {
         rng: &mut R,
         prover: &mut Prover,
     ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
-        let (mint1_comm, mint1_var) = prover.commit(Scalar::from(self.mint1), Scalar::random(rng));
+        let (mint1_comm, mint1_var) =
+            prover.commit(biguint_to_scalar(&self.mint1), Scalar::random(rng));
         let (volume1_comm, volume1_var) =
             prover.commit(Scalar::from(self.volume1), Scalar::random(rng));
         let (direction1_comm, direction1_var) =
             prover.commit(Scalar::from(self.direction1 as u8), Scalar::random(rng));
-        let (mint2_comm, mint2_var) = prover.commit(Scalar::from(self.mint2), Scalar::random(rng));
+        let (mint2_comm, mint2_var) =
+            prover.commit(biguint_to_scalar(&self.mint2), Scalar::random(rng));
         let (volume2_comm, volume2_var) =
             prover.commit(Scalar::from(self.volume2), Scalar::random(rng));
         let (direction2_comm, direction2_var) =
             prover.commit(Scalar::from(self.direction2 as u8), Scalar::random(rng));
         let (fee_mint_comm, fee_mint_var) =
-            prover.commit(Scalar::from(self.fee_mint), Scalar::random(rng));
+            prover.commit(biguint_to_scalar(&self.fee_mint), Scalar::random(rng));
         let (fee_volume_comm, fee_volume_var) =
             prover.commit(Scalar::from(self.fee_volume), Scalar::random(rng));
         let (fee_direction_comm, fee_direction_var) =

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -47,24 +47,24 @@ mod test_helpers {
             pk_view: Scalar::one(),
         };
         pub(crate) static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
-            Balance { mint: 1, amount: 5 },
+            Balance { mint: 1u8.into(), amount: 5 },
             Balance {
-                mint: 2,
+                mint: 2u8.into(),
                 amount: 10
             }
         ];
         pub(crate) static ref INITIAL_ORDERS: [Order; MAX_ORDERS] = [
             Order {
-                quote_mint: 1,
-                base_mint: 2,
+                quote_mint: 1u8.into(),
+                base_mint: 2u8.into(),
                 side: OrderSide::Buy,
                 price: FixedPoint::from(5.),
                 amount: 1,
                 timestamp: TIMESTAMP,
             },
             Order {
-                quote_mint: 1,
-                base_mint: 3,
+                quote_mint: 1u8.into(),
+                base_mint: 3u8.into(),
                 side: OrderSide::Sell,
                 price: FixedPoint::from(2.),
                 amount: 10,

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -561,7 +561,7 @@ mod valid_commitments_test {
 
         // Invalid, fake balance with a larger balance than the wallet has access to
         let balance = Balance {
-            mint: 2u64,
+            mint: 2u8.into(),
             amount: 20u64,
         };
         let fee_balance = wallet.balances[0].to_owned();
@@ -606,7 +606,7 @@ mod valid_commitments_test {
         let balance = wallet.balances[0].to_owned();
         // Invalid, fake balance with a larger balance than the wallet has access to
         let fee_balance = Balance {
-            mint: 1,
+            mint: 1u8.into(),
             amount: 10,
         };
         let fee = wallet.fees[0].to_owned();
@@ -646,8 +646,8 @@ mod valid_commitments_test {
     fn test_invalid_order() {
         let wallet: SizedWallet = INITIAL_WALLET.clone();
         let order = Order {
-            quote_mint: 1,
-            base_mint: 3,
+            quote_mint: 1u8.into(),
+            base_mint: 3u8.into(),
             side: OrderSide::Buy,
             price: FixedPoint::from(10.),
             amount: 15,

--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -17,6 +17,7 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
@@ -595,7 +596,7 @@ pub struct ValidMatchEncryptionWitnessVar {
 }
 
 /// A commitment to the witness type for the VALID MATCH ENCRYPTION circuit
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidMatchEncryptionWitnessCommitment {
     /// The result of the match process; a completed match
     pub match_res: CommittedMatchResult,
@@ -735,7 +736,7 @@ impl CommitVerifier for ValidMatchEncryptionWitnessCommitment {
 ///
 /// Each of the ciphertexts is a 2-tuple of scalars; one being the ElGamal shared
 /// secret of the encryption, and the other being the encrypted value itself
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidMatchEncryptionStatement {
     /// The commitment to the first party's note
     pub party0_note_commit: Scalar,

--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -999,7 +999,7 @@ mod valid_match_encryption_tests {
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
     use mpc_ristretto::mpc_scalar::scalar_to_u64;
-    use num_bigint::{BigInt, BigUint};
+    use num_bigint::BigUint;
     use rand_core::{OsRng, RngCore};
 
     use crate::{
@@ -1029,8 +1029,8 @@ mod valid_match_encryption_tests {
     const PROTOCOL_FEE: f32 = 0.01;
     lazy_static! {
         static ref DUMMY_MATCH: MatchResult = MatchResult {
-            quote_mint: BigInt::from(1u8),
-            base_mint: BigInt::from(1u8),
+            quote_mint: BigUint::from(1u8),
+            base_mint: BigUint::from(1u8),
             quote_amount: 300,
             base_amount: 200,
             direction: 1,
@@ -1104,13 +1104,13 @@ mod valid_match_encryption_tests {
         let fee_tuple2 = DUMMY_FEE2.clone();
 
         let party0_note = Note {
-            mint1: match_.base_mint.clone().try_into().unwrap(),
+            mint1: match_.base_mint.clone(),
             volume1: sel!(party_base_amount, match_.base_amount),
             direction1: sel!(buy, sell),
-            mint2: match_.quote_mint.clone().try_into().unwrap(),
+            mint2: match_.quote_mint.clone(),
             volume2: sel!(match_.quote_amount, party_quote_amount),
             direction2: sel!(sell, buy),
-            fee_mint: fee_tuple1.gas_addr.clone().try_into().unwrap(),
+            fee_mint: fee_tuple1.gas_addr.clone(),
             fee_volume: fee_tuple1.gas_token_amount,
             fee_direction: sell,
             type_: NoteType::Match,
@@ -1118,13 +1118,13 @@ mod valid_match_encryption_tests {
         };
 
         let party1_note = Note {
-            mint1: match_.base_mint.clone().try_into().unwrap(),
+            mint1: match_.base_mint.clone(),
             volume1: sel!(match_.base_amount, party_base_amount),
             direction1: sel!(sell, buy),
-            mint2: match_.quote_mint.clone().try_into().unwrap(),
+            mint2: match_.quote_mint.clone(),
             volume2: sel!(party_quote_amount, match_.quote_amount),
             direction2: sel!(buy, sell),
-            fee_mint: fee_tuple2.gas_addr.clone().try_into().unwrap(),
+            fee_mint: fee_tuple2.gas_addr.clone(),
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: sell,
             type_: NoteType::Match,
@@ -1132,13 +1132,13 @@ mod valid_match_encryption_tests {
         };
 
         let relayer0_note = Note {
-            mint1: match_.base_mint.clone().try_into().unwrap(),
+            mint1: match_.base_mint.clone(),
             volume1: sel!(relayer_base_amount, 0),
             direction1: buy,
-            mint2: match_.quote_mint.clone().try_into().unwrap(),
+            mint2: match_.quote_mint.clone(),
             volume2: sel!(0, relayer_quote_amount),
             direction2: buy,
-            fee_mint: fee_tuple1.gas_addr.try_into().unwrap(),
+            fee_mint: fee_tuple1.gas_addr,
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
@@ -1146,13 +1146,13 @@ mod valid_match_encryption_tests {
         };
 
         let relayer1_note = Note {
-            mint1: match_.base_mint.clone().try_into().unwrap(),
+            mint1: match_.base_mint.clone(),
             volume1: sel!(0, relayer_base_amount),
             direction1: buy,
-            mint2: match_.quote_mint.clone().try_into().unwrap(),
+            mint2: match_.quote_mint.clone(),
             volume2: sel!(relayer_quote_amount, 0),
             direction2: buy,
-            fee_mint: fee_tuple2.gas_addr.try_into().unwrap(),
+            fee_mint: fee_tuple2.gas_addr,
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
@@ -1160,13 +1160,13 @@ mod valid_match_encryption_tests {
         };
 
         let protocol_note = Note {
-            mint1: match_.base_mint.clone().try_into().unwrap(),
+            mint1: match_.base_mint.clone(),
             volume1: protocol_base_amount,
             direction1: buy,
-            mint2: match_.quote_mint.clone().try_into().unwrap(),
+            mint2: match_.quote_mint.clone(),
             volume2: protocol_quote_amount,
             direction2: buy,
-            fee_mint: 0,
+            fee_mint: 0u8.into(),
             fee_volume: 0,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
@@ -1191,11 +1191,11 @@ mod valid_match_encryption_tests {
             elgamal_encrypt(&BigUint::from(party1_note.volume2), &pk_settle_party1);
 
         let (protocol_mint1_cipher, randomness5) =
-            elgamal_encrypt(&BigUint::from(protocol_note.mint1), &pk_settle_protocol);
+            elgamal_encrypt(&protocol_note.mint1, &pk_settle_protocol);
         let (protocol_volume1_cipher, randomness6) =
             elgamal_encrypt(&BigUint::from(protocol_note.volume1), &pk_settle_protocol);
         let (protocol_mint2_cipher, randomness7) =
-            elgamal_encrypt(&BigUint::from(protocol_note.mint2), &pk_settle_protocol);
+            elgamal_encrypt(&protocol_note.mint2, &pk_settle_protocol);
         let (protocol_volume2_cipher, randomness8) =
             elgamal_encrypt(&BigUint::from(protocol_note.volume2), &pk_settle_protocol);
         let (protocol_randomness_cipher, randomness9) = elgamal_encrypt(

--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -1074,8 +1074,8 @@ mod valid_match_encryption_tests {
         let sell = OrderSide::Sell;
 
         let mut rng = OsRng {};
-        let party0_randomness_hash = rng.next_u32() as u64;
-        let party1_randomness_hash = rng.next_u32() as u64;
+        let party0_randomness_hash: BigUint = rng.next_u32().into();
+        let party1_randomness_hash: BigUint = rng.next_u32().into();
 
         let relayer_fee_fraction = DUMMY_FEE1.percentage_fee;
         let protocol_fee_fraction = DUMMY_FEE2.percentage_fee;
@@ -1114,7 +1114,7 @@ mod valid_match_encryption_tests {
             fee_volume: fee_tuple1.gas_token_amount,
             fee_direction: sell,
             type_: NoteType::Match,
-            randomness: party0_randomness_hash,
+            randomness: party0_randomness_hash.clone(),
         };
 
         let party1_note = Note {
@@ -1128,7 +1128,7 @@ mod valid_match_encryption_tests {
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: sell,
             type_: NoteType::Match,
-            randomness: party1_randomness_hash,
+            randomness: party1_randomness_hash.clone(),
         };
 
         let relayer0_note = Note {
@@ -1142,7 +1142,7 @@ mod valid_match_encryption_tests {
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
-            randomness: party0_randomness_hash + 1u64,
+            randomness: party0_randomness_hash.clone() + 1u64,
         };
 
         let relayer1_note = Note {
@@ -1156,7 +1156,7 @@ mod valid_match_encryption_tests {
             fee_volume: fee_tuple2.gas_token_amount,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
-            randomness: party1_randomness_hash + 1u64,
+            randomness: party1_randomness_hash.clone() + 1u64,
         };
 
         let protocol_note = Note {
@@ -1170,7 +1170,7 @@ mod valid_match_encryption_tests {
             fee_volume: 0,
             fee_direction: buy,
             type_: NoteType::InternalTransfer,
-            randomness: party0_randomness_hash + party1_randomness_hash,
+            randomness: party0_randomness_hash.clone() + party1_randomness_hash.clone(),
         };
 
         // Generate encryptions for the statement
@@ -1198,18 +1198,16 @@ mod valid_match_encryption_tests {
             elgamal_encrypt(&protocol_note.mint2, &pk_settle_protocol);
         let (protocol_volume2_cipher, randomness8) =
             elgamal_encrypt(&BigUint::from(protocol_note.volume2), &pk_settle_protocol);
-        let (protocol_randomness_cipher, randomness9) = elgamal_encrypt(
-            &BigUint::from(protocol_note.randomness),
-            &pk_settle_protocol,
-        );
+        let (protocol_randomness_cipher, randomness9) =
+            elgamal_encrypt(&protocol_note.randomness, &pk_settle_protocol);
 
         (
             ValidMatchEncryptionWitness {
                 match_res: match_,
                 party0_fee: DUMMY_FEE1.clone(),
                 party1_fee: DUMMY_FEE2.clone(),
-                party0_randomness_hash: Scalar::from(party0_randomness_hash),
-                party1_randomness_hash: Scalar::from(party1_randomness_hash),
+                party0_randomness_hash: biguint_to_scalar(&party0_randomness_hash),
+                party1_randomness_hash: biguint_to_scalar(&party1_randomness_hash),
                 party0_note: party0_note.clone(),
                 party1_note: party1_note.clone(),
                 relayer0_note: relayer0_note.clone(),

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -712,7 +712,7 @@ mod valid_settle_tests {
             fee_volume: 3,
             fee_direction: OrderSide::Sell,
             type_: NoteType::Match,
-            randomness: 1729,
+            randomness: 1729u64.into(),
         };
     }
 

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -667,6 +667,7 @@ mod valid_settle_tests {
     use lazy_static::lazy_static;
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+    use num_bigint::BigUint;
     use rand_core::OsRng;
 
     use crate::{
@@ -701,13 +702,13 @@ mod valid_settle_tests {
         ///
         /// Fees for the match were paid in token 2
         static ref DUMMY_MATCH_NOTE: Note = Note {
-            mint1: 2,
+            mint1: 2u8.into(),
             volume1: 1,
             direction1: OrderSide::Buy,
-            mint2: 1,
+            mint2: 1u8.into(),
             volume2: 4,
             direction2: OrderSide::Sell,
-            fee_mint: 2,
+            fee_mint: 2u8.into(),
             fee_volume: 3,
             fee_direction: OrderSide::Sell,
             type_: NoteType::Match,
@@ -726,7 +727,7 @@ mod valid_settle_tests {
 
         // Update the balances according to the note
         for balance in result_wallet.balances.iter_mut() {
-            if balance.mint == 0 {
+            if balance.mint == 0u8.into() {
                 continue;
             }
             if balance.mint == note.mint1 {
@@ -865,10 +866,10 @@ mod valid_settle_tests {
         let mut note = DUMMY_MATCH_NOTE.clone();
 
         // Modify the note to be a transfer note
-        note.mint2 = 0;
+        note.mint2 = 0u8.into();
         note.volume2 = 0;
         note.direction2 = OrderSide::Buy;
-        note.fee_mint = 0;
+        note.fee_mint = 0u8.into();
         note.fee_volume = 0;
         note.fee_direction = OrderSide::Buy;
 
@@ -901,7 +902,7 @@ mod valid_settle_tests {
         let initial_wallet = INITIAL_WALLET.clone();
         let note = DUMMY_MATCH_NOTE.clone();
         let mut post_wallet = apply_note_to_wallet(&note, &initial_wallet);
-        post_wallet.balances[0].mint = 42;
+        post_wallet.balances[0].mint = 42u8.into();
 
         let (witness, statement) = compute_witness_and_statement(initial_wallet, post_wallet, note);
 
@@ -1042,12 +1043,12 @@ mod valid_settle_tests {
 
         // Try changing the base mint
         let mut bad_post_wallet1 = post_wallet.clone();
-        bad_post_wallet1.orders[1].base_mint += 1;
+        bad_post_wallet1.orders[1].base_mint += BigUint::from(1u8);
         bad_post_wallets.push(bad_post_wallet1);
 
         // Try changing the quote mint
         let mut bad_post_wallet2 = post_wallet.clone();
-        bad_post_wallet2.orders[1].quote_mint += 1;
+        bad_post_wallet2.orders[1].quote_mint += BigUint::from(1u8);
         bad_post_wallets.push(bad_post_wallet2);
 
         // Try changing the direction

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -647,7 +647,7 @@ where
 mod valid_wallet_update_tests {
     use std::ops::Neg;
 
-    use crypto::fields::prime_field_to_scalar;
+    use crypto::fields::{biguint_to_scalar, prime_field_to_scalar};
     use curve25519_dalek::scalar::Scalar;
     use merlin::Transcript;
     use mpc_bulletproof::{
@@ -970,8 +970,8 @@ mod valid_wallet_update_tests {
 
         // Invalid, cannot have two orders of the same pair
         new_wallet.orders[0].timestamp = timestamp;
-        new_wallet.orders[0].quote_mint = new_wallet.orders[1].quote_mint;
-        new_wallet.orders[0].base_mint = new_wallet.orders[1].base_mint;
+        new_wallet.orders[0].quote_mint = new_wallet.orders[1].quote_mint.clone();
+        new_wallet.orders[0].base_mint = new_wallet.orders[1].base_mint.clone();
 
         initial_wallet.orders[1] = Order::default();
 
@@ -1032,7 +1032,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Invalid, multiple balances of the same mint
-        new_wallet.balances[0].mint = new_wallet.balances[1].mint;
+        new_wallet.balances[0].mint = new_wallet.balances[1].mint.clone();
 
         // Create a mock Merkle opening for the old wallet
         let random_index = rng.next_u32() % (2u32.pow(MERKLE_HEIGHT.try_into().unwrap()));
@@ -1091,7 +1091,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let internal_transfer_mint = new_wallet.balances[1].mint;
+        let internal_transfer_mint = new_wallet.balances[1].mint.clone();
         let internal_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
         new_wallet.balances[1].amount -= internal_transfer_volume;
 
@@ -1112,7 +1112,7 @@ mod valid_wallet_update_tests {
                 indices: mock_opening_indices,
             },
             internal_transfer: (
-                Scalar::from(internal_transfer_mint),
+                biguint_to_scalar(&internal_transfer_mint),
                 Scalar::from(internal_transfer_volume),
             ),
         };
@@ -1155,7 +1155,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let internal_transfer_mint = new_wallet.balances[1].mint;
+        let internal_transfer_mint = new_wallet.balances[1].mint.clone();
         let internal_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
 
         // Invalid, prover tries to decrease their balance by a smaller amount than transferred
@@ -1178,7 +1178,7 @@ mod valid_wallet_update_tests {
                 indices: mock_opening_indices,
             },
             internal_transfer: (
-                Scalar::from(internal_transfer_mint),
+                biguint_to_scalar(&internal_transfer_mint),
                 Scalar::from(internal_transfer_volume),
             ),
         };
@@ -1221,7 +1221,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let external_transfer_mint = new_wallet.balances[1].mint;
+        let external_transfer_mint = new_wallet.balances[1].mint.clone();
         let external_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
         let external_transfer_direction = 1u64; // withdraw
 
@@ -1262,7 +1262,7 @@ mod valid_wallet_update_tests {
             wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
             merkle_root: mock_root,
             external_transfer: (
-                Scalar::from(external_transfer_mint),
+                biguint_to_scalar(&external_transfer_mint),
                 Scalar::from(external_transfer_volume),
                 Scalar::from(external_transfer_direction),
             ),
@@ -1288,7 +1288,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let external_transfer_mint = new_wallet.balances[1].mint;
+        let external_transfer_mint = new_wallet.balances[1].mint.clone();
         let external_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
         let external_transfer_direction = 0u64; // withdraw
 
@@ -1329,7 +1329,7 @@ mod valid_wallet_update_tests {
             wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
             merkle_root: mock_root,
             external_transfer: (
-                Scalar::from(external_transfer_mint),
+                biguint_to_scalar(&external_transfer_mint),
                 Scalar::from(external_transfer_volume),
                 Scalar::from(external_transfer_direction),
             ),
@@ -1355,7 +1355,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let external_transfer_mint = new_wallet.balances[1].mint;
+        let external_transfer_mint = new_wallet.balances[1].mint.clone();
         let external_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
         let external_transfer_direction = 1u64; // withdraw
 
@@ -1397,7 +1397,7 @@ mod valid_wallet_update_tests {
             wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
             merkle_root: mock_root,
             external_transfer: (
-                Scalar::from(external_transfer_mint),
+                biguint_to_scalar(&external_transfer_mint),
                 Scalar::from(external_transfer_volume),
                 Scalar::from(external_transfer_direction),
             ),
@@ -1423,7 +1423,7 @@ mod valid_wallet_update_tests {
         initial_wallet.orders[1] = Order::default();
 
         // Modify the balance in balances[1] to deduct an amount for the internal transfer
-        let external_transfer_mint = new_wallet.balances[1].mint;
+        let external_transfer_mint = new_wallet.balances[1].mint.clone();
         let external_transfer_volume = new_wallet.balances[1].amount - 1; // all but 1 unit
         let external_transfer_direction = 0u64; // withdraw
 
@@ -1465,7 +1465,7 @@ mod valid_wallet_update_tests {
             wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
             merkle_root: mock_root,
             external_transfer: (
-                Scalar::from(external_transfer_mint),
+                biguint_to_scalar(&external_transfer_mint),
                 Scalar::from(external_transfer_volume),
                 Scalar::from(external_transfer_direction),
             ),
@@ -1680,7 +1680,7 @@ mod valid_wallet_update_tests {
         // Invalid, the user does not have the withdrawn balance present
         // We do not modify the balance here, because we cannot underflow a u64; below we
         // replace the balance in the witness with an underflowed scalar
-        let external_transfer_mint = new_wallet.balances[1].mint;
+        let external_transfer_mint = new_wallet.balances[1].mint.clone();
         let external_transfer_volume = new_wallet.balances[1].amount + 1; // overdraw
         let external_transfer_direction = 1u64; // withdraw
 
@@ -1719,7 +1719,7 @@ mod valid_wallet_update_tests {
             wallet_match_nullifier: prime_field_to_scalar(&old_wallet_match_nullifier),
             merkle_root: mock_root,
             external_transfer: (
-                Scalar::from(external_transfer_mint),
+                biguint_to_scalar(&external_transfer_mint),
                 Scalar::from(external_transfer_volume),
                 Scalar::from(external_transfer_direction),
             ),

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -11,6 +11,7 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
@@ -66,7 +67,7 @@ impl<const SCALAR_BITS: usize> ElGamalGadget<SCALAR_BITS> {
 }
 
 /// A type representing an ElGamal ciphertext
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ElGamalCiphertext {
     /// The shared secret; the generator raised to the randomness
     pub partial_shared_secret: Scalar,

--- a/core/src/handshake/encumber.rs
+++ b/core/src/handshake/encumber.rs
@@ -1,0 +1,199 @@
+//! Implements the handshake manager flow of encumbering a pair of wallets
+//! after a match has completed. This involves:
+//!     1. Creating notes for the wallets, relayers, and protocol
+//!     2. Proving `VALID MATCH ENCRYPTION`
+//!     3. Submitting the proofs and data to the contract
+
+use circuits::types::{
+    fee::Fee,
+    note::{Note, NoteType},
+    order::OrderSide,
+    r#match::MatchResult,
+};
+use curve25519_dalek::scalar::Scalar;
+use mpc_ristretto::mpc_scalar::scalar_to_u64;
+
+use crate::PROTOCOL_FEE;
+
+use super::{error::HandshakeManagerError, manager::HandshakeExecutor, r#match::HandshakeResult};
+
+impl HandshakeExecutor {
+    /// Entrypoint to the encumbering flow, creates notes, proves `VALID MATCH ENCRYPTION`,
+    /// and submits the match bundle to the contract
+    pub(super) fn submit_match(
+        &self,
+        handshake_result: HandshakeResult,
+    ) -> Result<(), HandshakeManagerError> {
+        // Create notes for all parties from the match
+        #[allow(unused)]
+        let (party0_note, party1_note, relayer0_note, relayer1_note, protocol_note) = self
+            .create_notes(
+                &handshake_result.match_,
+                &handshake_result.party0_fee,
+                &handshake_result.party1_fee,
+            );
+
+        Ok(())
+    }
+
+    /// Create notes from a match result
+    ///
+    /// There are 5 notes in total:
+    ///     - Each of the parties receives a note for their side of the match (2)
+    ///     - Each of the managing relayers receives a note for their fees (2)
+    ///     - The protocol receives a note for its fee (1)
+    fn create_notes(
+        &self,
+        match_res: &MatchResult,
+        party0_fee: &Fee,
+        party1_fee: &Fee,
+    ) -> (Note, Note, Note, Note, Note) {
+        // The match direction corresponds to the direction that party 0 goes in the match
+        // i.e. the match direction is 0 (buy) if party 0 is buying the base and selling the quote
+        let match_direction: OrderSide = match_res.direction.into();
+        let base_amount_scalar = Scalar::from(match_res.base_amount);
+        let quote_amount_scalar = Scalar::from(match_res.quote_amount);
+
+        // Apply fees to the match
+        let party0_net_percentage = Scalar::one() - party0_fee.percentage_fee - *PROTOCOL_FEE;
+        let party1_net_percentage = Scalar::one() - party1_fee.percentage_fee - *PROTOCOL_FEE;
+
+        let (party0_base_amount, party0_quote_amount, party1_base_amount, party1_quote_amount) =
+            match match_direction {
+                OrderSide::Buy => {
+                    let party0_base =
+                        scalar_to_u64(&(party0_net_percentage * base_amount_scalar).floor());
+                    let party1_quote =
+                        scalar_to_u64(&(party1_net_percentage * quote_amount_scalar).floor());
+
+                    (
+                        party0_base,
+                        match_res.quote_amount,
+                        match_res.base_amount,
+                        party1_quote,
+                    )
+                }
+                OrderSide::Sell => {
+                    let party0_quote =
+                        scalar_to_u64(&(party0_net_percentage * quote_amount_scalar).floor());
+                    let party1_base =
+                        scalar_to_u64(&(party1_net_percentage * base_amount_scalar).floor());
+
+                    (
+                        match_res.base_amount,
+                        party0_quote,
+                        party1_base,
+                        match_res.quote_amount,
+                    )
+                }
+            };
+
+        // TODO: Fix randomness
+        let party0_note = Note {
+            mint1: match_res.base_mint.clone(),
+            volume1: party0_base_amount,
+            direction1: match_direction,
+            mint2: match_res.quote_mint.clone(),
+            volume2: party0_quote_amount,
+            direction2: match_direction.opposite(),
+            fee_mint: party0_fee.gas_addr.clone(),
+            fee_volume: party0_fee.gas_token_amount,
+            fee_direction: OrderSide::Sell,
+            type_: NoteType::Match,
+            randomness: 0,
+        };
+
+        let party1_note = Note {
+            mint1: match_res.base_mint.clone(),
+            volume1: party1_base_amount,
+            direction1: match_direction.opposite(),
+            mint2: match_res.quote_mint.clone(),
+            volume2: party1_quote_amount,
+            direction2: match_direction,
+            fee_mint: party1_fee.gas_addr.clone(),
+            fee_volume: party1_fee.gas_token_amount,
+            fee_direction: OrderSide::Sell,
+            type_: NoteType::Match,
+            randomness: 0,
+        };
+
+        // Create the relayer notes
+        let (
+            relayer0_base_amount,
+            relayer0_quote_amount,
+            relayer1_base_amount,
+            relayer1_quote_amount,
+        ) = match match_direction {
+            OrderSide::Buy => {
+                let relayer0_base =
+                    scalar_to_u64(&(party0_fee.percentage_fee * base_amount_scalar).floor());
+                let relayer1_quote =
+                    scalar_to_u64(&(party1_fee.percentage_fee * quote_amount_scalar).floor());
+
+                (relayer0_base, 0, 0, relayer1_quote)
+            }
+            OrderSide::Sell => {
+                let relayer0_quote =
+                    scalar_to_u64(&(party0_fee.percentage_fee * quote_amount_scalar).floor());
+                let relayer1_base =
+                    scalar_to_u64(&(party1_fee.percentage_fee * base_amount_scalar).floor());
+
+                (0, relayer0_quote, relayer1_base, 0)
+            }
+        };
+
+        let relayer0_note = Note {
+            mint1: match_res.base_mint.clone(),
+            volume1: relayer0_base_amount,
+            direction1: OrderSide::Buy,
+            mint2: match_res.quote_mint.clone(),
+            volume2: relayer0_quote_amount,
+            direction2: OrderSide::Buy,
+            fee_mint: party0_fee.gas_addr.clone(),
+            fee_volume: party0_fee.gas_token_amount,
+            fee_direction: OrderSide::Buy,
+            type_: NoteType::InternalTransfer,
+            randomness: 0,
+        };
+
+        let relayer1_note = Note {
+            mint1: match_res.base_mint.clone(),
+            volume1: relayer1_base_amount,
+            direction1: OrderSide::Buy,
+            mint2: match_res.quote_mint.clone(),
+            volume2: relayer1_quote_amount,
+            direction2: OrderSide::Buy,
+            fee_mint: party1_fee.gas_addr.clone(),
+            fee_volume: party1_fee.gas_token_amount,
+            fee_direction: OrderSide::Buy,
+            type_: NoteType::InternalTransfer,
+            randomness: 0,
+        };
+
+        // Build the protocol note
+        let protocol_base_amount = scalar_to_u64(&(*PROTOCOL_FEE * base_amount_scalar).floor());
+        let protocol_quote_amount = scalar_to_u64(&(*PROTOCOL_FEE * quote_amount_scalar).floor());
+
+        let protocol_note = Note {
+            mint1: match_res.base_mint.clone(),
+            volume1: protocol_base_amount,
+            direction1: OrderSide::Buy,
+            mint2: match_res.quote_mint.clone(),
+            volume2: protocol_quote_amount,
+            direction2: OrderSide::Buy,
+            fee_mint: 0u8.into(),
+            fee_volume: 0,
+            fee_direction: OrderSide::Buy,
+            type_: NoteType::InternalTransfer,
+            randomness: 0,
+        };
+
+        (
+            party0_note,
+            party1_note,
+            relayer0_note,
+            relayer1_note,
+            protocol_note,
+        )
+    }
+}

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -5,6 +5,8 @@ use std::fmt::Display;
 /// The core error type for the handshake manager
 #[derive(Clone, Debug)]
 pub enum HandshakeManagerError {
+    /// A handshake was abandoned for the reason given in the parameter
+    Abandoned(String),
     /// An error while collaboratively proving a statement
     Multiprover(String),
     /// An invalid request ID was passed in a message; i.e. the request ID is not known

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -233,7 +233,10 @@ impl HandshakeExecutor {
                 );
 
                 // Run the MPC match process
-                Self::execute_match(party_id, order_state, net)?;
+                let res = Self::execute_match(party_id, order_state, net)?;
+
+                // Submit the match to the contract
+                self.submit_match(res)?;
 
                 // Record the match in the cache
                 self.record_completed_match(request_id)

--- a/core/src/handshake/mod.rs
+++ b/core/src/handshake/mod.rs
@@ -1,4 +1,5 @@
 //! The handshake module handles performing MPC handshakes with peers
+mod encumber;
 pub mod error;
 mod handshake_cache;
 pub mod jobs;

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -11,6 +11,7 @@ use crate::state::{OrderIdentifier, Shared};
 
 use super::error::HandshakeManagerError;
 use circuits::types::{balance::Balance, fee::Fee, order::Order};
+use num_bigint::BigUint;
 use uuid::Uuid;
 
 /// Holds state information for all in-flight handshake correspondences
@@ -41,6 +42,7 @@ impl HandshakeStateIndex {
         order: Order,
         balance: Balance,
         fee: Fee,
+        wallet_randomness: BigUint,
     ) {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         locked_state.insert(
@@ -52,6 +54,7 @@ impl HandshakeStateIndex {
                 order,
                 balance,
                 fee,
+                wallet_randomness,
             ),
         );
     }
@@ -109,6 +112,8 @@ pub struct HandshakeState {
     pub balance: Balance,
     /// The local peer's fee, paid out to the contract and the executing node
     pub fee: Fee,
+    /// The blinding randomness used in the wallet
+    pub wallet_randomness: BigUint,
     /// The current state information of the
     pub state: State,
 }
@@ -142,6 +147,7 @@ impl HandshakeState {
         order: Order,
         balance: Balance,
         fee: Fee,
+        wallet_randomness: BigUint,
     ) -> Self {
         Self {
             request_id,
@@ -150,6 +156,7 @@ impl HandshakeState {
             order,
             balance,
             fee,
+            wallet_randomness,
             state: State::OrderNegotiation,
         }
     }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -23,7 +23,7 @@ mod worker;
 use std::{io::Write, thread, time::Duration};
 
 use chrono::Local;
-use circuits::types::wallet::Wallet;
+use circuits::{types::wallet::Wallet, zk_gadgets::fixed_point::FixedPoint};
 use crossbeam::channel::{self, Receiver};
 use env_logger::Builder;
 use error::CoordinatorError;
@@ -54,6 +54,15 @@ extern crate lazy_static;
 /// A type alias for an empty channel used to signal cancellation to workers
 pub(crate) type CancelChannel = Receiver<()>;
 
+// --------------------
+// | Global Constants |
+// --------------------
+
+lazy_static! {
+    /// The fee the protocol takes on a match; one basis point
+    static ref PROTOCOL_FEE: FixedPoint = FixedPoint::from(0.0001);
+}
+
 /// The system-wide value of MAX_BALANCES; the number of allowable balances a wallet holds
 pub(crate) const MAX_BALANCES: usize = 5;
 /// The system-wide value of MAX_ORDERS; the number of allowable orders a wallet holds
@@ -66,6 +75,10 @@ pub(crate) const MERKLE_HEIGHT: usize = 30;
 pub(crate) type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 /// The amount of time to wait between sending teardown signals and terminating execution
 const TERMINATION_TIMEOUT_MS: u64 = 10_000; // 10 seconds
+
+// --------------
+// | Entrypoint |
+// --------------
 
 /// The entrypoint to the relayer's execution
 ///

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -163,5 +163,6 @@ pub enum ProofJob {
         merkle_root: MerkleRoot,
     },
     /// A request to create a proof of `VALID MATCH ENCRYPTION` for a match result
+    #[allow(unused)]
     ValidMatchEncrypt {},
 }

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -28,7 +28,10 @@ use crate::{proof_generation::jobs::ProofJob, SizedWallet, MAX_FEES};
 
 use super::{
     error::ProofManagerError,
-    jobs::{ProofBundle, ProofManagerJob, ValidCommitmentsBundle, ValidWalletCreateBundle},
+    jobs::{
+        ProofBundle, ProofManagerJob, ValidCommitmentsBundle, ValidMatchEncryptBundle,
+        ValidWalletCreateBundle,
+    },
 };
 
 // -------------
@@ -92,6 +95,7 @@ impl ProofManager {
                     .send(ProofBundle::ValidWalletCreate(proof_bundle))
                     .map_err(|_| ProofManagerError::Response(ERR_SENDING_RESPONSE.to_string()))?
             }
+
             ProofJob::ValidCommitments {
                 wallet,
                 wallet_opening,
@@ -116,6 +120,14 @@ impl ProofManager {
                 job.response_channel
                     .send(ProofBundle::ValidCommitments(proof_bundle))
                     .map_err(|_| ProofManagerError::Response(ERR_SENDING_RESPONSE.to_string()))?
+            }
+
+            ProofJob::ValidMatchEncrypt {} => {
+                // Prove `VALID MATCH ENCRYPTION`
+                let proof_bundle = Self::prove_valid_match_encrypt()?;
+                job.response_channel
+                    .send(ProofBundle::ValidMatchEncryption(proof_bundle))
+                    .map_err(|_| ProofManagerError::Response(ERR_SENDING_RESPONSE.to_string()))?;
             }
         };
 
@@ -206,5 +218,10 @@ impl ProofManager {
             statement,
             proof,
         })
+    }
+
+    /// Create a proof of `VALID MATCH ENCRYPTION`
+    fn prove_valid_match_encrypt() -> Result<ValidMatchEncryptBundle, ProofManagerError> {
+        unimplemented!("")
     }
 }

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -13,6 +13,7 @@ use libp2p::{
     identity::{self, Keypair},
     Multiaddr,
 };
+use num_bigint::BigUint;
 use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
 use std::{
     collections::HashMap,
@@ -318,6 +319,16 @@ impl RelayerState {
             .get_order_balance_and_fee(&order_wallet, order_id)?;
 
         Some((order, balance, fee))
+    }
+
+    /// Fetch the wallet randomness to attach to an order during the handshake
+    pub fn get_randomness_for_order(&self, order_id: &OrderIdentifier) -> Option<BigUint> {
+        // Use the randomness of the wallet that the order belongs to
+        let locked_wallet_index = self.read_wallet_index();
+        let wallet_id = locked_wallet_index.get_wallet_for_order(order_id)?;
+        locked_wallet_index
+            .read_wallet(&wallet_id)
+            .map(|wallet| wallet.randomness.clone())
     }
 
     /// Get a peer in the cluster that manages the given order, used to dial during

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -137,7 +137,7 @@ pub struct Wallet {
     pub orders: HashMap<OrderIdentifier, Order>,
     /// A mapping of mint (u64) to Balance information
     /// TODO: Key by BigUint to adequately represent mints
-    pub balances: HashMap<u64, Balance>,
+    pub balances: HashMap<BigUint, Balance>,
     /// A list of the fees in this wallet
     pub fees: Vec<Fee>,
     /// A list of the public keys in the wallet
@@ -286,8 +286,8 @@ impl WalletIndex {
 
         // The mint the local party will be spending if the order is matched
         let order_mint = match order.side {
-            OrderSide::Buy => order.quote_mint,
-            OrderSide::Sell => order.base_mint,
+            OrderSide::Buy => order.quote_mint.clone(),
+            OrderSide::Sell => order.base_mint.clone(),
         };
 
         // The maximum quantity of the mint that the local party will be spending
@@ -307,9 +307,7 @@ impl WalletIndex {
         }
 
         let fee = locked_wallet.fees.get(0 /* index */)?;
-        let fee_balance = locked_wallet
-            .balances
-            .get(&fee.gas_addr.clone().try_into().unwrap())?;
+        let fee_balance = locked_wallet.balances.get(&fee.gas_addr.clone())?;
         if fee_balance.amount < fee.gas_token_amount {
             return None;
         }


### PR DESCRIPTION
### Purpose
This PR makes the necessary initial code path and state changes for encrypting a match and submitting it on chain after an MPC. Specifically this involves:
1. Tracking fees and randomness in the handshake state; these are used when building and blinding notes
2. Implementing MPC functionality to share plaintext values after a match (e.g. for fees)

As well, this PR adds the note construction logic as an initial block in the submission flow.

### Testing
- Unit tests