### PR TITLE
core: tasks: deposit-balance: Add balance deposit task

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,7 @@ matchit = "0.7"
 mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 num-bigint = { version = "0.4.3" }
+num-traits = "0.2"
 once_cell = "1.17"
 portpicker = "0.1"
 rand = { version = "0.8.5", features = ["getrandom"] }

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -34,10 +34,11 @@ use self::{
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     task::{GetTaskStatusHandler, GET_TASK_STATUS_ROUTE},
     wallet::{
-        CreateOrderHandler, CreateWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
-        GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler,
-        CREATE_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE,
-        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, WALLET_ORDERS_ROUTE,
+        CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler, GetBalanceByMintHandler,
+        GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler,
+        GetWalletHandler, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, GET_BALANCES_ROUTE,
+        GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+        WALLET_ORDERS_ROUTE,
     },
 };
 
@@ -248,6 +249,18 @@ impl HttpServer {
             Method::GET,
             GET_BALANCE_BY_MINT_ROUTE.to_string(),
             GetBalanceByMintHandler::new(global_state.clone()),
+        );
+
+        // The "/wallet/:id/balances/deposit" route
+        router.add_route(
+            Method::POST,
+            DEPOSIT_BALANCE_ROUTE.to_string(),
+            DepositBalanceHandler::new(
+                config.starknet_client.clone(),
+                global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
+            ),
         );
 
         // The "/wallet/:id/fees" route

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use crossbeam::channel::Sender as CrossbeamSender;
 use hyper::StatusCode;
+use tracing::log;
 
 use crate::{
     api_server::{
@@ -12,8 +13,9 @@ use crate::{
     external_api::{
         http::wallet::{
             CreateOrderRequest, CreateOrderResponse, CreateWalletRequest, CreateWalletResponse,
-            GetBalanceByMintResponse, GetBalancesResponse, GetFeesResponse, GetOrderByIdResponse,
-            GetOrdersResponse, GetWalletResponse,
+            DepositBalanceRequest, DepositBalanceResponse, GetBalanceByMintResponse,
+            GetBalancesResponse, GetFeesResponse, GetOrderByIdResponse, GetOrdersResponse,
+            GetWalletResponse,
         },
         types::{Balance, Wallet},
         EmptyRequestResponse,
@@ -42,6 +44,8 @@ pub(super) const GET_ORDER_BY_ID_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:or
 pub(super) const GET_BALANCES_ROUTE: &str = "/v0/wallet/:wallet_id/balances";
 /// Returns the balance associated with the given mint
 pub(super) const GET_BALANCE_BY_MINT_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint";
+/// Deposits an ERC-20 token into the darkpool
+pub(super) const DEPOSIT_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/deposit";
 /// Returns the fees within a given wallet
 pub(super) const GET_FEES_ROUTE: &str = "/v0/wallet/:wallet_id/fees";
 
@@ -418,6 +422,59 @@ impl TypedHandler for GetBalanceByMintHandler {
                 StatusCode::NOT_FOUND,
                 ERR_WALLET_NOT_FOUND.to_string(),
             ))
+        }
+    }
+}
+
+/// Handler for the POST /wallet/:id/balances/deposit route
+/// TODO: Remove this
+#[allow(unused)]
+pub struct DepositBalanceHandler {
+    /// A starknet client
+    starknet_client: StarknetClient,
+    /// A copy of the relayer-global state
+    global_state: RelayerState,
+    /// A sender to the proof manager's work queue, used to enqueue
+    /// proofs of `VALID NEW WALLET` and await their completion
+    proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    /// A copy of the task driver used for long-lived async workflows
+    task_driver: TaskDriver,
+}
+
+#[async_trait]
+impl TypedHandler for DepositBalanceHandler {
+    type Request = DepositBalanceRequest;
+    type Response = DepositBalanceResponse;
+
+    async fn handle_typed(
+        &self,
+        req: Self::Request,
+        params: UrlParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        // Parse the wallet ID from the params
+        let wallet_id = parse_wallet_id_from_params(&params)?;
+        log::info!("got request {req:?} for wallet {wallet_id}");
+
+        Err(ApiServerError::HttpStatusCode(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "not implemented".to_string(),
+        ))
+    }
+}
+
+impl DepositBalanceHandler {
+    /// Constructor
+    pub fn new(
+        starknet_client: StarknetClient,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+        task_driver: TaskDriver,
+    ) -> Self {
+        Self {
+            starknet_client,
+            global_state,
+            proof_manager_work_queue,
+            task_driver,
         }
     }
 }

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -1,10 +1,14 @@
 //! Groups API type definitions for wallet API operations
 
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    external_api::types::{Balance, Fee, Order, Wallet},
+    external_api::{
+        biguint_from_hex_string, biguint_to_hex_string,
+        types::{Balance, Fee, Order, Wallet},
+    },
     state::wallet::WalletIdentifier,
     tasks::driver::TaskIdentifier,
 };
@@ -93,6 +97,40 @@ pub struct GetBalancesResponse {
 pub struct GetBalanceByMintResponse {
     /// The requested balance
     pub balance: Balance,
+}
+
+/// The request type to deposit a balance into the darkpool
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DepositBalanceRequest {
+    /// The starknet account contract address to send the balance from
+    #[serde(
+        serialize_with = "biguint_to_hex_string",
+        deserialize_with = "biguint_from_hex_string"
+    )]
+    pub from_addr: BigUint,
+    /// The mint (ERC-20 contract address) of the token to deposit
+    #[serde(
+        serialize_with = "biguint_to_hex_string",
+        deserialize_with = "biguint_from_hex_string"
+    )]
+    pub mint: BigUint,
+    /// The amount of the token to deposit
+    pub amount: BigUint,
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type to a request to deposit into the darkpool
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DepositBalanceResponse {
+    /// The ID of the internal task created for this request
+    /// May be used by the client to query task status
+    pub task_id: TaskIdentifier,
 }
 
 // -------------------------

--- a/core/src/external_api/mod.rs
+++ b/core/src/external_api/mod.rs
@@ -1,7 +1,9 @@
 //! The API module defines messaging interfaces between p2p nodes
 #![deny(missing_docs)]
 
-use serde::{Deserialize, Serialize};
+use num_bigint::BigUint;
+use num_traits::Num;
+use serde::{de::Error as DeserializeError, Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod http;
 pub mod types;
@@ -10,3 +12,25 @@ pub mod websocket;
 /// An empty request/response type
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct EmptyRequestResponse;
+
+/// A helper to serialize a BigUint to a hex string
+pub fn biguint_to_hex_string<S>(val: &BigUint, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(&val.to_str_radix(16 /* radix */))
+}
+
+/// A helper to deserialize a BigUint from a hex string
+pub fn biguint_from_hex_string<'de, D>(d: D) -> Result<BigUint, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize as a string and remove "0x" if present
+    let hex_string = String::deserialize(d)?;
+    let hex_string = hex_string.strip_prefix("0x").unwrap_or(&hex_string);
+
+    BigUint::from_str_radix(hex_string, 16 /* radix */).map_err(|e| {
+        DeserializeError::custom(format!("error deserializing BigUint from hex string: {e}"))
+    })
+}

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -15,6 +15,7 @@ use crate::MERKLE_HEIGHT;
 
 pub mod client;
 pub mod error;
+pub mod types;
 
 lazy_static! {
     // -------------

--- a/core/src/starknet_client/types.rs
+++ b/core/src/starknet_client/types.rs
@@ -1,0 +1,64 @@
+//! Defines contract type bindings and helpers for interacting with them
+
+use crypto::fields::biguint_to_starknet_felt;
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use starknet::core::types::FieldElement as StarknetFieldElement;
+
+/// An external transfer tuple represents either a deposit or withdraw
+/// to/from the darkpool
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalTransfer {
+    /// The account contract address to deposit from or withdraw to
+    pub sender_address: BigUint,
+    /// The contract address of the ERC-20 token to deposit/withdraw
+    pub mint: BigUint,
+    /// The amount of the mint token to deposit/withdraw
+    pub amount: BigUint,
+    /// The direction of the transfer
+    pub direction: ExternalTransferDirection,
+}
+
+impl ExternalTransfer {
+    /// Constructor
+    pub fn new(
+        sender_address: BigUint,
+        mint: BigUint,
+        amount: BigUint,
+        direction: ExternalTransferDirection,
+    ) -> Self {
+        Self {
+            sender_address,
+            mint,
+            amount,
+            direction,
+        }
+    }
+}
+
+/// A serialization implementation in the format that the Starknet client expects
+impl From<ExternalTransfer> for Vec<StarknetFieldElement> {
+    fn from(transfer: ExternalTransfer) -> Self {
+        vec![
+            biguint_to_starknet_felt(&transfer.sender_address),
+            biguint_to_starknet_felt(&transfer.mint),
+            biguint_to_starknet_felt(&transfer.amount),
+            transfer.direction.into(),
+        ]
+    }
+}
+
+/// Represents the direction (deposit/withdraw) of a transfer
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ExternalTransferDirection {
+    /// Deposit an ERC20 into the darkpool from an external address
+    Deposit = 0,
+    /// Withdraw an ERC20 from the darkpool to an external address
+    Withdrawal,
+}
+
+impl From<ExternalTransferDirection> for StarknetFieldElement {
+    fn from(dir: ExternalTransferDirection) -> Self {
+        StarknetFieldElement::from(dir as u8)
+    }
+}

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -419,6 +419,41 @@ impl Wallet {
         let staleness = self.proof_staleness.load(Ordering::Relaxed);
         staleness > *STALENESS_THRESHOLD
     }
+
+    /// Get the balance, fee, and fee_balance for an order by specifying the order directly
+    ///
+    /// This is useful for new orders that come in, and are not yet indexed in the global state
+    pub fn get_balance_and_fee_for_order(&self, order: &Order) -> Option<(Balance, Fee, Balance)> {
+        // The mint the local party will be spending if the order is matched
+        let order_mint = match order.side {
+            OrderSide::Buy => order.quote_mint.clone(),
+            OrderSide::Sell => order.base_mint.clone(),
+        };
+
+        // The maximum quantity of the mint that the local party will be spending
+        let order_amount = match order.side {
+            OrderSide::Buy => {
+                let res_amount = (order.amount as f64) * order.price.to_f64();
+                res_amount as u64
+            }
+            OrderSide::Sell => order.amount,
+        };
+
+        // Find a balance and fee to associate with this order
+        // Choose the first fee for simplicity
+        let balance = self.balances.get(&order_mint)?;
+        if balance.amount < order_amount {
+            return None;
+        }
+
+        let fee = self.fees.get(0 /* index */)?;
+        let fee_balance = self.balances.get(&fee.gas_addr.clone())?;
+        if fee_balance.amount < fee.gas_token_amount {
+            return None;
+        }
+
+        Some((balance.clone(), fee.clone(), fee_balance.clone()))
+    }
 }
 
 /// Metadata relevant to the wallet's network state
@@ -526,58 +561,11 @@ impl WalletIndex {
         wallet_id: &Uuid,
         order_id: &OrderIdentifier,
     ) -> Option<(Order, Balance, Fee, Balance)> {
-        let order = {
-            self.read_wallet(wallet_id)
-                .await?
-                .orders
-                .get(order_id)?
-                .clone()
-        };
-        let (balance, fee, fee_balance) = self
-            .get_balance_and_fee_for_order(wallet_id, &order)
-            .await?;
+        let locked_wallet = self.read_wallet(wallet_id).await?;
+        let order = locked_wallet.orders.get(order_id)?.clone();
+        let (balance, fee, fee_balance) = locked_wallet.get_balance_and_fee_for_order(&order)?;
 
         Some((order, balance, fee, fee_balance))
-    }
-
-    /// Get the balance, fee, and fee_balance for an order by specifying the order directly
-    ///
-    /// This is useful for new orders that come in, and are not yet indexed in the global state
-    pub async fn get_balance_and_fee_for_order(
-        &self,
-        wallet_id: &WalletIdentifier,
-        order: &Order,
-    ) -> Option<(Balance, Fee, Balance)> {
-        // The mint the local party will be spending if the order is matched
-        let order_mint = match order.side {
-            OrderSide::Buy => order.quote_mint.clone(),
-            OrderSide::Sell => order.base_mint.clone(),
-        };
-
-        // The maximum quantity of the mint that the local party will be spending
-        let order_amount = match order.side {
-            OrderSide::Buy => {
-                let res_amount = (order.amount as f64) * order.price.to_f64();
-                res_amount as u64
-            }
-            OrderSide::Sell => order.amount,
-        };
-
-        // Find a balance and fee to associate with this order
-        // Choose the first fee for simplicity
-        let locked_wallet = self.read_wallet(wallet_id).await?;
-        let balance = locked_wallet.balances.get(&order_mint)?;
-        if balance.amount < order_amount {
-            return None;
-        }
-
-        let fee = locked_wallet.fees.get(0 /* index */)?;
-        let fee_balance = locked_wallet.balances.get(&fee.gas_addr.clone())?;
-        if fee_balance.amount < fee.gas_token_amount {
-            return None;
-        }
-
-        Some((balance.clone(), fee.clone(), fee_balance.clone()))
     }
 
     // -----------

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -40,7 +40,7 @@ use crate::{
 
 use super::{
     driver::{StateWrapper, Task},
-    encrypt_wallet,
+    encrypt_wallet, RANDOMNESS_INCREMENT,
 };
 
 /// The wallet does not have a merkle proof attached to it
@@ -51,8 +51,6 @@ const ERR_TRANSACTION_FAILED: &str = "transaction rejected";
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found in state";
 /// The order creation task name
 const NEW_ORDER_TASK_NAME: &str = "create-new-order";
-/// The amount to increment the randomness each time a wallet is nullified
-const RANDOMNESS_INCREMENT: u8 = 2;
 
 /// Helper function to get the current UNIX epoch time in milliseconds
 pub fn get_current_time() -> u128 {

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -294,13 +294,13 @@ impl NewOrderTask {
         let encrypted_wallet = encrypt_wallet(self.new_wallet.clone().into(), &pk_view);
 
         // Submit on-chain
-        // TODO: Remove this
         let tx_hash = self
             .starknet_client
             .update_wallet(
                 self.new_wallet.get_commitment(),
                 self.old_wallet.get_match_nullifier(),
                 self.old_wallet.get_spend_nullifier(),
+                None, /* external_transfer */
                 encrypted_wallet,
                 proof,
             )

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -356,7 +356,6 @@ impl NewOrderTask {
             let witness = if let Some(witness) = self
                 .get_witness_for_order(
                     &order_id,
-                    &self.new_wallet.wallet_id,
                     order,
                     circuit_wallet.clone(),
                     wallet_opening.clone(),
@@ -414,7 +413,6 @@ impl NewOrderTask {
     async fn get_witness_for_order(
         &self,
         order_id: &OrderIdentifier,
-        wallet_id: &WalletIdentifier,
         order: CircuitOrder,
         wallet: SizedWallet,
         wallet_opening: MerkleOpening,
@@ -436,12 +434,8 @@ impl NewOrderTask {
         } else {
             // Otherwise, create a brand new witness
             // Select a balance and fee for the order
-            let (balance, fee, fee_balance) = self
-                .global_state
-                .read_wallet_index()
-                .await
-                .get_balance_and_fee_for_order(wallet_id, &order)
-                .await?;
+            let (balance, fee, fee_balance) =
+                self.new_wallet.get_balance_and_fee_for_order(&order)?;
 
             Some(SizedValidCommitmentsWitness {
                 wallet,

--- a/core/src/tasks/deposit_balance.rs
+++ b/core/src/tasks/deposit_balance.rs
@@ -1,0 +1,145 @@
+//! Defines a task that submits a transaction transferring an ERC20 token into
+//! an existing darkpool wallet
+//!
+//! This involves proving `VALID WALLET UPDATE`, submitting on-chain, and re-indexing state
+
+// TODO: Remove this
+#![allow(unused)]
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use async_trait::async_trait;
+use crossbeam::channel::Sender as CrossbeamSender;
+use num_bigint::BigUint;
+use serde::Serialize;
+
+use crate::{
+    proof_generation::jobs::{ProofManagerJob, ValidWalletUpdateBundle},
+    starknet_client::client::StarknetClient,
+    state::RelayerState,
+};
+
+use super::driver::{StateWrapper, Task};
+
+/// The display name of the task
+const DEPOSIT_BALANCE_TASK_NAME: &str = "deposit-balance";
+
+/// Defines the long running flow for adding a balance to a wallet
+pub struct DepositBalanceTask {
+    /// The ERC20 address of the token to deposit
+    pub mint: BigUint,
+    /// The amount of the token to deposit
+    pub amount: BigUint,
+    /// The address to deposit from
+    pub sender_address: BigUint,
+    /// The starknet client to use for submitting transactions
+    pub starknet_client: StarknetClient,
+    /// A copy of the relayer-global state
+    pub global_state: RelayerState,
+    /// The work queue to add proof management jobs to
+    pub proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    /// The state of the task
+    pub state: DepositBalanceTaskState,
+}
+
+/// The error type for the deposit balance task
+#[derive(Clone, Debug)]
+pub enum DepositBalanceTaskError {
+    /// Error generating a proof of `VALID WALLET UPDATE`
+    ProofGeneration(String),
+}
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Defines the state of the deposit balance task
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum DepositBalanceTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is awaiting a proof of `VALID WALLET UPDATE` from
+    /// the proof management worker
+    Proving,
+    /// The task is submitting the transaction to the contract and awaiting
+    /// transaction finality
+    SubmittingTx {
+        /// The proof of `VALID WALLET UPDATE` submitted to the contract
+        proof_bundle: ValidWalletUpdateBundle,
+    },
+    /// The task has finished
+    Completed,
+}
+
+impl Display for DepositBalanceTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::SubmittingTx { .. } => write!(f, "SubmittingTx"),
+            _ => write!(f, "{self:?}"),
+        }
+    }
+}
+
+impl Serialize for DepositBalanceTaskState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl From<DepositBalanceTaskState> for StateWrapper {
+    fn from(state: DepositBalanceTaskState) -> Self {
+        StateWrapper::DepositBalance(state)
+    }
+}
+
+#[async_trait]
+impl Task for DepositBalanceTask {
+    type Error = DepositBalanceTaskError;
+    type State = DepositBalanceTaskState;
+
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("")
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self.state(), Self::State::Completed)
+    }
+
+    fn state(&self) -> Self::State {
+        self.state.clone()
+    }
+
+    fn name(&self) -> String {
+        DEPOSIT_BALANCE_TASK_NAME.to_string()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl DepositBalanceTask {
+    /// Constructor
+    pub fn new(
+        mint: BigUint,
+        amount: BigUint,
+        sender_address: BigUint,
+        starknet_client: StarknetClient,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    ) -> Self {
+        Self {
+            mint,
+            amount,
+            sender_address,
+            starknet_client,
+            global_state,
+            proof_manager_work_queue,
+            state: DepositBalanceTaskState::Pending,
+        }
+    }
+}

--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -12,7 +12,10 @@ use uuid::Uuid;
 
 use crate::state::{new_async_shared, AsyncShared};
 
-use super::{create_new_order::NewOrderTaskState, create_new_wallet::NewWalletTaskState};
+use super::{
+    create_new_order::NewOrderTaskState, create_new_wallet::NewWalletTaskState,
+    deposit_balance::DepositBalanceTaskState,
+};
 
 /// A type alias for the identifier underlying a task
 pub type TaskIdentifier = Uuid;
@@ -52,6 +55,8 @@ pub trait Task: Send {
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "task_type", content = "state")]
 pub enum StateWrapper {
+    /// The state object for the deposit balance task
+    DepositBalance(DepositBalanceTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
     /// The state object for the new order task
@@ -92,7 +97,7 @@ impl TaskDriver {
     /// Spawn a new task in the driver
     ///
     /// Returns the ID of the task being spawned
-    pub async fn run<T: Task + 'static>(&self, task: T) -> Uuid {
+    pub async fn start_task<T: Task + 'static>(&self, task: T) -> Uuid {
         // Add the task to the bookkeeping structure
         let task_id = Uuid::new_v4();
         {

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -18,6 +18,9 @@ pub mod create_new_wallet;
 pub mod deposit_balance;
 pub mod driver;
 
+/// The amount to increment the randomness each time a wallet is nullified
+pub(self) const RANDOMNESS_INCREMENT: u8 = 2;
+
 // -----------
 // | Helpers |
 // -----------

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -15,6 +15,7 @@ use crate::SizedWallet;
 
 pub mod create_new_order;
 pub mod create_new_wallet;
+pub mod deposit_balance;
 pub mod driver;
 
 // -----------


### PR DESCRIPTION
### Purpose
This PR adds the initial implementation of the `deposit-balance` relayer task. This is the entrypoint of ERC20 tokens into the darkpool. The user submits this request to the relayer after finalizing an ERC20 allowance for the contract to custody the token. The relayer then:
- Proves `VALID WALLET UPDATE` for the wallet state transition
- Submits an `update_wallet` transaction to the contract
- Awaits finality and looks up the new Merkle authentication path for the wallet
- Re-proves `VALID COMMITMENTS` for each order in the wallet
- Indexes the new state

### Testing
- Tested the end-to-end flow
- TODO: Test the full user onboarding flow: wallet create -> deposit -> order create -> match.