### PR TITLE
core: chain-events: Bootstrap on-chain event listener

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = "0.11.13"
 ring-channel = "0.11.0"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
-starknet = "0.2"
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
 starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
 streaming-stats = "0.1.28"
 termion = "2.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,6 +58,8 @@ reqwest = "0.11.13"
 ring-channel = "0.11.0"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
+starknet = "0.2"
+starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
 streaming-stats = "0.1.28"
 termion = "2.0"
 tokio = { version = "1", features = ["full"] }

--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -1,5 +1,18 @@
 //! Defines error types for the on-chain event listener
 
+use std::fmt::Display;
+
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
-pub enum OnChainEventListenerError {}
+pub enum OnChainEventListenerError {
+    /// An RPC error with the StarkNet provider
+    Rpc(String),
+    /// Error setting up the on-chain event listener
+    Setup(String),
+}
+
+impl Display for OnChainEventListenerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}

--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -1,0 +1,5 @@
+//! Defines error types for the on-chain event listener
+
+/// The error type that the event listener emits
+#[derive(Clone, Debug)]
+pub enum OnChainEventListenerError {}

--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -1,0 +1,19 @@
+//! Defines the core implementation of the on-chain event listener
+
+use crossbeam::channel::Receiver;
+
+/// The configuration passed to the listener upon startup
+#[derive(Debug, Clone)]
+pub struct OnChainEventListenerConfig {
+    /// The channel on which the coordinator may send a cancel signal
+    pub cancel_channel: Receiver<()>,
+}
+
+/// The worker responsible for listening for on-chain events, translating them to jobs for
+/// other workers, and forwarding these jobs to the relevant workers
+#[derive(Debug)]
+pub struct OnChainEventListener {
+    /// The config passed to the listener at startup
+    #[allow(unused)]
+    pub(super) config: OnChainEventListenerConfig,
+}

--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -1,12 +1,43 @@
 //! Defines the core implementation of the on-chain event listener
 
+use std::{thread::JoinHandle, time::Duration};
+
 use crossbeam::channel::Receiver;
+use reqwest::Url;
+use starknet_providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use tokio::time::{sleep_until, Instant};
+use tracing::log;
+
+use super::error::OnChainEventListenerError;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The interval at which the worker should poll for new contract events
+const EVENTS_POLL_INTERVAL_MS: u64 = 5_000; // 5 seconds
+
+// ----------
+// | Worker |
+// ----------
 
 /// The configuration passed to the listener upon startup
 #[derive(Debug, Clone)]
 pub struct OnChainEventListenerConfig {
+    /// The starknet HTTP api url
+    pub starknet_api_gateway: Option<String>,
+    /// The infura API key to use for API access
+    pub infura_api_key: Option<String>,
     /// The channel on which the coordinator may send a cancel signal
     pub cancel_channel: Receiver<()>,
+}
+
+impl OnChainEventListenerConfig {
+    /// Determines whether the parameters needed to enable the on-chain event
+    /// listener are present. If not the worker should not startup
+    pub fn enabled(&self) -> bool {
+        self.starknet_api_gateway.is_some()
+    }
 }
 
 /// The worker responsible for listening for on-chain events, translating them to jobs for
@@ -16,4 +47,64 @@ pub struct OnChainEventListener {
     /// The config passed to the listener at startup
     #[allow(unused)]
     pub(super) config: OnChainEventListenerConfig,
+    /// The executor run in a separate thread
+    pub(super) executor: Option<OnChainEventListenerExecutor>,
+    /// The thread handle of the executor
+    pub(super) executor_handle: Option<JoinHandle<OnChainEventListenerError>>,
+}
+
+// ------------
+// | Executor |
+// ------------
+
+/// The executor that runs in a thread and polls events from on-chain state
+#[derive(Debug)]
+pub struct OnChainEventListenerExecutor {
+    /// The JSON-RPC client used to connect to StarkNet
+    rpc_client: JsonRpcClient<HttpTransport>,
+    /// A copy of the config that the executor maintains
+    config: OnChainEventListenerConfig,
+}
+
+impl OnChainEventListenerExecutor {
+    /// Create a new executor
+    pub fn new(config: OnChainEventListenerConfig) -> Self {
+        let rpc_client = JsonRpcClient::new(HttpTransport::new(
+            Url::parse(&config.starknet_api_gateway.clone().unwrap_or_default()).unwrap(),
+        ));
+
+        Self { rpc_client, config }
+    }
+
+    /// The main execution loop for the executor
+    pub async fn execute(self) -> OnChainEventListenerError {
+        // Get the current block number to start from
+        let starting_block_number = self.get_block_number().await;
+        if starting_block_number.is_err() {
+            return starting_block_number.err().unwrap();
+        }
+
+        let starting_block_number = starting_block_number.unwrap();
+        log::info!("Starting on-chain event listener with current block {starting_block_number}");
+
+        // Poll for new events in a loop
+        loop {
+            // Sleep for some time then re-poll events
+            sleep_until(Instant::now() + Duration::from_millis(EVENTS_POLL_INTERVAL_MS)).await;
+            self.poll_contract_events().await;
+        }
+    }
+
+    /// Get the current StarkNet block number
+    async fn get_block_number(&self) -> Result<u64, OnChainEventListenerError> {
+        self.rpc_client
+            .block_number()
+            .await
+            .map_err(|err| OnChainEventListenerError::Rpc(err.to_string()))
+    }
+
+    /// Poll for new contract events
+    async fn poll_contract_events(&self) {
+        log::info!("polling for events...");
+    }
 }

--- a/core/src/chain_events/mod.rs
+++ b/core/src/chain_events/mod.rs
@@ -1,0 +1,5 @@
+//! Defines and implements the worker that listens for on-chain events
+
+pub mod error;
+pub mod listener;
+pub mod worker;

--- a/core/src/chain_events/worker.rs
+++ b/core/src/chain_events/worker.rs
@@ -1,0 +1,47 @@
+//! The relayer worker implementation for the event listener
+
+use crate::worker::Worker;
+
+use super::{
+    error::OnChainEventListenerError,
+    listener::{OnChainEventListener, OnChainEventListenerConfig},
+};
+
+impl Worker for OnChainEventListener {
+    type WorkerConfig = OnChainEventListenerConfig;
+    type Error = OnChainEventListenerError;
+
+    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self { config })
+    }
+
+    fn name(&self) -> String {
+        "on-chain-event-listener".to_string()
+    }
+
+    fn join(&mut self) -> Vec<std::thread::JoinHandle<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("")
+    }
+
+    fn is_recoverable(&self) -> bool {
+        false
+    }
+
+    fn recover(self) -> Self
+    where
+        Self: Sized,
+    {
+        unimplemented!("")
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("")
+    }
+}

--- a/core/src/chain_events/worker.rs
+++ b/core/src/chain_events/worker.rs
@@ -1,10 +1,14 @@
 //! The relayer worker implementation for the event listener
 
+use std::thread::{self, Builder, JoinHandle};
+use tokio::runtime::Builder as RuntimeBuilder;
+use tracing::log;
+
 use crate::worker::Worker;
 
 use super::{
     error::OnChainEventListenerError,
-    listener::{OnChainEventListener, OnChainEventListenerConfig},
+    listener::{OnChainEventListener, OnChainEventListenerConfig, OnChainEventListenerExecutor},
 };
 
 impl Worker for OnChainEventListener {
@@ -15,19 +19,58 @@ impl Worker for OnChainEventListener {
     where
         Self: Sized,
     {
-        Ok(Self { config })
+        let executor = if config.enabled() {
+            Some(OnChainEventListenerExecutor::new(config.clone()))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            config,
+            executor,
+            // Replaced at startup
+            executor_handle: None,
+        })
     }
 
     fn name(&self) -> String {
         "on-chain-event-listener".to_string()
     }
 
-    fn join(&mut self) -> Vec<std::thread::JoinHandle<Self::Error>> {
-        unimplemented!()
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        vec![self.executor_handle.take().unwrap()]
     }
 
     fn start(&mut self) -> Result<(), Self::Error> {
-        unimplemented!("")
+        // Spawn the execution loop in a separate thread
+        let executor = self.executor.take();
+        let join_handle = Builder::new()
+            .name("on-chain-event-listener-executor".to_string())
+            .spawn(move || {
+                // If we were unable to build an executor from the config, park the executing thread
+                // This is simpler than forcing some partial-operating logic up to the coordinator
+                if let Some(executor) = executor {
+                    let runtime = RuntimeBuilder::new_current_thread()
+                        .enable_all()
+                        .thread_name("on-chain-listener-runtime")
+                        .build()
+                        .map_err(|err| OnChainEventListenerError::Setup(err.to_string()));
+                    if let Err(e) = runtime {
+                        return e;
+                    }
+
+                    let runtime = runtime.unwrap();
+                    runtime.block_on(executor.execute())
+                } else {
+                    log::info!("on-chain event listener missing config options; parking worker...");
+                    thread::park();
+                    unreachable!();
+                }
+            })
+            .map_err(|err| OnChainEventListenerError::Setup(err.to_string()))?;
+
+        self.executor_handle = Some(join_handle);
+        Ok(())
     }
 
     fn is_recoverable(&self) -> bool {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -86,6 +86,9 @@ struct Cli {
     /// The Ethereum RPC node websocket address to dial for on-chain data
     #[clap(long = "eth-websocket", value_parser)]
     pub eth_websocket_addr: Option<String>,
+    /// The StarkNet JSON-RPC gateway
+    #[clap(long = "starknet-gateway", value_parser)]
+    pub starknet_gateway: Option<String>,
     /// A file holding a json representation of the wallets the local node
     /// should manage
     #[clap(short, long, value_parser)]
@@ -121,6 +124,8 @@ pub struct RelayerConfig {
     pub coinbase_api_key: Option<String>,
     /// The Coinbase API secret to use for price streaming
     pub coinbase_api_secret: Option<String>,
+    /// The StarkNet JSON-RPC API gateway
+    pub starknet_gateway: Option<String>,
     /// The Ethereum RPC node websocket address to dial for on-chain data
     pub eth_websocket_addr: Option<String>,
     /// Whether or not the relayer is in debug mode
@@ -202,6 +207,7 @@ pub fn parse_command_line_args() -> Result<Box<RelayerConfig>, CoordinatorError>
         cluster_id,
         coinbase_api_key: cli_args.coinbase_api_key,
         coinbase_api_secret: cli_args.coinbase_api_secret,
+        starknet_gateway: cli_args.starknet_gateway,
         eth_websocket_addr: cli_args.eth_websocket_addr,
         debug: cli_args.debug,
     };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -36,6 +36,13 @@ struct Cli {
     #[clap(long, value_parser)]
     pub config_file: Option<String>,
 
+    // -----------------------
+    // | Environment Configs |
+    // -----------------------
+    /// The address of the darkpool contract, defaults to the Goerli deployment
+    #[clap(long, value_parser, default_value = "0x07d45b975709b894c87ef0318b4f20924e5542ce85116d523c2faef602e491a0")]
+    pub contract_address: String,
+    
     // -------------------------
     // | Cluster Configuration |
     // -------------------------
@@ -100,6 +107,8 @@ struct Cli {
 pub struct RelayerConfig {
     /// Software version of the relayer
     pub version: String,
+    /// The address of the contract in the target network
+    pub contract_address: String,
     /// Bootstrap servers that the peer should connect to
     pub bootstrap_servers: Vec<(WrappedPeerId, Multiaddr)>,
     /// The port to listen on for libp2p
@@ -196,6 +205,7 @@ pub fn parse_command_line_args() -> Result<Box<RelayerConfig>, CoordinatorError>
         version: cli_args
             .version
             .unwrap_or_else(|| String::from(DEFAULT_VERSION)),
+        contract_address: cli_args.contract_address,
         bootstrap_servers: parsed_bootstrap_addrs,
         p2p_port: cli_args.p2p_port,
         http_port: cli_args.http_port,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -235,6 +235,8 @@ async fn main() -> Result<(), CoordinatorError> {
         channel::bounded(1 /* capacity */);
     let mut chain_listener = OnChainEventListener::new(OnChainEventListenerConfig {
         cancel_channel: chain_listener_cancel_receiver,
+        starknet_api_gateway: args.starknet_gateway,
+        infura_api_key: None,
     })
     .expect("failed to build on-chain event listener");
     chain_listener

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -234,9 +234,10 @@ async fn main() -> Result<(), CoordinatorError> {
     let (chain_listener_cancel_sender, chain_listener_cancel_receiver) =
         channel::bounded(1 /* capacity */);
     let mut chain_listener = OnChainEventListener::new(OnChainEventListenerConfig {
-        cancel_channel: chain_listener_cancel_receiver,
         starknet_api_gateway: args.starknet_gateway,
         infura_api_key: None,
+        contract_address: args.contract_address,
+        cancel_channel: chain_listener_cancel_receiver,
     })
     .expect("failed to build on-chain event listener");
     chain_listener


### PR DESCRIPTION
### Purpose
This PR adds the initial code structure and event polling loop for the `OnChainEventListener`. This worker primarily acts as a relay that:
1. Polls a StarkNet gateway JSON-RPC node for new events coming from the Darkpool contract.
2. Dispatches relevant events as jobs to other workers in the relayer

Currently, we poll the JSON-RPC API (hitting `getEvents`) because the StarkNet API does not have an events websocket. If, in the future, they add a websocket; we will make the changes here.

### Testing
- Unit tests
- Ran a relayer, submitted a new wallet to the [Goerli contract](https://goerli.voyager.online/contract/0x07d45b975709b894c87ef0318b4f20924e5542ce85116d523c2faef602e491a0#transactions), verified that a `Merkle_root_updated` event was consumed by the relayer once the transaction reached "Accepted on L2"