### PR TITLE
core: chain-events: listener: Add MPC shootdowns when nullifier is spent on-chain

### DIFF
--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -7,6 +7,8 @@ use std::fmt::Display;
 pub enum OnChainEventListenerError {
     /// An RPC error with the StarkNet provider
     Rpc(String),
+    /// An error sending a message to another worker in the local node
+    SendMessage(String),
     /// Error setting up the on-chain event listener
     Setup(String),
 }

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -12,6 +12,8 @@ pub enum HandshakeManagerError {
     InvalidRequest(String),
     /// Error in MPC networking
     MpcNetwork(String),
+    /// An MpcShootdown request has stopped the handshake
+    MpcShootdown,
     /// Error verifying a proof
     VerificationError(String),
     /// Error awaiting a proof from the proof generation module

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -1,5 +1,6 @@
 //! Defines jobs that other workers in the relayer may enqueue for the handshake module
 
+use curve25519_dalek::scalar::Scalar;
 use libp2p::request_response::ResponseChannel;
 use mpc_ristretto::network::QuicTwoPartyNet;
 use uuid::Uuid;
@@ -43,6 +44,16 @@ pub enum HandshakeExecutionJob {
         party_id: u64,
         /// The net that was setup for the party
         net: QuicTwoPartyNet,
+    },
+    /// Indicates that the local peer should halt any MPCs active on the given match nullifier
+    ///
+    /// This job is constructed when a nullifier is seen on chain, indicating that it is
+    /// no longer valid to match on. The local party should hangup immediately to avoid
+    /// leaking the order after opening
+    MpcShootdown {
+        /// The match-nullifier value seen on-chain; any in-flight MPCs on this nullifier
+        /// are to be terminated
+        match_nullifier: Scalar,
     },
     /// Indicates that a cluster replica has initiated a match on the given order pair.
     /// The local peer should not schedule this order pair for a match for some duration

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -50,6 +50,8 @@ pub enum HandshakeExecutionJob {
     /// This job is constructed when a nullifier is seen on chain, indicating that it is
     /// no longer valid to match on. The local party should hangup immediately to avoid
     /// leaking the order after opening
+    /// TODO: Remove this lint allowance
+    #[allow(unused)]
     MpcShootdown {
         /// The match-nullifier value seen on-chain; any in-flight MPCs on this nullifier
         /// are to be terminated

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -50,8 +50,6 @@ pub enum HandshakeExecutionJob {
     /// This job is constructed when a nullifier is seen on chain, indicating that it is
     /// no longer valid to match on. The local party should hangup immediately to avoid
     /// leaking the order after opening
-    /// TODO: Remove this lint allowance
-    #[allow(unused)]
     MpcShootdown {
         /// The match-nullifier value seen on-chain; any in-flight MPCs on this nullifier
         /// are to be terminated

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -3,6 +3,7 @@
 
 use crossbeam::channel::{Receiver, Sender};
 
+use curve25519_dalek::scalar::Scalar;
 use libp2p::request_response::ResponseChannel;
 use portpicker::pick_unused_port;
 use rayon::{ThreadPool, ThreadPoolBuilder};
@@ -244,6 +245,12 @@ impl HandshakeExecutor {
 
                 // Record the match in the cache
                 self.record_completed_match(request_id)
+            }
+
+            // Indicates that in-flight MPCs on the given nullifier should be terminated
+            HandshakeExecutionJob::MpcShootdown { match_nullifier } => {
+                self.handle_mpc_shootdown(match_nullifier);
+                Ok(())
             }
         }
     }
@@ -533,6 +540,11 @@ impl HandshakeExecutor {
 
         // Send back an ack
         self.send_request_response(request_id, peer_id, HandshakeMessage::Ack, response_channel)
+    }
+
+    /// Handles an MPC shootdown request from elsewhere in the local node
+    fn handle_mpc_shootdown(&self, match_nullifier: Scalar) {
+        unimplemented!("implement mpc shootdowns")
     }
 
     /// Sends a request or response depending on whether the response channel is None

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -3,13 +3,15 @@
 #![allow(dead_code)]
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
 
-use crate::state::{OrderIdentifier, Shared};
+use crate::state::{OrderIdentifier, RelayerState, Shared};
 
 use super::error::HandshakeManagerError;
+use crossbeam::channel::Sender;
+use curve25519_dalek::scalar::Scalar;
 use uuid::Uuid;
 
 /// Holds state information for all in-flight handshake correspondences
@@ -20,15 +22,25 @@ use uuid::Uuid;
 pub struct HandshakeStateIndex {
     /// The underlying map of request identifiers to state machine instances
     state_map: Shared<HashMap<Uuid, HandshakeState>>,
+    /// A mapping from nullifier to a set of request_ids on that nullifier
+    nullifier_map: Shared<HashMap<Scalar, HashSet<Uuid>>>,
+    /// A copy of the relayer global state
+    global_state: RelayerState,
 }
 
 impl HandshakeStateIndex {
     /// Creates a new instance of the state index
-    pub fn new() -> Self {
+    pub fn new(global_state: RelayerState) -> Self {
         Self {
             state_map: Arc::new(RwLock::new(HashMap::new())),
+            nullifier_map: Arc::new(RwLock::new(HashMap::new())),
+            global_state,
         }
     }
+
+    // ----------------------------
+    // | Index Management Methods |
+    // ----------------------------
 
     /// Adds a new handshake to the state where the peer's order is already known (e.g. the peer initiated the handshake)
     #[allow(clippy::too_many_arguments)]
@@ -37,19 +49,116 @@ impl HandshakeStateIndex {
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
-    ) {
-        let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
-        locked_state.insert(
-            request_id,
-            HandshakeState::new(request_id, peer_order_id, local_order_id),
-        );
+    ) -> Result<(), HandshakeManagerError> {
+        // Lookup the match nullifiers for the order
+        let locked_order_book = self.global_state.read_order_book();
+        let local_nullifier = locked_order_book
+            .get_match_nullifier(&local_order_id)
+            .ok_or_else(|| {
+                HandshakeManagerError::StateNotFound(
+                    "match nullifier not found for order".to_string(),
+                )
+            })?;
+        let peer_nullifier = locked_order_book
+            .get_match_nullifier(&peer_order_id)
+            .ok_or_else(|| {
+                HandshakeManagerError::StateNotFound(
+                    "match nullifier not found for order".to_string(),
+                )
+            })?;
+
+        // Index by request ID
+        {
+            let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
+            locked_state.insert(
+                request_id,
+                HandshakeState::new(
+                    request_id,
+                    peer_order_id,
+                    local_order_id,
+                    peer_nullifier,
+                    local_nullifier,
+                ),
+            );
+        } // locked_state released
+
+        // Index by nullifier
+        {
+            let mut locked_nullifier_map = self
+                .nullifier_map
+                .write()
+                .expect("nullifier_map lock poisoned");
+
+            locked_nullifier_map
+                .entry(local_nullifier)
+                .or_default()
+                .insert(request_id);
+            locked_nullifier_map
+                .entry(peer_nullifier)
+                .or_default()
+                .insert(request_id);
+        } // locked_nullifier_map released
+
+        Ok(())
     }
 
     /// Removes a handshake after processing is complete; either by match completion or error
-    pub fn remove_handshake(&self, request_id: &Uuid) {
-        let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
-        locked_state.remove(request_id);
+    pub fn remove_handshake(&self, request_id: &Uuid) -> Option<HandshakeState> {
+        // Remove from the state
+        let state = {
+            let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
+            locked_state.remove(request_id)
+        }; // locked_state released
+
+        // Remove from the nullifier index
+        if let Some(state) = state.clone() {
+            let mut locked_nullifier_map = self
+                .nullifier_map
+                .write()
+                .expect("nullifier_map lock poisoned");
+
+            if let Some(nullifier_set) = locked_nullifier_map.get_mut(&state.local_match_nullifier)
+            {
+                nullifier_set.remove(request_id);
+            }
+
+            if let Some(nullifier_set) = locked_nullifier_map.get_mut(&state.peer_match_nullifier) {
+                nullifier_set.remove(request_id);
+            }
+        } // locked_nullifier_map released
+
+        state
     }
+
+    /// Shootdown all active handshakes on a given nullifier
+    pub fn shootdown_nullifier(&self, nullifier: Scalar) -> Result<(), HandshakeManagerError> {
+        let requests = {
+            let mut locked_nullifier_map = self
+                .nullifier_map
+                .write()
+                .expect("nullifier_map lock poisoned");
+
+            locked_nullifier_map.remove(&nullifier).unwrap_or_default()
+        }; // locked_nullifier_map released
+
+        // For each request, remove the state entry for the request and send a cancel signal
+        // over the request's cancel channel if one has already been allocated. The receiver
+        // of this channel is the worker running in the MPC runtime
+        for request in requests.iter() {
+            if let Some(state) = self.remove_handshake(request)
+            && let Some(channel) = state.cancel_channel
+            {
+                channel.send(())
+                    .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    // --------------------
+    // | State Transition |
+    // --------------------
 
     /// Gets the state of the given handshake
     pub fn get_state(&self, request_id: &Uuid) -> Option<HandshakeState> {
@@ -58,10 +167,11 @@ impl HandshakeStateIndex {
     }
 
     /// Transition the given handshake into the MatchInProgress state
-    pub fn in_progress(&self, request_id: &Uuid) {
+    pub fn in_progress(&self, request_id: &Uuid, cancel_channel: Sender<()>) {
         let mut locked_state = self.state_map.write().expect("state_map lock poisoned");
         if let Some(entry) = locked_state.get_mut(request_id) {
-            entry.in_progress()
+            entry.in_progress();
+            entry.cancel_channel = Some(cancel_channel);
         }
     }
 
@@ -71,6 +181,9 @@ impl HandshakeStateIndex {
         if let Some(entry) = locked_state.get_mut(request_id) {
             entry.completed()
         }
+
+        // For now, we simply remove the handshake from the state
+        self.remove_handshake(request_id);
     }
 
     /// Transition the given handshake into the Error state
@@ -79,6 +192,9 @@ impl HandshakeStateIndex {
         if let Some(entry) = locked_state.get_mut(request_id) {
             entry.error(err)
         }
+
+        // For now we simply remove the handshake from the state
+        self.remove_handshake(request_id);
     }
 }
 
@@ -92,8 +208,14 @@ pub struct HandshakeState {
     pub peer_order_id: OrderIdentifier,
     /// The identifier of the order that the local peer has proposed for match
     pub local_order_id: OrderIdentifier,
+    /// The match nullifier of remote peer's order
+    pub peer_match_nullifier: Scalar,
+    /// The match nullifier of the local peer's order
+    pub local_match_nullifier: Scalar,
     /// The current state information of the
     pub state: State,
+    /// The cancel channel that the coordinator may use to cancel MPC execution
+    pub cancel_channel: Option<Sender<()>>,
 }
 
 /// A state enumeration for the valid states a handshake may take
@@ -122,12 +244,17 @@ impl HandshakeState {
         request_id: Uuid,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
+        peer_match_nullifier: Scalar,
+        local_match_nullifier: Scalar,
     ) -> Self {
         Self {
             request_id,
             peer_order_id,
             local_order_id,
+            peer_match_nullifier,
+            local_match_nullifier,
             state: State::OrderNegotiation,
+            cancel_channel: None,
         }
     }
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -237,6 +237,7 @@ async fn main() -> Result<(), CoordinatorError> {
         starknet_api_gateway: args.starknet_gateway,
         infura_api_key: None,
         contract_address: args.contract_address,
+        handshake_manager_job_queue: handshake_worker_sender,
         cancel_channel: chain_listener_cancel_receiver,
     })
     .expect("failed to build on-chain event listener");

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -14,6 +14,7 @@
 #![allow(unused)]
 
 use circuits::zk_circuits::valid_commitments::ValidCommitmentsWitness;
+use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -263,6 +264,14 @@ impl NetworkOrderBook {
         self.order_map
             .get(order_id)
             .map(|order| order.read().expect(ERR_ORDER_POISONED).clone())
+    }
+
+    /// Fetch the match nullifier for an order
+    pub fn get_match_nullifier(&self, order_id: &OrderIdentifier) -> Option<Scalar> {
+        self.read_order(order_id)?
+            .valid_commit_proof
+            .as_ref()
+            .map(|proof| proof.statement.nullifier)
     }
 
     /// Fetch all the verified orders in the order book

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,3 +15,4 @@ memoize = "0.4"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = { version = "0.8" }
 rand_core = "0.5"
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }


### PR DESCRIPTION
### Purpose
When a match nullifier is spent on chain; future matches using that nullifier will no longer be valid (this is the point of a nullifier). Peers that have in-flight handshakes on an order referencing that nullifier should shoot down (terminate) the match computation as soon as possible, and certainly not open the match result if the nullifier is known to be spent. Doing so would leak privacy.

This PR adds:
1. An MPC Shootdown flow in the handshake manager; built on unit type, bounded crossbeam channels that serve as "cancel channels".
2. Event listener dispatch in the on-chain event listener -- specifically to enqueue an MPC shootdown job in the handshake manager's work queue when a `Nullifier_spent` event is emitted from the contract.

### Testing
- Unit tests
- The flow is a bit hard to test end-to-end with timing transactions; so I tested each half individually:
    - Requesting an MPC shootdown on an in-flight match prevents further progress of the match
    - Submitting an `update_wallet` transaction on Goerli results in an MPC shootdown request in the handshake manager's work queue on the nullifiers sent to the contract.