### PR TITLE
core: tasks: create-new-order: Add initial order creation API + task

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ privacy, both pre- and post-trade. For full cryptographic details, see the
 [documentation](https://docs.renegade.fi).
 
 Relayers are organized into fail-stop fault-tolerant clusters that replicate
-and horiztonally scale matching engine execution for increased trading
+and horizontally scale matching engine execution for increased trading
 throughput.
 
 Note that even though intra-cluster logic depends on fail-stop assumptions, the

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -18,6 +18,7 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
@@ -437,7 +438,7 @@ pub struct ValidWalletUpdateWitnessVar<
 }
 
 /// A commitment to the witness of VALID WALLET UPDATE
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletUpdateWitnessCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
@@ -522,7 +523,7 @@ where
 }
 
 /// The statement type for VALID WALLET UPDATE
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletUpdateStatement {
     /// The timestamp (user set) of the request, used for order timestamping
     pub timestamp: Scalar,

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -32,10 +32,10 @@ use self::{
     },
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     wallet::{
-        GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler,
-        GetOrdersHandler, GetWalletHandler, PostWalletHandler, GET_BALANCES_ROUTE,
-        GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE, GET_ORDERS_ROUTE, GET_ORDER_BY_ID_ROUTE,
-        GET_WALLET_ROUTE, POST_WALLET_ROUTE,
+        CreateOrderHandler, CreateWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
+        GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler,
+        CREATE_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE,
+        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, WALLET_ORDERS_ROUTE,
     },
 };
 
@@ -180,19 +180,30 @@ impl HttpServer {
         // The "/wallet" route
         router.add_route(
             Method::POST,
-            POST_WALLET_ROUTE.to_string(),
-            PostWalletHandler::new(
+            CREATE_WALLET_ROUTE.to_string(),
+            CreateWalletHandler::new(
                 config.starknet_client.clone(),
                 global_state.clone(),
                 config.proof_generation_work_queue.clone(),
             ),
         );
 
-        // The "/wallet/:id/orders" route
+        // Getter for the "/wallet/:id/orders" route
         router.add_route(
             Method::GET,
-            GET_ORDERS_ROUTE.to_string(),
+            WALLET_ORDERS_ROUTE.to_string(),
             GetOrdersHandler::new(global_state.clone()),
+        );
+
+        // Post to the "/wallet/:id/orders" route
+        router.add_route(
+            Method::POST,
+            WALLET_ORDERS_ROUTE.to_string(),
+            CreateOrderHandler::new(
+                config.starknet_client.clone(),
+                config.global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+            ),
         );
 
         // The "/wallet/:id/orders/:id" route

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -1,6 +1,7 @@
 //! Groups API type definitions for wallet API operations
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     external_api::types::{Balance, Fee, Order, Wallet},
@@ -42,12 +43,32 @@ pub struct GetOrdersResponse {
     /// The orders within a given wallet
     pub orders: Vec<Order>,
 }
-
 /// The response type to get a single order by ID
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetOrderByIdResponse {
     /// The order requested
     pub order: Order,
+}
+
+/// The request type to add a new order to a given wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateOrderRequest {
+    /// The order to be created
+    pub order: Order,
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type to a request that adds a new order to a wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateOrderResponse {
+    /// The ID of the order created
+    pub id: Uuid,
 }
 
 // -----------------------------

--- a/core/src/starknet_client/error.rs
+++ b/core/src/starknet_client/error.rs
@@ -7,6 +7,8 @@ use std::fmt::Display;
 pub enum StarknetClientError {
     /// An error executing a transaction
     ExecuteTransaction(String),
+    /// An error performing a request against the sequencer gateway
+    Gateway(String),
     /// No value was found when scanning contract state
     NotFound(String),
     /// An error performing a JSON-RPC request

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -16,20 +16,29 @@ use crate::MERKLE_HEIGHT;
 pub mod client;
 pub mod error;
 
-// -------------
-// | Selectors |
-// -------------
-
 lazy_static! {
-    /// Contract selector to create a new wallet
+    // -------------
+    // | Selectors |
+    // -------------
+
+    /// Contract function selector to create a new wallet
     static ref NEW_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("new_wallet")
         .unwrap();
+    /// Contract function selector to update an existing wallet, nullifying the previous version
+    static ref UPDATE_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("update_wallet")
+        .unwrap();
+
     /// The event selector for internal node changes
     pub static ref INTERNAL_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement =
         get_selector_from_name("Merkle_internal_node_changed").unwrap();
     /// The event selector for Merkle value insertion
     pub static ref VALUE_INSERTED_EVENT_SELECTOR: StarknetFieldElement =
         get_selector_from_name("Merkle_value_inserted").unwrap();
+
+    // ------------------------
+    // | Merkle Tree Metadata |
+    // ------------------------
+
     /// The value of an empty leaf in the Merkle tree
     static ref EMPTY_LEAF_VALUE: Scalar = {
         let val_bigint = BigUint::from_str(

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -12,6 +12,7 @@ use std::{
 use circuits::{
     native_helpers::{
         compute_poseidon_hash, compute_wallet_commitment, compute_wallet_match_nullifier,
+        compute_wallet_spend_nullifier,
     },
     types::{
         balance::Balance,
@@ -392,6 +393,15 @@ impl Wallet {
     pub fn get_match_nullifier(&self) -> Nullifier {
         let circuit_wallet: SizedCircuitWallet = self.clone().into();
         prime_field_to_scalar(&compute_wallet_match_nullifier(
+            &circuit_wallet,
+            compute_wallet_commitment(&circuit_wallet),
+        ))
+    }
+
+    /// Computes the spend nullifier of the wallet
+    pub fn get_spend_nullifier(&self) -> Nullifier {
+        let circuit_wallet: SizedCircuitWallet = self.clone().into();
+        prime_field_to_scalar(&compute_wallet_spend_nullifier(
             &circuit_wallet,
             compute_wallet_commitment(&circuit_wallet),
         ))

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -1,16 +1,19 @@
 //! Handles the flow of adding a new order to a wallet
 
 use std::{
+    collections::HashMap,
     fmt::Display,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use circuits::{
+    native_helpers::compute_poseidon_hash,
     types::{
         order::Order as CircuitOrder,
         wallet::{Nullifier, WalletCommitment},
     },
     zk_circuits::valid_wallet_update::ValidWalletUpdateStatement,
+    zk_gadgets::merkle::MerkleOpening,
 };
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::{
@@ -18,6 +21,7 @@ use crypto::{
     fields::{scalar_to_biguint, starknet_felt_to_biguint},
 };
 use curve25519_dalek::scalar::Scalar;
+use rand_core::OsRng;
 use starknet::core::types::TransactionStatus;
 use tokio::sync::oneshot;
 use tracing::log;
@@ -42,6 +46,8 @@ const ERR_NO_MERKLE_PROOF: &str = "wallet merkle proof not attached";
 const ERR_TRANSACTION_FAILED: &str = "transaction rejected";
 /// The wallet to create the order within was not found
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found in state";
+/// The amount to increment the randomness each time a wallet is nullified
+const RANDOMNESS_INCREMENT: u8 = 2;
 
 /// Helper function to get the current UNIX epoch time in milliseconds
 pub fn get_current_time() -> u128 {
@@ -137,6 +143,7 @@ impl NewOrderTask {
 
         let mut new_wallet = old_wallet.clone();
         new_wallet.orders.insert(self.order_id, self.order.clone());
+        new_wallet.randomness += RANDOMNESS_INCREMENT;
 
         // Compute public statement variables sent to the contract
         let new_wallet_comm = new_wallet.get_commitment();
@@ -151,7 +158,7 @@ impl NewOrderTask {
         // Encrypt the new wallet under the public view key
         // TODO: This will eventually come directly from the user as they sign the encryption
         let pk_view = scalar_to_biguint(&new_wallet.public_keys.pk_view);
-        let encrypted_wallet = encrypt_wallet(new_wallet.into(), &pk_view);
+        let encrypted_wallet = encrypt_wallet(new_wallet.clone().into(), &pk_view);
 
         self.submit_tx(
             new_wallet_comm,
@@ -163,6 +170,7 @@ impl NewOrderTask {
         .await?;
 
         // Re-prove validity proofs for all orders in wallet
+        self.update_validity_proofs(new_wallet).await?;
 
         // Update state
         Ok(())
@@ -227,12 +235,14 @@ impl NewOrderTask {
         proof: ValidWalletUpdateBundle,
     ) -> Result<(), NewOrderTaskError> {
         // Submit on-chain
+        // TODO: Remove this
+        let mut rng = OsRng {};
         let tx_hash = self
             .starknet_client
             .update_wallet(
                 new_wallet_comm,
-                old_wallet_match_nullifier,
-                old_wallet_spend_nullifier,
+                old_wallet_match_nullifier + Scalar::random(&mut rng),
+                old_wallet_spend_nullifier + Scalar::random(&mut rng),
                 wallet_ciphertext,
                 proof,
             )
@@ -252,6 +262,80 @@ impl NewOrderTask {
                 ERR_TRANSACTION_FAILED.to_string(),
             ));
         }
+
+        Ok(())
+    }
+
+    /// After a wallet update has been submitted on-chain, find its authentication
+    /// path, and re-prove `VALID COMMITMENTS` for all orders in the wallet
+    async fn update_validity_proofs(&self, new_wallet: Wallet) -> Result<(), NewOrderTaskError> {
+        // Find the new wallet in the Merkle state
+        let authentication_path = self
+            .starknet_client
+            .find_merkle_authentication_path(new_wallet.get_commitment())
+            .await
+            .map_err(|err| NewOrderTaskError::StarknetClient(err.to_string()))?;
+        let new_root = authentication_path.compute_root();
+
+        let match_nullifier = new_wallet.get_match_nullifier();
+
+        // A wallet that is compatible with circuit types
+        let circuit_wallet: SizedWallet = new_wallet.clone().into();
+        let randomness_hash = compute_poseidon_hash(&[circuit_wallet.randomness]);
+        let wallet_opening: MerkleOpening = authentication_path.into();
+
+        // Request that the proof manager prove `VALID COMMITMENTS` for each order
+        let mut proof_response_channels = HashMap::new();
+        let locked_order_book = self.global_state.read_order_book().await;
+        for order_id in new_wallet.orders.keys() {
+            // Fetch the old witness
+            let old_witness = locked_order_book.get_validity_proof_witness(order_id).await;
+            if old_witness.is_none() {
+                // TODO: If a witness is not present, generate one now
+                continue;
+            }
+            let mut new_witness = old_witness.unwrap();
+
+            // Update the witness with the new wallet information
+            new_witness.wallet = circuit_wallet.clone();
+            new_witness.wallet_opening = wallet_opening.clone();
+            new_witness.randomness_hash = randomness_hash.into();
+
+            // Update the statement for the new wallet
+            let mut new_statement = locked_order_book
+                .get_validity_proof(order_id)
+                .await
+                .unwrap()
+                .statement;
+
+            new_statement.nullifier = match_nullifier;
+            new_statement.merkle_root = new_root;
+
+            // Send a job to the proof manager to prove `VALID COMMITMENTS` for this wallet
+            let (response_sender, response_receiver) = oneshot::channel();
+            self.proof_manager_work_queue
+                .send(ProofManagerJob {
+                    type_: ProofJob::ValidCommitments {
+                        witness: new_witness,
+                        statement: new_statement,
+                    },
+                    response_channel: response_sender,
+                })
+                .map_err(|err| NewOrderTaskError::SendMessage(err.to_string()))?;
+
+            proof_response_channels.insert(*order_id, response_receiver);
+        }
+
+        // Await proofs for all orders
+        for (order_id, proof_channel) in proof_response_channels.into_iter() {
+            let _proof = proof_channel
+                .await
+                .map_err(|err| NewOrderTaskError::ProofGeneration(err.to_string()))?;
+
+            log::info!("received proof for order: {order_id}");
+        }
+
+        log::info!("got proofs for all orders");
 
         Ok(())
     }

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -1,21 +1,54 @@
 //! Handles the flow of adding a new order to a wallet
 
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use circuits::types::order::Order as CircuitOrder;
+use circuits::{
+    types::order::Order as CircuitOrder,
+    zk_circuits::valid_wallet_update::ValidWalletUpdateStatement,
+};
 use crossbeam::channel::Sender as CrossbeamSender;
+use curve25519_dalek::scalar::Scalar;
+use tokio::sync::oneshot;
 use tracing::log;
 
 use crate::{
     external_api::types::Order,
-    proof_generation::jobs::ProofManagerJob,
+    proof_generation::jobs::{ProofJob, ProofManagerJob, ValidWalletUpdateBundle},
     starknet_client::client::StarknetClient,
-    state::{wallet::WalletIdentifier, RelayerState},
+    state::{
+        wallet::{Wallet, WalletIdentifier},
+        OrderIdentifier, RelayerState,
+    },
+    types::SizedValidWalletUpdateWitness,
+    SizedWallet,
 };
+
+/// The wallet does not have a merkle proof attached to it
+const ERR_NO_MERKLE_PROOF: &str = "wallet merkle proof not attached";
+/// The wallet to create the order within was not found
+const ERR_WALLET_NOT_FOUND: &str = "wallet not found in state";
+
+/// Helper function to get the current UNIX epoch time in milliseconds
+pub fn get_current_time() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+}
 
 /// The error type for the task
 #[derive(Clone, Debug)]
-pub enum NewOrderTaskError {}
+pub enum NewOrderTaskError {
+    /// A piece of state necessary for task execution is missing
+    MissingState(String),
+    /// Error generating a proof of `VALID WALLET UPDATE`
+    ProofGeneration(String),
+    /// An error occurred sending a message to another local worker
+    SendMessage(String),
+}
 
 impl Display for NewOrderTaskError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -28,6 +61,8 @@ impl Display for NewOrderTaskError {
 pub struct NewOrderTask {
     /// The ID of the wallet to create the order within
     wallet_id: WalletIdentifier,
+    /// The ID of the order being added to the wallet
+    order_id: OrderIdentifier,
     /// The order to add to the wallet
     order: CircuitOrder,
     /// A starknet client for the task to submit transactions
@@ -48,10 +83,12 @@ impl NewOrderTask {
         proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
     ) -> Self {
         // Cast explicitly to an order type that is indexed in the state
+        let order_id = order.id;
         let order: CircuitOrder = order.into();
 
         Self {
             wallet_id,
+            order_id,
             order,
             starknet_client,
             global_state,
@@ -61,7 +98,91 @@ impl NewOrderTask {
 
     /// Run the task to completion
     pub async fn run(self) -> Result<(), NewOrderTaskError> {
-        log::info!("got to create new order task");
+        log::info!("Beginning new order task execution");
+
+        if let Err(e) = self.run_helper().await {
+            log::error!("Error creating new order in wallet: {e}")
+        } else {
+            log::info!("Successfully added order to wallet")
+        }
+
         Ok(())
+    }
+
+    /// A helper function that allows the caller to log errors in a central piece
+    /// of logic
+    async fn run_helper(self) -> Result<(), NewOrderTaskError> {
+        // Get a copy of the old wallet and update it with the new order
+        let old_wallet = self
+            .global_state
+            .read_wallet_index()
+            .await
+            .get_wallet(&self.wallet_id)
+            .await
+            .ok_or_else(|| NewOrderTaskError::MissingState(ERR_WALLET_NOT_FOUND.to_string()))?;
+
+        let mut new_wallet = old_wallet.clone();
+        new_wallet.orders.insert(self.order_id, self.order.clone());
+
+        // Prove `VALID WALLET UPDATE`
+        let _proof = self
+            .prove_valid_wallet_update(old_wallet, new_wallet)
+            .await?;
+        log::info!("generated a proof of valid wallet update!");
+
+        // Submit on-chain
+
+        // Re-prove validity proofs
+
+        // Update state
+        Ok(())
+    }
+
+    /// Prove `VALID WALLET UPDATE` on the given change between old and new wallet
+    async fn prove_valid_wallet_update(
+        &self,
+        old_wallet: Wallet,
+        new_wallet: Wallet,
+    ) -> Result<ValidWalletUpdateBundle, NewOrderTaskError> {
+        let timestamp: Scalar = get_current_time().into();
+        let merkle_opening = old_wallet
+            .merkle_proof
+            .clone()
+            .ok_or_else(|| NewOrderTaskError::MissingState(ERR_NO_MERKLE_PROOF.to_string()))?;
+
+        // Build the statement
+        let statement = ValidWalletUpdateStatement {
+            timestamp,
+            pk_root: old_wallet.public_keys.pk_root,
+            new_wallet_commitment: new_wallet.get_commitment(),
+            wallet_match_nullifier: old_wallet.get_match_nullifier(),
+            wallet_spend_nullifier: old_wallet.get_spend_nullifier(),
+            merkle_root: merkle_opening.compute_root(),
+            external_transfer: (Scalar::zero(), Scalar::zero(), Scalar::zero()),
+        };
+
+        // Construct the witness
+        let old_circuit_wallet: SizedWallet = old_wallet.into();
+        let new_circuit_wallet: SizedWallet = new_wallet.into();
+        let witness = SizedValidWalletUpdateWitness {
+            wallet1: old_circuit_wallet,
+            wallet2: new_circuit_wallet,
+            wallet1_opening: merkle_opening.into(),
+            internal_transfer: (Scalar::zero(), Scalar::zero()),
+        };
+
+        // Send a job to the proof manager and await completion
+        let (response_sender, response_receiver) = oneshot::channel();
+        self.proof_manager_work_queue
+            .send(ProofManagerJob {
+                type_: ProofJob::ValidWalletUpdate { witness, statement },
+                response_channel: response_sender,
+            })
+            .map_err(|err| NewOrderTaskError::SendMessage(err.to_string()))?;
+
+        response_receiver
+            .await
+            .map(|bundle| bundle.into())
+            .map_err(|err| NewOrderTaskError::ProofGeneration(err.to_string()))
     }
 }

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -1,0 +1,67 @@
+//! Handles the flow of adding a new order to a wallet
+
+use std::fmt::Display;
+
+use circuits::types::order::Order as CircuitOrder;
+use crossbeam::channel::Sender as CrossbeamSender;
+use tracing::log;
+
+use crate::{
+    external_api::types::Order,
+    proof_generation::jobs::ProofManagerJob,
+    starknet_client::client::StarknetClient,
+    state::{wallet::WalletIdentifier, RelayerState},
+};
+
+/// The error type for the task
+#[derive(Clone, Debug)]
+pub enum NewOrderTaskError {}
+
+impl Display for NewOrderTaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+/// The task definition for the long-run async flow of creating
+/// a new order within a wallet
+pub struct NewOrderTask {
+    /// The ID of the wallet to create the order within
+    wallet_id: WalletIdentifier,
+    /// The order to add to the wallet
+    order: CircuitOrder,
+    /// A starknet client for the task to submit transactions
+    starknet_client: StarknetClient,
+    /// A copy of the relayer-global state
+    global_state: RelayerState,
+    /// The work queue for the proof manager
+    proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+}
+
+impl NewOrderTask {
+    /// Constructor
+    pub fn new(
+        wallet_id: WalletIdentifier,
+        order: Order,
+        starknet_client: StarknetClient,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    ) -> Self {
+        // Cast explicitly to an order type that is indexed in the state
+        let order: CircuitOrder = order.into();
+
+        Self {
+            wallet_id,
+            order,
+            starknet_client,
+            global_state,
+            proof_manager_work_queue,
+        }
+    }
+
+    /// Run the task to completion
+    pub async fn run(self) -> Result<(), NewOrderTaskError> {
+        log::info!("got to create new order task");
+        Ok(())
+    }
+}

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -30,6 +30,8 @@ use crate::{
 /// The error type for the task
 #[derive(Clone, Debug)]
 pub enum NewWalletTaskError {
+    /// Error generating a proof of `VALID WALLET CREATE`
+    ProofGeneration(String),
     /// Error interacting with the Starknet client
     Starknet(String),
     /// Error sending a message to another worker
@@ -112,7 +114,9 @@ impl NewWalletTask {
             .send(job_req)
             .map_err(|err| NewWalletTaskError::SendMessage(err.to_string()))?;
 
-        let proof_bundle = response_receiver.await.unwrap();
+        let proof_bundle = response_receiver
+            .await
+            .map_err(|err| NewWalletTaskError::ProofGeneration(err.to_string()))?;
 
         // Submit the wallet on-chain
         self.submit_new_wallet(proof_bundle.into())

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -4,4 +4,5 @@
 //! node to prove `VALID NEW WALLET`, submit the wallet on-chain, wait for
 //! transaction success, and then prove `VALID COMMITMENTS`
 
+pub mod create_new_order;
 pub mod create_new_wallet;

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -4,5 +4,60 @@
 //! node to prove `VALID NEW WALLET`, submit the wallet on-chain, wait for
 //! transaction success, and then prove `VALID COMMITMENTS`
 
+use crypto::{
+    elgamal::{encrypt_scalar, ElGamalCiphertext},
+    fields::biguint_to_scalar,
+};
+use itertools::Itertools;
+use num_bigint::BigUint;
+
+use crate::SizedWallet;
+
 pub mod create_new_order;
 pub mod create_new_wallet;
+
+// -----------
+// | Helpers |
+// -----------
+
+/// A helper to encrypt a wallet under a given public view key
+pub(self) fn encrypt_wallet(wallet: SizedWallet, pk_view: &BigUint) -> Vec<ElGamalCiphertext> {
+    let mut ciphertexts = Vec::new();
+
+    // Encrypt the balances
+    wallet.balances.iter().for_each(|balance| {
+        ciphertexts.push(encrypt_scalar(biguint_to_scalar(&balance.mint), pk_view));
+        ciphertexts.push(encrypt_scalar(balance.amount.into(), pk_view));
+    });
+
+    // Encrypt the orders
+    wallet.orders.iter().for_each(|order| {
+        ciphertexts.push(encrypt_scalar(
+            biguint_to_scalar(&order.quote_mint),
+            pk_view,
+        ));
+        ciphertexts.push(encrypt_scalar(biguint_to_scalar(&order.base_mint), pk_view));
+        ciphertexts.push(encrypt_scalar(order.side.into(), pk_view));
+        ciphertexts.push(encrypt_scalar(order.price.into(), pk_view));
+        ciphertexts.push(encrypt_scalar(order.amount.into(), pk_view));
+        ciphertexts.push(encrypt_scalar(order.timestamp.into(), pk_view));
+    });
+
+    // Encrypt the fees
+    wallet.fees.iter().for_each(|fee| {
+        ciphertexts.push(encrypt_scalar(biguint_to_scalar(&fee.settle_key), pk_view));
+        ciphertexts.push(encrypt_scalar(biguint_to_scalar(&fee.gas_addr), pk_view));
+        ciphertexts.push(encrypt_scalar(fee.gas_token_amount.into(), pk_view));
+        ciphertexts.push(encrypt_scalar(fee.percentage_fee.into(), pk_view));
+    });
+
+    // Encrypt the wallet randomness
+    ciphertexts.push(encrypt_scalar(wallet.randomness, pk_view));
+
+    // Remove the randomness used in each encryption, cleaner this way than
+    // indexing into the tuple struct in all of the above
+    ciphertexts
+        .into_iter()
+        .map(|(cipher, _)| cipher)
+        .collect_vec()
+}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,6 +1,9 @@
 //! Groups type definitions relevant to all modules and at the top level
 
-use circuits::zk_circuits::valid_commitments::{ValidCommitments, ValidCommitmentsWitness};
+use circuits::zk_circuits::{
+    valid_commitments::{ValidCommitments, ValidCommitmentsWitness},
+    valid_wallet_update::ValidWalletUpdateWitness,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -17,6 +20,9 @@ use crate::{
 pub type SizedValidCommitments = ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 /// A `VALID COMMITMENTS` witness with default const generic sizing parameters
 pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A `VALID WALLET UPDATE` witness with default const generic sizing parameters
+pub type SizedValidWalletUpdateWitness =
+    ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
 // ----------------------
 // | Pubsub Topic Names |


### PR DESCRIPTION
### Purpose
This PR adds the bulk of the logic for the order creation API `POST /wallet/:id/orders` and the task `create-new-order`. This task takes the following steps:
- Prove `VALID WALLET UPDATE` for the old and new wallet pair
- Submit this to the contract, calling `update_wallet`
- Await transaction finality
- Re-prove `VALID COMMITMENTS` for each order in the wallet; the use of the nullifier on-chain nullifies their proofs

Left to do in a follow up is:
- Index these orders in the global state
- Clean up stale orders that the new wallet replaces
- Verify that once an order has gone through the above steps, it may be matched by a counterparty

As well, we will soon want to add some form of task manager with retries over the task abstraction. It is becoming clear that the APIs are flakey enough to where failures are somewhat common.

### Testing
- Ad-hoc verified the above steps with transactions sent to Goerli