### PR TITLE
core: handshake: encumber: Generate proof of `VALID MATCH ENCRYPTION`

### DIFF
--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -946,7 +946,7 @@ impl<const SCALAR_BITS: usize> SingleProverCircuit for ValidMatchEncryption<SCAL
     type WitnessCommitment = ValidMatchEncryptionWitnessCommitment;
     type Statement = ValidMatchEncryptionStatement;
 
-    const BP_GENS_CAPACITY: usize = 32768;
+    const BP_GENS_CAPACITY: usize = 65536;
 
     fn prove(
         witness: Self::Witness,

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -27,7 +27,7 @@ lazy_static! {
     /// This generator is intended to be used with the Ristretto scalar field of prime
     /// order defined here:
     /// https://docs.rs/curve25519-dalek-ng/latest/curve25519_dalek_ng/scalar/index.html
-    pub(crate) static ref DEFAULT_ELGAMAL_GENERATOR: Scalar = Scalar::from(2u64);
+    pub static ref DEFAULT_ELGAMAL_GENERATOR: Scalar = Scalar::from(2u64);
 }
 
 /// Implements an ElGamal gadget that verifies encryption of some plaintext under a private key

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -70,6 +70,14 @@ impl FixedPoint {
         Self { repr: val_shifted }
     }
 
+    /// Create a new fixed point representation, rounding down to the nearest representable float
+    pub fn from_f32_round_down(val: f32) -> Self {
+        let shifted_val = val * (2u64.pow(DEFAULT_PRECISION as u32) as f32);
+        Self {
+            repr: Scalar::from(shifted_val.floor() as u64),
+        }
+    }
+
     /// Commit to the fixed point variable as a public input in a given constraint system
     pub fn commit_public<CS: RandomizableConstraintSystem>(&self, cs: &mut CS) -> FixedPointVar {
         let repr = cs.commit_public(self.repr);
@@ -79,7 +87,7 @@ impl FixedPoint {
     /// Return the represented value as an f64
     pub fn to_f64(&self) -> f64 {
         let mut dec = BigDecimal::from(scalar_to_bigint(&self.repr));
-        dec = &dec / (2u64 << DEFAULT_PRECISION);
+        dec = &dec / (1u64 << DEFAULT_PRECISION);
         dec.to_f64().unwrap()
     }
 

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -5,8 +5,6 @@ use std::fmt::Display;
 /// The core error type for the handshake manager
 #[derive(Clone, Debug)]
 pub enum HandshakeManagerError {
-    /// A handshake was abandoned for the reason given in the parameter
-    Abandoned(String),
     /// An error while collaboratively proving a statement
     Multiprover(String),
     /// An invalid request ID was passed in a message; i.e. the request ID is not known
@@ -20,6 +18,11 @@ pub enum HandshakeManagerError {
     SendMessage(String),
     /// Error while setting up the handshake manager
     SetupError(String),
+    /// A state element was referenced, but cannot be found locally
+    ///
+    /// This may happen if, for example, an order is cancelled during the course
+    /// of a match
+    StateNotFound(String),
     /// Error resulting from a cancellation signal
     Cancelled(String),
 }

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -14,6 +14,8 @@ pub enum HandshakeManagerError {
     MpcNetwork(String),
     /// Error verifying a proof
     VerificationError(String),
+    /// Error awaiting a proof from the proof generation module
+    ReceiveProof(String),
     /// Error sending a message to the network
     SendMessage(String),
     /// Error while setting up the handshake manager

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -26,6 +26,7 @@ use crate::{
         handshake::{HandshakeMessage, MatchRejectionReason},
     },
     gossip::types::WrappedPeerId,
+    proof_generation::jobs::ProofManagerJob,
     state::{NetworkOrderState, OrderIdentifier, RelayerState},
     system_bus::SystemBus,
     types::{SystemBusMessage, HANDSHAKE_STATUS_TOPIC},
@@ -80,6 +81,8 @@ pub struct HandshakeExecutor {
     pub(super) job_channel: Receiver<HandshakeExecutionJob>,
     /// The channel on which the handshake executor may forward requests to the network
     pub(super) network_channel: UnboundedSender<GossipOutbound>,
+    /// The channel on which to send proof manager jobs
+    pub(super) proof_manager_work_queue: Sender<ProofManagerJob>,
     /// The global relayer state
     pub(super) global_state: RelayerState,
     /// The system bus used to publish internal broadcast messages
@@ -93,6 +96,7 @@ impl HandshakeExecutor {
     pub fn new(
         job_channel: Receiver<HandshakeExecutionJob>,
         network_channel: UnboundedSender<GossipOutbound>,
+        proof_manager_work_queue: Sender<ProofManagerJob>,
         global_state: RelayerState,
         system_bus: SystemBus<SystemBusMessage>,
         cancel: CancelChannel,
@@ -112,6 +116,7 @@ impl HandshakeExecutor {
             handshake_state_index,
             job_channel,
             network_channel,
+            proof_manager_work_queue,
             global_state,
             system_bus,
             cancel: Some(cancel),

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -11,7 +11,6 @@ use crate::state::{OrderIdentifier, Shared};
 
 use super::error::HandshakeManagerError;
 use circuits::types::{balance::Balance, fee::Fee, order::Order};
-use num_bigint::BigUint;
 use uuid::Uuid;
 
 /// Holds state information for all in-flight handshake correspondences
@@ -42,7 +41,6 @@ impl HandshakeStateIndex {
         order: Order,
         balance: Balance,
         fee: Fee,
-        wallet_randomness: BigUint,
     ) {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         locked_state.insert(
@@ -54,7 +52,6 @@ impl HandshakeStateIndex {
                 order,
                 balance,
                 fee,
-                wallet_randomness,
             ),
         );
     }
@@ -112,8 +109,6 @@ pub struct HandshakeState {
     pub balance: Balance,
     /// The local peer's fee, paid out to the contract and the executing node
     pub fee: Fee,
-    /// The blinding randomness used in the wallet
-    pub wallet_randomness: BigUint,
     /// The current state information of the
     pub state: State,
 }
@@ -147,7 +142,6 @@ impl HandshakeState {
         order: Order,
         balance: Balance,
         fee: Fee,
-        wallet_randomness: BigUint,
     ) -> Self {
         Self {
             request_id,
@@ -156,7 +150,6 @@ impl HandshakeState {
             order,
             balance,
             fee,
-            wallet_randomness,
             state: State::OrderNegotiation,
         }
     }

--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -9,6 +9,7 @@ use tracing::log;
 use crate::{
     api::gossip::GossipOutbound,
     handshake::manager::{HandshakeExecutor, HandshakeScheduler},
+    proof_generation::jobs::ProofManagerJob,
     state::RelayerState,
     system_bus::SystemBus,
     types::SystemBusMessage,
@@ -29,6 +30,8 @@ pub struct HandshakeManagerConfig {
     pub job_sender: Sender<HandshakeExecutionJob>,
     /// The job queue on which to receive handshake requests
     pub job_receiver: Receiver<HandshakeExecutionJob>,
+    /// A sender to forward jobs to the proof manager on
+    pub proof_manager_sender: Sender<ProofManagerJob>,
     /// The system bus to which all workers have access
     pub system_bus: SystemBus<SystemBusMessage>,
     /// The channel on which the coordinator may mandate that the
@@ -50,6 +53,7 @@ impl Worker for HandshakeManager {
         let executor = HandshakeExecutor::new(
             config.job_receiver.clone(),
             config.network_channel.clone(),
+            config.proof_manager_sender.clone(),
             config.global_state.clone(),
             config.system_bus.clone(),
             config.cancel_channel.clone(),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -30,6 +30,7 @@ use error::CoordinatorError;
 use gossip::worker::GossipServerConfig;
 use handshake::worker::HandshakeManagerConfig;
 use network_manager::worker::NetworkManagerConfig;
+use num_bigint::BigUint;
 use price_reporter::worker::PriceReporterManagerConfig;
 use tokio::{select, sync::mpsc};
 use tracing::log::{self, LevelFilter};
@@ -58,9 +59,13 @@ pub(crate) type CancelChannel = Receiver<()>;
 // | Global Constants |
 // --------------------
 
+// TODO: Move these constants to a more discoverable location
 lazy_static! {
     /// The fee the protocol takes on a match; one basis point
     static ref PROTOCOL_FEE: FixedPoint = FixedPoint::from(0.0001);
+    /// The public settle key of the protocol wallet
+    /// Dummy value for now
+    static ref PROTOCOL_SETTLE_KEY: BigUint = BigUint::from(0u8);
 }
 
 /// The system-wide value of MAX_BALANCES; the number of allowable balances a wallet holds

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -62,7 +62,7 @@ pub(crate) type CancelChannel = Receiver<()>;
 // TODO: Move these constants to a more discoverable location
 lazy_static! {
     /// The fee the protocol takes on a match; one basis point
-    static ref PROTOCOL_FEE: FixedPoint = FixedPoint::from(0.0001);
+    static ref PROTOCOL_FEE: FixedPoint = FixedPoint::from_f32_round_down(0.0002);
     /// The public settle key of the protocol wallet
     /// Dummy value for now
     static ref PROTOCOL_SETTLE_KEY: BigUint = BigUint::from(0u8);
@@ -194,6 +194,7 @@ async fn main() -> Result<(), CoordinatorError> {
         network_channel: network_sender,
         job_receiver: handshake_worker_receiver,
         job_sender: handshake_worker_sender.clone(),
+        proof_manager_sender: proof_generation_worker_sender.clone(),
         system_bus: system_bus.clone(),
         cancel_channel: handshake_cancel_receiver,
     })

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -9,7 +9,8 @@ use circuits::{
     zk_circuits::{
         valid_commitments::{ValidCommitmentsStatement, ValidCommitmentsWitnessCommitment},
         valid_match_encryption::{
-            ValidMatchEncryptionStatement, ValidMatchEncryptionWitnessCommitment,
+            ValidMatchEncryptionStatement, ValidMatchEncryptionWitness,
+            ValidMatchEncryptionWitnessCommitment,
         },
         valid_wallet_create::{ValidWalletCreateCommitment, ValidWalletCreateStatement},
     },
@@ -163,6 +164,15 @@ pub enum ProofJob {
         merkle_root: MerkleRoot,
     },
     /// A request to create a proof of `VALID MATCH ENCRYPTION` for a match result
+    ///
+    /// The statement and witness types are complicated enough for `VALID MATCH ENCRYPTION`
+    /// that we don't bother constructing them in the proof manager; this responsibility is
+    /// passed to the caller; so the job definition directly stores the witness and statement
     #[allow(unused)]
-    ValidMatchEncrypt {},
+    ValidMatchEncrypt {
+        /// The witness to use in the proof of `VALID MATCH ENCRYPTION`
+        witness: ValidMatchEncryptionWitness,
+        /// The statement (public variables) to use in the proof of `VALID MATCH ENCRYPTION`
+        statement: ValidMatchEncryptionStatement,
+    },
 }

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -13,7 +13,6 @@ use libp2p::{
     identity::{self, Keypair},
     Multiaddr,
 };
-use num_bigint::BigUint;
 use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
 use std::{
     collections::HashMap,
@@ -319,16 +318,6 @@ impl RelayerState {
             .get_order_balance_and_fee(&order_wallet, order_id)?;
 
         Some((order, balance, fee))
-    }
-
-    /// Fetch the wallet randomness to attach to an order during the handshake
-    pub fn get_randomness_for_order(&self, order_id: &OrderIdentifier) -> Option<BigUint> {
-        // Use the randomness of the wallet that the order belongs to
-        let locked_wallet_index = self.read_wallet_index();
-        let wallet_id = locked_wallet_index.get_wallet_for_order(order_id)?;
-        locked_wallet_index
-            .read_wallet(&wallet_id)
-            .map(|wallet| wallet.randomness.clone())
     }
 
     /// Get a peer in the cluster that manages the given order, used to dial during


### PR DESCRIPTION
### Purpose
This PR connects together the handshake manager's match flow with the proof manager's creation of `VALID MATCH ENCRYPTION`. The flow for matches as it is currently implemented is now:
1. Each party generates a proof of `VALID COMMITMENTS` and gossips this proof through the network.
2. Local peers verify remote proofs; once verified, a remote order is eligible to be scheduled for handshake.
3. Once a handshake is initiated, the peers perform the match MPC and collaboratively prove `VALID MATCH MPC`.
4. The peers each individually construct notes and and encryptions for the match; and prove `VALID MATCH ENCRYPTION`. This step is redundant across peers, but necessarily so

Left for completion:
- Proof linkability; to ensure input consistency between proofs, we need to link Pedersen commitments between proofs of `VALID COMMITMENTS`, `VALID MATCH MPC`, and `VALID MATCH ENCRYPTION`.
- Submitting the match bundle (proofs, statement variables, etc) to the contract to encumber the wallets.

### Testing
- Unit tests
- Tested the full match flow as described above, verified that all proofs were generated as expected.