### PR TITLE
core: gossip: orderbook: Check nullifier on-chain before accepting order

### DIFF
--- a/core/src/default_wrapper.rs
+++ b/core/src/default_wrapper.rs
@@ -17,6 +17,12 @@ use std::{
 /// be taken or cloned once.
 pub struct DefaultWrapper<D: Default>(D);
 
+impl<D: Default> From<D> for DefaultWrapper<D> {
+    fn from(d: D) -> Self {
+        Self(d)
+    }
+}
+
 impl<D: Default> DefaultWrapper<D> {
     /// Wrap a value
     pub fn new(d: D) -> Self {

--- a/core/src/gossip/errors.rs
+++ b/core/src/gossip/errors.rs
@@ -15,6 +15,8 @@ pub enum GossipError {
     ServerSetup(String),
     /// An error forwarding a message to the network manager
     SendMessage(String),
+    /// An error occurred making a request to a StarkNet node
+    StarknetRequest(String),
     /// Timer failed to send a heartbeat
     TimerFailed(String),
     /// An error verifying a peer's proof of `VALID COMMITMENTS`

--- a/core/src/gossip/heartbeat.rs
+++ b/core/src/gossip/heartbeat.rs
@@ -268,7 +268,7 @@ impl GossipProtocolExecutor {
         &self,
         recipient_peer_id: WrappedPeerId,
     ) -> Result<(), GossipError> {
-        if recipient_peer_id == self.local_peer_id {
+        if recipient_peer_id == self.config.local_peer_id {
             return Ok(());
         }
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -47,7 +47,6 @@ use crate::{
     api::gossip::GossipOutbound,
     api_server::{server::ApiServer, worker::ApiServerConfig},
     chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig},
-    default_wrapper::DefaultWrapper,
     gossip::{jobs::GossipServerJob, server::GossipServer},
     handshake::{jobs::HandshakeExecutionJob, manager::HandshakeManager},
     network_manager::manager::NetworkManager,
@@ -206,10 +205,11 @@ async fn main() -> Result<(), CoordinatorError> {
         local_peer_id: network_manager.local_peer_id,
         local_addr: network_manager.local_addr.clone(),
         cluster_id: args.cluster_id,
+        contract_address: args.contract_address.clone(),
         bootstrap_servers: args.bootstrap_servers,
         global_state: global_state.clone(),
         job_sender: gossip_worker_sender.clone(),
-        job_receiver: Some(gossip_worker_receiver),
+        job_receiver: Some(gossip_worker_receiver).into(),
         network_sender: network_sender.clone(),
         cancel_channel: gossip_cancel_receiver,
     })
@@ -244,7 +244,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (price_reporter_cancel_sender, price_reporter_cancel_receiver) = watch::channel(());
     let mut price_reporter_manager = PriceReporterManager::new(PriceReporterManagerConfig {
         system_bus: system_bus.clone(),
-        job_receiver: DefaultWrapper::new(Some(price_reporter_worker_receiver)),
+        job_receiver: Some(price_reporter_worker_receiver).into(),
         cancel_channel: price_reporter_cancel_receiver,
         coinbase_api_key: args.coinbase_api_key,
         coinbase_api_secret: args.coinbase_api_secret,

--- a/crypto/src/fields.rs
+++ b/crypto/src/fields.rs
@@ -43,6 +43,15 @@ pub fn scalar_to_prime_field(a: &Scalar) -> DalekRistrettoField {
     Fp256::from(scalar_to_biguint(a))
 }
 
+/// Converts a dalek scalar to a StarkNet field element
+pub fn scalar_to_starknet_felt(a: &Scalar) -> StarknetFieldElement {
+    // A dalek scalar stores its bytes in little-endian order and
+    // a Starknet felt stores its bytes in big-endian order
+    let mut bytes = a.to_bytes();
+    bytes.reverse();
+    StarknetFieldElement::from_bytes_be(&bytes).unwrap()
+}
+
 // ----------------------------
 // | Conversions from Bigints |
 // ----------------------------
@@ -92,6 +101,12 @@ pub fn bigint_to_scalar_bits<const D: usize>(a: &BigInt) -> Vec<Scalar> {
     res
 }
 
+/// Convert a biguint to a Starknet field element
+pub fn biguint_to_starknet_felt(a: &BigUint) -> StarknetFieldElement {
+    // Simpler than padding bytes
+    scalar_to_starknet_felt(&biguint_to_scalar(a))
+}
+
 // -----------------------------------------
 // | Conversions from Arkworks Field Types |
 // -----------------------------------------
@@ -123,6 +138,11 @@ pub fn starknet_felt_to_scalar(element: &StarknetFieldElement) -> Scalar {
     let mut felt_bytes = element.to_bytes_be();
     felt_bytes.reverse();
     Scalar::from_bytes_mod_order(felt_bytes)
+}
+
+/// Convert from a Starknet felt to a BigUint
+pub fn starknet_felt_to_biguint(element: &StarknetFieldElement) -> BigUint {
+    BigUint::from_bytes_be(&element.to_bytes_be())
 }
 
 // ---------


### PR DESCRIPTION
### Purpose
This PR adds an on-chain check in the new async-capable gossip server that ensures nullifiers are not spent when matching on orders.

### Testing
- Unit tests
- Tested both the case in which an unspent and spent nullifier were submitted