### PR TITLE
core: task: driver: Add `TaskDriver` for automatic partial retries within a task

### DIFF
--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -185,6 +185,7 @@ impl HttpServer {
                 config.starknet_client.clone(),
                 global_state.clone(),
                 config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
             ),
         );
 
@@ -203,6 +204,7 @@ impl HttpServer {
                 config.starknet_client.clone(),
                 config.global_state.clone(),
                 config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
             ),
         );
 

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -308,10 +308,14 @@ impl TypedHandler for CreateOrderHandler {
             self.starknet_client.clone(),
             self.global_state.clone(),
             self.proof_manager_work_queue.clone(),
-        );
-        unimplemented!("add task driver here");
+        )
+        .await
+        .map_err(|err| {
+            ApiServerError::HttpStatusCode(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+        })?;
+        let task_id = self.task_driver.run(task).await;
 
-        Ok(CreateOrderResponse { id })
+        Ok(CreateOrderResponse { id, task_id })
     }
 }
 

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -12,7 +12,7 @@ use tokio::{
 use crate::{
     price_reporter::jobs::PriceReporterManagerJob, proof_generation::jobs::ProofManagerJob,
     starknet_client::client::StarknetClient, state::RelayerState, system_bus::SystemBus,
-    types::SystemBusMessage, worker::Worker, CancelChannel,
+    tasks::driver::TaskDriver, types::SystemBusMessage, worker::Worker, CancelChannel,
 };
 
 use super::{error::ApiServerError, http::HttpServer, websocket::WebsocketServer};
@@ -51,6 +51,8 @@ pub struct ApiServerConfig {
     pub proof_generation_work_queue: CrossbeamSender<ProofManagerJob>,
     /// The relayer-global state
     pub global_state: RelayerState,
+    /// The task driver, used to create and manage long-running async tasks
+    pub task_driver: TaskDriver,
     /// The system pubsub bus that all workers have access to
     /// The ApiServer uses this bus to forward internal events onto open
     /// websocket connections

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     external_api::types::{Balance, Fee, Order, Wallet},
-    state::wallet::WalletIdentifier,
+    state::wallet::WalletIdentifier, tasks::driver::TaskIdentifier,
 };
 
 // --------------------
@@ -31,6 +31,9 @@ pub struct CreateWalletRequest {
 pub struct CreateWalletResponse {
     /// The wallet identifier provisioned for the new wallet
     pub id: WalletIdentifier,
+    /// The system-internal task ID that the client may use to query
+    /// task status
+    pub task_id: TaskIdentifier,
 }
 
 // ---------------------------

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -5,7 +5,8 @@ use uuid::Uuid;
 
 use crate::{
     external_api::types::{Balance, Fee, Order, Wallet},
-    state::wallet::WalletIdentifier, tasks::driver::TaskIdentifier,
+    state::wallet::WalletIdentifier,
+    tasks::driver::TaskIdentifier,
 };
 
 // --------------------
@@ -72,6 +73,8 @@ pub struct CreateOrderRequest {
 pub struct CreateOrderResponse {
     /// The ID of the order created
     pub id: Uuid,
+    /// The ID of the internal task created for the operation
+    pub task_id: TaskIdentifier,
 }
 
 // -----------------------------

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -58,6 +58,7 @@ use crate::{
     starknet_client::client::{StarknetClient, StarknetClientConfig},
     state::RelayerState,
     system_bus::SystemBus,
+    tasks::driver::TaskDriver,
     types::SystemBusMessage,
     worker::{watch_worker, Worker},
 };
@@ -193,6 +194,10 @@ async fn main() -> Result<(), CoordinatorError> {
         network_sender.clone(),
     );
 
+    // Build a task driver that may be used to spawn long-lived asynchronous tasks that
+    // are common among workers
+    let task_driver = TaskDriver::new();
+
     // ----------------
     // | Worker Setup |
     // ----------------
@@ -306,6 +311,7 @@ async fn main() -> Result<(), CoordinatorError> {
         websocket_port: args.websocket_port,
         starknet_client: starknet_client.clone(),
         global_state: global_state.clone(),
+        task_driver,
         system_bus,
         price_reporter_work_queue: price_reporter_worker_sender,
         proof_generation_work_queue: proof_generation_worker_sender,

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -14,7 +14,6 @@ use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 use serde::Serialize;
 use starknet::core::types::TransactionStatus;
 use tokio::sync::oneshot;
-use tracing::log;
 
 use crate::{
     external_api::types::Wallet,
@@ -255,7 +254,6 @@ impl NewWalletTask {
     /// A helper to find the new Merkle authentication path in the contract state
     /// and update the global state with the new wallet's authentication path
     async fn find_merkle_path(&self) -> Result<(), NewWalletTaskError> {
-        log::info!("starting find_merkle_path");
         // Find the updated Merkle path for the wallet
         let merkle_auth_path = self
             .starknet_client

--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -1,0 +1,124 @@
+//! The task driver drives a task forwards and executes partial retries
+//! of certain critical sections of a task
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use tokio::runtime::{Builder as TokioRuntimeBuilder, Runtime as TokioRuntime};
+use tracing::log;
+use uuid::Uuid;
+
+use crate::state::{new_async_shared, AsyncShared};
+
+use super::create_new_wallet::NewWalletTaskState;
+
+/// A type alias for the identifier underlying a task
+pub type TaskIdentifier = Uuid;
+
+/// The number of threads backing the tokio runtime
+const TASK_DRIVER_N_THREADS: usize = 1;
+/// The name of the threads backing the task driver
+const TASK_DRIVER_THREAD_NAME: &str = "renegade-task-driver";
+/// The number of times to retry a step in a task before propagating the error
+const TASK_DRIVER_N_RETRIES: usize = 5;
+
+/// The task trait defines a sequence of largely async flows, each of which is possibly
+/// unreliable and may need to be retried until completion or to some retry threshold
+#[async_trait]
+pub trait Task: Send {
+    /// The state type of the task, used for task introspection
+    type State: Send + Serialize + Deserialize<'static> + Into<StateWrapper>;
+    /// The error type that the task may give
+    type Error: Send + Debug;
+
+    /// Take a step in the task, steps should represent largely async behavior
+    async fn step(&mut self) -> Result<(), Self::Error>;
+
+    /// Get the current state of the task
+    fn state(&self) -> Self::State;
+
+    /// Whether or not the task is completed
+    fn completed(&self) -> bool;
+}
+
+/// Defines a wrapper that allows state objects to be stored generically
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum StateWrapper {
+    /// The state object for the new wallet task
+    NewWallet(NewWalletTaskState),
+}
+
+/// Drives tasks to completion
+#[derive(Clone)]
+pub struct TaskDriver {
+    /// The set of open tasks
+    open_tasks: AsyncShared<HashMap<Uuid, StateWrapper>>,
+    /// The runtime to spawn tasks onto
+    runtime: AsyncShared<TokioRuntime>,
+}
+
+impl TaskDriver {
+    /// Constructor
+    pub fn new() -> Self {
+        // Build a runtime
+        let runtime = TokioRuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .worker_threads(TASK_DRIVER_N_THREADS)
+            .thread_name(TASK_DRIVER_THREAD_NAME)
+            .build()
+            .expect("error building task driver runtime");
+
+        Self {
+            open_tasks: new_async_shared(HashMap::new()),
+            runtime: new_async_shared(runtime),
+        }
+    }
+
+    /// Spawn a new task in the driver
+    ///
+    /// Returns the ID of the task being spawned
+    pub async fn run<T: Task + 'static>(&self, task: T) -> Uuid {
+        // Add the task to the bookkeeping structure
+        let task_id = Uuid::new_v4();
+        {
+            self.open_tasks
+                .write()
+                .await
+                .insert(task_id, task.state().into());
+        } // open_tasks lock released
+
+        // Drive the task
+        let self_clone = self.clone();
+        self.runtime.read().await.spawn(async move {
+            self_clone.run_task_to_completion(task_id, task).await;
+        });
+
+        task_id
+    }
+
+    /// Run a task to completion
+    async fn run_task_to_completion<T: Task>(&self, task_id: Uuid, mut task: T) {
+        // Run each step individually and update the state after each step
+        while !task.completed() {
+            // Take a step
+            let mut retries = TASK_DRIVER_N_RETRIES;
+            while let Err(e) = task.step().await {
+                log::error!("error executing task step: {e:?}");
+                retries -= 1;
+
+                if retries == 0 {
+                    log::error!("retries exceeded... task failed");
+                    break;
+                }
+            }
+
+            // Update the state in the registry
+            let task_state = task.state();
+            {
+                *self.open_tasks.write().await.get_mut(&task_id).unwrap() = task_state.into()
+            } // open_tasks lock released
+        }
+    }
+}

--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::state::{new_async_shared, AsyncShared};
 
-use super::create_new_wallet::NewWalletTaskState;
+use super::{create_new_order::NewOrderTaskState, create_new_wallet::NewWalletTaskState};
 
 /// A type alias for the identifier underlying a task
 pub type TaskIdentifier = Uuid;
@@ -45,9 +45,12 @@ pub trait Task: Send {
 
 /// Defines a wrapper that allows state objects to be stored generically
 #[derive(Clone, Debug, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum StateWrapper {
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
+    /// The state object for the new order task
+    NewOrder(NewOrderTaskState),
 }
 
 /// Drives tasks to completion
@@ -114,6 +117,8 @@ impl TaskDriver {
                     log::error!("retries exceeded... task failed");
                     break 'outer;
                 }
+
+                log::info!("retrying task from state: {}", task.state())
             }
 
             // Update the state in the registry

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -15,6 +15,7 @@ use crate::SizedWallet;
 
 pub mod create_new_order;
 pub mod create_new_wallet;
+pub mod driver;
 
 // -----------
 // | Helpers |


### PR DESCRIPTION
### Purpose
This PR adds the `TaskDriver` abstraction, which tracks task state and drives tasks forward with retry logic. In testing the tasks already defined, the flows are flakey enough -- largely due to StarkNet API instability and the `starknet-rs` library being out of date -- that we need to retry certain parts of the task.

These tasks take a while however, and it's worth it to support partial retries from the get-go. For example, after awaiting transaction finality, looking up Merkle state sometimes fails with an unsupported deserialization. We'd not like to retry the entire flow of prove -> submit -> await finality.

### Testing
- Tested both `create_new_wallet` and `create_new_order` with retries