### PR TITLE
core: api-server: http: Implement remaining initial `GET` endpoints

### DIFF
--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 use self::{
+    network::{GetNetworkTopologyHandler, GET_NETWORK_TOPOLOGY_ROUTE},
     order_book::{
         GetNetworkOrderByIdHandler, GetNetworkOrdersHandler, GET_NETWORK_ORDERS_ROUTE,
         GET_NETWORK_ORDER_BY_ID_ROUTE,
@@ -39,6 +40,7 @@ use super::{
     worker::ApiServerConfig,
 };
 
+mod network;
 mod order_book;
 mod price_report;
 mod wallet;
@@ -187,7 +189,13 @@ impl HttpServer {
         router.add_route(
             Method::GET,
             GET_NETWORK_ORDER_BY_ID_ROUTE.to_string(),
-            GetNetworkOrderByIdHandler::new(global_state),
+            GetNetworkOrderByIdHandler::new(global_state.clone()),
+        );
+
+        router.add_route(
+            Method::GET,
+            GET_NETWORK_TOPOLOGY_ROUTE.to_string(),
+            GetNetworkTopologyHandler::new(global_state),
         );
 
         router

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 use self::{
+    order_book::{GetNetworkOrdersHandler, GET_NETWORK_ORDERS_ROUTE},
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     wallet::{
         GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler,
@@ -33,6 +34,7 @@ use super::{
     worker::ApiServerConfig,
 };
 
+mod order_book;
 mod price_report;
 mod wallet;
 
@@ -115,7 +117,14 @@ impl HttpServer {
         router.add_route(
             Method::GET,
             GET_FEES_ROUTE.to_string(),
-            GetFeesHandler::new(global_state),
+            GetFeesHandler::new(global_state.clone()),
+        );
+
+        // The "/order_book/orders" route
+        router.add_route(
+            Method::GET,
+            GET_NETWORK_ORDERS_ROUTE.to_string(),
+            GetNetworkOrdersHandler::new(global_state),
         );
 
         router

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -21,9 +21,9 @@ use crate::{
 use self::{
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     wallet::{
-        GetBalanceByMintHandler, GetBalancesHandler, GetOrderByIdHandler, GetOrdersHandler,
-        GetWalletHandler, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_ORDERS_ROUTE,
-        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+        GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler,
+        GetOrdersHandler, GetWalletHandler, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE,
+        GET_FEES_ROUTE, GET_ORDERS_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
     },
 };
 
@@ -108,7 +108,14 @@ impl HttpServer {
         router.add_route(
             Method::GET,
             GET_BALANCE_BY_MINT_ROUTE.to_string(),
-            GetBalanceByMintHandler::new(global_state),
+            GetBalanceByMintHandler::new(global_state.clone()),
+        );
+
+        // The "/wallet/:id/fees" route
+        router.add_route(
+            Method::GET,
+            GET_FEES_ROUTE.to_string(),
+            GetFeesHandler::new(global_state),
         );
 
         router

--- a/core/src/api_server/http/network.rs
+++ b/core/src/api_server/http/network.rs
@@ -11,18 +11,27 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use itertools::Itertools;
 
 use crate::{
     api_server::{
         error::ApiServerError,
         router::{TypedHandler, UrlParams},
     },
-    external_api::{http::network::GetNetworkTopologyResponse, types::Peer, EmptyRequestResponse},
+    external_api::{
+        http::network::{GetClusterInfoResponse, GetNetworkTopologyResponse},
+        types::{Cluster, Peer},
+        EmptyRequestResponse,
+    },
     state::RelayerState,
 };
 
+use super::parse_cluster_id_from_params;
+
 /// Returns the full network topology known to the local node
 pub(super) const GET_NETWORK_TOPOLOGY_ROUTE: &str = "/v0/network";
+/// Returns the cluster information for the specified cluster
+pub(super) const GET_CLUSTER_INFO_ROUTE: &str = "/v0/network/clusters/:cluster_id";
 
 // ------------------
 // | Route Handlers |
@@ -73,6 +82,55 @@ impl TypedHandler for GetNetworkTopologyHandler {
         // Reformat into response
         Ok(GetNetworkTopologyResponse {
             network: peers_by_cluster.into(),
+        })
+    }
+}
+
+/// Handler for the GET "/network/clusters" route
+#[derive(Clone, Debug)]
+pub struct GetClusterInfoHandler {
+    /// A copy of the relayer-global state
+    global_state: RelayerState,
+}
+
+impl GetClusterInfoHandler {
+    /// Constructor
+    pub fn new(global_state: RelayerState) -> Self {
+        Self { global_state }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for GetClusterInfoHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetClusterInfoResponse;
+
+    async fn handle_typed(
+        &self,
+        _req: Self::Request,
+        params: UrlParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let cluster_id = parse_cluster_id_from_params(&params)?;
+
+        // For simplicity, fetch all peer info and filter by cluster
+        let peers = self
+            .global_state
+            .read_peer_index()
+            .await
+            .get_info_map()
+            .await;
+
+        let peers: Vec<Peer> = peers
+            .into_iter()
+            .filter(|(_, peer_info)| peer_info.get_cluster_id().eq(&cluster_id))
+            .map(|(_, peer_info)| peer_info.into())
+            .collect_vec();
+
+        Ok(GetClusterInfoResponse {
+            cluster: Cluster {
+                id: cluster_id.to_string(),
+                peers,
+            },
         })
     }
 }

--- a/core/src/api_server/http/network.rs
+++ b/core/src/api_server/http/network.rs
@@ -1,0 +1,78 @@
+//! Groups API routes and handlers for network information API operations
+
+// ------------------
+// | Error Messages |
+// ------------------
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::{
+    api_server::{
+        error::ApiServerError,
+        router::{TypedHandler, UrlParams},
+    },
+    external_api::{http::network::GetNetworkTopologyResponse, types::Peer, EmptyRequestResponse},
+    state::RelayerState,
+};
+
+/// Returns the full network topology known to the local node
+pub(super) const GET_NETWORK_TOPOLOGY_ROUTE: &str = "/v0/network";
+
+// ------------------
+// | Route Handlers |
+// ------------------
+
+/// Handler for the GET "/network/clusters" route
+#[derive(Clone, Debug)]
+pub struct GetNetworkTopologyHandler {
+    /// A copy of the relayer-global state
+    global_state: RelayerState,
+}
+
+impl GetNetworkTopologyHandler {
+    /// Constructor
+    pub fn new(global_state: RelayerState) -> Self {
+        Self { global_state }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for GetNetworkTopologyHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetNetworkTopologyResponse;
+
+    async fn handle_typed(
+        &self,
+        _req: Self::Request,
+        _params: UrlParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        // Fetch all peer info
+        let peers = self
+            .global_state
+            .read_peer_index()
+            .await
+            .get_info_map()
+            .await;
+
+        // Gather by cluster
+        let mut peers_by_cluster: HashMap<String, Vec<Peer>> = HashMap::with_capacity(peers.len());
+        for peer in peers.values().cloned() {
+            let peer: Peer = peer.into();
+            peers_by_cluster
+                .entry(peer.cluster_id.clone())
+                .or_default()
+                .push(peer);
+        }
+
+        // Reformat into response
+        Ok(GetNetworkTopologyResponse {
+            network: peers_by_cluster.into(),
+        })
+    }
+}

--- a/core/src/api_server/http/order_book.rs
+++ b/core/src/api_server/http/order_book.rs
@@ -1,0 +1,65 @@
+//! Groups routes and handlers for order book API operations
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+use async_trait::async_trait;
+use itertools::Itertools;
+
+use crate::{
+    api_server::{
+        error::ApiServerError,
+        router::{TypedHandler, UrlParams},
+    },
+    external_api::{
+        http::order_book::GetNetworkOrdersResponse, types::NetworkOrder, EmptyRequestResponse,
+    },
+    state::RelayerState,
+};
+
+/// Returns all known network orders
+pub(super) const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
+
+// ----------------------
+// | Order Book Routers |
+// ----------------------
+
+/// Handler for the GET /order_book/orders route
+#[derive(Clone, Debug)]
+pub struct GetNetworkOrdersHandler {
+    /// A copy of the relayer-global state
+    pub global_state: RelayerState,
+}
+
+impl GetNetworkOrdersHandler {
+    /// Constructor
+    pub fn new(global_state: RelayerState) -> Self {
+        Self { global_state }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for GetNetworkOrdersHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetNetworkOrdersResponse;
+
+    async fn handle_typed(
+        &self,
+        _req: Self::Request,
+        _params: UrlParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let orders: Vec<NetworkOrder> = self
+            .global_state
+            .read_order_book()
+            .await
+            .get_order_book_snapshot()
+            .await
+            .values()
+            .cloned()
+            .map(|order| order.into())
+            .collect_vec();
+
+        Ok(GetNetworkOrdersResponse { orders })
+    }
+}

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -2,8 +2,6 @@
 
 use async_trait::async_trait;
 use hyper::StatusCode;
-use num_bigint::BigUint;
-use uuid::Uuid;
 
 use crate::{
     api_server::{
@@ -21,45 +19,7 @@ use crate::{
     state::RelayerState,
 };
 
-// ----------------
-// | URL Captures |
-// ----------------
-
-/// The :mint param in a URL
-const MINT_URL_PARAM: &str = "mint";
-/// The :wallet_id param in a URL
-const WALLET_ID_URL_PARAM: &str = "wallet_id";
-/// The :order_id param in a URL
-const ORDER_ID_URL_PARAM: &str = "order_id";
-
-/// A helper to parse out a mint from a URL param
-fn parse_mint_from_params(params: &UrlParams) -> Result<BigUint, ApiServerError> {
-    params.get(MINT_URL_PARAM).unwrap().parse().map_err(|_| {
-        ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_MINT_PARSE.to_string())
-    })
-}
-
-/// A helper to parse out a wallet ID from a URL param
-fn parse_wallet_id_from_params(params: &UrlParams) -> Result<Uuid, ApiServerError> {
-    params
-        .get(WALLET_ID_URL_PARAM)
-        .unwrap()
-        .parse()
-        .map_err(|_| {
-            ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_WALLET_ID_PARSE.to_string())
-        })
-}
-
-/// A helper to parse out an order ID from a URL param
-fn parse_order_id_from_params(params: &UrlParams) -> Result<Uuid, ApiServerError> {
-    params
-        .get(ORDER_ID_URL_PARAM)
-        .unwrap()
-        .parse()
-        .map_err(|_| {
-            ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_ORDER_ID_PARSE.to_string())
-        })
-}
+use super::{parse_mint_from_params, parse_order_id_from_params, parse_wallet_id_from_params};
 
 // ---------------
 // | HTTP Routes |
@@ -82,12 +42,6 @@ pub(super) const GET_FEES_ROUTE: &str = "/v0/wallet/:wallet_id/fees";
 // | Error Messages |
 // ------------------
 
-/// Error message displayed when a mint cannot be parsed from URL
-const ERR_MINT_PARSE: &str = "could not parse mint";
-/// Error message displayed when a given order ID is not parsable
-const ERR_ORDER_ID_PARSE: &str = "could not parse order id";
-/// Error message displayed when a given wallet ID is not parsable
-const ERR_WALLET_ID_PARSE: &str = "could not parse wallet id";
 /// Error message displayed when a given order cannot be found
 const ERR_ORDER_NOT_FOUND: &str = "order not found";
 /// The error message to display when a wallet cannot be found

--- a/core/src/external_api/http/mod.rs
+++ b/core/src/external_api/http/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod price_report;
 pub mod order_book;
+pub mod network;
 pub mod wallet;
 
 /// A ping response

--- a/core/src/external_api/http/mod.rs
+++ b/core/src/external_api/http/mod.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
-pub mod price_report;
-pub mod order_book;
 pub mod network;
+pub mod order_book;
+pub mod price_report;
 pub mod wallet;
 
 /// A ping response

--- a/core/src/external_api/http/mod.rs
+++ b/core/src/external_api/http/mod.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod price_report;
+pub mod order_book;
 pub mod wallet;
 
 /// A ping response

--- a/core/src/external_api/http/network.rs
+++ b/core/src/external_api/http/network.rs
@@ -1,0 +1,12 @@
+//! Groups API type definitions for peer-to-peer network API operations
+
+use serde::{Deserialize, Serialize};
+
+use crate::external_api::types::Network;
+
+/// The response type to fetch the entire known network topology
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetNetworkTopologyResponse {
+    /// The network topology
+    pub network: Network,
+}

--- a/core/src/external_api/http/network.rs
+++ b/core/src/external_api/http/network.rs
@@ -2,11 +2,18 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::external_api::types::Network;
+use crate::external_api::types::{Cluster, Network};
 
 /// The response type to fetch the entire known network topology
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkTopologyResponse {
     /// The network topology
     pub network: Network,
+}
+
+/// The response type to fetch a cluster's info by its cluster ID
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetClusterInfoResponse {
+    /// The requested cluster
+    pub cluster: Cluster,
 }

--- a/core/src/external_api/http/network.rs
+++ b/core/src/external_api/http/network.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::external_api::types::{Cluster, Network};
+use crate::external_api::types::{Cluster, Network, Peer};
 
 /// The response type to fetch the entire known network topology
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -16,4 +16,11 @@ pub struct GetNetworkTopologyResponse {
 pub struct GetClusterInfoResponse {
     /// The requested cluster
     pub cluster: Cluster,
+}
+
+/// The response type to fetch a given peer's info
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetPeerInfoResponse {
+    /// The requested peer
+    pub peer: Peer,
 }

--- a/core/src/external_api/http/order_book.rs
+++ b/core/src/external_api/http/order_book.rs
@@ -1,0 +1,12 @@
+//! Groups API types for order book API operations
+
+use serde::{Deserialize, Serialize};
+
+use crate::external_api::types::NetworkOrder;
+
+/// The response type to fetch all the known orders in the network
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetNetworkOrdersResponse {
+    /// The orders known to the local peer
+    pub orders: Vec<NetworkOrder>,
+}

--- a/core/src/external_api/http/order_book.rs
+++ b/core/src/external_api/http/order_book.rs
@@ -10,3 +10,10 @@ pub struct GetNetworkOrdersResponse {
     /// The orders known to the local peer
     pub orders: Vec<NetworkOrder>,
 }
+
+/// The response type to fetch a given network order by its ID
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetNetworkOrderByIdResponse {
+    /// The requested network order
+    pub order: NetworkOrder,
+}

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::external_api::types::{Balance, Order, Wallet};
+use crate::external_api::types::{Balance, Fee, Order, Wallet};
 
 /// The response type to get a wallet's information
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -37,4 +37,11 @@ pub struct GetBalancesResponse {
 pub struct GetBalanceByMintResponse {
     /// The requested balance
     pub balance: Balance,
+}
+
+/// The response type to get a wallet's fees
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetFeesResponse {
+    /// The fees in a given wallet
+    pub fees: Vec<Fee>,
 }

--- a/core/src/external_api/types.rs
+++ b/core/src/external_api/types.rs
@@ -1,5 +1,7 @@
 //! Defines API type definitions used in request/response messages
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use circuits::{
     types::{
         balance::Balance as IndexedBalance,
@@ -14,7 +16,10 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::state::{wallet::Wallet as IndexedWallet, NetworkOrderState, OrderIdentifier};
+use crate::state::{
+    wallet::Wallet as IndexedWallet, NetworkOrder as IndexedNetworkOrder, NetworkOrderState,
+    OrderIdentifier,
+};
 
 // --------------------
 // | Wallet API Types |
@@ -254,6 +259,25 @@ pub struct NetworkOrder {
     pub state: NetworkOrderState,
     /// The timestamp that this order was first received at
     pub timestamp: u64,
+}
+
+impl From<IndexedNetworkOrder> for NetworkOrder {
+    fn from(order: IndexedNetworkOrder) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        NetworkOrder {
+            id: order.id,
+            match_nullifier: scalar_to_biguint(&order.match_nullifier),
+            local: order.local,
+            cluster: order.cluster.to_string(),
+            state: order.state,
+            // TODO: Replace this with the time the order was received
+            timestamp: now,
+        }
+    }
 }
 
 // ------------------------------

--- a/core/src/gossip/types.rs
+++ b/core/src/gossip/types.rs
@@ -229,7 +229,6 @@ impl<'de> Visitor<'de> for PeerIDVisitor {
 /// A type alias for the cluster identifier
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterId(String);
-
 impl ClusterId {
     /// Construct a clusterID, it's more readable and debuggable to compress the
     /// public key into a base64 encoded representation than to use the value directly
@@ -253,6 +252,14 @@ impl ClusterId {
 impl Display for ClusterId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for ClusterId {
+    // Conversion does not error
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_string()))
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR follows up on the previous PR, adding the rest of the `GET` endpoints we plan to ship initially. These are:
- `/wallet/:id/fees`
- `/order_book/orders`
- `/order_book/order/:id`
- `/network`
- `/network/clusters/:id`
- `/network/peers/:id`

### Testing
- Ad hoc tested each of the new endpoints