### PR TITLE
core: state: orderbook: Cancel orders when their nullifier is witnessed on-chain

### DIFF
--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -18,8 +18,10 @@ use super::{
     serialize_array,
 };
 
-/// A type alias for readability
+/// Commitment type alias for readability
 pub type WalletCommitment = Scalar;
+/// Nullifier type alias for readability
+pub type Nullifier = Scalar;
 
 /// Represents the base type of a wallet holding orders, balances, fees, keys
 /// and cryptographic randomness

--- a/core/src/api/orderbook_management.rs
+++ b/core/src/api/orderbook_management.rs
@@ -1,5 +1,6 @@
 //! Defines types related to orderbook message passing within the p2p network
 
+use circuits::types::wallet::Nullifier;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -38,6 +39,8 @@ pub enum OrderBookManagementMessage {
     OrderReceived {
         /// The identifier of the new order
         order_id: OrderIdentifier,
+        /// The match nullifier of the new order
+        match_nullifier: Nullifier,
         /// The cluster that manages this order
         cluster: ClusterId,
     },

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -214,8 +214,6 @@ impl GossipProtocolExecutor {
         order_id: OrderIdentifier,
         proof: ValidCommitmentsBundle,
     ) {
-        self.global_state
-            .read_order_book()
-            .update_order_validity_proof(&order_id, proof);
+        self.global_state.add_order_validity_proof(&order_id, proof)
     }
 }

--- a/core/src/gossip/jobs.rs
+++ b/core/src/gossip/jobs.rs
@@ -1,6 +1,7 @@
 //! Groups job definitions for the gossip server
 //! These jobs are enqueued for execution by other workers within the relayer
 
+use circuits::types::wallet::Nullifier;
 use libp2p::request_response::ResponseChannel;
 
 use crate::{
@@ -95,6 +96,8 @@ pub enum OrderBookManagementJob {
     OrderReceived {
         /// The identifier of the new order
         order_id: OrderIdentifier,
+        /// The match nullifier of the containing wallet
+        match_nullifier: Nullifier,
         /// The cluster that manages this order
         cluster: ClusterId,
     },

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -181,8 +181,7 @@ impl GossipProtocolExecutor {
         }
 
         self.global_state
-            .read_order_book()
-            .update_order_validity_proof(&order_id, proof_bundle);
+            .add_order_validity_proof(&order_id, proof_bundle);
 
         // If the order is locally managed, also fetch the wintess used in the proof,
         // this is used for proof linking. I.e. the local node needs the commitment parameters

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -151,8 +151,6 @@ impl GossipProtocolExecutor {
         cluster: ClusterId,
         proof_bundle: ValidCommitmentsBundle,
     ) -> Result<(), GossipError> {
-        // Verify that the order's identifier is the same as the match nullifier
-        // in the given circuit statement
         let is_local = cluster.eq(&self.global_state.local_cluster_id);
 
         // Verify the proof

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -1,6 +1,6 @@
 //! Defines jobs that other workers in the relayer may enqueue for the handshake module
 
-use curve25519_dalek::scalar::Scalar;
+use circuits::types::wallet::Nullifier;
 use libp2p::request_response::ResponseChannel;
 use mpc_ristretto::network::QuicTwoPartyNet;
 use uuid::Uuid;
@@ -53,7 +53,7 @@ pub enum HandshakeExecutionJob {
     MpcShootdown {
         /// The match-nullifier value seen on-chain; any in-flight MPCs on this nullifier
         /// are to be terminated
-        match_nullifier: Scalar,
+        match_nullifier: Nullifier,
     },
     /// Indicates that a cluster replica has initiated a match on the given order pair.
     /// The local peer should not schedule this order pair for a match for some duration

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -259,6 +259,7 @@ async fn main() -> Result<(), CoordinatorError> {
         starknet_api_gateway: args.starknet_gateway,
         infura_api_key: None,
         contract_address: args.contract_address,
+        global_state: global_state.clone(),
         handshake_manager_job_queue: handshake_worker_sender,
         cancel_channel: chain_listener_cancel_receiver,
     })

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -673,10 +673,18 @@ impl NetworkManagerExecutor {
                 }
             }
             PubsubMessage::OrderBookManagement(msg) => match msg {
-                OrderBookManagementMessage::OrderReceived { order_id, match_nullifier, cluster } => self
+                OrderBookManagementMessage::OrderReceived {
+                    order_id,
+                    match_nullifier,
+                    cluster,
+                } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
-                        OrderBookManagementJob::OrderReceived { order_id, match_nullifier, cluster },
+                        OrderBookManagementJob::OrderReceived {
+                            order_id,
+                            match_nullifier,
+                            cluster,
+                        },
                     ))
                     .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?,
 

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -673,10 +673,10 @@ impl NetworkManagerExecutor {
                 }
             }
             PubsubMessage::OrderBookManagement(msg) => match msg {
-                OrderBookManagementMessage::OrderReceived { order_id, cluster } => self
+                OrderBookManagementMessage::OrderReceived { order_id, match_nullifier, cluster } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
-                        OrderBookManagementJob::OrderReceived { order_id, cluster },
+                        OrderBookManagementJob::OrderReceived { order_id, match_nullifier, cluster },
                     ))
                     .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?,
 

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -3,6 +3,7 @@
 
 use circuits::{
     native_helpers::compute_poseidon_hash,
+    types::wallet::Nullifier,
     zk_circuits::valid_commitments::ValidCommitmentsWitness,
     zk_gadgets::merkle::{MerkleOpening, MerkleRoot},
     LinkableCommitment,
@@ -397,6 +398,19 @@ impl RelayerState {
         self.write_order_book()
             .update_order_validity_proof(order_id, proof)
     }
+
+    /// Nullify all orders with a given nullifier
+    pub fn nullify_orders(&self, nullifier: Nullifier) {
+        let mut locked_order_book = self.write_order_book();
+        let orders_to_nullify = locked_order_book.get_orders_by_nullifier(nullifier);
+        for order_id in orders_to_nullify.into_iter() {
+            locked_order_book.transition_cancelled(&order_id);
+        }
+    }
+
+    // ------------------------
+    // | Wallet Index Setters |
+    // ------------------------
 
     /// Add wallets to the state as managed wallets
     ///

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -10,13 +10,13 @@ use std::{
 };
 
 use circuits::{
-    native_helpers::compute_wallet_commitment,
+    native_helpers::{compute_wallet_commitment, compute_wallet_match_nullifier},
     types::{
         balance::Balance,
         fee::Fee,
         keychain::{KeyChain, NUM_KEYS},
         order::{Order, OrderSide},
-        wallet::{Wallet as CircuitWallet, WalletCommitment},
+        wallet::{Nullifier, Wallet as CircuitWallet, WalletCommitment},
     },
 };
 use crypto::fields::{biguint_to_scalar, prime_field_to_scalar, scalar_to_biguint};
@@ -230,6 +230,15 @@ impl Wallet {
     pub fn get_commitment(&self) -> WalletCommitment {
         let circuit_wallet: SizedCircuitWallet = self.clone().into();
         prime_field_to_scalar(&compute_wallet_commitment(&circuit_wallet))
+    }
+
+    /// Computes the match nullifier of the wallet
+    pub fn get_match_nullifier(&self) -> Nullifier {
+        let circuit_wallet: SizedCircuitWallet = self.clone().into();
+        prime_field_to_scalar(&compute_wallet_match_nullifier(
+            &circuit_wallet,
+            compute_wallet_commitment(&circuit_wallet),
+        ))
     }
 }
 


### PR DESCRIPTION
### Purpose
We previously introduced MPC shootdown to cancel in-flight MPCs on nullified orders. This PR adds the second half of this effort: disable future MPCs from being scheduled on orders after their nullifiers are seen on-chain. 

This involves indexing orders by their match nullifier and transitioning their state to `Cancelled` in the `OnChainEventListener` when a nullifier is witnessed.

### Testing
- Unit tests pass
- Hit `update_wallet` on Goerli with a nullifier of one of the wallets used by an active relayer. Verified that once the event was emitted on-chain, the relayer cancelled the order.