### PR TITLE
core: tasks: create-new-wallet: Add proof and wallet ciphertext blobs to `new_wallet` tx

### DIFF
--- a/circuits/src/zk_circuits/valid_match_encryption.rs
+++ b/circuits/src/zk_circuits/valid_match_encryption.rs
@@ -9,6 +9,7 @@
 //! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.7
 //! for a formal specification
 
+use crypto::elgamal::ElGamalCiphertext;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
 use mpc_bulletproof::{
@@ -29,9 +30,7 @@ use crate::{
     zk_gadgets::{
         commitments::NoteCommitmentGadget,
         comparators::EqGadget,
-        elgamal::{
-            ElGamalCiphertext, ElGamalCiphertextVar, ElGamalGadget, DEFAULT_ELGAMAL_GENERATOR,
-        },
+        elgamal::{ElGamalCiphertextVar, ElGamalGadget, DEFAULT_ELGAMAL_GENERATOR},
         fixed_point::{FixedPoint, FixedPointVar},
         select::CondSelectGadget,
     },
@@ -846,18 +845,30 @@ impl CommitProver for ValidMatchEncryptionStatement {
         let pk_settle_relayer1_var = prover.commit_public(self.pk_settle_relayer1);
         let pk_settle_protocol_var = prover.commit_public(self.pk_settle_protocol);
         let protocol_fee_var = self.protocol_fee.commit_public(prover);
-        let volume1_ciphertext1_var = self.volume1_ciphertext1.commit_public(prover);
-        let volume2_ciphertext1_var = self.volume2_ciphertext1.commit_public(prover);
-        let volume1_ciphertext2_var = self.volume1_ciphertext2.commit_public(prover);
-        let volume2_ciphertext2_var = self.volume2_ciphertext2.commit_public(prover);
-        let mint1_protocol_ciphertext_var = self.mint1_protocol_ciphertext.commit_public(prover);
-        let volume1_protocol_ciphertext_var =
-            self.volume1_protocol_ciphertext.commit_public(prover);
-        let mint2_protocol_ciphertext_var = self.mint2_protocol_ciphertext.commit_public(prover);
-        let volume2_protocol_ciphertext_var =
-            self.volume2_protocol_ciphertext.commit_public(prover);
-        let randomness_protocol_ciphertext_var =
-            self.randomness_protocol_ciphertext.commit_public(prover);
+        let volume1_ciphertext1_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume1_ciphertext1, prover);
+        let volume2_ciphertext1_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume2_ciphertext1, prover);
+        let volume1_ciphertext2_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume1_ciphertext2, prover);
+        let volume2_ciphertext2_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume2_ciphertext2, prover);
+        let mint1_protocol_ciphertext_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.mint1_protocol_ciphertext, prover);
+        let volume1_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.volume1_protocol_ciphertext,
+            prover,
+        );
+        let mint2_protocol_ciphertext_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.mint2_protocol_ciphertext, prover);
+        let volume2_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.volume2_protocol_ciphertext,
+            prover,
+        );
+        let randomness_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.randomness_protocol_ciphertext,
+            prover,
+        );
 
         Ok((
             ValidMatchEncryptionStatementVar {
@@ -903,18 +914,34 @@ impl CommitVerifier for ValidMatchEncryptionStatement {
         let pk_settle_relayer1_var = verifier.commit_public(self.pk_settle_relayer1);
         let pk_settle_protocol_var = verifier.commit_public(self.pk_settle_protocol);
         let protocol_fee_var = self.protocol_fee.commit_public(verifier);
-        let volume1_ciphertext1_var = self.volume1_ciphertext1.commit_public(verifier);
-        let volume2_ciphertext1_var = self.volume2_ciphertext1.commit_public(verifier);
-        let volume1_ciphertext2_var = self.volume1_ciphertext2.commit_public(verifier);
-        let volume2_ciphertext2_var = self.volume2_ciphertext2.commit_public(verifier);
-        let mint1_protocol_ciphertext_var = self.mint1_protocol_ciphertext.commit_public(verifier);
-        let volume1_protocol_ciphertext_var =
-            self.volume1_protocol_ciphertext.commit_public(verifier);
-        let mint2_protocol_ciphertext_var = self.mint2_protocol_ciphertext.commit_public(verifier);
-        let volume2_protocol_ciphertext_var =
-            self.volume2_protocol_ciphertext.commit_public(verifier);
-        let randomness_protocol_ciphertext_var =
-            self.randomness_protocol_ciphertext.commit_public(verifier);
+        let volume1_ciphertext1_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume1_ciphertext1, verifier);
+        let volume2_ciphertext1_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume2_ciphertext1, verifier);
+        let volume1_ciphertext2_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume1_ciphertext2, verifier);
+        let volume2_ciphertext2_var =
+            ElGamalCiphertextVar::commit_public_from_native(self.volume2_ciphertext2, verifier);
+        let mint1_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.mint1_protocol_ciphertext,
+            verifier,
+        );
+        let volume1_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.volume1_protocol_ciphertext,
+            verifier,
+        );
+        let mint2_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.mint2_protocol_ciphertext,
+            verifier,
+        );
+        let volume2_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.volume2_protocol_ciphertext,
+            verifier,
+        );
+        let randomness_protocol_ciphertext_var = ElGamalCiphertextVar::commit_public_from_native(
+            self.randomness_protocol_ciphertext,
+            verifier,
+        );
 
         Ok(ValidMatchEncryptionStatementVar {
             party0_note_commit: party0_note_commit_var,
@@ -992,7 +1019,10 @@ impl<const SCALAR_BITS: usize> SingleProverCircuit for ValidMatchEncryption<SCAL
 #[cfg(test)]
 mod valid_match_encryption_tests {
 
-    use crypto::fields::{biguint_to_scalar, prime_field_to_scalar, scalar_to_biguint};
+    use crypto::{
+        elgamal::ElGamalCiphertext,
+        fields::{biguint_to_scalar, prime_field_to_scalar, scalar_to_biguint},
+    };
     use curve25519_dalek::scalar::Scalar;
     use integration_helpers::mpc_network::field::get_ristretto_group_modulus;
     use lazy_static::lazy_static;
@@ -1011,10 +1041,7 @@ mod valid_match_encryption_tests {
             order::OrderSide,
             r#match::MatchResult,
         },
-        zk_gadgets::{
-            elgamal::{ElGamalCiphertext, DEFAULT_ELGAMAL_GENERATOR},
-            fixed_point::FixedPoint,
-        },
+        zk_gadgets::{elgamal::DEFAULT_ELGAMAL_GENERATOR, fixed_point::FixedPoint},
         CommitProver,
     };
 

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -16,13 +16,16 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
     mpc_gadgets::poseidon::PoseidonSpongeParameters,
     types::{
+        deserialize_array,
         fee::{CommittedFee, Fee, FeeVar},
         keychain::{CommittedKeyChain, KeyChain, KeyChainVar},
+        serialize_array,
     },
     zk_gadgets::poseidon::PoseidonHashGadget,
     CommitProver, CommitVerifier, SingleProverCircuit, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
@@ -116,7 +119,7 @@ where
 }
 
 /// The parameterization for the VALID WALLET CREATE statement
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletCreateStatement {
     /// The expected commitment of the newly created wallet
     pub wallet_commitment: Scalar,
@@ -134,9 +137,13 @@ pub struct ValidWalletCreateWitness<const MAX_FEES: usize> {
 }
 
 /// The committed witness for the VALID WALLET CREATE proof
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletCreateCommitment<const MAX_FEES: usize> {
     /// The fees to initialize the wallet with; may be nonzero
+    #[serde(
+        serialize_with = "serialize_array",
+        deserialize_with = "deserialize_array"
+    )]
     pub fees: [CommittedFee; MAX_FEES],
     /// The keys used to authenticate operations on the wallet
     pub keys: CommittedKeyChain,

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -27,7 +27,7 @@ use crate::{types::SizedValidCommitmentsWitness, MAX_BALANCES, MAX_FEES, MAX_ORD
 // ----------------------
 
 /// The response type for a request to generate a proof of `VALID WALLET CREATE`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletCreateBundle {
     /// A commitment to the witness type for `VALID WALLET CREATE`
     pub commitment: ValidWalletCreateCommitment<MAX_FEES>,

--- a/core/src/starknet_client/error.rs
+++ b/core/src/starknet_client/error.rs
@@ -11,6 +11,8 @@ pub enum StarknetClientError {
     NotFound(String),
     /// An error performing a JSON-RPC request
     Rpc(String),
+    /// An error serializing/deserializing calldata
+    Serde(String),
 }
 
 impl Display for StarknetClientError {

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -11,8 +11,11 @@ ark-crypto-primitives = { version = "0.4", features = ["sponge"] }
 bigdecimal = "0.3"
 curve25519-dalek = "2"
 itertools = "0.10"
+lazy_static = "1.4"
 memoize = "0.4"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = { version = "0.8" }
 rand_core = "0.5"
+serde = { version = "1.0.139", features = ["serde_derive"] }
+serde_json = "1.0"
 starknet = { git = "https://github.com/joeykraut/starknet-rs" }

--- a/crypto/src/elgamal.rs
+++ b/crypto/src/elgamal.rs
@@ -1,0 +1,51 @@
+//! Helpers for creating encryptions of values
+
+use curve25519_dalek::scalar::Scalar;
+use lazy_static::lazy_static;
+use num_bigint::BigUint;
+use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
+
+use crate::fields::{biguint_to_scalar, get_ristretto_group_modulus, scalar_to_biguint};
+
+lazy_static! {
+    /// We use the generator 2 here as per the same field configured in Arkworks:
+    /// https://github.com/arkworks-rs/curves/blob/master/curve25519/src/fields/fr.rs
+    ///
+    /// This generator is intended to be used with the Ristretto scalar field of prime
+    /// order defined here:
+    /// https://docs.rs/curve25519-dalek-ng/latest/curve25519_dalek_ng/scalar/index.html
+    pub static ref DEFAULT_ELGAMAL_GENERATOR: Scalar = Scalar::from(2u64);
+}
+
+/// The result of creating an ElGamal encryption
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct ElGamalCiphertext {
+    /// The shared secret; the generator raised to the randomness
+    pub partial_shared_secret: Scalar,
+    /// The encrypted value; the pubkey raised to the randomness, multiplied with the message
+    pub encrypted_message: Scalar,
+}
+
+/// Create an ElGamal encryption of the given value
+///
+/// Return both the encryption (used as a public variable) and the randomness
+/// used to generate the encryption (used as a witness variable)
+pub fn encrypt_scalar(val: Scalar, pubkey: &BigUint) -> (ElGamalCiphertext, Scalar) {
+    let mut rng = OsRng {};
+    let randomness = scalar_to_biguint(&Scalar::random(&mut rng));
+
+    let field_mod = get_ristretto_group_modulus();
+    let ciphertext1 = scalar_to_biguint(&DEFAULT_ELGAMAL_GENERATOR).modpow(&randomness, &field_mod);
+    let shared_secret = pubkey.modpow(&randomness, &field_mod);
+
+    let encrypted_message = (shared_secret * scalar_to_biguint(&val)) % &field_mod;
+
+    (
+        ElGamalCiphertext {
+            partial_shared_secret: biguint_to_scalar(&ciphertext1),
+            encrypted_message: biguint_to_scalar(&encrypted_message),
+        },
+        biguint_to_scalar(&randomness),
+    )
+}

--- a/crypto/src/fields.rs
+++ b/crypto/src/fields.rs
@@ -18,6 +18,23 @@ pub struct DalekRistrettoFieldConfig;
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]
 pub type DalekRistrettoField = Fp256<MontBackend<DalekRistrettoFieldConfig, 4>>;
 
+// -----------
+// | Helpers |
+// -----------
+
+/// Returns the prime group modulus for the scalar field that Dalek Ristretto
+/// arithmetic is defined over.
+pub fn get_ristretto_group_modulus() -> BigUint {
+    let modulus: BigUint = BigUint::from(1u64) << 252;
+    let delta_digits = String::from("27742317777372353535851937790883648493")
+        .chars()
+        .map(|c| c.to_digit(10).unwrap() as u8)
+        .collect::<Vec<_>>();
+
+    let delta = BigUint::from_radix_be(&delta_digits, 10 /* radix */).unwrap();
+    modulus + delta
+}
+
 // ---------------------------
 // | Conversions From Scalar |
 // ---------------------------

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -3,5 +3,6 @@
 #![deny(clippy::missing_docs_in_private_items)]
 
 pub mod constants;
+pub mod elgamal;
 pub mod fields;
 pub mod hash;


### PR DESCRIPTION
### Purpose
This PR adds the proof of `VALID WALLET CREATE` as an uninterpreted blob to the `new_wallet` transaction, as well as the initial wallet's ciphertext. This completes the initial implementation of the `create_new_wallet` task.

We will need to re-structure these blobs when we start actually validating proofs and storing encryptions on-chain. 

### Testing
- Hit `POST /v0/wallet` to create a new wallet, verified that the transaction was created with the ciphertext and proof blobs, and was successfully accepted on Starknet Goerli