### PR TITLE
core: handshake, gossip, state: Refactor workers to be `async`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,7 +23,7 @@ crypto = { path = "../crypto" }
 curve25519-dalek = "2"
 ed25519-dalek = { version = "1.0.1" }
 env_logger = "0.10"
-futures = { version = "0.3.25" }
+futures = { version = "0.3.26" }
 futures-util = { version = "0.3" }
 hex = "0.3.1"
 hmac-sha256 = "1.1.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ lru = { version = "0.8" }
 mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 num-bigint = { version = "0.4.3" }
-once_cell = "1.5"
+once_cell = "1.17"
 portpicker = "0.1"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_core = "0.5"

--- a/core/src/api_server/http_handlers.rs
+++ b/core/src/api_server/http_handlers.rs
@@ -189,7 +189,9 @@ impl TypedHandler for ReplicasHandler {
         let replicas = if let Some(wallet_info) = self
             .global_state
             .read_wallet_index()
+            .await
             .read_wallet(&req.wallet_id)
+            .await
         {
             wallet_info.metadata.replicas.clone().into_iter().collect()
         } else {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -222,7 +222,6 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
             .expect("Invalid address passed as --bootstrap-server");
         let peer_id = PeerId::try_from_multiaddr(&parsed_addr)
             .expect("Invalid address passed as --bootstrap-server");
-        println!("parsed peer {}: {}", peer_id, parsed_addr);
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 

--- a/core/src/default_wrapper.rs
+++ b/core/src/default_wrapper.rs
@@ -1,0 +1,66 @@
+//! Defines a container type that implements clone on any default capable type
+//!
+//! Replaces the cloned value with the underlying default, allowing a value to be
+//! passed once to across thread boundaries and then cloned again as default
+//!
+//! This is particularly useful when passing parameters into async runtimes, they
+//! may be `take`n at the executor level, and then passed as default via dispatch
+//! methods. See the gossip server for an example
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    fmt::{Debug, Display},
+    mem,
+};
+
+/// The default wrapper structure, wraps a default capable value in a cell that may
+/// be taken or cloned once.
+pub struct DefaultWrapper<D: Default>(D);
+
+impl<D: Default> DefaultWrapper<D> {
+    /// Wrap a value
+    pub fn new(d: D) -> Self {
+        Self(d)
+    }
+
+    /// Take the underlying value, replacing it with default
+    pub fn take(&mut self) -> D {
+        mem::take(self).0
+    }
+}
+
+impl<D: Default> Default for DefaultWrapper<D> {
+    fn default() -> Self {
+        Self(D::default())
+    }
+}
+
+impl<D: Default> Clone for DefaultWrapper<D> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<D: Default> Borrow<D> for DefaultWrapper<D> {
+    fn borrow(&self) -> &D {
+        &self.0
+    }
+}
+
+impl<D: Default> BorrowMut<D> for DefaultWrapper<D> {
+    fn borrow_mut(&mut self) -> &mut D {
+        &mut self.0
+    }
+}
+
+impl<D: Debug + Default> Debug for DefaultWrapper<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<D: Display + Default> Display for DefaultWrapper<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 /// An error type at the coordinator level
 #[derive(Clone, Debug)]
 pub enum CoordinatorError {
-    /// Error attemting to recover a failed worker
+    /// Error attempting to recover a failed worker
     Recovery(String),
     /// Failure to send a cancel signal to a worker
     CancelSend(String),

--- a/core/src/gossip/cluster.rs
+++ b/core/src/gossip/cluster.rs
@@ -67,7 +67,8 @@ impl GossipProtocolExecutor {
 
         // Add the peer to the cluster metadata
         // Move out of message to avoid clones
-        self.add_peer_to_cluster(message.peer_id, message.peer_info, cluster_id).await?;
+        self.add_peer_to_cluster(message.peer_id, message.peer_info, cluster_id)
+            .await?;
 
         // Request that the peer replicate all locally replicated wallets
         let wallets = self
@@ -92,7 +93,7 @@ impl GossipProtocolExecutor {
         }
 
         // Add the peer to the known peers index
-        self.global_state.add_single_peer(peer_id, peer_info);
+        self.global_state.add_single_peer(peer_id, peer_info).await;
 
         // Request that the peer replicate all locally replicated wallets
         let wallets = self

--- a/core/src/gossip/errors.rs
+++ b/core/src/gossip/errors.rs
@@ -7,6 +7,8 @@ use std::fmt;
 pub enum GossipError {
     /// An error resulting from a cancellation signal
     Cancelled(String),
+    /// The job queue for the gossip server has closed
+    ChannelClosed(String),
     /// An error occurred looking up a critical state element
     MissingState(String),
     /// An error parsing a gossip message

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -127,6 +127,7 @@ impl GossipProtocolExecutor {
                     )
                 })
                 .await
+                .unwrap()
                 .map_err(|err| GossipError::ValidCommitmentVerification(err.to_string()))?;
             }
 
@@ -185,6 +186,7 @@ impl GossipProtocolExecutor {
                 )
             })
             .await
+            .unwrap()
             .map_err(|err| GossipError::ValidCommitmentVerification(err.to_string()))?;
         }
 

--- a/core/src/gossip/worker.rs
+++ b/core/src/gossip/worker.rs
@@ -4,7 +4,7 @@ use futures::executor::block_on;
 use libp2p::Multiaddr;
 use std::thread::{Builder, JoinHandle};
 use tokio::runtime::Builder as RuntimeBuilder;
-use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender as TokioSender};
+use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
 
 use crate::{api::gossip::GossipOutbound, state::RelayerState, worker::Worker, CancelChannel};
 
@@ -30,9 +30,9 @@ pub struct GossipServerConfig {
     /// A reference to the relayer-global state
     pub(crate) global_state: RelayerState,
     /// A job queue to send outbound heartbeat requests on
-    pub(crate) job_sender: Sender<GossipServerJob>,
+    pub(crate) job_sender: TokioSender<GossipServerJob>,
     /// A job queue to receive inbound heartbeat requests on
-    pub(crate) job_receiver: Option<Receiver<GossipServerJob>>,
+    pub(crate) job_receiver: Option<TokioReceiver<GossipServerJob>>,
     /// A job queue to send outbound network requests on
     pub(crate) network_sender: TokioSender<GossipOutbound>,
     /// The channel on which the coordinator may mandate that the

--- a/core/src/handshake/handshake_cache.rs
+++ b/core/src/handshake/handshake_cache.rs
@@ -17,10 +17,10 @@ use std::{
 
 use lru::LruCache;
 
-use crate::state::Shared;
+use crate::state::AsyncShared;
 
 /// A type alias for a HandshakeCache shared between threads
-pub(super) type SharedHandshakeCache<O> = Shared<HandshakeCache<O>>;
+pub(super) type SharedHandshakeCache<O> = AsyncShared<HandshakeCache<O>>;
 
 /// Caches pairs of orders that have already been matched so that we may avoid attempting to
 /// match orders multiple times

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -232,13 +232,12 @@ impl HandshakeExecutor {
                 })
                 .await
                 .unwrap()?;
-                // let res = self.execute_match(request_id, party_id, net)?;
-
-                // Submit the match to the contract
-                self.submit_match(res)?;
 
                 // Record the match in the cache
-                self.record_completed_match(request_id).await
+                self.record_completed_match(request_id).await?;
+
+                // Submit the match to the contract
+                self.submit_match(res).await
             }
 
             // Indicates that in-flight MPCs on the given nullifier should be terminated

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -10,6 +10,7 @@ mod api;
 mod api_server;
 mod chain_events;
 mod config;
+mod default_wrapper;
 mod error;
 mod gossip;
 mod handshake;
@@ -197,8 +198,8 @@ async fn main() -> Result<(), CoordinatorError> {
         cluster_id: args.cluster_id,
         bootstrap_servers: args.bootstrap_servers,
         global_state: global_state.clone(),
-        heartbeat_worker_sender,
-        heartbeat_worker_receiver,
+        job_sender: heartbeat_worker_sender,
+        job_receiver: heartbeat_worker_receiver,
         network_sender: network_sender.clone(),
         cancel_channel: gossip_cancel_receiver,
     })

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -98,15 +98,18 @@ impl NetworkManager {
     /// Setup global state after peer_id and address have been assigned
     pub(super) async fn update_global_state_after_startup(&self) {
         // Add self to peer info index
-        self.config.global_state.add_single_peer(
-            self.local_peer_id,
-            PeerInfo::new_with_cluster_secret_key(
+        self.config
+            .global_state
+            .add_single_peer(
                 self.local_peer_id,
-                self.cluster_id.clone(),
-                self.local_addr.clone(),
-                self.config.cluster_keypair.as_ref().unwrap(),
-            ),
-        ).await;
+                PeerInfo::new_with_cluster_secret_key(
+                    self.local_peer_id,
+                    self.cluster_id.clone(),
+                    self.local_addr.clone(),
+                    self.config.cluster_keypair.as_ref().unwrap(),
+                ),
+            )
+            .await;
     }
 
     /// Setup pubsub subscriptions for the network manager

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -14,13 +14,14 @@
 #![allow(unused)]
 
 use circuits::{types::wallet::Nullifier, zk_circuits::valid_commitments::ValidCommitmentsWitness};
+use futures::stream::{futures_unordered::FuturesUnordered, iter as to_stream, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::{Display, Formatter, Result as FmtResult},
-    sync::{RwLockReadGuard, RwLockWriteGuard},
 };
+use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use uuid::Uuid;
 
 use crate::{
@@ -30,7 +31,7 @@ use crate::{
     types::{SizedValidCommitmentsWitness, SystemBusMessage, ORDER_STATE_CHANGE_TOPIC},
 };
 
-use super::{new_shared, Shared};
+use super::{new_async_shared, AsyncShared};
 
 /// Error message emitted when the local order lock is poisoned
 const ERR_LOCAL_ORDERS_POISONED: &str = "local order lock poisoned";
@@ -196,13 +197,13 @@ impl Display for NetworkOrderState {
 #[derive(Clone, Debug)]
 pub struct NetworkOrderBook {
     /// The mapping from order identifier to order information
-    order_map: HashMap<OrderIdentifier, Shared<NetworkOrder>>,
+    order_map: HashMap<OrderIdentifier, AsyncShared<NetworkOrder>>,
     /// A mapping from the wallet match nullifier to the order
-    orders_by_nullifier: HashMap<Nullifier, Shared<HashSet<OrderIdentifier>>>,
+    orders_by_nullifier: HashMap<Nullifier, AsyncShared<HashSet<OrderIdentifier>>>,
     /// A list of order IDs maintained locally
-    local_orders: Shared<HashSet<OrderIdentifier>>,
+    local_orders: AsyncShared<HashSet<OrderIdentifier>>,
     /// The set of orders in the `Verified` state; i.e. ready to match
-    verified_orders: Shared<HashSet<OrderIdentifier>>,
+    verified_orders: AsyncShared<HashSet<OrderIdentifier>>,
     /// A handle referencing the system bus to publish state transition events onto
     system_bus: SystemBus<SystemBusMessage>,
 }
@@ -213,8 +214,8 @@ impl NetworkOrderBook {
         Self {
             order_map: HashMap::new(),
             orders_by_nullifier: HashMap::new(),
-            local_orders: new_shared(HashSet::new()),
-            verified_orders: new_shared(HashSet::new()),
+            local_orders: new_async_shared(HashSet::new()),
+            verified_orders: new_async_shared(HashSet::new()),
             system_bus,
         }
     }
@@ -224,72 +225,63 @@ impl NetworkOrderBook {
     // -----------
 
     /// Acquire a read lock on an order
-    pub fn read_order(&self, order_id: &OrderIdentifier) -> Option<RwLockReadGuard<NetworkOrder>> {
-        Some(
-            self.order_map
-                .get(order_id)?
-                .read()
-                .expect(ERR_ORDER_POISONED),
-        )
+    pub async fn read_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Option<RwLockReadGuard<NetworkOrder>> {
+        Some(self.order_map.get(order_id)?.read().await)
     }
 
     /// Acquire a read lock on the verified orders
-    pub fn read_verified_orders(&self) -> RwLockReadGuard<HashSet<OrderIdentifier>> {
-        self.verified_orders
-            .read()
-            .expect(ERR_VERIFIED_ORDERS_POISONED)
+    pub async fn read_verified_orders(&self) -> RwLockReadGuard<HashSet<OrderIdentifier>> {
+        self.verified_orders.read().await
     }
 
     /// Acquire a read lock on the locally managed orders
-    pub fn read_local_orders(&self) -> RwLockReadGuard<HashSet<OrderIdentifier>> {
-        self.local_orders.read().expect(ERR_LOCAL_ORDERS_POISONED)
+    pub async fn read_local_orders(&self) -> RwLockReadGuard<HashSet<OrderIdentifier>> {
+        self.local_orders.read().await
     }
 
     /// Acquire a write lock on an order
-    pub fn write_order(
+    pub async fn write_order(
         &self,
         order_id: &OrderIdentifier,
     ) -> Option<RwLockWriteGuard<NetworkOrder>> {
-        Some(
-            self.order_map
-                .get(order_id)?
-                .write()
-                .expect(ERR_ORDER_POISONED),
-        )
+        Some(self.order_map.get(order_id)?.write().await)
     }
 
     /// Acquire a write lock on the verified orders
-    pub fn write_verified_orders(&self) -> RwLockWriteGuard<HashSet<OrderIdentifier>> {
-        self.verified_orders
-            .write()
-            .expect(ERR_VERIFIED_ORDERS_POISONED)
+    pub async fn write_verified_orders(&self) -> RwLockWriteGuard<HashSet<OrderIdentifier>> {
+        self.verified_orders.write().await
     }
 
     /// Acquire a write lock on the locally managed orders
-    pub fn write_local_orders(&self) -> RwLockWriteGuard<HashSet<OrderIdentifier>> {
-        self.local_orders.write().expect(ERR_LOCAL_ORDERS_POISONED)
+    pub async fn write_local_orders(&self) -> RwLockWriteGuard<HashSet<OrderIdentifier>> {
+        self.local_orders.write().await
     }
 
     /// Acquire a read lock on an order by nullifier set
-    pub fn read_nullifier_order_set(
+    pub async fn read_nullifier_order_set(
         &self,
         nullifier: &Nullifier,
     ) -> Option<RwLockReadGuard<HashSet<OrderIdentifier>>> {
-        self.orders_by_nullifier
-            .get(nullifier)
-            .map(|locked_set| locked_set.read().expect(ERR_NULLIFIER_INDEX_POISONED))
+        if let Some(locked_orders) = self.orders_by_nullifier.get(nullifier) {
+            Some(locked_orders.read().await)
+        } else {
+            None
+        }
     }
 
     /// Acquire a write lock on an order by nullifier set
-    pub fn write_nullifier_order_set(
+    pub async fn write_nullifier_order_set(
         &mut self,
         match_nullifier: Nullifier,
     ) -> RwLockWriteGuard<HashSet<OrderIdentifier>> {
         self.orders_by_nullifier
             .entry(match_nullifier)
-            .or_insert_with(|| new_shared(HashSet::new()))
+            .or_insert_with(|| new_async_shared(HashSet::new()))
             .write()
-            .expect(ERR_NULLIFIER_INDEX_POISONED)
+            .await
     }
 
     // -----------
@@ -302,23 +294,26 @@ impl NetworkOrderBook {
     }
 
     /// Fetch the info for an order if it is stored
-    pub fn get_order_info(&self, order_id: &OrderIdentifier) -> Option<NetworkOrder> {
-        self.order_map
-            .get(order_id)
-            .map(|order| order.read().expect(ERR_ORDER_POISONED).clone())
+    pub async fn get_order_info(&self, order_id: &OrderIdentifier) -> Option<NetworkOrder> {
+        if let Some(order_info_locked) = self.order_map.get(order_id) {
+            Some(order_info_locked.read().await.clone())
+        } else {
+            None
+        }
     }
 
     /// Fetch the match nullifier for an order
-    pub fn get_match_nullifier(&self, order_id: &OrderIdentifier) -> Option<Nullifier> {
-        self.read_order(order_id)?
+    pub async fn get_match_nullifier(&self, order_id: &OrderIdentifier) -> Option<Nullifier> {
+        self.read_order(order_id)
+            .await?
             .valid_commit_proof
             .as_ref()
             .map(|proof| proof.statement.nullifier)
     }
 
     /// Fetch all orders under a given nullifier
-    pub fn get_orders_by_nullifier(&self, nullifier: Nullifier) -> Vec<OrderIdentifier> {
-        if let Some(set) = self.read_nullifier_order_set(&nullifier) {
+    pub async fn get_orders_by_nullifier(&self, nullifier: Nullifier) -> Vec<OrderIdentifier> {
+        if let Some(set) = self.read_nullifier_order_set(&nullifier).await {
             set.iter().cloned().collect_vec()
         } else {
             Vec::new()
@@ -326,8 +321,9 @@ impl NetworkOrderBook {
     }
 
     /// Fetch all the verified orders in the order book
-    pub fn get_verified_orders(&self) -> Vec<OrderIdentifier> {
+    pub async fn get_verified_orders(&self) -> Vec<OrderIdentifier> {
         self.read_verified_orders()
+            .await
             .clone()
             .into_iter()
             .collect_vec()
@@ -337,14 +333,14 @@ impl NetworkOrderBook {
     ///
     /// This amounts to validating that a copy of the validity proof and witness are stored
     /// locally
-    pub fn order_ready_for_handshake(&self, order_id: &OrderIdentifier) -> bool {
-        self.has_validity_proof(order_id) && self.has_validity_witness(order_id)
+    pub async fn order_ready_for_handshake(&self, order_id: &OrderIdentifier) -> bool {
+        self.has_validity_proof(order_id).await && self.has_validity_witness(order_id).await
     }
 
     /// Fetch a list of locally managed orders for which
-    pub fn get_local_scheduleable_orders(&self) -> Vec<OrderIdentifier> {
-        let locked_verified_orders = self.read_verified_orders();
-        let locked_local_orders = self.read_local_orders();
+    pub async fn get_local_scheduleable_orders(&self) -> Vec<OrderIdentifier> {
+        let locked_verified_orders = self.read_verified_orders().await;
+        let locked_local_orders = self.read_local_orders().await;
 
         // Get the set of local, verified orders
         let local_verified_orders = locked_verified_orders
@@ -353,18 +349,24 @@ impl NetworkOrderBook {
             .collect_vec();
 
         // Filter out those for which the local node does not have a copy of the witness
-        local_verified_orders
-            .into_iter()
-            .filter(|order_id| self.has_validity_witness(order_id))
-            .collect_vec()
+        to_stream(local_verified_orders)
+            .filter_map(|order_id| async move {
+                if self.has_validity_witness(&order_id).await {
+                    Some(order_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .await
     }
 
     /// Fetch all the non-locally managed, verified orders
     ///
     /// Used for choosing orders to schedule handshakes on
-    pub fn get_nonlocal_verified_orders(&self) -> Vec<OrderIdentifier> {
-        let locked_verified_orders = self.read_verified_orders();
-        let locked_local_orders = self.read_local_orders();
+    pub async fn get_nonlocal_verified_orders(&self) -> Vec<OrderIdentifier> {
+        let locked_verified_orders = self.read_verified_orders().await;
+        let locked_local_orders = self.read_local_orders().await;
 
         locked_verified_orders
             .difference(&locked_local_orders)
@@ -373,13 +375,10 @@ impl NetworkOrderBook {
     }
 
     /// Return a list of all known order IDs in the book with clusters to contact for info
-    pub fn get_order_owner_pairs(&self) -> Vec<(OrderIdentifier, ClusterId)> {
+    pub async fn get_order_owner_pairs(&self) -> Vec<(OrderIdentifier, ClusterId)> {
         let mut pairs = Vec::new();
         for (order_id, info) in self.order_map.iter() {
-            pairs.push((
-                *order_id,
-                info.read().expect(ERR_ORDER_POISONED).cluster.clone(),
-            ))
+            pairs.push((*order_id, info.read().await.cluster.clone()))
         }
 
         pairs
@@ -387,8 +386,8 @@ impl NetworkOrderBook {
 
     /// Returns whether or not the local node holds a proof of `VALID COMMITMENTS`
     /// for the given order
-    pub fn has_validity_proof(&self, order_id: &OrderIdentifier) -> bool {
-        if let Some(order_info) = self.read_order(order_id) {
+    pub async fn has_validity_proof(&self, order_id: &OrderIdentifier) -> bool {
+        if let Some(order_info) = self.read_order(order_id).await {
             return order_info.valid_commit_proof.is_some();
         }
 
@@ -397,14 +396,17 @@ impl NetworkOrderBook {
 
     /// Fetch a copy of the validity proof for the given order, or `None` if a proof
     /// is not locally stored
-    pub fn get_validity_proof(&self, order_id: &OrderIdentifier) -> Option<ValidCommitmentsBundle> {
-        self.read_order(order_id)?.valid_commit_proof.clone()
+    pub async fn get_validity_proof(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Option<ValidCommitmentsBundle> {
+        self.read_order(order_id).await?.valid_commit_proof.clone()
     }
 
     /// Returns whether the local node holds a witness to a the proof of `VALID COMMITMENTS`
     /// for the given order
-    pub fn has_validity_witness(&self, order_id: &OrderIdentifier) -> bool {
-        if let Some(order_info) = self.read_order(order_id) {
+    pub async fn has_validity_witness(&self, order_id: &OrderIdentifier) -> bool {
+        if let Some(order_info) = self.read_order(order_id).await {
             return order_info.valid_commit_witness.is_some();
         }
 
@@ -412,18 +414,21 @@ impl NetworkOrderBook {
     }
 
     /// Fetch a copy of the witness to the validity proof if one exists
-    pub fn get_validity_proof_witness(
+    pub async fn get_validity_proof_witness(
         &self,
         order_id: &OrderIdentifier,
     ) -> Option<SizedValidCommitmentsWitness> {
-        self.read_order(order_id)?.valid_commit_witness.clone()
+        self.read_order(order_id)
+            .await?
+            .valid_commit_witness
+            .clone()
     }
 
     /// Fetch a copy of the local order book
-    pub fn get_order_book_snapshot(&self) -> HashMap<OrderIdentifier, NetworkOrder> {
+    pub async fn get_order_book_snapshot(&self) -> HashMap<OrderIdentifier, NetworkOrder> {
         let mut res = HashMap::new();
         for order_id in self.order_map.keys() {
-            let mut info = { self.read_order(order_id).unwrap().clone() };
+            let mut info = { self.read_order(order_id).await.unwrap().clone() };
             res.insert(*order_id, info);
         }
 
@@ -436,36 +441,38 @@ impl NetworkOrderBook {
 
     /// Add an order to the book, necessarily this order is in the received state because
     /// we must fetch a validity proof to move it to verified
-    pub fn add_order(&mut self, mut order: NetworkOrder) {
+    pub async fn add_order(&mut self, mut order: NetworkOrder) {
         // If the order is local, add it to the local order list
         if order.local {
-            self.write_local_orders().insert(order.id);
+            self.write_local_orders().await.insert(order.id);
         }
 
         // If the order is verified already, add it to the list of verified orders
         if matches!(order.state, NetworkOrderState::Verified) {
-            self.add_verified_order(order.id)
+            self.add_verified_order(order.id).await;
         }
 
         // Add an entry in the orders by nullifier index
         self.write_nullifier_order_set(order.match_nullifier)
+            .await
             .insert(order.id);
 
         // Add an entry in the order index
-        self.order_map.insert(order.id, new_shared(order));
+        self.order_map.insert(order.id, new_async_shared(order));
     }
 
     /// Update the validity proof for an order
-    pub fn update_order_validity_proof(
+    pub async fn update_order_validity_proof(
         &mut self,
         order_id: &OrderIdentifier,
         proof: ValidCommitmentsBundle,
     ) {
         // Index by the match nullifier seen in the proof, this is guaranteed correct
         self.write_nullifier_order_set(proof.statement.nullifier)
+            .await
             .insert(*order_id);
 
-        if let Some(mut locked_order) = self.write_order(order_id) {
+        if let Some(mut locked_order) = self.write_order(order_id).await {
             locked_order.attach_commitment_proof(proof);
         }
 
@@ -473,35 +480,27 @@ impl NetworkOrderBook {
     }
 
     /// Attach a validity proof witness to the local order state
-    pub fn attach_validity_proof_witness(
+    pub async fn attach_validity_proof_witness(
         &self,
         order_id: &OrderIdentifier,
         witness: SizedValidCommitmentsWitness,
     ) {
-        if let Some(mut locked_order) = self.write_order(order_id) {
+        if let Some(mut locked_order) = self.write_order(order_id).await {
             locked_order.valid_commit_witness = Some(witness);
         }
     }
 
     /// Add an order to the verified orders list
-    fn add_verified_order(&self, order_id: Uuid) {
-        if !self.read_verified_orders().contains(&order_id) {
-            self.write_verified_orders().insert(order_id);
+    async fn add_verified_order(&self, order_id: Uuid) {
+        if !self.read_verified_orders().await.contains(&order_id) {
+            self.write_verified_orders().await.insert(order_id);
         }
     }
 
     /// Remove an order from the verified orders list
-    fn remove_verified_order(&self, order_id: &Uuid) {
-        if self
-            .verified_orders
-            .read()
-            .expect(ERR_VERIFIED_ORDERS_POISONED)
-            .contains(order_id)
-        {
-            self.verified_orders
-                .write()
-                .expect(ERR_VERIFIED_ORDERS_POISONED)
-                .remove(order_id);
+    async fn remove_verified_order(&self, order_id: &Uuid) {
+        if self.verified_orders.read().await.contains(order_id) {
+            self.verified_orders.write().await.remove(order_id);
         }
     }
 
@@ -511,8 +510,8 @@ impl NetworkOrderBook {
 
     /// Transitions the state of an order back to the received state, this drops
     /// the existing proof of `VALID COMMITMENTS`
-    pub fn transition_order_received(&mut self, order_id: &OrderIdentifier) {
-        if let Some(mut order) = self.write_order(order_id) {
+    pub async fn transition_order_received(&mut self, order_id: &OrderIdentifier) {
+        if let Some(mut order) = self.write_order(order_id).await {
             let prev_state = order.state;
             order.transition_received();
 
@@ -530,16 +529,16 @@ impl NetworkOrderBook {
     }
 
     /// Transitions the state of an order to the verified state
-    pub fn transition_verified(
+    pub async fn transition_verified(
         &mut self,
         order_id: &OrderIdentifier,
         proof: ValidCommitmentsBundle,
     ) {
-        if let Some(mut order) = self.write_order(order_id) {
+        if let Some(mut order) = self.write_order(order_id).await {
             let prev_state = order.state;
             order.transition_verified(proof);
 
-            self.add_verified_order(*order_id);
+            self.add_verified_order(*order_id).await;
 
             self.system_bus.publish(
                 ORDER_STATE_CHANGE_TOPIC.to_string(),
@@ -553,12 +552,12 @@ impl NetworkOrderBook {
     }
 
     /// Transitions the state of an order from `Verified` to `Matched`
-    pub fn transition_matched(&mut self, order_id: &OrderIdentifier, by_local_node: bool) {
-        if let Some(mut order) = self.write_order(order_id) {
+    pub async fn transition_matched(&mut self, order_id: &OrderIdentifier, by_local_node: bool) {
+        if let Some(mut order) = self.write_order(order_id).await {
             let prev_state = order.state;
             order.transition_matched(by_local_node);
 
-            self.remove_verified_order(order_id);
+            self.remove_verified_order(order_id).await;
 
             self.system_bus.publish(
                 ORDER_STATE_CHANGE_TOPIC.to_string(),
@@ -572,12 +571,12 @@ impl NetworkOrderBook {
     }
 
     /// Transitions the state of an order to `Cancelled`
-    pub fn transition_cancelled(&mut self, order_id: &OrderIdentifier) {
-        if let Some(mut order) = self.write_order(order_id) {
+    pub async fn transition_cancelled(&mut self, order_id: &OrderIdentifier) {
+        if let Some(mut order) = self.write_order(order_id).await {
             let prev_state = order.state;
             order.transition_cancelled();
 
-            self.remove_verified_order(order_id);
+            self.remove_verified_order(order_id).await;
 
             self.system_bus.publish(
                 ORDER_STATE_CHANGE_TOPIC.to_string(),
@@ -591,12 +590,12 @@ impl NetworkOrderBook {
     }
 
     /// Transitions the state of an order to `Pruned`
-    pub fn transition_pruned(&mut self, order_id: &OrderIdentifier) {
-        if let Some(mut order) = self.write_order(order_id) {
+    pub async fn transition_pruned(&mut self, order_id: &OrderIdentifier) {
+        if let Some(mut order) = self.write_order(order_id).await {
             let prev_state = order.state;
             order.transition_pruned();
 
-            self.remove_verified_order(order_id);
+            self.remove_verified_order(order_id).await;
 
             self.system_bus.publish(
                 ORDER_STATE_CHANGE_TOPIC.to_string(),

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -476,7 +476,7 @@ impl NetworkOrderBook {
             locked_order.attach_commitment_proof(proof);
         }
 
-        self.add_verified_order(*order_id);
+        self.add_verified_order(*order_id).await;
     }
 
     /// Attach a validity proof witness to the local order state
@@ -495,6 +495,8 @@ impl NetworkOrderBook {
         if !self.read_verified_orders().await.contains(&order_id) {
             self.write_verified_orders().await.insert(order_id);
         }
+
+        let orders = self.read_verified_orders().await.clone();
     }
 
     /// Remove an order from the verified orders list

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -12,11 +12,6 @@ use crate::gossip::types::{ClusterId, PeerInfo, WrappedPeerId};
 
 use super::{new_async_shared, AsyncShared};
 
-/// Error message emitted when a cluster peer list lock is poisoned
-const ERR_CLUSTER_LIST_POISONED: &str = "cluster peer list poisoned";
-/// The error message to panic with when a peer's lock has been poisoned
-const ERR_PEER_POISONED: &str = "peer lock poisoned";
-
 /// An index over known peers in the network
 #[derive(Debug)]
 pub struct PeerIndex {

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -1,17 +1,16 @@
 //! Groups concurrent safe type definitions for indexing peers in the network
 
+use itertools::Itertools;
+use rand::{thread_rng, Rng};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Debug,
-    sync::{RwLockReadGuard, RwLockWriteGuard},
 };
-
-use itertools::Itertools;
-use rand::{thread_rng, Rng};
+use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::gossip::types::{ClusterId, PeerInfo, WrappedPeerId};
 
-use super::{new_shared, Shared};
+use super::{new_async_shared, AsyncShared};
 
 /// Error message emitted when a cluster peer list lock is poisoned
 const ERR_CLUSTER_LIST_POISONED: &str = "cluster peer list poisoned";
@@ -22,9 +21,9 @@ const ERR_PEER_POISONED: &str = "peer lock poisoned";
 #[derive(Debug)]
 pub struct PeerIndex {
     /// A mapping from peer ID to information about the peer
-    peer_map: HashMap<WrappedPeerId, Shared<PeerInfo>>,
+    peer_map: HashMap<WrappedPeerId, AsyncShared<PeerInfo>>,
     /// A mapping from cluster ID to a list of known peers in the cluster
-    cluster_peers: HashMap<ClusterId, Shared<HashSet<WrappedPeerId>>>,
+    cluster_peers: HashMap<ClusterId, AsyncShared<HashSet<WrappedPeerId>>>,
 }
 
 impl PeerIndex {
@@ -41,37 +40,45 @@ impl PeerIndex {
     // -----------
 
     /// Acquire a read lock on a peer's info
-    pub fn read_peer(&self, peer_id: &WrappedPeerId) -> Option<RwLockReadGuard<PeerInfo>> {
-        self.peer_map
-            .get(peer_id)
-            .map(|peer_info| peer_info.read().expect(ERR_PEER_POISONED))
+    pub async fn read_peer(&self, peer_id: &WrappedPeerId) -> Option<RwLockReadGuard<PeerInfo>> {
+        if let Some(peer_info) = self.peer_map.get(peer_id) {
+            Some(peer_info.read().await)
+        } else {
+            None
+        }
     }
 
     /// Acquires a read lock on a cluster's peer list
-    pub fn read_cluster_peers(
+    pub async fn read_cluster_peers(
         &self,
         cluster_id: &ClusterId,
     ) -> Option<RwLockReadGuard<HashSet<WrappedPeerId>>> {
-        self.cluster_peers
-            .get(cluster_id)
-            .map(|cluster| cluster.read().expect(ERR_CLUSTER_LIST_POISONED))
+        if let Some(cluster) = self.cluster_peers.get(cluster_id) {
+            Some(cluster.read().await)
+        } else {
+            None
+        }
     }
 
     /// Acquire a write lock on a peer's info
-    pub fn write_peer(&self, peer_id: &WrappedPeerId) -> Option<RwLockWriteGuard<PeerInfo>> {
-        self.peer_map
-            .get(peer_id)
-            .map(|peer_info| peer_info.write().expect(ERR_PEER_POISONED))
+    pub async fn write_peer(&self, peer_id: &WrappedPeerId) -> Option<RwLockWriteGuard<PeerInfo>> {
+        if let Some(peer_info) = self.peer_map.get(peer_id) {
+            Some(peer_info.write().await)
+        } else {
+            None
+        }
     }
 
     /// Acquire a write lock on a cluster's peer list
-    pub fn write_cluster_peers(
+    pub async fn write_cluster_peers(
         &self,
         cluster_id: &ClusterId,
     ) -> Option<RwLockWriteGuard<HashSet<WrappedPeerId>>> {
-        self.cluster_peers
-            .get(cluster_id)
-            .map(|cluster| cluster.write().expect(ERR_CLUSTER_LIST_POISONED))
+        if let Some(cluster) = self.cluster_peers.get(cluster_id) {
+            Some(cluster.write().await)
+        } else {
+            None
+        }
     }
 
     // -----------
@@ -84,10 +91,8 @@ impl PeerIndex {
     }
 
     /// Returns the info for a given peer
-    pub fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
-        self.peer_map
-            .get(peer_id)
-            .map(|info| info.read().expect(ERR_PEER_POISONED).clone())
+    pub async fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
+        Some(self.peer_map.get(peer_id)?.read().await.clone())
     }
 
     /// Returns whether the given peer is already indexed by the peer index
@@ -96,16 +101,18 @@ impl PeerIndex {
     }
 
     /// Returns a list of all cluster peers
-    pub fn get_all_cluster_peers(&self, cluster_id: &ClusterId) -> Vec<WrappedPeerId> {
-        self.read_cluster_peers(cluster_id)
-            .map(|peers| peers.iter().cloned().collect_vec())
-            .unwrap_or_default()
+    pub async fn get_all_cluster_peers(&self, cluster_id: &ClusterId) -> Vec<WrappedPeerId> {
+        if let Some(peers) = self.read_cluster_peers(cluster_id).await {
+            peers.clone().into_iter().collect_vec()
+        } else {
+            Vec::new()
+        }
     }
 
     /// Returns a random cluster peer for the given cluster
-    pub fn sample_cluster_peer(&self, cluster_id: &ClusterId) -> Option<WrappedPeerId> {
+    pub async fn sample_cluster_peer(&self, cluster_id: &ClusterId) -> Option<WrappedPeerId> {
         let mut rng = thread_rng();
-        let cluster_peers = self.read_cluster_peers(cluster_id)?;
+        let cluster_peers = self.read_cluster_peers(cluster_id).await?;
 
         // Choose a random value from the set of peers
         if cluster_peers.is_empty() {
@@ -117,15 +124,8 @@ impl PeerIndex {
     }
 
     /// Return an nth index into an iterator formed over the hashmap
-    pub fn nth(&self, index: usize) -> Option<RwLockReadGuard<PeerInfo>> {
-        Some(
-            self.peer_map
-                .iter()
-                .nth(index)?
-                .1
-                .read()
-                .expect(ERR_PEER_POISONED),
-        )
+    pub async fn nth(&self, index: usize) -> Option<RwLockReadGuard<PeerInfo>> {
+        Some(self.peer_map.iter().nth(index)?.1.read().await)
     }
 
     /// Returns a list of known peer IDs
@@ -137,10 +137,10 @@ impl PeerIndex {
     ///
     /// This is constructed when the heartbeat message is constructed and sent to
     /// heartbeat peers
-    pub fn get_info_map(&self) -> HashMap<WrappedPeerId, PeerInfo> {
+    pub async fn get_info_map(&self) -> HashMap<WrappedPeerId, PeerInfo> {
         let mut res = HashMap::new();
         for (peer_id, info) in self.peer_map.iter() {
-            res.insert(*peer_id, info.read().expect(ERR_PEER_POISONED).clone());
+            res.insert(*peer_id, info.read().await.clone());
         }
 
         res
@@ -151,35 +151,31 @@ impl PeerIndex {
     // -----------
 
     /// Add a peer to the peer index
-    pub fn add_peer(&mut self, peer_info: PeerInfo) {
+    pub async fn add_peer(&mut self, peer_info: PeerInfo) {
         // Add the peer to the list of known peers in its cluster
         let peer_cluster_record = self
             .cluster_peers
             .entry(peer_info.get_cluster_id())
-            .or_insert_with(|| new_shared(HashSet::new()));
+            .or_insert_with(|| new_async_shared(HashSet::new()));
         peer_cluster_record
             .write()
-            .expect(ERR_CLUSTER_LIST_POISONED)
+            .await
             .insert(peer_info.get_peer_id());
 
         // Add the peer only if it does not already exist
         if let Entry::Vacant(e) = self.peer_map.entry(peer_info.get_peer_id()) {
-            e.insert(new_shared(peer_info));
+            e.insert(new_async_shared(peer_info));
         }
     }
 
     /// Remove a peer from the index
-    pub fn remove_peer(&mut self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
+    pub async fn remove_peer(&mut self, peer_id: &WrappedPeerId) -> Option<PeerInfo> {
         // Remove from the peer info index
-        let entry = self
-            .peer_map
-            .remove(peer_id)?
-            .read()
-            .expect(ERR_PEER_POISONED)
-            .clone();
+        let entry = self.peer_map.remove(peer_id)?.read().await.clone();
 
         // Remove from the peer's cluster list
         self.write_cluster_peers(&entry.get_cluster_id())
+            .await
             .unwrap()
             .remove(&entry.get_peer_id());
 
@@ -187,8 +183,8 @@ impl PeerIndex {
     }
 
     /// Record a successful heartbeat for a peer
-    pub fn record_heartbeat(&self, peer_id: &WrappedPeerId) {
-        if let Some(peer_info_guard) = self.write_peer(peer_id) {
+    pub async fn record_heartbeat(&self, peer_id: &WrappedPeerId) {
+        if let Some(peer_info_guard) = self.write_peer(peer_id).await {
             peer_info_guard.successful_heartbeat();
         }
     }

--- a/core/src/state/peers.rs
+++ b/core/src/state/peers.rs
@@ -111,7 +111,6 @@ impl PeerIndex {
 
     /// Returns a random cluster peer for the given cluster
     pub async fn sample_cluster_peer(&self, cluster_id: &ClusterId) -> Option<WrappedPeerId> {
-        let mut rng = thread_rng();
         let cluster_peers = self.read_cluster_peers(cluster_id).await?;
 
         // Choose a random value from the set of peers
@@ -119,6 +118,7 @@ impl PeerIndex {
             return None;
         }
 
+        let mut rng = thread_rng();
         let random_index = rng.gen_range(0..cluster_peers.len());
         cluster_peers.iter().nth(random_index).cloned()
     }

--- a/core/src/state/priority.rs
+++ b/core/src/state/priority.rs
@@ -3,18 +3,13 @@
 
 use std::{
     collections::HashMap,
-    sync::{
-        atomic::{AtomicU32, Ordering},
-    },
+    sync::atomic::{AtomicU32, Ordering},
 };
 use tokio::sync::RwLockReadGuard;
 
 use crate::gossip::types::ClusterId;
 
 use super::{new_async_shared, AsyncShared, OrderIdentifier};
-
-/// The error emitted when an order's priority lock is poisoned
-const ERR_ORDER_PRIORITY_POISONED: &str = "order priority lock poisoned";
 
 /// The default priority for a cluster
 const CLUSTER_DEFAULT_PRIORITY: u32 = 1;

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -1,6 +1,19 @@
 //! This file groups type definitions and helpers around global state that
 //! is passed around throughout the code
 
+use crate::{
+    api::{
+        gossip::{GossipOutbound, PubsubMessage},
+        heartbeat::HeartbeatMessage,
+        orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
+    },
+    gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
+    proof_generation::jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle},
+    state::orderbook::NetworkOrder,
+    system_bus::SystemBus,
+    types::SystemBusMessage,
+    MERKLE_HEIGHT,
+};
 use circuits::{
     native_helpers::compute_poseidon_hash,
     types::wallet::Nullifier,
@@ -24,20 +37,6 @@ use std::{
 };
 use tokio::sync::{
     mpsc::UnboundedSender, oneshot, RwLock as AsyncRwLock, RwLockReadGuard, RwLockWriteGuard,
-};
-
-use crate::{
-    api::{
-        gossip::{GossipOutbound, PubsubMessage},
-        heartbeat::HeartbeatMessage,
-        orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
-    },
-    gossip::types::{ClusterId, PeerInfo, WrappedPeerId},
-    proof_generation::jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle},
-    state::orderbook::NetworkOrder,
-    system_bus::SystemBus,
-    types::SystemBusMessage,
-    MERKLE_HEIGHT,
 };
 
 use super::{

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -552,7 +552,7 @@ impl RelayerState {
     /// Construct a heartbeat message from the relayer state
     pub async fn construct_heartbeat(&self) -> HeartbeatMessage {
         // Get a mapping from wallet ID to information
-        let wallet_info = self.read_wallet_index().await.get_metadata_map();
+        let wallet_info = self.read_wallet_index().await.get_metadata_map().await;
 
         // Convert peer info keys to strings for serialization/deserialization
         let peer_info = self

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -37,8 +37,6 @@ use super::{new_async_shared, orderbook::OrderIdentifier, AsyncShared};
 
 /// A type that attaches default size parameters to a circuit allocated wallet
 type SizedCircuitWallet = CircuitWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-/// An error message to panic with when a wallet lock is poisoned
-const ERR_WALLET_POISONED: &str = "wallet lock poisoned";
 
 /// A type alias for the wallet identifier type, currently a UUID
 pub type WalletIdentifier = Uuid;
@@ -296,11 +294,6 @@ impl WalletIndex {
 
     /// Returns a list of all wallets
     pub async fn get_all_wallets(&self) -> Vec<Wallet> {
-        let wallet_values = self.wallet_map.values().cloned();
-        for wallet in self.wallet_map.values().cloned() {
-            let val = wallet.read().await.clone();
-        }
-
         to_stream(self.wallet_map.values().cloned())
             .then(|locked_wallet| async move { locked_wallet.read().await.clone() })
             .collect::<Vec<_>>()

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -28,7 +28,7 @@ use serde::{
     ser::SerializeSeq,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::RwLockReadGuard;
 use uuid::Uuid;
 
 use crate::{gossip::types::WrappedPeerId, MAX_BALANCES, MAX_FEES, MAX_ORDERS};


### PR DESCRIPTION
### Purpose
This PR refactors most of the workers and state synchronization to be `async`. The workers were originally somewhat synchronous to accommodate CPU bound workloads. However, we've mostly siloed compute intensive workloads to the proof manager, which remains synchronous. 

The remaining workers are largely async compatible -- consisting of network calls with simple locking and message passing. This also makes the worker framework fit much nicer with the type of logic we are writing for on-chain event consumption.

### Testing
- Unit tests
- Tested gossip and matching engine functionalities of the relayer ad-hoc