### PR TITLE
core: handshake: match: Link validity, match, and encryption proofs with shared commitments

### DIFF
--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -114,7 +114,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
         // Compute matches
         let res = compute_match(&order1, &order2, test_args.mpc_fabric.clone())
             .map_err(|err| format!("Error computing order match: {:?}", err))?
-            .open_and_authenticate()
+            .open_and_authenticate(test_args.mpc_fabric.clone())
             .map_err(|err| format!("Error opening match result: {:?}", err))?;
 
         // Assert that no match occurred
@@ -220,7 +220,7 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
         // Compute matches
         let res = compute_match(&order1, &order2, test_args.mpc_fabric.clone())
             .map_err(|err| format!("Error computing order match: {:?}", err))?
-            .open_and_authenticate()
+            .open_and_authenticate(test_args.mpc_fabric.clone())
             .map_err(|err| format!("Error opening match result: {:?}", err))?;
 
         // Assert that no match occurred

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -84,9 +84,9 @@ fn setup_witness_and_statement<N: MpcNetwork + Send, S: SharedValueSource<Scalar
     let match_res = match_orders(&order, fabric)?;
     Ok((
         ValidMatchMpcWitness {
-            my_order: order,
-            my_balance: balance,
-            match_res,
+            my_order: order.into(),
+            my_balance: balance.into(),
+            match_res: match_res.into(),
         },
         ValidMatchMpcStatement {},
     ))

--- a/circuits/integration/zk_gadgets/mod.rs
+++ b/circuits/integration/zk_gadgets/mod.rs
@@ -37,15 +37,18 @@ where
     let prover = MpcProver::new_with_fabric(fabric.0.clone(), &mut transcript, &pc_gens);
 
     // Prove the statement
-    let (witness_commitment, proof) = C::prove(witness, statement.clone(), prover, fabric).unwrap();
+    let (witness_commitment, proof) =
+        C::prove(witness, statement.clone(), prover, fabric.clone()).unwrap();
 
     // Open the proof and commitments
     let opened_proof = proof.open()?;
-    let opened_commit = witness_commitment.open_and_authenticate().map_err(|_| {
-        MultiproverError::Mpc(MpcError::ArithmeticError(
-            "error opening commitments".to_string(),
-        ))
-    })?;
+    let opened_commit = witness_commitment
+        .open_and_authenticate(fabric)
+        .map_err(|_| {
+            MultiproverError::Mpc(MpcError::ArithmeticError(
+                "error opening commitments".to_string(),
+            ))
+        })?;
 
     // Verify the statement with a fresh transcript
     let mut verifier_transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -23,9 +23,9 @@ use crate::{
     errors::{ProverError, VerifierError},
     mpc_gadgets::poseidon::PoseidonSpongeParameters,
     types::{
-        balance::{Balance, BalanceVar, CommittedBalance},
-        fee::{CommittedFee, Fee, FeeVar},
-        order::{CommittedOrder, Order, OrderVar},
+        balance::{BalanceVar, CommittedBalance, LinkableBalanceCommitment},
+        fee::{CommittedFee, FeeVar, LinkableFeeCommitment},
+        order::{CommittedOrder, LinkableOrderCommitment, OrderVar},
         wallet::{CommittedWallet, Wallet, WalletVar},
     },
     zk_gadgets::{
@@ -187,13 +187,13 @@ pub struct ValidCommitmentsWitness<
     /// The wallet that the committed values come from
     pub wallet: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The selected order to commit to
-    pub order: Order,
+    pub order: LinkableOrderCommitment,
     /// The selected balance to commit to
-    pub balance: Balance,
+    pub balance: LinkableBalanceCommitment,
     /// The balance used to pay out constant fees in
-    pub fee_balance: Balance,
+    pub fee_balance: LinkableBalanceCommitment,
     /// The selected fee to commit to
-    pub fee: Fee,
+    pub fee: LinkableFeeCommitment,
     /// The merkle proof that the wallet is valid within the state tree
     pub wallet_opening: MerkleOpening,
     /// The Poseidon hash of the wallet's randomness, used as the blinder
@@ -492,10 +492,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -534,10 +534,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -575,10 +575,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -619,10 +619,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -665,10 +665,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -707,10 +707,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -747,10 +747,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -787,10 +787,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,
@@ -829,10 +829,10 @@ mod valid_commitments_test {
 
         let witness = ValidCommitmentsWitness {
             wallet: wallet.clone(),
-            order,
-            balance,
-            fee_balance,
-            fee,
+            order: order.into(),
+            balance: balance.into(),
+            fee_balance: fee_balance.into(),
+            fee: fee.into(),
             wallet_opening: MerkleOpening {
                 elems: opening,
                 indices: opening_indices,

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -564,7 +564,6 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Open for ValidMatchComm
 /// The parameterization for the VALID MATCH MPC statement
 ///
 /// TODO: Add in midpoint oracle prices
-/// TODO: Commitments to the randomness
 #[derive(Debug, Clone)]
 pub struct ValidMatchMpcStatement {}
 

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -22,39 +22,42 @@ use mpc_ristretto::{
 };
 use rand_core::OsRng;
 
-use crate::zk_gadgets::{
-    comparators::{
-        GreaterThanEqGadget, GreaterThanEqZeroGadget, MultiproverGreaterThanEqGadget,
-        MultiproverGreaterThanEqZeroGadget,
-    },
-    fixed_point::{CommittedFixedPoint, FixedPointVar},
-};
-use crate::zk_gadgets::{
-    fixed_point::AuthenticatedFixedPointVar,
-    select::{
-        CondSelectGadget, CondSelectVectorGadget, MultiproverCondSelectGadget,
-        MultiproverCondSelectVectorGadget,
-    },
-};
 use crate::{
     errors::{MpcError, ProverError, VerifierError},
     mpc::SharedFabric,
     mpc_gadgets::poseidon::PoseidonSpongeParameters,
     types::{
         balance::{
-            AuthenticatedBalanceVar, AuthenticatedCommittedBalance, Balance, BalanceVar,
-            CommittedBalance,
+            AuthenticatedBalanceVar, AuthenticatedCommittedBalance, BalanceVar, CommittedBalance,
         },
-        order::{
-            AuthenticatedCommittedOrder, AuthenticatedOrderVar, CommittedOrder, Order, OrderVar,
-        },
+        order::{AuthenticatedCommittedOrder, AuthenticatedOrderVar, CommittedOrder, OrderVar},
         r#match::{
-            AuthenticatedCommittedMatchResult, AuthenticatedMatchResult,
-            AuthenticatedMatchResultVar, CommittedMatchResult, MatchResultVar,
+            AuthenticatedCommittedMatchResult, AuthenticatedMatchResultVar, CommittedMatchResult,
+            MatchResultVar,
         },
     },
     zk_gadgets::poseidon::MultiproverPoseidonHashGadget,
     CommitSharedProver, CommitVerifier, MultiProverCircuit, Open,
+};
+use crate::{
+    types::r#match::AuthenticatedLinkableMatchResultCommitment,
+    zk_gadgets::{
+        fixed_point::AuthenticatedFixedPointVar,
+        select::{
+            CondSelectGadget, CondSelectVectorGadget, MultiproverCondSelectGadget,
+            MultiproverCondSelectVectorGadget,
+        },
+    },
+};
+use crate::{
+    types::{balance::LinkableBalanceCommitment, order::LinkableOrderCommitment},
+    zk_gadgets::{
+        comparators::{
+            GreaterThanEqGadget, GreaterThanEqZeroGadget, MultiproverGreaterThanEqGadget,
+            MultiproverGreaterThanEqZeroGadget,
+        },
+        fixed_point::{CommittedFixedPoint, FixedPointVar},
+    },
 };
 
 /// The circuitry for the valid match
@@ -424,15 +427,15 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 #[derive(Clone, Debug)]
 pub struct ValidMatchMpcWitness<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
     /// The local party's order that was matched by MPC
-    pub my_order: Order,
+    pub my_order: LinkableOrderCommitment,
     /// A balance known by the local party that covers the position
     /// expressed in their order
-    pub my_balance: Balance,
+    pub my_balance: LinkableBalanceCommitment,
     /// The result of running a match MPC on the given orders
     ///
     /// We do not open this value before proving so that we can avoid leaking information
     /// before the collaborative proof has finished
-    pub match_res: AuthenticatedMatchResult<N, S>,
+    pub match_res: AuthenticatedLinkableMatchResultCommitment<N, S>,
 }
 
 /// Represents a commitment to the VALID MATCH MPC witness

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -490,8 +490,9 @@ impl<'a, N: MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCircuit<
     > {
         // Commit to the input
         let mut rng = OsRng {};
+        let blinder = Scalar::random(&mut rng);
         let (witness_commit, witness_var) = prover
-            .commit_preshared(&witness.x, Scalar::random(&mut rng))
+            .commit_preshared(&witness.x, blinder)
             .map_err(|err| ProverError::Mpc(MpcError::SharingError(err.to_string())))?;
 
         // Commit to the public expected hash output

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -223,7 +223,7 @@ impl<'a, const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>
     }
 
     fn verify(
-        witness_commitments: <Self::WitnessCommitment as Open>::OpenOutput,
+        witness_commitments: <Self::WitnessCommitment as Open<N, S>>::OpenOutput,
         statement: Self::Statement,
         proof: R1CSProof,
         verifier: Verifier,

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -24,8 +24,9 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    errors::MpcError, mpc::SharedFabric, mpc_gadgets::modulo::shift_right, Allocate, CommitProver,
-    CommitSharedProver, CommitVerifier, LinkableCommitment,
+    errors::MpcError, mpc::SharedFabric, mpc_gadgets::modulo::shift_right, Allocate,
+    AuthenticatedLinkableCommitment, CommitProver, CommitSharedProver, CommitVerifier,
+    LinkableCommitment,
 };
 
 use super::{arithmetic::DivRemGadget, comparators::EqGadget};
@@ -979,6 +980,25 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitVerifier
         let repr = verifier.commit(opened_value);
 
         Ok(FixedPointVar { repr: repr.into() })
+    }
+}
+
+/// Represents a fixed point value that has been allocated in an MPC fabric and may be shared across
+/// proofs
+#[derive(Clone, Debug)]
+pub struct AuthenticatedLinkableFixedPointCommitment<
+    N: MpcNetwork + Send,
+    S: SharedValueSource<Scalar>,
+> {
+    /// The underlying scalar representing the fixed point variable
+    pub(crate) repr: AuthenticatedLinkableCommitment<N, S>,
+}
+
+impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<AuthenticatedFixedPoint<N, S>> for AuthenticatedLinkableFixedPointCommitment<N, S> {
+    fn from(fp: AuthenticatedFixedPoint<N, S>) -> Self {
+        Self {
+            repr: AuthenticatedLinkableCommitment::new(fp.repr),
+        }
     }
 }
 

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -242,8 +242,14 @@ impl From<FixedPoint> for LinkableFixedPointCommitment {
     }
 }
 
+impl From<LinkableFixedPointCommitment> for FixedPoint {
+    fn from(fp: LinkableFixedPointCommitment) -> Self {
+        Self { repr: fp.repr.val }
+    }
+}
+
 /// A fixed point commitment that may be linked across proofs
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LinkableFixedPointCommitment {
     /// The underlying scalar representation
     pub(crate) repr: LinkableCommitment,
@@ -985,7 +991,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitVerifier
 
 /// Represents a fixed point value that has been allocated in an MPC fabric and may be shared across
 /// proofs
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct AuthenticatedLinkableFixedPointCommitment<
     N: MpcNetwork + Send,
     S: SharedValueSource<Scalar>,
@@ -994,7 +1000,19 @@ pub struct AuthenticatedLinkableFixedPointCommitment<
     pub(crate) repr: AuthenticatedLinkableCommitment<N, S>,
 }
 
-impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<AuthenticatedFixedPoint<N, S>> for AuthenticatedLinkableFixedPointCommitment<N, S> {
+impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone
+    for AuthenticatedLinkableFixedPointCommitment<N, S>
+{
+    fn clone(&self) -> Self {
+        Self {
+            repr: self.repr.clone(),
+        }
+    }
+}
+
+impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<AuthenticatedFixedPoint<N, S>>
+    for AuthenticatedLinkableFixedPointCommitment<N, S>
+{
     fn from(fp: AuthenticatedFixedPoint<N, S>) -> Self {
         Self {
             repr: AuthenticatedLinkableCommitment::new(fp.repr),

--- a/core/src/handshake/encumber.rs
+++ b/core/src/handshake/encumber.rs
@@ -107,11 +107,11 @@ impl HandshakeExecutor {
         // Construct a statement and witness for `VALID MATCH ENCRYPTION`
         #[allow(unused_variables)]
         let witness = ValidMatchEncryptionWitness {
-            match_res: handshake_result.match_,
-            party0_fee: handshake_result.party0_fee,
-            party1_fee: handshake_result.party1_fee,
-            party0_randomness_hash: handshake_result.party0_randomness_hash,
-            party1_randomness_hash: handshake_result.party1_randomness_hash,
+            match_res: handshake_result.match_.into(),
+            party0_fee: handshake_result.party0_fee.into(),
+            party1_fee: handshake_result.party1_fee.into(),
+            party0_randomness_hash: handshake_result.party0_randomness_hash.into(),
+            party1_randomness_hash: handshake_result.party1_randomness_hash.into(),
             party0_note: party0_note.clone(),
             party1_note: party1_note.clone(),
             relayer0_note: relayer0_note.clone(),

--- a/core/src/handshake/match.rs
+++ b/core/src/handshake/match.rs
@@ -163,10 +163,11 @@ impl HandshakeExecutor {
         fabric: SharedFabric<N, S>,
     ) -> Result<R1CSProof, HandshakeManagerError> {
         // Build a witness to the VALID MATCH MPC statement
+        // TODO: Use proof-linked witness vars
         let witness = ValidMatchMpcWitness {
-            my_order: order,
-            my_balance: balance,
-            match_res,
+            my_order: order.into(),
+            my_balance: balance.into(),
+            match_res: match_res.into(),
         };
 
         // Prove the statement

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -10,7 +10,6 @@ use std::{
 use crate::state::{OrderIdentifier, Shared};
 
 use super::error::HandshakeManagerError;
-use circuits::types::{balance::Balance, fee::Fee, order::Order};
 use uuid::Uuid;
 
 /// Holds state information for all in-flight handshake correspondences
@@ -38,21 +37,11 @@ impl HandshakeStateIndex {
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
-        order: Order,
-        balance: Balance,
-        fee: Fee,
     ) {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         locked_state.insert(
             request_id,
-            HandshakeState::new(
-                request_id,
-                peer_order_id,
-                local_order_id,
-                order,
-                balance,
-                fee,
-            ),
+            HandshakeState::new(request_id, peer_order_id, local_order_id),
         );
     }
 
@@ -103,12 +92,6 @@ pub struct HandshakeState {
     pub peer_order_id: OrderIdentifier,
     /// The identifier of the order that the local peer has proposed for match
     pub local_order_id: OrderIdentifier,
-    /// The local peer's order being matched on
-    pub order: Order,
-    /// The local peer's balance, covering their side of the order
-    pub balance: Balance,
-    /// The local peer's fee, paid out to the contract and the executing node
-    pub fee: Fee,
     /// The current state information of the
     pub state: State,
 }
@@ -139,17 +122,11 @@ impl HandshakeState {
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
-        order: Order,
-        balance: Balance,
-        fee: Fee,
     ) -> Self {
         Self {
             request_id,
             peer_order_id,
             local_order_id,
-            order,
-            balance,
-            fee,
             state: State::OrderNegotiation,
         }
     }

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -198,10 +198,10 @@ impl ProofManager {
         // Build a witness and statement
         let witness = ValidCommitmentsWitness {
             wallet,
-            order,
-            balance,
-            fee,
-            fee_balance,
+            order: order.into(),
+            balance: balance.into(),
+            fee: fee.into(),
+            fee_balance: fee_balance.into(),
             wallet_opening,
             randomness_hash,
             sk_match,

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -328,6 +328,14 @@ impl NetworkOrderBook {
         self.read_order(order_id)?.valid_commit_proof.clone()
     }
 
+    /// Fetch a copy of the witness to the validity proof if one exists
+    pub fn get_validity_proof_witness(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Option<SizedValidCommitmentsWitness> {
+        self.read_order(order_id)?.valid_commit_witness.clone()
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -3,7 +3,6 @@
 
 use circuits::{
     native_helpers::compute_poseidon_hash,
-    types::{balance::Balance, fee::Fee, order::Order},
     zk_circuits::valid_commitments::ValidCommitmentsWitness,
     zk_gadgets::merkle::{MerkleOpening, MerkleRoot},
 };
@@ -328,19 +327,6 @@ impl RelayerState {
         let mut rng = thread_rng();
         let distribution = WeightedIndex::new(&priorities).unwrap();
         Some(*verified_orders.get(distribution.sample(&mut rng)).unwrap())
-    }
-
-    /// Get the order, balance, and fee information for a given order_id
-    pub fn get_order_balance_fee(
-        &self,
-        order_id: &OrderIdentifier,
-    ) -> Option<(Order, Balance, Fee)> {
-        let order_wallet = { self.read_wallet_index().get_wallet_for_order(order_id) }?;
-        let (order, balance, fee, _) = self
-            .read_wallet_index()
-            .get_order_balance_and_fee(&order_wallet, order_id)?;
-
-        Some((order, balance, fee))
     }
 
     /// Get a peer in the cluster that manages the given order, used to dial during

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,6 +1,6 @@
 //! Groups type definitions relevant to all modules and at the top level
 
-use circuits::zk_circuits::valid_commitments::ValidCommitments;
+use circuits::zk_circuits::valid_commitments::{ValidCommitments, ValidCommitmentsWitness};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -15,6 +15,8 @@ use crate::{
 
 /// `VALID COMMITMENTS` with default state element sizing
 pub type SizedValidCommitments = ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A `VALID COMMITMENTS` witness with default const generic sizing parameters
+pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
 // ----------------------
 // | Pubsub Topic Names |


### PR DESCRIPTION
## Background: Linking Proofs
The basic idea of the match process is to:
1. Verify that inputs (orders, balances, fees, etc) are valid members of the state tree
2. Verify that the matching engine is run correctly on the inputs
3. Verify that the outputs of the matching engine are properly encrypted for end user data-availability.

Only **2** needs to be done inside of an MPC, so to limit the computation inside of the MPC (quite expensive) we only add the constraints of the matching engine to the collaborative proof. The challenge then becomes enforcing input consistency between proofs; i.e. enforcing that the order used in the proof of `VALID COMMITMENTS` is the same order used as input to the matching engine (`VALID MATCH MPC`).

We do this by sharing commitments across proofs. That is, instead of committing to a shared input $x$ once per proof (e.g. using randomness $r_{\text{VALID COMMITMENTS}}, r_{\text{VALID MATCH MPC}}, \ldots$) we commit to $x$ once using a value $r$ that is shared between proofs. This can be thought of dually as one larger circuit, part of which is executed in an MPC.

---

### Purpose
This PR adds logic to link the shared variables of `VALID COMMITMENTS`, `VALID MATCH MPC`, and `VALID MATCH ENCRYPTION` in their flows defined by the handshake manager. The verifier may then use a single copy of the commitment to each shared variable, across multiple verifications.

### Todo
- Link randomness hashes from `VALID COMMITMENTS` into `VALID MATCH ENCRYPTION`.
- Link public keys
- Gossip about shared commitment values within a cluster; the relayers gossip about proofs of `VALID MATCH ENCRYPTION`; so it is important that all nodes managing a wallet also have access to the shared commitment values so that they may link any proofs they create locally.

### Testing
- Unit tests
- Ad-hoc verified that the proofs were verifiable successfully
- Ran a few full matches (from new order -> proving `VALID COMMITMENTS` -> match MPC + collaborative proof of `VALID MATCH MPC` -> proving `VALID MATCH ENCRYPTION`)