### PR TITLE
core: api-server: http: Add `/wallet/:id/balances/:mint/withdraw` handler

### DIFF
--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -20,11 +20,11 @@ use crate::{
         EmptyRequestResponse,
     },
     proof_generation::jobs::ProofManagerJob,
-    starknet_client::client::StarknetClient,
+    starknet_client::{client::StarknetClient, types::ExternalTransferDirection},
     state::RelayerState,
     tasks::{
-        create_new_order::NewOrderTask, create_new_wallet::NewWalletTask,
-        deposit_balance::DepositBalanceTask, driver::TaskDriver,
+        create_new_order::NewOrderTask, create_new_wallet::NewWalletTask, driver::TaskDriver,
+        external_transfer::ExternalTransferTask,
     },
 };
 
@@ -474,10 +474,11 @@ impl TypedHandler for DepositBalanceHandler {
         let wallet_id = parse_wallet_id_from_params(&params)?;
 
         // Begin a task
-        let task = DepositBalanceTask::new(
+        let task = ExternalTransferTask::new(
             req.mint,
             req.amount,
             req.from_addr,
+            ExternalTransferDirection::Deposit,
             &wallet_id,
             self.starknet_client.clone(),
             self.global_state.clone(),
@@ -541,10 +542,11 @@ impl TypedHandler for WithdrawBalanceHandler {
         let mint = parse_mint_from_params(&params)?;
 
         // Begin a task
-        let task = DepositBalanceTask::new(
+        let task = ExternalTransferTask::new(
             mint,
-            0u8.into(),
+            req.amount,
             req.destination_addr,
+            ExternalTransferDirection::Withdrawal,
             &wallet_id,
             self.starknet_client.clone(),
             self.global_state.clone(),

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -133,6 +133,33 @@ pub struct DepositBalanceResponse {
     pub task_id: TaskIdentifier,
 }
 
+/// The request type to withdraw a balance from the Darkpool
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WithdrawBalanceRequest {
+    /// The destination address to withdraw the balance to
+    #[serde(
+        serialize_with = "biguint_to_hex_string",
+        deserialize_with = "biguint_from_hex_string"
+    )]
+    pub destination_addr: BigUint,
+    /// The amount of the token to withdraw
+    pub amount: BigUint,
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type to a request to withdraw a balance
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WithdrawBalanceResponse {
+    /// The ID of the task allocated for this operation
+    pub task_id: TaskIdentifier,
+}
+
 // -------------------------
 // | Wallet Fees API Types |
 // -------------------------

--- a/core/src/starknet_client/types.rs
+++ b/core/src/starknet_client/types.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crypto::fields::{biguint_to_starknet_felt, u128_to_starknet_felt};
+use curve25519_dalek::scalar::Scalar;
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -65,7 +66,7 @@ impl From<ExternalTransfer> for Vec<StarknetFieldElement> {
 }
 
 /// Represents the direction (deposit/withdraw) of a transfer
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum ExternalTransferDirection {
     /// Deposit an ERC20 into the darkpool from an external address
     Deposit = 0,
@@ -76,6 +77,12 @@ pub enum ExternalTransferDirection {
 impl From<ExternalTransferDirection> for StarknetFieldElement {
     fn from(dir: ExternalTransferDirection) -> Self {
         StarknetFieldElement::from(dir as u8)
+    }
+}
+
+impl From<ExternalTransferDirection> for Scalar {
+    fn from(dir: ExternalTransferDirection) -> Self {
+        Scalar::from(dir as u8)
     }
 }
 

--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -14,7 +14,7 @@ use crate::state::{new_async_shared, AsyncShared};
 
 use super::{
     create_new_order::NewOrderTaskState, create_new_wallet::NewWalletTaskState,
-    deposit_balance::DepositBalanceTaskState,
+    external_transfer::ExternalTransferTaskState,
 };
 
 /// A type alias for the identifier underlying a task
@@ -56,7 +56,7 @@ pub trait Task: Send {
 #[serde(tag = "task_type", content = "state")]
 pub enum StateWrapper {
     /// The state object for the deposit balance task
-    DepositBalance(DepositBalanceTaskState),
+    ExternalTransfer(ExternalTransferTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
     /// The state object for the new order task

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -15,8 +15,8 @@ use crate::SizedWallet;
 
 pub mod create_new_order;
 pub mod create_new_wallet;
-pub mod deposit_balance;
 pub mod driver;
+pub mod external_transfer;
 
 /// The amount to increment the randomness each time a wallet is nullified
 pub(self) const RANDOMNESS_INCREMENT: u8 = 2;


### PR DESCRIPTION
### Purpose
This PR adds the `/wallet/:id/balances/:mint/withdraw` endpoint and handler. This handler follows a similar flow to the deposit handler, except that the direction on the external transfer tuple is flipped (0 = deposit, 1 = withdraw). So, this PR simply changes the deposit handler to be generic over deposit/withdraw.

### Testing
- Tested the following flow:
    - Deposited into a Darkpool wallet, verified ERC20 balances visible on-chain decremented for the originating wallet.
    - Withdrew the balance back from the darkpool to the wallet, verified that ERC20 balances visible on-chain returned to their original values