### PR TITLE
core: api-server: http: Add initial `POST /v0/wallet` handler

### DIFF
--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -11,8 +11,6 @@ pub enum ApiServerError {
     HttpStatusCode(StatusCode, String),
     /// HTTP server has failed
     HttpServerFailure(String),
-    /// Error enqueueing a job in another worker
-    SendMessage(String),
     /// Error setting up the API server
     Setup(String),
     /// Websocket server has failed

--- a/core/src/api_server/error.rs
+++ b/core/src/api_server/error.rs
@@ -11,6 +11,8 @@ pub enum ApiServerError {
     HttpStatusCode(StatusCode, String),
     /// HTTP server has failed
     HttpServerFailure(String),
+    /// Error enqueueing a job in another worker
+    SendMessage(String),
     /// Error setting up the API server
     Setup(String),
     /// Websocket server has failed

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -33,8 +33,9 @@ use self::{
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     wallet::{
         GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler,
-        GetOrdersHandler, GetWalletHandler, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE,
-        GET_FEES_ROUTE, GET_ORDERS_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+        GetOrdersHandler, GetWalletHandler, PostWalletHandler, GET_BALANCES_ROUTE,
+        GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE, GET_ORDERS_ROUTE, GET_ORDER_BY_ID_ROUTE,
+        GET_WALLET_ROUTE, POST_WALLET_ROUTE,
     },
 };
 
@@ -174,6 +175,13 @@ impl HttpServer {
             Method::GET,
             GET_WALLET_ROUTE.to_string(),
             GetWalletHandler::new(global_state.clone()),
+        );
+
+        // The "/wallet" route
+        router.add_route(
+            Method::POST,
+            POST_WALLET_ROUTE.to_string(),
+            PostWalletHandler::new(config.proof_generation_work_queue.clone()),
         );
 
         // The "/wallet/:id/orders" route

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -181,7 +181,10 @@ impl HttpServer {
         router.add_route(
             Method::POST,
             POST_WALLET_ROUTE.to_string(),
-            PostWalletHandler::new(config.proof_generation_work_queue.clone()),
+            PostWalletHandler::new(
+                global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+            ),
         );
 
         // The "/wallet/:id/orders" route

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -1,13 +1,8 @@
 //! Groups wallet API handlers and definitions
 
 use async_trait::async_trait;
-use circuits::types::keychain::KeyChain as CircuitKeyChain;
 use crossbeam::channel::Sender as CrossbeamSender;
-use crypto::fields::biguint_to_scalar;
 use hyper::StatusCode;
-use itertools::Itertools;
-use tokio::sync::oneshot;
-use tracing::log;
 
 use crate::{
     api_server::{
@@ -23,8 +18,9 @@ use crate::{
         types::{Balance, Wallet},
         EmptyRequestResponse,
     },
-    proof_generation::jobs::{ProofJob, ProofManagerJob},
+    proof_generation::jobs::ProofManagerJob,
     state::RelayerState,
+    tasks::create_new_wallet::NewWalletTask,
 };
 
 use super::{parse_mint_from_params, parse_order_id_from_params, parse_wallet_id_from_params};
@@ -108,6 +104,8 @@ impl TypedHandler for GetWalletHandler {
 /// Handler for the POST /wallet route
 #[derive(Debug)]
 pub struct PostWalletHandler {
+    /// A copy of the relayer-global state
+    global_state: RelayerState,
     /// A sender to the proof manager's work queue, used to enqueue
     /// proofs of `VALID NEW WALLET` and await their completion
     proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
@@ -120,6 +118,7 @@ impl PostWalletHandler {
         proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
     ) -> Self {
         Self {
+            global_state,
             proof_manager_work_queue,
         }
     }
@@ -135,48 +134,17 @@ impl TypedHandler for PostWalletHandler {
         req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
-        // Convert API types to circuit specific types
-        let fees = req
-            .wallet
-            .fees
-            .into_iter()
-            .map(|fee| fee.into())
-            .collect_vec();
+        // Create an async task to drive this new wallet into the on-chain state
+        // and create proofs of validity
+        let id = req.wallet.id;
+        let task = NewWalletTask::new(
+            req.wallet,
+            self.global_state.clone(),
+            self.proof_manager_work_queue.clone(),
+        );
+        tokio::spawn(task.run());
 
-        let keys = CircuitKeyChain {
-            pk_root: biguint_to_scalar(&req.wallet.key_chain.public_keys.pk_root),
-            pk_match: biguint_to_scalar(&req.wallet.key_chain.public_keys.pk_match),
-            pk_settle: biguint_to_scalar(&req.wallet.key_chain.public_keys.pk_settle),
-            pk_view: biguint_to_scalar(&req.wallet.key_chain.public_keys.pk_view),
-        };
-
-        // 1. Add the wallet to the global state
-        // 2. Prove `VALID NEW WALLET`
-        // 3. Submit this on-chain
-        // 4. Await transaction confirmation
-        // 5. Prove `VALID COMMITMENTS` once this wallet is on-chain and has a Merkle entry
-
-        // Enqueue a job with the proof manager to prove `VALID NEW WALLET`
-        let (response_sender, response_receiver) = oneshot::channel();
-        let job_req = ProofManagerJob {
-            type_: ProofJob::ValidWalletCreate {
-                fees,
-                keys,
-                randomness: biguint_to_scalar(&req.wallet.randomness),
-            },
-            response_channel: response_sender,
-        };
-        self.proof_manager_work_queue
-            .send(job_req)
-            .map_err(|err| ApiServerError::SendMessage(err.to_string()))?;
-
-        tokio::spawn(async move {
-            // Await a proof response
-            let _proof_bundle = response_receiver.await;
-            log::info!("got back proof of valid new wallet");
-        });
-
-        Ok(CreateWalletResponse { id: req.wallet.id })
+        Ok(CreateWalletResponse { id })
     }
 }
 

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -2,7 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::external_api::types::{Balance, Fee, Order, Wallet};
+use crate::{
+    external_api::types::{Balance, Fee, Order, Wallet},
+    state::wallet::WalletIdentifier,
+};
+
+// --------------------
+// | Wallet API Types |
+// --------------------
 
 /// The response type to get a wallet's information
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -10,6 +17,24 @@ pub struct GetWalletResponse {
     /// The wallet requested by the client
     pub wallet: Wallet,
 }
+
+/// The request type to create a new wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateWalletRequest {
+    /// The wallet info to be created
+    pub wallet: Wallet,
+}
+
+/// The response type to a request to create a new wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateWalletResponse {
+    /// The wallet identifier provisioned for the new wallet
+    pub id: WalletIdentifier,
+}
+
+// ---------------------------
+// | Wallet Orders API Types |
+// ---------------------------
 
 /// The response type to get a wallet's orders
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -25,6 +50,10 @@ pub struct GetOrderByIdResponse {
     pub order: Order,
 }
 
+// -----------------------------
+// | Wallet Balances API Types |
+// -----------------------------
+
 /// The response type to get a wallet's balances
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetBalancesResponse {
@@ -38,6 +67,10 @@ pub struct GetBalanceByMintResponse {
     /// The requested balance
     pub balance: Balance,
 }
+
+// -------------------------
+// | Wallet Fees API Types |
+// -------------------------
 
 /// The response type to get a wallet's fees
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -21,6 +21,7 @@ mod proof_generation;
 mod starknet_client;
 mod state;
 mod system_bus;
+mod tasks;
 mod types;
 mod worker;
 

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -135,7 +135,6 @@ pub enum ProofJob {
     /// The proof generation module should generate a proof of
     /// `VALID WALLET CREATE`
     /// TODO: Remove this lint allowance
-    #[allow(unused)]
     ValidWalletCreate {
         /// The fees to initialize the wallet with
         fees: Vec<Fee>,

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -390,7 +390,7 @@ impl Wallet {
 }
 
 /// Metadata relevant to the wallet's network state
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct WalletMetadata {
     /// The peers which are believed by the local node to be replicating a given wallet
     pub replicas: HashSet<WrappedPeerId>,

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -1,0 +1,82 @@
+//! A task defining the flow to create a new wallet, at a high level the steps are:
+//!     1. Index the wallet locally
+//!     2. Prove `VALID NEW WALLETS` for the wallet
+//!     3. Submit this on-chain and await transaction success
+//!     4. Pull the Merkle authentication path of the newly created wallet from on-chain state
+//!     5. Prove `VALID COMMITMENTS`
+
+use circuits::types::keychain::KeyChain as CircuitKeyChain;
+use crossbeam::channel::Sender as CrossbeamSender;
+use crypto::fields::biguint_to_scalar;
+use itertools::Itertools;
+use tokio::sync::oneshot;
+use tracing::log;
+
+use crate::{
+    external_api::types::Wallet,
+    proof_generation::jobs::{ProofJob, ProofManagerJob},
+    state::RelayerState,
+};
+
+/// The task struct defining the long-run async flow for creating a new wallet
+pub struct NewWalletTask {
+    /// The wallet to create
+    pub wallet: Wallet,
+    /// A copy of the relayer-global state
+    pub global_state: RelayerState,
+    /// The work queue to add proof management jobs to
+    pub proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+}
+
+impl NewWalletTask {
+    /// Constructor
+    pub fn new(
+        wallet: Wallet,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    ) -> Self {
+        Self {
+            wallet,
+            global_state,
+            proof_manager_work_queue,
+        }
+    }
+
+    /// Run the task to completion
+    pub async fn run(self) {
+        log::info!("Beginning new wallet task execution");
+
+        // Convert API types to circuit specific types
+        let fees = self
+            .wallet
+            .fees
+            .clone()
+            .into_iter()
+            .map(|fee| fee.into())
+            .collect_vec();
+
+        let keys = CircuitKeyChain {
+            pk_root: biguint_to_scalar(&self.wallet.key_chain.public_keys.pk_root),
+            pk_match: biguint_to_scalar(&self.wallet.key_chain.public_keys.pk_match),
+            pk_settle: biguint_to_scalar(&self.wallet.key_chain.public_keys.pk_settle),
+            pk_view: biguint_to_scalar(&self.wallet.key_chain.public_keys.pk_view),
+        };
+
+        // Enqueue a job with the proof manager to prove `VALID NEW WALLET`
+        let (response_sender, response_receiver) = oneshot::channel();
+        let job_req = ProofManagerJob {
+            type_: ProofJob::ValidWalletCreate {
+                fees,
+                keys,
+                randomness: biguint_to_scalar(&self.wallet.randomness),
+            },
+            response_channel: response_sender,
+        };
+        self.proof_manager_work_queue
+            .send(job_req)
+            .expect("error enqueuing proof manager job");
+
+        let _proof_bundle = response_receiver.await;
+        log::info!("got proof bundle for new wallet");
+    }
+}

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -1,0 +1,7 @@
+//! Groups together long-running async tasks for best discoverability
+//!
+//! Examples of such tasks are creating a new wallet; which requires the
+//! node to prove `VALID NEW WALLET`, submit the wallet on-chain, wait for
+//! transaction success, and then prove `VALID COMMITMENTS`
+
+pub mod create_new_wallet;


### PR DESCRIPTION
### Purpose
This PR adds the initial handler for the `/v0/wallet` API route. As spillover, this also adds the `task` abstraction to the relayer which handles long running, largely asynchronous tasks.

One such example is the task of creating a new wallet, which is largely divided into a few steps:
1. Prove `VALID NEW WALLET` on the empty wallet
2. Submit the proof and commitment on-chain, await transaction success
3. Re-construct the Merkle inclusion proof for the wallet in the on-chain state
4. Prove `VALID COMMITMENTS` or await wallet updates and prove `VALID WALLET UPDATE`

Down the line we will have a task driver backing these tasks which handles reliability concerns; and a cluster-wide task tracker that fails over automatically.

### Testing
- Created a new wallet through the API, verified that the proof was generated successfully