### PR TITLE
core: tasks: new-order: Complete `create-new-order` task

### DIFF
--- a/core/resources/wallets1.json
+++ b/core/resources/wallets1.json
@@ -64,7 +64,7 @@
             []
         ],
         "randomness": [
-            42
+            45
         ],
         "metadata": {
             "replicas": []

--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -260,16 +260,17 @@ impl OnChainEventListenerExecutor {
 
             // Skip this event if all Merkle events for this block have been consumed
             let last_consistent_block = self.merkle_last_consistent_block.load(Ordering::Relaxed);
-            if event.block_number <= last_consistent_block {
+            let event_block = event.block_number.unwrap_or(last_consistent_block);
+            if event_block <= last_consistent_block {
                 return Ok(());
             }
 
-            let block_number = BlockId::Number(event.block_number);
+            let block_number = BlockId::Number(event_block);
             self.handle_root_changed(block_number).await?;
 
             // Update the last consistent block
             self.merkle_last_consistent_block
-                .store(event.block_number, Ordering::Relaxed);
+                .store(event_block, Ordering::Relaxed);
         } else if key == *NULLIFIER_SPENT_EVENT_SELECTOR {
             // Parse the nullifier from the felt
             log::info!("Handling nullifier spent event");

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -289,6 +289,12 @@ impl RelayerState {
         }
     }
 
+    /// Update an existing wallet in the global state
+    pub async fn update_wallet(&self, wallet: Wallet) {
+        let mut locked_wallet_index = self.write_wallet_index().await;
+        locked_wallet_index.add_wallet(wallet);
+    }
+
     /// Mark an order pair as matched, this is both for bookkeeping and for
     /// order state updates that are available to the frontend
     pub async fn mark_order_pair_matched(&self, o1: OrderIdentifier, o2: OrderIdentifier) {


### PR DESCRIPTION
### Purpose
This PR completes the order creation task which:
1. Computes a proof of `VALID WALLET UPDATE`
2. Submits this on-chain and awaits transaction confirmation
3. Finds the updated Merkle path for the new wallet commitment
4. Re-prove `VALID COMMITMENTS` for each order in the wallet -- or prove it for the first time in the case that a new order is added
5. Update the global state with the newly updated orders.

### Testing
- Tested the following flow end-to-end:
    - Setup a counterparty on the network with an order resting on the book that matches the one I create later on
    - Created a new wallet via `POST /v0/wallet`
    - Created a new order via `POST /v0/wallet/:id/orders`
    - Verified that the new order was committed into the wallet, and submitted on-chain.
    - Verified that the resting order matched with the new order and the counterparties proved `VALID MATCH ENCRYPTION` for the match.