### PR TITLE
core: chain-events: listener: Update wallet Merkle state and regen proofs

### DIFF
--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -5,6 +5,8 @@ use std::fmt::Display;
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
 pub enum OnChainEventListenerError {
+    /// An error generating a proof
+    ProofGeneration(String),
     /// An RPC error with the StarkNet provider
     Rpc(String),
     /// An error sending a message to another worker in the local node

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -88,6 +88,8 @@ pub(crate) const MAX_ORDERS: usize = 5;
 pub(crate) const MAX_FEES: usize = 2;
 /// The height of the Merkle state tree used by the contract
 pub(crate) const MERKLE_HEIGHT: usize = 32;
+/// The number of historical roots the contract stores as being valid
+pub(crate) const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 /// A type wrapper around the wallet type that adds the default generics above
 pub(crate) type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 /// The amount of time to wait between sending teardown signals and terminating execution
@@ -274,6 +276,7 @@ async fn main() -> Result<(), CoordinatorError> {
         contract_address: args.contract_address,
         global_state: global_state.clone(),
         handshake_manager_job_queue: handshake_worker_sender,
+        proof_generation_work_queue: proof_generation_worker_sender.clone(),
         cancel_channel: chain_listener_cancel_receiver,
     })
     .expect("failed to build on-chain event listener");

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -5,7 +5,7 @@
 //! of the types defined here
 
 use circuits::{
-    types::{balance::Balance, fee::Fee, keychain::KeyChain, order::Order},
+    types::{fee::Fee, keychain::KeyChain},
     zk_circuits::{
         valid_commitments::{ValidCommitmentsStatement, ValidCommitmentsWitnessCommitment},
         valid_match_encryption::{
@@ -14,14 +14,13 @@ use circuits::{
         },
         valid_wallet_create::{ValidWalletCreateCommitment, ValidWalletCreateStatement},
     },
-    zk_gadgets::merkle::{MerkleOpening, MerkleRoot},
 };
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::r1cs::R1CSProof;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot::Sender;
 
-use crate::{SizedWallet, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
+use crate::{types::SizedValidCommitmentsWitness, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 
 // ----------------------
 // | Proof Return Types |
@@ -146,22 +145,10 @@ pub enum ProofJob {
     /// A request to create a proof of `VALID COMMITMENTS` for an order, balance, fee
     /// tuple. This will be matched against in the handshake process
     ValidCommitments {
-        /// The wallet from which the committed order balance and fee come from
-        wallet: SizedWallet,
-        /// The opening of the wallet commitment to the Merkle root of the contract
-        wallet_opening: MerkleOpening,
-        /// The order being committed to
-        order: Order,
-        /// The balance covering the order
-        balance: Balance,
-        /// The fee authorized to be paid on match
-        fee: Fee,
-        /// The balance used to cover the fee
-        fee_balance: Balance,
-        /// The secret match key, used to authorize the proof
-        sk_match: Scalar,
-        /// The merkle root to prove wallet inclusion into
-        merkle_root: MerkleRoot,
+        /// The witness to use in the proof of `VALID COMMITMENTS`
+        witness: SizedValidCommitmentsWitness,
+        /// The statement (public variables) to use in the proof of `VALID COMMITMENTS`
+        statement: ValidCommitmentsStatement,
     },
     /// A request to create a proof of `VALID MATCH ENCRYPTION` for a match result
     ///

--- a/core/src/state/initialize.rs
+++ b/core/src/state/initialize.rs
@@ -38,7 +38,7 @@ use crate::{
 
 use super::{
     wallet::{MerkleAuthenticationPath, Wallet},
-    NetworkOrder, RelayerState,
+    MerkleTreeCoords, NetworkOrder, RelayerState,
 };
 
 /// An error emitted when order initialization fails
@@ -75,27 +75,6 @@ lazy_static! {
 
         values.try_into().unwrap()
     };
-}
-
-/// A wrapper representing the coordinates of a value in a Merkle tree
-///
-/// Used largely for readability
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct MerkleTreeCoords {
-    /// The height (0 is root) of the coordinate in the tree
-    height: usize,
-    /// The leaf index of the coordinate
-    ///
-    /// I.e. if we look at the nodes at a given height left to right in a list
-    /// the index of the coordinate in that list
-    index: BigUint,
-}
-
-impl MerkleTreeCoords {
-    /// Constructor
-    pub fn new(height: usize, index: BigUint) -> Self {
-        Self { height, index }
-    }
 }
 
 impl RelayerState {

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -9,5 +9,28 @@ mod state;
 pub mod tui;
 pub mod wallet;
 
+use num_bigint::BigUint;
+
 pub use self::orderbook::{NetworkOrder, NetworkOrderBook, NetworkOrderState, OrderIdentifier};
 pub use self::state::*;
+
+/// A wrapper representing the coordinates of a value in a Merkle tree
+///
+/// Used largely for readability
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MerkleTreeCoords {
+    /// The height (0 is root) of the coordinate in the tree
+    height: usize,
+    /// The leaf index of the coordinate
+    ///
+    /// I.e. if we look at the nodes at a given height left to right in a list
+    /// the index of the coordinate in that list
+    index: BigUint,
+}
+
+impl MerkleTreeCoords {
+    /// Constructor
+    pub fn new(height: usize, index: BigUint) -> Self {
+        Self { height, index }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR gives the steady state event consumption for Merkle updates. In particular, for every Merkle insertion event, the on-chain event listener:
1. Updates any internal nodes in the authentication paths of the wallets
2. Determines whether any proofs of `VALID COMMITMENTS` are now stale as a result of the root update
3. If so, enqueues a job to the proof manager to re-prove `VALID COMMITMENTS` and updates the proof in the global state once it receives a reply.

Left TODO are:
- Incorporate updated proofs into scheduling; i.e. do not schedule on peer orders that have stale `VALID COMMITMENTS` proofs.
- Gossip about updated proofs within a cluster, so that peers need not duplicate the re-proving work. Here we may want to randomize `needs_new_commitment_proof` so that it is unlikely that each node creates their own copy of the proof.

### Testing
- Unit tests
- Tested that the commitment proofs validate correctly
- Tested the proof update case; sent a transaction on Goerli that changed the root, and verified that a new proof was generated and attached to the state.