### PR TITLE
core: tasks: create-new-wallet: Submit wallet on-chain and recover Merkle proof

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,8 +62,7 @@ reqwest = "0.11.13"
 ring-channel = "0.11.0"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
-starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
+starknet = { git = "https://github.com/joeykraut/starknet-rs" }
 streaming-stats = "0.1.28"
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.5.9" }

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -182,6 +182,7 @@ impl HttpServer {
             Method::POST,
             POST_WALLET_ROUTE.to_string(),
             PostWalletHandler::new(
+                config.starknet_client.clone(),
                 global_state.clone(),
                 config.proof_generation_work_queue.clone(),
             ),

--- a/core/src/api_server/http/price_report.rs
+++ b/core/src/api_server/http/price_report.rs
@@ -28,7 +28,7 @@ pub(super) const EXCHANGE_HEALTH_ROUTE: &str = "/v0/exchange/health_check";
 
 /// Handler for the / route, returns the health report for each individual
 /// exchange and the aggregate median
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct ExchangeHealthStatesHandler {
     /// The config for the API server
     config: ApiServerConfig,

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -19,6 +19,7 @@ use crate::{
         EmptyRequestResponse,
     },
     proof_generation::jobs::ProofManagerJob,
+    starknet_client::client::StarknetClient,
     state::RelayerState,
     tasks::create_new_wallet::NewWalletTask,
 };
@@ -102,8 +103,9 @@ impl TypedHandler for GetWalletHandler {
 }
 
 /// Handler for the POST /wallet route
-#[derive(Debug)]
 pub struct PostWalletHandler {
+    /// A starknet client
+    starknet_client: StarknetClient,
     /// A copy of the relayer-global state
     global_state: RelayerState,
     /// A sender to the proof manager's work queue, used to enqueue
@@ -114,10 +116,12 @@ pub struct PostWalletHandler {
 impl PostWalletHandler {
     /// Constructor
     pub fn new(
+        starknet_client: StarknetClient,
         global_state: RelayerState,
         proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
     ) -> Self {
         Self {
+            starknet_client,
             global_state,
             proof_manager_work_queue,
         }
@@ -139,6 +143,7 @@ impl TypedHandler for PostWalletHandler {
         let id = req.wallet.id;
         let task = NewWalletTask::new(
             req.wallet,
+            self.starknet_client.clone(),
             self.global_state.clone(),
             self.proof_manager_work_queue.clone(),
         );

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -11,8 +11,8 @@ use tokio::{
 
 use crate::{
     price_reporter::jobs::PriceReporterManagerJob, proof_generation::jobs::ProofManagerJob,
-    state::RelayerState, system_bus::SystemBus, types::SystemBusMessage, worker::Worker,
-    CancelChannel,
+    starknet_client::client::StarknetClient, state::RelayerState, system_bus::SystemBus,
+    types::SystemBusMessage, worker::Worker, CancelChannel,
 };
 
 use super::{error::ApiServerError, http::HttpServer, websocket::WebsocketServer};
@@ -37,12 +37,14 @@ pub struct ApiServer {
 }
 
 /// The worker config for the ApiServer
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ApiServerConfig {
     /// The port that the HTTP server should listen on
     pub http_port: u16,
     /// The port that the websocket server should listen on
     pub websocket_port: u16,
+    /// A starknet client
+    pub starknet_client: StarknetClient,
     /// The worker job queue for the PriceReporterManager
     pub price_reporter_work_queue: TokioSender<PriceReporterManagerJob>,
     /// The worker job queue for the ProofGenerationManager

--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -13,6 +13,8 @@ pub enum OnChainEventListenerError {
     SendMessage(String),
     /// Error setting up the on-chain event listener
     Setup(String),
+    /// An error executing some method in the Starknet client
+    StarknetClient(String),
 }
 
 impl Display for OnChainEventListenerError {

--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -20,7 +20,7 @@ use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::{starknet_felt_to_biguint, starknet_felt_to_scalar, starknet_felt_to_u64};
 use curve25519_dalek::scalar::Scalar;
 use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
-use starknet_providers::jsonrpc::{
+use starknet::providers::jsonrpc::{
     models::{BlockId, EmittedEvent, ErrorCode, EventFilter},
     HttpTransport, JsonRpcClient, JsonRpcClientError, RpcError,
 };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -101,8 +101,11 @@ struct Cli {
     /// The HTTP addressable StarkNet JSON-RPC node
     #[clap(long = "starknet-gateway", value_parser)]
     pub starknet_jsonrpc_node: Option<String>,
+    /// The StarkNet address corresponding to the given key
+    #[clap(long = "starknet-account-addr", value_parser, requires = "starknet-private-key")]
+    pub starknet_account_address: Option<String>,
     /// The StarkNet private key used to send transactions
-    #[clap(long = "starknet-pkey", value_parser)]
+    #[clap(long = "starknet-account-pkey", value_parser, requires = "starknet-account-address")]
     pub starknet_private_key: Option<String>,
     /// A file holding a json representation of the wallets the local node
     /// should manage
@@ -145,6 +148,8 @@ pub struct RelayerConfig {
     pub coinbase_api_secret: Option<String>,
     /// The StarkNet JSON-RPC API gateway
     pub starknet_jsonrpc_node: Option<String>,
+    /// The StarkNet address corresponding to the given key
+    pub starknet_account_address: Option<String>,
     /// The StarkNet private key used for signing transactions
     pub starknet_private_key: Option<String>,
     /// The Ethereum RPC node websocket address to dial for on-chain data
@@ -173,6 +178,7 @@ impl Clone for RelayerConfig {
             coinbase_api_key: self.coinbase_api_key.clone(),
             coinbase_api_secret: self.coinbase_api_secret.clone(),
             starknet_jsonrpc_node: self.starknet_jsonrpc_node.clone(),
+            starknet_account_address: self.starknet_account_address.clone(),
             starknet_private_key: self.starknet_private_key.clone(),
             eth_websocket_addr: self.eth_websocket_addr.clone(),
             debug: self.debug,
@@ -257,6 +263,7 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         coinbase_api_key: cli_args.coinbase_api_key,
         coinbase_api_secret: cli_args.coinbase_api_secret,
         starknet_jsonrpc_node: cli_args.starknet_jsonrpc_node,
+        starknet_account_address: cli_args.starknet_account_address,
         starknet_private_key: cli_args.starknet_private_key,
         eth_websocket_addr: cli_args.eth_websocket_addr,
         debug: cli_args.debug,

--- a/core/src/gossip/orderbook.rs
+++ b/core/src/gossip/orderbook.rs
@@ -11,7 +11,7 @@ use starknet::core::{
     types::{BlockId, CallFunction, FieldElement as StarknetFieldElement},
     utils::get_selector_from_name,
 };
-use starknet_providers::Provider;
+use starknet::providers::Provider;
 use tracing::log;
 
 use crate::{

--- a/core/src/gossip/server.rs
+++ b/core/src/gossip/server.rs
@@ -5,7 +5,7 @@
 
 use lru::LruCache;
 use starknet::core::types::FieldElement as StarknetFieldElement;
-use starknet_providers::SequencerGatewayProvider;
+use starknet::providers::SequencerGatewayProvider;
 use std::{
     collections::HashMap,
     num::NonZeroUsize,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -175,19 +175,6 @@ async fn main() -> Result<(), CoordinatorError> {
         configure_default_log_capture();
     }
 
-    // Spawn a thread to sync the relayer-global state with on-chain state and
-    // network state
-    global_state.initialize(
-        args.contract_address.clone(),
-        args.starknet_jsonrpc_node.clone().unwrap(),
-        proof_generation_worker_sender.clone(),
-        network_sender.clone(),
-    );
-
-    // ----------------
-    // | Worker Setup |
-    // ----------------
-
     // Construct a starknet client that workers will use to communicate with Starknet
     let starknet_client = StarknetClient::new(StarknetClientConfig {
         chain: args.chain_id,
@@ -197,6 +184,18 @@ async fn main() -> Result<(), CoordinatorError> {
         starknet_account_address: args.starknet_account_address,
         starknet_pkey: args.starknet_private_key,
     });
+
+    // Spawn a thread to sync the relayer-global state with on-chain state and
+    // network state
+    global_state.initialize(
+        starknet_client.clone(),
+        proof_generation_worker_sender.clone(),
+        network_sender.clone(),
+    );
+
+    // ----------------
+    // | Worker Setup |
+    // ----------------
 
     // Start the network manager
     let (network_cancel_sender, network_cancel_receiver) = watch::channel(());

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -194,7 +194,8 @@ async fn main() -> Result<(), CoordinatorError> {
         contract_addr: args.contract_address.clone(),
         infura_api_key: None,
         starknet_json_rpc_addr: args.starknet_jsonrpc_node.clone(),
-        starknet_pkey: None,
+        starknet_account_address: args.starknet_account_address,
+        starknet_pkey: args.starknet_private_key,
     });
 
     // Start the network manager
@@ -304,6 +305,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let mut api_server = ApiServer::new(ApiServerConfig {
         http_port: args.http_port,
         websocket_port: args.websocket_port,
+        starknet_client: starknet_client.clone(),
         global_state: global_state.clone(),
         system_bus,
         price_reporter_work_queue: price_reporter_worker_sender,

--- a/core/src/starknet_client/client.rs
+++ b/core/src/starknet_client/client.rs
@@ -1,16 +1,48 @@
 //! A wrapper around the starknet client made available by:
 //! https://docs.rs/starknet-core/latest/starknet_core/
 
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 
+use circuits::types::wallet::WalletCommitment;
+use crypto::fields::{biguint_to_starknet_felt, scalar_to_biguint, starknet_felt_to_biguint};
+use curve25519_dalek::scalar::Scalar;
+use lazy_static::lazy_static;
 use reqwest::Url;
-use starknet::core::types::FieldElement as StarknetFieldElement;
-use starknet_providers::{
+use starknet::providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    SequencerGatewayProvider,
+    Provider, ProviderError,
 };
+use starknet::{
+    accounts::{Account, AccountError, Call, SingleOwnerAccount},
+    core::{
+        types::{FieldElement as StarknetFieldElement, TransactionInfo, TransactionStatus},
+        utils::get_selector_from_name,
+    },
+    providers::{SequencerGatewayProvider, SequencerGatewayProviderError},
+    signers::{LocalWallet, SigningKey},
+};
+use tracing::log;
+
+use crate::proof_generation::jobs::ValidWalletCreateBundle;
 
 use super::ChainId;
+
+/// A type alias for the Starknet client's common account error pattern
+pub type AccountErr = AccountError<
+    <SingleOwnerAccount<SequencerGatewayProvider, LocalWallet> as Account>::SignError,
+    <SequencerGatewayProvider as Provider>::Error,
+>;
+
+/// The interval at which to poll the gateway for transaction status
+const TX_STATUS_POLL_INTERVAL_MS: u64 = 10_000; // 10 seconds
+/// The fee estimate multiplier to use as `MAX_FEE` for transactions
+const MAX_FEE_MULTIPLIER: f32 = 1.5;
+
+lazy_static! {
+    /// Contract selector to create a new wallet
+    static ref NEW_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("new_wallet")
+        .unwrap();
+}
 
 /// The config type for the client, consists of secrets needed to connect to
 /// the gateway and API server, as well as keys for sending transactions
@@ -28,6 +60,8 @@ pub struct StarknetClientConfig {
     /// For now, we require only the API key's ID on our RPC node,
     /// so this parameter is unused
     pub infura_api_key: Option<String>,
+    /// The starknet address of the account corresponding to the given key
+    pub starknet_account_address: Option<String>,
     /// The starknet signing key, used to submit transactions on-chain
     pub starknet_pkey: Option<String>,
 }
@@ -36,6 +70,13 @@ impl StarknetClientConfig {
     /// Whether or not the client is enabled given its configuration
     pub fn enabled(&self) -> bool {
         self.starknet_json_rpc_addr.is_some()
+    }
+
+    /// Whether or not a signing account has been passed with the config
+    ///
+    /// Only when this is enabled may the client write transactions to the sequencer
+    pub fn account_enabled(&self) -> bool {
+        self.starknet_pkey.is_some() && self.starknet_account_address.is_some()
     }
 
     /// Build a gateway client from the config values
@@ -72,13 +113,41 @@ pub struct StarknetClient {
     gateway_client: Arc<SequencerGatewayProvider>,
     /// The client used to send starknet JSON-RPC requests
     jsonrpc_client: Option<Arc<JsonRpcClient<HttpTransport>>>,
+    /// The account that may be used to sign outbound transactions
+    account: Option<Arc<SingleOwnerAccount<SequencerGatewayProvider, LocalWallet>>>,
 }
 
 impl StarknetClient {
     /// Constructor
     pub fn new(config: StarknetClientConfig) -> Self {
+        // Build the gateway and JSON-RPC clients
         let gateway_client = Arc::new(config.new_gateway_client());
         let jsonrpc_client = config.new_jsonrpc_client().map(Arc::new);
+
+        log::info!("write enabled: {}", config.account_enabled());
+
+        // Build an account to sign transactions with
+        let account = if config.account_enabled() {
+            let account_addr = config.starknet_account_address.clone().unwrap();
+            let key = config.starknet_pkey.clone().unwrap();
+            let account_addr_felt = StarknetFieldElement::from_str(&account_addr).unwrap();
+            let key_felt = StarknetFieldElement::from_str(&key).unwrap();
+
+            let signer = LocalWallet::from(SigningKey::from_secret_scalar(key_felt));
+            let account = SingleOwnerAccount::new(
+                config.new_gateway_client(),
+                signer,
+                account_addr_felt,
+                config.chain.into(),
+            );
+
+            Some(account)
+        } else {
+            None
+        };
+
+        // Wrap in an Arc for read access across workers
+        let account = account.map(Arc::new);
 
         // Parse the contract address
         let contract_address: StarknetFieldElement =
@@ -91,6 +160,7 @@ impl StarknetClient {
             contract_address,
             gateway_client,
             jsonrpc_client,
+            account,
         }
     }
 
@@ -107,5 +177,91 @@ impl StarknetClient {
     /// Get the underlying RPC client as an immutable reference
     pub fn get_jsonrpc_client(&self) -> &JsonRpcClient<HttpTransport> {
         self.jsonrpc_client.as_ref().unwrap()
+    }
+
+    /// Get the underlying account as an immutable reference
+    pub fn get_account(&self) -> &SingleOwnerAccount<SequencerGatewayProvider, LocalWallet> {
+        self.account.as_ref().unwrap()
+    }
+
+    /// A helper to reduce a Dalek scalar modulo the Stark field
+    ///
+    /// Note that this a bandaid, we will be replacing all the felts with U256
+    /// values in the contract to emulate the Dalek field
+    fn reduce_scalar_to_felt(val: &Scalar) -> StarknetFieldElement {
+        let val_bigint = scalar_to_biguint(val);
+        let modulus_bigint = starknet_felt_to_biguint(&StarknetFieldElement::MAX) + 1u8;
+        let val_mod_starknet_prime = val_bigint % modulus_bigint;
+
+        biguint_to_starknet_felt(&val_mod_starknet_prime)
+    }
+
+    // ---------------
+    // | Chain State |
+    // ---------------
+
+    /// Poll a transaction until it is finalized into the accepted on L2 state
+    pub async fn poll_transaction_completed(
+        &self,
+        tx_hash: StarknetFieldElement,
+    ) -> Result<TransactionInfo, ProviderError<SequencerGatewayProviderError>> {
+        let sleep_duration = Duration::from_millis(TX_STATUS_POLL_INTERVAL_MS);
+        loop {
+            let res = self.gateway_client.get_transaction(tx_hash).await?;
+            log::info!("polling transaction, status: {:?}", res.status);
+
+            // Break if the transaction has made it out of the received state
+            match res.status {
+                TransactionStatus::Rejected
+                | TransactionStatus::AcceptedOnL2
+                | TransactionStatus::AcceptedOnL1 => return Ok(res),
+                _ => {}
+            }
+
+            // Sleep and poll again
+            tokio::time::sleep(sleep_duration).await;
+        }
+    }
+
+    // ------------------------
+    // | Contract Interaction |
+    // ------------------------
+
+    /// Call the `new_wallet` contract method with the given source data
+    ///
+    /// Returns the transaction hash corresponding to the `new_wallet` invocation
+    ///
+    /// TODO: Add proof and wallet encryption under pk_view to the contract
+    pub async fn new_wallet(
+        &self,
+        wallet_commitment: WalletCommitment,
+        _valid_wallet_create: ValidWalletCreateBundle,
+    ) -> Result<StarknetFieldElement, AccountErr> {
+        assert!(
+            self.config.account_enabled(),
+            "no private key given to sign transactions with"
+        );
+
+        // Call the `new_wallet` contract function
+        let commitment_felt = Self::reduce_scalar_to_felt(&wallet_commitment);
+        let call = Call {
+            to: self.contract_address,
+            selector: *NEW_WALLET_SELECTOR,
+            calldata: vec![commitment_felt],
+        };
+
+        // Estimate the fee and add a buffer to avoid rejected transaction
+        let execution = self.get_account().execute(vec![call]);
+
+        let fee_estimate = execution.estimate_fee().await?;
+        let max_fee = (fee_estimate.overall_fee as f32) * MAX_FEE_MULTIPLIER;
+        let max_fee = StarknetFieldElement::from(max_fee as u64);
+
+        // Send the transaction and await receipt
+        execution
+            .max_fee(max_fee)
+            .send()
+            .await
+            .map(|res| res.transaction_hash)
     }
 }

--- a/core/src/starknet_client/error.rs
+++ b/core/src/starknet_client/error.rs
@@ -5,8 +5,8 @@ use std::fmt::Display;
 /// The error type returned by the StarknetClient interface
 #[derive(Clone, Debug)]
 pub enum StarknetClientError {
-    /// Pagination finished without finding a satisfactory value
-    PaginationFinished,
+    /// No value was found when scanning contract state
+    NotFound(String),
     /// An error performing a JSON-RPC request
     Rpc(String),
 }

--- a/core/src/starknet_client/error.rs
+++ b/core/src/starknet_client/error.rs
@@ -1,0 +1,18 @@
+//! Groups error types returned by the client
+
+use std::fmt::Display;
+
+/// The error type returned by the StarknetClient interface
+#[derive(Clone, Debug)]
+pub enum StarknetClientError {
+    /// Pagination finished without finding a satisfactory value
+    PaginationFinished,
+    /// An error performing a JSON-RPC request
+    Rpc(String),
+}
+
+impl Display for StarknetClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}

--- a/core/src/starknet_client/error.rs
+++ b/core/src/starknet_client/error.rs
@@ -5,6 +5,8 @@ use std::fmt::Display;
 /// The error type returned by the StarknetClient interface
 #[derive(Clone, Debug)]
 pub enum StarknetClientError {
+    /// An error executing a transaction
+    ExecuteTransaction(String),
     /// No value was found when scanning contract state
     NotFound(String),
     /// An error performing a JSON-RPC request

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -2,10 +2,16 @@
 //! specific information (keys, api credentials, etc) and provides a cleaner
 //! interface for interacting with on-chain state in Renegade specific patterns
 
-use std::str::FromStr;
+use std::{convert::TryInto, str::FromStr};
 
+use circuits::native_helpers::compute_poseidon_hash;
+use crypto::fields::biguint_to_scalar;
+use curve25519_dalek::scalar::Scalar;
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
+
+use crate::MERKLE_HEIGHT;
 
 pub mod client;
 pub mod error;
@@ -15,12 +21,37 @@ pub mod error;
 // -------------
 
 lazy_static! {
+    /// Contract selector to create a new wallet
+    static ref NEW_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("new_wallet")
+        .unwrap();
     /// The event selector for internal node changes
     pub static ref INTERNAL_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement =
         get_selector_from_name("Merkle_internal_node_changed").unwrap();
     /// The event selector for Merkle value insertion
     pub static ref VALUE_INSERTED_EVENT_SELECTOR: StarknetFieldElement =
         get_selector_from_name("Merkle_value_inserted").unwrap();
+    /// The value of an empty leaf in the Merkle tree
+    static ref EMPTY_LEAF_VALUE: Scalar = {
+        let val_bigint = BigUint::from_str(
+            "306932273398430716639340090025251549301604242969558673011416862133942957551"
+        ).unwrap();
+        biguint_to_scalar(&val_bigint)
+    };
+    /// The default values of an authentication path; i.e. the values in the path before any
+    /// path elements are changed by insertions
+    ///
+    /// These values are simply recursive hashes of the empty leaf value, as this builds the
+    /// empty tree
+    pub static ref DEFAULT_AUTHENTICATION_PATH: [Scalar; MERKLE_HEIGHT] = {
+        let mut values = Vec::with_capacity(MERKLE_HEIGHT);
+
+        let curr_val = *EMPTY_LEAF_VALUE;
+        for _ in 0..MERKLE_HEIGHT {
+            values.push(compute_poseidon_hash(&[curr_val, curr_val]));
+        }
+
+        values.try_into().unwrap()
+    };
 }
 
 /// Starknet mainnet chain-id

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -5,9 +5,23 @@
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use starknet::core::types::FieldElement as StarknetFieldElement;
+use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
 
 pub mod client;
+pub mod error;
+
+// -------------
+// | Selectors |
+// -------------
+
+lazy_static! {
+    /// The event selector for internal node changes
+    pub static ref INTERNAL_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement =
+        get_selector_from_name("Merkle_internal_node_changed").unwrap();
+    /// The event selector for Merkle value insertion
+    pub static ref VALUE_INSERTED_EVENT_SELECTOR: StarknetFieldElement =
+        get_selector_from_name("Merkle_value_inserted").unwrap();
+}
 
 /// Starknet mainnet chain-id
 /// TODO: use `starknet-rs` implementation once we upgrade versions

--- a/core/src/state/initialize.rs
+++ b/core/src/state/initialize.rs
@@ -7,21 +7,8 @@ use circuits::{
     LinkableCommitment,
 };
 use crossbeam::channel::Sender as CrossbeamSender;
-use crypto::fields::{
-    biguint_to_scalar, biguint_to_starknet_felt, scalar_to_biguint, starknet_felt_to_biguint,
-    starknet_felt_to_scalar, starknet_felt_to_u64,
-};
-use curve25519_dalek::scalar::Scalar;
-use num_bigint::BigUint;
-use reqwest::Url;
-use starknet::core::types::FieldElement as StarknetFieldElement;
-use starknet::providers::jsonrpc::{models::EventFilter, HttpTransport, JsonRpcClient};
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryInto,
-    str::FromStr,
-    thread::Builder as ThreadBuilder,
-};
+use crypto::fields::biguint_to_scalar;
+use std::thread::Builder as ThreadBuilder;
 use tokio::{
     runtime::Builder as RuntimeBuilder,
     sync::{mpsc::UnboundedSender, oneshot},
@@ -35,44 +22,17 @@ use crate::{
         orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
     },
     proof_generation::jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle},
-    starknet_client::{INTERNAL_NODE_CHANGED_EVENT_SELECTOR, VALUE_INSERTED_EVENT_SELECTOR},
-    MERKLE_HEIGHT,
+    starknet_client::client::StarknetClient,
 };
 
-use super::{
-    wallet::{MerkleAuthenticationPath, Wallet},
-    MerkleTreeCoords, NetworkOrder, RelayerState,
-};
+use super::{NetworkOrder, RelayerState};
 
 /// An error emitted when order initialization fails
 const ERR_STATE_INIT_FAILED: &str = "state initialization thread panic";
 /// The name of the thread initialized to generate proofs of `VALID COMMITMENTS` at startup
 const STATE_INIT_THREAD: &str = "state-init";
 
-lazy_static! {
-    /// The value of an empty leaf in the Merkle tree
-    static ref EMPTY_LEAF_VALUE: Scalar = {
-        let val_bigint = BigUint::from_str(
-            "306932273398430716639340090025251549301604242969558673011416862133942957551"
-        ).unwrap();
-        biguint_to_scalar(&val_bigint)
-    };
-    /// The default values of an authentication path; i.e. the values in the path before any
-    /// path elements are changed by insertions
-    ///
-    /// These values are simply recursive hashes of the empty leaf value, as this builds the
-    /// empty tree
-    static ref DEFAULT_AUTHENTICATION_PATH: [Scalar; MERKLE_HEIGHT] = {
-        let mut values = Vec::with_capacity(MERKLE_HEIGHT);
-
-        let curr_val = *EMPTY_LEAF_VALUE;
-        for _ in 0..MERKLE_HEIGHT {
-            values.push(compute_poseidon_hash(&[curr_val, curr_val]));
-        }
-
-        values.try_into().unwrap()
-    };
-}
+lazy_static! {}
 
 impl RelayerState {
     /// Initialize the state by syncing and constructing indexes from on-chain and in
@@ -84,8 +44,7 @@ impl RelayerState {
     /// state the entire time
     pub fn initialize(
         &self,
-        contract_address: String,
-        starknet_api_gateway: String,
+        starknet_client: StarknetClient,
         proof_manager_queue: CrossbeamSender<ProofManagerJob>,
         network_sender: UnboundedSender<GossipOutbound>,
     ) {
@@ -98,12 +57,18 @@ impl RelayerState {
                     .enable_all()
                     .build()
                     .unwrap();
-                runtime.block_on(self_clone.initialize_order_proof_helper(
-                    contract_address,
-                    starknet_api_gateway,
-                    proof_manager_queue,
-                    network_sender,
-                ))
+                runtime.block_on(async move {
+                    if let Err(e) = self_clone
+                        .initialize_order_proof_helper(
+                            starknet_client,
+                            proof_manager_queue,
+                            network_sender,
+                        )
+                        .await
+                    {
+                        log::error!("error initializing state: {e}")
+                    }
+                })
             })
             .expect(ERR_STATE_INIT_FAILED);
     }
@@ -111,16 +76,10 @@ impl RelayerState {
     /// A helper passed as a callback to the threading logic in the caller
     async fn initialize_order_proof_helper(
         &self,
-        contract_address: String,
-        starknet_api_gateway: String,
+        starknet_client: StarknetClient,
         proof_manager_queue: CrossbeamSender<ProofManagerJob>,
         network_sender: UnboundedSender<GossipOutbound>,
     ) -> Result<(), CoordinatorError> {
-        // Build a starknet RPC client
-        let starknet_client = JsonRpcClient::new(HttpTransport::new(
-            Url::parse(&starknet_api_gateway).unwrap(),
-        ));
-
         // Store a handle to the response channels for each proof; await them one by one
         let mut proof_response_channels = Vec::new();
 
@@ -129,14 +88,12 @@ impl RelayerState {
             let locked_wallet_index = self.read_wallet_index().await;
             for wallet in locked_wallet_index.get_all_wallets().await.into_iter() {
                 // Build a Merkle authentication path for the wallet and attach it to the state
-                let merkle_path = self
-                    .build_merkle_authentication_path(
-                        &wallet,
-                        contract_address.clone(),
-                        &starknet_client,
-                    )
-                    .await?;
+                let merkle_path = starknet_client
+                    .find_merkle_authentication_path(wallet.get_commitment())
+                    .await
+                    .map_err(|err| CoordinatorError::StateInit(err.to_string()))?;
 
+                // Index the wallet
                 locked_wallet_index
                     .add_wallet_merkle_proof(&wallet.wallet_id, merkle_path.clone())
                     .await;
@@ -245,149 +202,5 @@ impl RelayerState {
         }
 
         Ok(())
-    }
-
-    /// Searches on-chain state for the insertion of the given wallet, then finds the most
-    /// recent updates of the path's siblings and creates a Merkle authentication path
-    async fn build_merkle_authentication_path(
-        &self,
-        wallet: &Wallet,
-        contract_address: String,
-        starknet_client: &JsonRpcClient<HttpTransport>,
-    ) -> Result<MerkleAuthenticationPath, CoordinatorError> {
-        // Find the wallet in the commitment tree
-        let leaf_index = self
-            .find_wallet_in_merkle_tree(wallet, contract_address.clone(), starknet_client)
-            .await?;
-
-        // Construct a set that holds pairs of (depth, index) values in the authentication path; i.e. the
-        // tree coordinates of the sibling nodes in the authentication path
-        let mut sibling_tree_coords = HashSet::new();
-        let mut curr_height_index = leaf_index.clone();
-        for height in (1..MERKLE_HEIGHT + 1).rev() {
-            // If the LSB of the node index at the current height is zero, the node
-            // is a left hand child. If the LSB is one, it is a right hand child.
-            // Choose the index of its sibling
-            let sibling_index = if &curr_height_index % 2u8 == BigUint::from(0u8) {
-                &curr_height_index + 1u8
-            } else {
-                &curr_height_index - 1u8
-            };
-
-            sibling_tree_coords.insert(MerkleTreeCoords::new(height, sibling_index));
-            curr_height_index >>= 1;
-        }
-
-        // Search for the last time these values changed in the tree
-        let path_values = self
-            .scan_for_tree_coords(sibling_tree_coords, contract_address, starknet_client)
-            .await?;
-
-        // Order by height and return
-        let mut path = *DEFAULT_AUTHENTICATION_PATH;
-        for (coordinate, value) in path_values.into_iter() {
-            let path_index = MERKLE_HEIGHT - coordinate.height;
-            path[path_index] = starknet_felt_to_scalar(&value);
-        }
-
-        Ok(MerkleAuthenticationPath::new(
-            path,
-            leaf_index,
-            wallet.get_commitment(),
-        ))
-    }
-
-    /// Finds the commitment to the wallet in the Merkle tree and returns its
-    /// leaf index
-    async fn find_wallet_in_merkle_tree(
-        &self,
-        wallet: &Wallet,
-        contract_address: String,
-        starknet_client: &JsonRpcClient<HttpTransport>,
-    ) -> Result<BigUint, CoordinatorError> {
-        // TODO: Do this as a bigint instead of a scalar mod the starknet prime
-        let wallet_commitment = scalar_to_biguint(&wallet.get_commitment());
-        let starknet_mod = starknet_felt_to_biguint(&StarknetFieldElement::MAX) + 1u8;
-        let wallet_commit_mod = biguint_to_starknet_felt(&(wallet_commitment % starknet_mod));
-
-        let contract_addr = StarknetFieldElement::from_str(&contract_address).unwrap();
-        let events_filter = EventFilter {
-            from_block: None,
-            to_block: None,
-            address: Some(contract_addr),
-            keys: Some(vec![*VALUE_INSERTED_EVENT_SELECTOR]),
-        };
-
-        let mut pagination_token = Some("0".to_string());
-        while pagination_token.is_some() {
-            let events_batch = starknet_client
-                .get_events(
-                    events_filter.clone(),
-                    pagination_token,
-                    100, /* chunk_size */
-                )
-                .await
-                .unwrap();
-            pagination_token = events_batch.continuation_token;
-
-            for event in events_batch.events.iter() {
-                let index = event.data[0];
-                let value = event.data[1];
-
-                if value == wallet_commit_mod {
-                    return Ok(starknet_felt_to_biguint(&index));
-                }
-            }
-        }
-
-        log::info!("Failed to find wallet in commitment tree");
-        Err(CoordinatorError::StateInit(
-            "could not find wallet in commitment tree".to_string(),
-        ))
-    }
-
-    /// Finds the last time the given tree coordinate pairs changed in the
-    /// transaction history, and returns their most recent value
-    #[allow(unused)]
-    async fn scan_for_tree_coords(
-        &self,
-        coords: HashSet<MerkleTreeCoords>,
-        contract_address: String,
-        starknet_client: &JsonRpcClient<HttpTransport>,
-    ) -> Result<HashMap<MerkleTreeCoords, StarknetFieldElement>, CoordinatorError> {
-        // Build a filter to query events with
-        let parsed_contract_address = StarknetFieldElement::from_str(&contract_address).unwrap();
-        let filter = EventFilter {
-            from_block: None,
-            to_block: None,
-            address: Some(parsed_contract_address),
-            keys: Some(vec![*INTERNAL_NODE_CHANGED_EVENT_SELECTOR]),
-        };
-
-        // Loop over pages to find all the coords
-        let mut pagination_token = Some("0".to_string());
-        let mut result_map = HashMap::new();
-        while pagination_token.is_some() {
-            // Fetch the next page of events
-            let events_page = starknet_client
-                .get_events(filter.clone(), pagination_token, 100 /* chunk_size */)
-                .await
-                .map_err(|err| CoordinatorError::StateInit(err.to_string()))?;
-
-            pagination_token = events_page.continuation_token;
-            for event in events_page.events.into_iter() {
-                let height: usize = starknet_felt_to_u64(&event.data[0]) as usize;
-                let index = starknet_felt_to_biguint(&event.data[1]);
-                let new_value = event.data[2];
-
-                // If this is one of the coordinates requested, add it to the result
-                let tree_coords = MerkleTreeCoords { height, index };
-                if coords.contains(&tree_coords) {
-                    result_map.insert(tree_coords, new_value);
-                }
-            }
-        }
-
-        Ok(result_map)
     }
 }

--- a/core/src/state/initialize.rs
+++ b/core/src/state/initialize.rs
@@ -14,7 +14,7 @@ use crypto::fields::{
 use curve25519_dalek::scalar::Scalar;
 use num_bigint::BigUint;
 use reqwest::Url;
-use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
+use starknet::core::types::FieldElement as StarknetFieldElement;
 use starknet::providers::jsonrpc::{models::EventFilter, HttpTransport, JsonRpcClient};
 use std::{
     collections::{HashMap, HashSet},
@@ -35,6 +35,7 @@ use crate::{
         orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
     },
     proof_generation::jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle},
+    starknet_client::{INTERNAL_NODE_CHANGED_EVENT_SELECTOR, VALUE_INSERTED_EVENT_SELECTOR},
     MERKLE_HEIGHT,
 };
 
@@ -49,12 +50,6 @@ const ERR_STATE_INIT_FAILED: &str = "state initialization thread panic";
 const STATE_INIT_THREAD: &str = "state-init";
 
 lazy_static! {
-    /// The event selector for internal node changes
-    static ref INTERNAL_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement =
-        get_selector_from_name("Merkle_internal_node_changed").unwrap();
-    /// The event selector for Merkle value insertion
-    static ref VALUE_INSERTED_EVENT_SELECTOR: StarknetFieldElement =
-        get_selector_from_name("Merkle_value_inserted").unwrap();
     /// The value of an empty leaf in the Merkle tree
     static ref EMPTY_LEAF_VALUE: Scalar = {
         let val_bigint = BigUint::from_str(

--- a/core/src/state/initialize.rs
+++ b/core/src/state/initialize.rs
@@ -15,7 +15,7 @@ use curve25519_dalek::scalar::Scalar;
 use num_bigint::BigUint;
 use reqwest::Url;
 use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
-use starknet_providers::jsonrpc::{models::EventFilter, HttpTransport, JsonRpcClient};
+use starknet::providers::jsonrpc::{models::EventFilter, HttpTransport, JsonRpcClient};
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -20,12 +20,12 @@ pub use self::state::*;
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MerkleTreeCoords {
     /// The height (0 is root) of the coordinate in the tree
-    height: usize,
+    pub height: usize,
     /// The leaf index of the coordinate
     ///
     /// I.e. if we look at the nodes at a given height left to right in a list
     /// the index of the coordinate in that list
-    index: BigUint,
+    pub index: BigUint,
 }
 
 impl MerkleTreeCoords {

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -175,6 +175,28 @@ impl MerkleAuthenticationPath {
         }
     }
 
+    /// Static helper method to get the coordinates of a Merkle authentication path from
+    /// the leaf value
+    pub fn construct_path_coords(leaf_index: BigUint, height: usize) -> Vec<MerkleTreeCoords> {
+        let mut coords = Vec::with_capacity(height);
+        let mut curr_height_index = leaf_index;
+        for height in (1..height + 1).rev() {
+            // If the LSB of the node index at the current height is zero, the node
+            // is a left hand child. If the LSB is one, it is a right hand child.
+            // Choose the index of its sibling
+            let sibling_index = if &curr_height_index % 2u8 == BigUint::from(0u8) {
+                &curr_height_index + 1u8
+            } else {
+                &curr_height_index - 1u8
+            };
+
+            coords.push(MerkleTreeCoords::new(height, sibling_index));
+            curr_height_index >>= 1;
+        }
+
+        coords
+    }
+
     /// Compute the coordinates of the wallet's authentication path in the tree
     ///
     /// The result is sorted from leaf level to depth 1

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -67,7 +67,24 @@ impl NewWalletTask {
         log::info!("got proof bundle for new wallet");
 
         // Submit the wallet on-chain
-        let _res = self.submit_new_wallet(proof_bundle.into()).await;
+        if let Err(e) = self.submit_new_wallet(proof_bundle.into()).await {
+            log::error!("error submitting new wallet on-chain: {e}");
+        };
+
+        // Find the updated Merkle path for the wallet
+        let merkle_index = self
+            .starknet_client
+            .find_commitment_in_state(self.wallet.get_commitment())
+            .await;
+        match merkle_index {
+            Ok(index) => {
+                log::info!("found wallet at merkle index: {index} ")
+            }
+            Err(e) => {
+                log::error!("error finding merkle index: {e}")
+            }
+        }
+
         log::info!("submitted wallet on-chain")
     }
 

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -13,7 +13,7 @@ use tracing::log;
 use crate::{
     external_api::types::Wallet,
     proof_generation::jobs::{ProofJob, ProofManagerJob, ValidWalletCreateBundle},
-    starknet_client::client::{AccountErr, StarknetClient},
+    starknet_client::{client::StarknetClient, error::StarknetClientError},
     state::{wallet::Wallet as StateWallet, RelayerState},
 };
 
@@ -91,7 +91,10 @@ impl NewWalletTask {
     /// Submits a proof and wallet commitment + encryption on-chain
     ///
     /// TODO: Add wallet encryptions as well
-    async fn submit_new_wallet(&self, proof: ValidWalletCreateBundle) -> Result<(), AccountErr> {
+    async fn submit_new_wallet(
+        &self,
+        proof: ValidWalletCreateBundle,
+    ) -> Result<(), StarknetClientError> {
         // Compute a commitment to the wallet and submit the bundle on-chain
         let wallet_commitment = self.wallet.get_commitment();
         let tx_hash = self

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,4 +15,4 @@ memoize = "0.4"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = { version = "0.8" }
 rand_core = "0.5"
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca077d3" }
+starknet = { git = "https://github.com/joeykraut/starknet-rs" }


### PR DESCRIPTION
### Purpose
This PR adds additional logic in the `create-new-wallet` task that:
- Submits the wallet on-chain
- Awaits the `new_wallet` transaction's completion by polling transaction status
- Once completed, scans the transaction history backwards to recover the Merkle entry and authentication path of the new wallet.

Left to do in this task are:
- Index the wallet in the global state once its Merkle path is found
- Create a proof of `VALID COMMITMENTS` for the wallet

### Testing
- Hit the `POST /v0/wallet` endpoint and verified that the above task steps executed correctly. Verified that the recovered path was the correctly emitted one from contract events.