### PR TITLE
core: gossip: Gossip within cluster about proof-linking commitments

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -237,6 +237,26 @@ impl CommitProver for LinkableCommitment {
     }
 }
 
+impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> SharePublic<N, S> for LinkableCommitment {
+    type ErrorType = MpcError;
+
+    fn share_public(
+        &self,
+        owning_party: u64,
+        fabric: SharedFabric<N, S>,
+    ) -> Result<Self, Self::ErrorType> {
+        let shared_values = fabric
+            .borrow_fabric()
+            .batch_shared_plaintext_scalars(owning_party, &[self.val, self.randomness])
+            .map_err(|err| MpcError::SharingError(err.to_string()))?;
+
+        Ok(Self {
+            val: shared_values[0],
+            randomness: shared_values[1],
+        })
+    }
+}
+
 /// A linkable commitment that has been allocated inside of an MPC fabric
 #[derive(Debug)]
 pub struct AuthenticatedLinkableCommitment<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -95,7 +95,7 @@ impl CommitVerifier for CommittedBalance {
 }
 
 /// Represents a balance that may be linked across proofs
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkableBalanceCommitment {
     /// The mint (erc-20 token address) of the token in this balance
     pub mint: LinkableCommitment,

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -171,7 +171,7 @@ impl CommitVerifier for CommittedFee {
 }
 
 /// A fee that can be linked across proofs
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkableFeeCommitment {
     /// The public settle key of the cluster collecting fees
     pub settle_key: LinkableCommitment,

--- a/circuits/src/types/mod.rs
+++ b/circuits/src/types/mod.rs
@@ -1,4 +1,6 @@
 //! Groups type definitions and abstractions useful in the circuitry
+
+use serde::{de::Error as SerdeErr, Deserialize, Deserializer, Serialize, Serializer};
 pub mod balance;
 pub mod fee;
 pub mod handshake_tuple;
@@ -7,3 +9,38 @@ pub mod r#match;
 pub mod note;
 pub mod order;
 pub mod wallet;
+
+// -----------------------------------------
+// | Serialization Deserialization Helpers |
+// -----------------------------------------
+
+/// A helper for serializing array types
+pub(crate) fn serialize_array<const ARR_SIZE: usize, T, S>(
+    arr: &[T; ARR_SIZE],
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize + Clone,
+    [(); ARR_SIZE]: Sized,
+{
+    // Convert the array to a vec
+    let arr_vec: Vec<T> = arr.clone().into();
+    arr_vec.serialize(s)
+}
+
+/// A helper for deserializing array types
+pub(crate) fn deserialize_array<'de, const ARR_SIZE: usize, T, D>(
+    d: D,
+) -> Result<[T; ARR_SIZE], D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+    [(); ARR_SIZE]: Sized,
+{
+    // Deserialize a vec and then convert to an array
+    let deserialized_vec: Vec<T> = Vec::deserialize(d)?;
+    deserialized_vec
+        .try_into()
+        .map_err(|_| SerdeErr::custom("incorrect size of serialized array"))
+}

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -257,7 +257,7 @@ impl CommitVerifier for CommittedOrder {
 }
 
 /// A linkable commitment to an Order that may be used across proofs
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkableOrderCommitment {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: LinkableCommitment,

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -11,9 +11,11 @@ use crate::{CommitProver, CommitVerifier};
 
 use super::{
     balance::{Balance, BalanceVar, CommittedBalance},
+    deserialize_array,
     fee::{CommittedFee, Fee, FeeVar},
     keychain::{CommittedKeyChain, KeyChain, KeyChainVar},
     order::{CommittedOrder, Order, OrderVar},
+    serialize_array,
 };
 
 /// A type alias for readability
@@ -21,16 +23,28 @@ pub type WalletCommitment = Scalar;
 
 /// Represents the base type of a wallet holding orders, balances, fees, keys
 /// and cryptographic randomness
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Wallet<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
 where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// The list of balances in the wallet
+    #[serde(
+        serialize_with = "serialize_array",
+        deserialize_with = "deserialize_array"
+    )]
     pub balances: [Balance; MAX_BALANCES],
     /// The list of open orders in the wallet
+    #[serde(
+        serialize_with = "serialize_array",
+        deserialize_with = "deserialize_array"
+    )]
     pub orders: [Order; MAX_ORDERS],
     /// The list of payable fees in the wallet
+    #[serde(
+        serialize_with = "serialize_array",
+        deserialize_with = "deserialize_array"
+    )]
     pub fees: [Fee; MAX_FEES],
     /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
     pub keys: KeyChain,

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -37,7 +37,7 @@ use crate::{
         poseidon::PoseidonHashGadget,
         select::CondSelectGadget,
     },
-    CommitProver, CommitVerifier, SingleProverCircuit,
+    CommitProver, CommitVerifier, LinkableCommitment, SingleProverCircuit,
 };
 
 /// The circuitry for the VALID COMMITMENTS statement
@@ -198,7 +198,7 @@ pub struct ValidCommitmentsWitness<
     pub wallet_opening: MerkleOpening,
     /// The Poseidon hash of the wallet's randomness, used as the blinder
     /// on any notes generated for a match
-    pub randomness_hash: Scalar,
+    pub randomness_hash: LinkableCommitment,
     /// The private match key, used as an authorization check that the prover
     /// may match for the given wallet
     pub sk_match: Scalar,
@@ -284,8 +284,8 @@ where
             self.fee_balance.commit_prover(rng, prover).unwrap();
         let (fee_var, fee_commit) = self.fee.commit_prover(rng, prover).unwrap();
         let (opening_var, opening_commit) = self.wallet_opening.commit_prover(rng, prover).unwrap();
-        let (randomness_hash_comm, randomness_hash_var) =
-            prover.commit(self.randomness_hash, Scalar::random(rng));
+        let (randomness_hash_var, randomness_hash_comm) =
+            self.randomness_hash.commit_prover(rng, prover).unwrap();
         let (sk_match_comm, sk_match_var) = prover.commit(self.sk_match, Scalar::random(rng));
 
         Ok((
@@ -437,7 +437,7 @@ mod valid_commitments_test {
             PRIVATE_KEYS,
         },
         zk_gadgets::{fixed_point::FixedPoint, merkle::MerkleOpening},
-        CommitProver,
+        CommitProver, LinkableCommitment,
     };
 
     use super::{ValidCommitments, ValidCommitmentsStatement, ValidCommitmentsWitness};
@@ -500,7 +500,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -542,7 +542,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -583,7 +583,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -627,7 +627,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -673,7 +673,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -715,7 +715,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -755,7 +755,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -795,7 +795,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {
@@ -837,7 +837,7 @@ mod valid_commitments_test {
                 elems: opening,
                 indices: opening_indices,
             },
-            randomness_hash: compute_poseidon_hash(&[wallet.randomness]),
+            randomness_hash: LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness])),
             sk_match: PRIVATE_KEYS[1],
         };
         let statement = ValidCommitmentsStatement {

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -179,7 +179,7 @@ where
 }
 
 /// The witness type for VALID COMMITMENTS
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidCommitmentsWitness<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -218,7 +218,7 @@ impl Serialize for FixedPoint {
     {
         // Serialize the value as a floating point
         let mut bigdec = scalar_to_bigdecimal(&self.repr);
-        bigdec = &bigdec / (2u64 << DEFAULT_PRECISION);
+        bigdec = &bigdec / (1u64 << DEFAULT_PRECISION);
 
         serializer.serialize_f32(bigdec.to_f32().unwrap())
     }
@@ -249,7 +249,7 @@ impl From<LinkableFixedPointCommitment> for FixedPoint {
 }
 
 /// A fixed point commitment that may be linked across proofs
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkableFixedPointCommitment {
     /// The underlying scalar representation
     pub(crate) repr: LinkableCommitment,

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -175,7 +175,7 @@ impl PoseidonMerkleHashGadget {
 }
 
 /// A fully specified merkle opening from hashed leaf to root
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MerkleOpening {
     /// The opening from the leaf node to the root, i.e. the set of sister nodes
     /// that hash together with the input from the leaf to the root

--- a/core/src/api/cluster_management.rs
+++ b/core/src/api/cluster_management.rs
@@ -44,6 +44,9 @@ pub enum ClusterManagementMessage {
     /// along with the wallet. Instead of immediately generating such a proof locally,
     /// the peer may request it from its cluster
     RequestOrderValidityProof(ValidityProofRequest),
+    /// A request from a peer to its cluster for a copy of the witness to `VALID COMMITMENTS`
+    /// for a given order
+    RequestOrderValidityWitness(ValidityWitnessRequest),
 }
 
 impl From<&ClusterManagementMessage> for Vec<u8> {
@@ -111,7 +114,19 @@ pub struct ClusterAuthResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidityProofRequest {
     /// The orders for which a proof is requested
+    ///
+    /// We allow for a batch of request so that a bootstrapping peer may
+    /// save on published messages
     pub order_ids: Vec<OrderIdentifier>,
+    /// The address that a response should be sent back to
+    pub sender: WrappedPeerId,
+}
+
+/// The boyd of a witness request published to a cluster
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidityWitnessRequest {
+    /// The order for which a witness is requested
+    pub order_id: OrderIdentifier,
     /// The address that a response should be sent back to
     pub sender: WrappedPeerId,
 }

--- a/core/src/api/gossip.rs
+++ b/core/src/api/gossip.rs
@@ -10,6 +10,7 @@ use crate::{
     gossip::types::{ClusterId, WrappedPeerId},
     proof_generation::jobs::ValidCommitmentsBundle,
     state::OrderIdentifier,
+    types::SizedValidCommitmentsWitness,
 };
 
 use super::{
@@ -131,6 +132,17 @@ pub enum GossipRequest {
         /// The proof of `VALID COMMITMENTS` for this order
         proof: ValidCommitmentsBundle,
     },
+    /// A request type that pushes the witness used in `VALID COMMITMENTS` for an order to the
+    /// receiver
+    ///
+    /// This may be triggered when the receiver broadcasts a pubsub message indicating that it
+    /// needs a copy of the witness
+    ValidityWitness {
+        /// The order this witness is for
+        order_id: OrderIdentifier,
+        /// The witness used to prove `VALID COMMITMENTS`
+        witness: SizedValidCommitmentsWitness,
+    },
 }
 
 impl GossipRequest {
@@ -146,6 +158,7 @@ impl GossipRequest {
             GossipRequest::OrderInfo(..) => false,
             GossipRequest::Replicate(..) => false,
             GossipRequest::ValidityProof { .. } => true,
+            GossipRequest::ValidityWitness { .. } => true,
         }
     }
 }

--- a/core/src/gossip/errors.rs
+++ b/core/src/gossip/errors.rs
@@ -7,6 +7,8 @@ use std::fmt;
 pub enum GossipError {
     /// An error resulting from a cancellation signal
     Cancelled(String),
+    /// An error occurred looking up a critical state element
+    MissingState(String),
     /// An error parsing a gossip message
     Parse(String),
     /// An error setting up the gossip server

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     proof_generation::jobs::ValidCommitmentsBundle,
     state::{wallet::WalletIdentifier, NetworkOrder, OrderIdentifier},
+    types::SizedValidCommitmentsWitness,
 };
 
 use super::types::{ClusterId, WrappedPeerId};
@@ -106,5 +107,19 @@ pub enum OrderBookManagementJob {
         cluster: ClusterId,
         /// The new proof of `VALID COMMITMENTS`
         proof: ValidCommitmentsBundle,
+    },
+    /// A request for an order's witness to `VALID COMMITMENTS` has come in
+    OrderWitness {
+        /// The order ID that info is requested for
+        order_id: OrderIdentifier,
+        /// The peer to return the response to
+        requesting_peer: WrappedPeerId,
+    },
+    /// A response for an order's witness to `VALID COMMITMENTS` has come in
+    OrderWitnessResponse {
+        /// The order ID that info is requested for
+        order_id: OrderIdentifier,
+        /// The witness used to prove `VALID COMMITMENTS` for the order
+        witness: SizedValidCommitmentsWitness,
     },
 }

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -6,17 +6,23 @@ use libp2p::request_response::ResponseChannel;
 
 use crate::{
     api::{
-        gossip::{AuthenticatedGossipResponse, GossipOutbound, GossipResponse},
+        cluster_management::{ClusterManagementMessage, ValidityWitnessRequest},
+        gossip::{
+            AuthenticatedGossipResponse, GossipOutbound, GossipRequest, GossipResponse,
+            PubsubMessage,
+        },
         orderbook_management::OrderInfoResponse,
     },
     proof_generation::jobs::ValidCommitmentsBundle,
     state::{NetworkOrder, OrderIdentifier},
-    types::SizedValidCommitments,
+    types::{SizedValidCommitments, SizedValidCommitmentsWitness},
 };
 
 use super::{
-    errors::GossipError, jobs::OrderBookManagementJob, server::GossipProtocolExecutor,
-    types::ClusterId,
+    errors::GossipError,
+    jobs::OrderBookManagementJob,
+    server::GossipProtocolExecutor,
+    types::{ClusterId, WrappedPeerId},
 };
 
 impl GossipProtocolExecutor {
@@ -49,6 +55,16 @@ impl GossipProtocolExecutor {
                 cluster,
                 proof,
             } => self.handle_new_validity_proof(order_id, cluster, proof),
+
+            OrderBookManagementJob::OrderWitness {
+                order_id,
+                requesting_peer,
+            } => self.handle_validity_witness_request(order_id, requesting_peer),
+
+            OrderBookManagementJob::OrderWitnessResponse { order_id, witness } => {
+                self.handle_validity_witness_response(order_id, witness);
+                Ok(())
+            }
         }
     }
 
@@ -79,17 +95,29 @@ impl GossipProtocolExecutor {
     /// Handles a response to a request for order info
     fn handle_order_info_response(&self, mut order_info: NetworkOrder) -> Result<(), GossipError> {
         // If there is a proof attached to the order, verify it
+        let is_local = order_info.cluster == self.global_state.local_cluster_id;
         if let Some(proof_bundle) = order_info.valid_commit_proof.clone() {
-            verify_singleprover_proof::<SizedValidCommitments>(
-                proof_bundle.statement,
-                proof_bundle.commitment,
-                proof_bundle.proof,
-            )
-            .map_err(|err| GossipError::ValidCommitmentVerification(err.to_string()))?;
+            // We can trust local (i.e. originating from cluster peers) proofs
+            if !is_local {
+                verify_singleprover_proof::<SizedValidCommitments>(
+                    proof_bundle.statement,
+                    proof_bundle.commitment,
+                    proof_bundle.proof,
+                )
+                .map_err(|err| GossipError::ValidCommitmentVerification(err.to_string()))?;
+            }
+
+            // If the order is a locally managed order, the local peer also needs a copy of the witness
+            // so that it may link commitments between the validity proof and subsequent match/encryption
+            // proofs
+            if is_local {
+                self.request_order_witness(order_info.id)?;
+            }
         }
 
-        order_info.local = order_info.cluster == self.global_state.local_cluster_id;
+        order_info.local = is_local;
         self.global_state.add_order(order_info);
+
         Ok(())
     }
 
@@ -137,6 +165,82 @@ impl GossipProtocolExecutor {
             .read_order_book()
             .update_order_validity_proof(&order_id, proof_bundle);
 
+        // If the order is locally managed, also fetch the wintess used in the proof,
+        // this is used for proof linking. I.e. the local node needs the commitment parameters
+        // for each witness element so that it may share commitments with future proofs
+        self.request_order_witness(order_id)?;
+
         Ok(())
+    }
+
+    /// Requests a copy of the witness used in an order's validity proof for a locally
+    /// managed order
+    fn request_order_witness(&self, order_id: OrderIdentifier) -> Result<(), GossipError> {
+        let message =
+            ClusterManagementMessage::RequestOrderValidityWitness(ValidityWitnessRequest {
+                order_id,
+                sender: self.global_state.local_peer_id,
+            });
+
+        self.network_channel
+            .send(GossipOutbound::Pubsub {
+                topic: self.global_state.local_cluster_id.get_management_topic(),
+                message: PubsubMessage::ClusterManagement {
+                    cluster_id: self.global_state.local_cluster_id.clone(),
+                    message,
+                },
+            })
+            .map_err(|err| GossipError::SendMessage(err.to_string()))
+    }
+
+    /// Handles a request for a validity proof witness from a peer
+    fn handle_validity_witness_request(
+        &self,
+        order_id: OrderIdentifier,
+        requesting_peer: WrappedPeerId,
+    ) -> Result<(), GossipError> {
+        // Sanity check that the requesting peer is part of the cluster,
+        // authentication of the message is done at the network manager level,
+        // so this check is a bit redundant, but worth doing
+        {
+            let info = self
+                .global_state
+                .read_peer_index()
+                .get_peer_info(&requesting_peer)
+                .ok_or_else(|| {
+                    GossipError::MissingState("peer info not found in state".to_string())
+                })?;
+
+            if info.get_cluster_id() != self.global_state.local_cluster_id {
+                return Ok(());
+            }
+        } // peer_index lock released
+
+        // If the local peer has a copy of the witness stored locally, send it to the peer
+        if let Some(order_info) = self
+            .global_state
+            .read_order_book()
+            .get_order_info(&order_id)
+            && let Some(witness) = order_info.valid_commit_witness
+        {
+            self.network_channel
+                .send(GossipOutbound::Request { peer_id: requesting_peer, message: GossipRequest::ValidityWitness {
+                    order_id, witness
+                }})
+                .map_err(|err| GossipError::SendMessage(err.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    /// Handle a response from a peer containing a witness for `VALID COMMITMENTS`
+    fn handle_validity_witness_response(
+        &self,
+        order_id: OrderIdentifier,
+        witness: SizedValidCommitmentsWitness,
+    ) {
+        self.global_state
+            .read_order_book()
+            .attach_validity_proof_witness(&order_id, witness);
     }
 }

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -20,7 +20,7 @@ use circuits::{
         },
     },
     zk_gadgets::merkle::MerkleOpening,
-    MAX_BALANCES, MAX_ORDERS,
+    LinkableCommitment, MAX_BALANCES, MAX_ORDERS,
 };
 use crossbeam::channel::Receiver;
 use crypto::fields::prime_field_to_scalar;
@@ -191,7 +191,7 @@ impl ProofManager {
         merkle_root: Scalar,
     ) -> Result<ValidCommitmentsBundle, ProofManagerError> {
         // Compute the hash of the randomness
-        let randomness_hash = compute_poseidon_hash(&[wallet.randomness]);
+        let randomness_hash = LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness]));
         let wallet_nullifier =
             compute_wallet_match_nullifier(&wallet, compute_wallet_commitment(&wallet));
 

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -194,6 +194,7 @@ impl ProofManager {
         let randomness_hash = LinkableCommitment::new(compute_poseidon_hash(&[wallet.randomness]));
         let wallet_nullifier =
             compute_wallet_match_nullifier(&wallet, compute_wallet_commitment(&wallet));
+        let pk_settle = wallet.keys.pk_settle;
 
         // Build a witness and statement
         let witness = ValidCommitmentsWitness {
@@ -209,6 +210,7 @@ impl ProofManager {
         let statement = ValidCommitmentsStatement {
             nullifier: prime_field_to_scalar(&wallet_nullifier),
             merkle_root,
+            pk_settle,
         };
 
         // Prove the statement `VALID COMMITMENTS`

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -5,6 +5,7 @@ use circuits::{
     native_helpers::compute_poseidon_hash,
     zk_circuits::valid_commitments::ValidCommitmentsWitness,
     zk_gadgets::merkle::{MerkleOpening, MerkleRoot},
+    LinkableCommitment,
 };
 use crossbeam::channel::Sender;
 use crypto::fields::biguint_to_scalar;
@@ -190,6 +191,8 @@ impl RelayerState {
                         // This witness is reference by match computations which compute linkable commitments
                         // to the order and balance; i.e. they commit with the same randomness
                         {
+                            let randomness_hash =
+                                compute_poseidon_hash(&[biguint_to_scalar(&wallet.randomness)]);
                             self.read_order_book().attach_validity_proof_witness(
                                 order_id,
                                 ValidCommitmentsWitness {
@@ -199,9 +202,7 @@ impl RelayerState {
                                     fee: fee.clone().into(),
                                     fee_balance: fee_balance.clone().into(),
                                     wallet_opening: wallet_opening.clone(),
-                                    randomness_hash: compute_poseidon_hash(&[biguint_to_scalar(
-                                        &wallet.randomness,
-                                    )]),
+                                    randomness_hash: LinkableCommitment::new(randomness_hash),
                                     sk_match: wallet.secret_keys.sk_match,
                                 },
                             );


### PR DESCRIPTION
### Purpose
This PR makes two meaningful changes:
1. Add linkable commitments for wallet randomness hashes used to derive note randomness; as well as attaching `pk_settle` to the statement of `VALID COMMITMENTS` so that it may be linked with `VALID MATCH ENCRYPTION`.
2. Peers now gossip with one another about the witness and linkable commitments used when proving `VALID COMMITMENTS`. This is done to ensure that if a peer receives a proof of `VALID COMMITMENTS` from a cluster peer; it has access to the commitments used so that it may link these commitments into other proofs.

### Testing
- Unit tests + integration tests
- Tested two cases for sharing validity proof witnesses, validating that the witness was appropriately gossiped:
    - A cluster peer finishes a proof of `VALID COMMITMENTS` and then gossips it to existing peers.
    - A cluster peer joins the cluster after a proof has been generated.