### PR TITLE
core: tasks: lookup-wallet: Add API to lookup wallet in contract storage

### DIFF
--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -51,6 +51,13 @@ pub struct Order {
     pub timestamp: u64,
 }
 
+impl Order {
+    /// Whether or not this is the zero'd order
+    pub fn is_default(&self) -> bool {
+        self.eq(&Self::default())
+    }
+}
+
 /// Convert a vector of u64s to an Order
 impl TryFrom<&[u64]> for Order {
     type Error = TypeConversionError;

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -35,11 +35,12 @@ use self::{
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     task::{GetTaskStatusHandler, GET_TASK_STATUS_ROUTE},
     wallet::{
-        CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler, GetBalanceByMintHandler,
-        GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler,
-        GetWalletHandler, WithdrawBalanceHandler, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE,
-        GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE, GET_ORDER_BY_ID_ROUTE,
-        GET_WALLET_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
+        CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler, FindWalletHandler,
+        GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler, GetOrderByIdHandler,
+        GetOrdersHandler, GetWalletHandler, WithdrawBalanceHandler, CREATE_WALLET_ROUTE,
+        DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE,
+        GET_FEES_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, WALLET_ORDERS_ROUTE,
+        WITHDRAW_BALANCE_ROUTE,
     },
 };
 
@@ -214,6 +215,18 @@ impl HttpServer {
             CreateWalletHandler::new(
                 config.starknet_client.clone(),
                 global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
+            ),
+        );
+
+        // The "/wallet/lookup" route
+        router.add_route(
+            Method::POST,
+            FIND_WALLET_ROUTE.to_string(),
+            FindWalletHandler::new(
+                config.starknet_client.clone(),
+                config.global_state.clone(),
                 config.proof_generation_work_queue.clone(),
                 config.task_driver.clone(),
             ),

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -25,7 +25,7 @@ use crate::{
     state::RelayerState,
     tasks::{
         create_new_order::NewOrderTask, create_new_wallet::NewWalletTask, driver::TaskDriver,
-        external_transfer::ExternalTransferTask,
+        external_transfer::ExternalTransferTask, lookup_wallet::LookupWalletTask,
     },
 };
 
@@ -214,9 +214,14 @@ impl TypedHandler for FindWalletHandler {
         // Create a task in thew driver to find and prove validity for
         // the wallet
         let wallet_id = Uuid::new_v4();
-        let task_id = Uuid::new_v4();
+        let task = LookupWalletTask::new(
+            req.key_chain,
+            self.starknet_client.clone(),
+            self.global_state.clone(),
+            self.proof_manager_work_queue.clone(),
+        );
+        let task_id = self.task_driver.start_task(task).await;
 
-        // TODO: Create task and start it
         Ok(FindWalletResponse { wallet_id, task_id })
     }
 }

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -215,6 +215,7 @@ impl TypedHandler for FindWalletHandler {
         // the wallet
         let wallet_id = Uuid::new_v4();
         let task = LookupWalletTask::new(
+            wallet_id,
             req.key_chain,
             self.starknet_client.clone(),
             self.global_state.clone(),

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use crossbeam::channel::Sender as CrossbeamSender;
 use hyper::StatusCode;
-use uuid::Uuid;
 
 use crate::{
     api_server::{
@@ -213,9 +212,8 @@ impl TypedHandler for FindWalletHandler {
     ) -> Result<Self::Response, ApiServerError> {
         // Create a task in thew driver to find and prove validity for
         // the wallet
-        let wallet_id = Uuid::new_v4();
         let task = LookupWalletTask::new(
-            wallet_id,
+            req.wallet_id,
             req.key_chain,
             self.starknet_client.clone(),
             self.global_state.clone(),
@@ -223,7 +221,10 @@ impl TypedHandler for FindWalletHandler {
         );
         let task_id = self.task_driver.start_task(task).await;
 
-        Ok(FindWalletResponse { wallet_id, task_id })
+        Ok(FindWalletResponse {
+            wallet_id: req.wallet_id,
+            task_id,
+        })
     }
 }
 

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::{
     external_api::{
         biguint_from_hex_string, biguint_to_hex_string,
-        types::{Balance, Fee, Order, Wallet},
+        types::{Balance, Fee, KeyChain, Order, Wallet},
     },
     state::wallet::WalletIdentifier,
     tasks::driver::TaskIdentifier,
@@ -35,9 +35,25 @@ pub struct CreateWalletRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateWalletResponse {
     /// The wallet identifier provisioned for the new wallet
-    pub id: WalletIdentifier,
+    pub wallet_id: WalletIdentifier,
     /// The system-internal task ID that the client may use to query
     /// task status
+    pub task_id: TaskIdentifier,
+}
+
+/// The request type to find a wallet in contract storage and begin managing it
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FindWalletRequest {
+    /// The keychain to use for management after the wallet is found
+    pub key_chain: KeyChain,
+}
+
+/// The response type to a request to find a wallet in contract storage
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FindWalletResponse {
+    /// The ID provisioned as a handle for the wallet
+    pub wallet_id: WalletIdentifier,
+    /// The ID of the task created on behalf of this request
     pub task_id: TaskIdentifier,
 }
 

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -44,6 +44,8 @@ pub struct CreateWalletResponse {
 /// The request type to find a wallet in contract storage and begin managing it
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FindWalletRequest {
+    /// The ID to handle the wallet by
+    pub wallet_id: WalletIdentifier,
     /// The keychain to use for management after the wallet is found
     pub key_chain: KeyChain,
 }
@@ -51,7 +53,7 @@ pub struct FindWalletRequest {
 /// The response type to a request to find a wallet in contract storage
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FindWalletResponse {
-    /// The ID provisioned as a handle for the wallet
+    /// The ID to handle the wallet by
     pub wallet_id: WalletIdentifier,
     /// The ID of the task created on behalf of this request
     pub task_id: TaskIdentifier,

--- a/core/src/external_api/types.rs
+++ b/core/src/external_api/types.rs
@@ -130,22 +130,8 @@ impl From<Wallet> for IndexedWallet {
             orders,
             balances,
             fees,
-            public_keys: IndexedKeychain {
-                pk_root: biguint_to_scalar(&wallet.key_chain.public_keys.pk_root),
-                pk_match: biguint_to_scalar(&wallet.key_chain.public_keys.pk_match),
-                pk_settle: biguint_to_scalar(&wallet.key_chain.public_keys.pk_settle),
-                pk_view: biguint_to_scalar(&wallet.key_chain.public_keys.pk_view),
-            },
-            secret_keys: IndexedPrivateKeychain {
-                sk_root: wallet
-                    .key_chain
-                    .secret_keys
-                    .sk_root
-                    .map(|key| biguint_to_scalar(&key)),
-                sk_match: biguint_to_scalar(&wallet.key_chain.secret_keys.sk_match),
-                sk_settle: biguint_to_scalar(&wallet.key_chain.secret_keys.sk_settle),
-                sk_view: biguint_to_scalar(&wallet.key_chain.secret_keys.sk_view),
-            },
+            public_keys: wallet.key_chain.public_keys.into(),
+            secret_keys: wallet.key_chain.secret_keys.into(),
             randomness: wallet.randomness,
             metadata: WalletMetadata::default(),
             proof_staleness: AtomicU32::new(0),
@@ -342,6 +328,17 @@ pub struct PublicKeys {
     pub pk_view: BigUint,
 }
 
+impl From<PublicKeys> for IndexedKeychain {
+    fn from(keys: PublicKeys) -> Self {
+        IndexedKeychain {
+            pk_root: biguint_to_scalar(&keys.pk_root),
+            pk_match: biguint_to_scalar(&keys.pk_match),
+            pk_settle: biguint_to_scalar(&keys.pk_settle),
+            pk_view: biguint_to_scalar(&keys.pk_view),
+        }
+    }
+}
+
 /// The set of secret keys for a wallet
 ///
 /// Note that `sk_root` may be unknown as a relayer that holds `sk_root` is said
@@ -375,6 +372,17 @@ pub struct SecretKeys {
         deserialize_with = "biguint_from_hex_string"
     )]
     pub sk_view: BigUint,
+}
+
+impl From<SecretKeys> for IndexedPrivateKeychain {
+    fn from(keys: SecretKeys) -> Self {
+        IndexedPrivateKeychain {
+            sk_root: keys.sk_root.map(|key| biguint_to_scalar(&key)),
+            sk_match: biguint_to_scalar(&keys.sk_match),
+            sk_settle: biguint_to_scalar(&keys.sk_settle),
+            sk_view: biguint_to_scalar(&keys.sk_view),
+        }
+    }
 }
 
 // ------------------------

--- a/core/src/starknet_client/client.rs
+++ b/core/src/starknet_client/client.rs
@@ -500,6 +500,7 @@ impl StarknetClient {
     /// TODO: Add proof and wallet encryption under pk_view to the contract
     pub async fn new_wallet(
         &self,
+        pk_view: Scalar,
         wallet_commitment: WalletCommitment,
         wallet_ciphertext: Vec<ElGamalCiphertext>,
         valid_wallet_create: ValidWalletCreateBundle,
@@ -510,7 +511,10 @@ impl StarknetClient {
         );
 
         // Reduce the wallet commitment mod the Starknet field
-        let mut calldata = vec![Self::reduce_scalar_to_felt(&wallet_commitment)];
+        let mut calldata = vec![
+            Self::reduce_scalar_to_felt(&pk_view),
+            Self::reduce_scalar_to_felt(&wallet_commitment),
+        ];
         // Pack the ciphertext into a list of felts
         calldata.append(&mut pack_serializable!(wallet_ciphertext));
         // Pack the proof into a list of felts
@@ -531,9 +535,11 @@ impl StarknetClient {
     ///
     /// Returns the transaction hash of the `update_wallet` call
     ///
-    /// TODO: Add internal/external transfers
+    /// TODO: Add internal
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_wallet(
         &self,
+        pk_view: Scalar,
         new_wallet_commitment: WalletCommitment,
         old_match_nullifier: Nullifier,
         old_spend_nullifier: Nullifier,
@@ -542,6 +548,7 @@ impl StarknetClient {
         valid_wallet_update: ValidWalletUpdateBundle,
     ) -> Result<TransactionHash, StarknetClientError> {
         let mut calldata = vec![
+            Self::reduce_scalar_to_felt(&pk_view),
             Self::reduce_scalar_to_felt(&new_wallet_commitment),
             Self::reduce_scalar_to_felt(&old_match_nullifier),
             Self::reduce_scalar_to_felt(&old_spend_nullifier),
@@ -623,8 +630,10 @@ impl StarknetClient {
     /// Submit a `settle` transaction to the contract
     ///
     /// Returns the transaction hash of the call
+    #[allow(clippy::too_many_arguments)]
     pub async fn submit_settle(
         &self,
+        pk_view: Scalar,
         new_wallet_commit: WalletCommitment,
         old_match_nullifier: Nullifier,
         old_spend_nullifier: Nullifier,
@@ -633,6 +642,7 @@ impl StarknetClient {
         proof: ValidSettleBundle,
     ) -> Result<TransactionHash, StarknetClientError> {
         let mut calldata = vec![
+            Self::reduce_scalar_to_felt(&pk_view),
             StarknetFieldElement::from(0u8), // from_internal_transfer
             Self::reduce_scalar_to_felt(&new_wallet_commit),
             Self::reduce_scalar_to_felt(&old_match_nullifier),

--- a/core/src/starknet_client/helpers.rs
+++ b/core/src/starknet_client/helpers.rs
@@ -1,0 +1,175 @@
+//! Various helpers for Starknet client execution
+
+use std::{convert::TryInto, iter};
+
+use crypto::elgamal::ElGamalCiphertext;
+use itertools::Itertools;
+use starknet::core::types::FieldElement as StarknetFieldElement;
+
+use crate::starknet_client::{NEW_WALLET_SELECTOR, SETTLE_SELECTOR, UPDATE_WALLET_SELECTOR};
+
+use super::error::StarknetClientError;
+
+/// The number of bytes we can pack into a given Starknet field element
+///
+/// The starknet field is of size 2 ** 251 + \delta, which fits at most
+/// 31 bytes cleanly into a single felt
+const BYTES_PER_FELT: usize = 31;
+/// The index of the `encryption_blob_len` parameter in the `new_wallet` calldata
+const NEW_WALLET_ENCRYPTION_BLOB_IDX: usize = 2;
+/// The index of the `internal_transfer_ciphertext_len` argument in the `update_wallet` calldata
+const UPDATE_WALLET_INTERNAL_TRANSFER_IDX: usize = 4;
+/// The index of the `wallet_ciphertext_len` argument in the `settle` calldata
+const SETTLE_WALLET_CIPHERTEXT_IDX: usize = 6;
+
+/// Error thrown when a blob is not properly encoded
+const ERR_INVALID_BLOB_ENCODING: &str = "invalid blob encoding";
+/// Error thrown when an invalid selector is encountered observing a transaction's details
+const ERR_INVALID_SELECTOR: &str = "invalid selector received";
+
+/// A helper to parse a ciphertext blob from transaction calldata
+pub(super) fn parse_ciphertext_from_calldata(
+    selector: StarknetFieldElement,
+    calldata: &[StarknetFieldElement],
+) -> Result<Vec<ElGamalCiphertext>, StarknetClientError> {
+    // Parse the ciphertext blob from the calldata
+    let blob = match selector {
+        _ if selector == *NEW_WALLET_SELECTOR => parse_ciphertext_new_wallet(calldata),
+        _ if selector == *UPDATE_WALLET_SELECTOR => parse_ciphertext_update_wallet(calldata),
+        _ if selector == *SETTLE_SELECTOR => parse_ciphertext_settle(calldata),
+        _ => {
+            return Err(StarknetClientError::NotFound(
+                ERR_INVALID_SELECTOR.to_string(),
+            ));
+        }
+    };
+
+    // Parse a packed ciphertext from the calldata
+    ciphertext_vec_from_felt_blob(&blob)
+}
+
+/// Parse a ciphertext blob from a `new_wallet` transaction
+fn parse_ciphertext_new_wallet(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
+    let blob_len: u64 = calldata[NEW_WALLET_ENCRYPTION_BLOB_IDX].try_into().unwrap();
+    let start_idx = NEW_WALLET_ENCRYPTION_BLOB_IDX + 1;
+    let end_idx = start_idx + (blob_len as usize);
+    calldata[start_idx..end_idx].to_vec()
+}
+
+/// Parse a ciphertext blob from an `update_wallet` transaction
+fn parse_ciphertext_update_wallet(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
+    // Read through the internal ciphertext
+    let mut cursor = UPDATE_WALLET_INTERNAL_TRANSFER_IDX;
+    let internal_wallet_ciphertext_len: u64 = calldata[cursor].try_into().unwrap();
+    cursor += (internal_wallet_ciphertext_len as usize) + 1;
+
+    // Read through the external transfers
+    let external_transfers_len: u64 = calldata[cursor].try_into().unwrap();
+    cursor += (external_transfers_len as usize) + 1;
+
+    // The next argument is the ciphertext blob length
+    let ciphertext_blob_len: u64 = calldata[cursor].try_into().unwrap();
+    let start_idx: usize = cursor + 1;
+    let end_idx: usize = start_idx + (ciphertext_blob_len as usize);
+
+    calldata[start_idx..end_idx].to_vec()
+}
+
+/// Parse a ciphertext blob from a `settle` transaction
+fn parse_ciphertext_settle(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
+    let blob_len: u64 = calldata[SETTLE_WALLET_CIPHERTEXT_IDX].try_into().unwrap();
+    let start_idx = SETTLE_WALLET_CIPHERTEXT_IDX + 1;
+    let end_idx = start_idx + (blob_len as usize);
+
+    calldata[start_idx..end_idx].to_vec()
+}
+
+/// Pack bytes into Starknet field elements
+pub(super) fn pack_bytes_into_felts(bytes: &[u8]) -> Vec<StarknetFieldElement> {
+    // Run-length encoded
+    let mut res = vec![StarknetFieldElement::from(bytes.len() as u64)];
+    for i in (0..bytes.len()).step_by(BYTES_PER_FELT) {
+        // Construct a felt from bytes [i..i+BYTES_PER_FELT], padding
+        // to 32 in length
+        let range_end = usize::min(i + BYTES_PER_FELT, bytes.len());
+        let mut bytes_padded: Vec<u8> = bytes[i..range_end]
+            .iter()
+            .cloned()
+            .chain(iter::repeat(0u8))
+            .take(32)
+            .collect_vec();
+
+        // We pack into the felt in little endian format so that the felt does
+        // not overflow the field size
+        bytes_padded.reverse();
+
+        // Cast to array
+        let bytes_padded: [u8; 32] = bytes_padded.try_into().unwrap();
+        res.push(StarknetFieldElement::from_bytes_be(&bytes_padded).unwrap());
+    }
+
+    res
+}
+
+/// Deserialization from packed felts into a vector of ElGamal ciphertexts
+///
+/// When we pack the ciphertext into blob format for submission to the contract, we
+/// byte serialize the ciphertext vector, then pack the bytes into felts. The
+/// deserialization process is the opposite, chunk up the felts into byte windows,
+/// then concatenate these and deserialize explicitly into a `Vec<ElGamalCiphertext>`
+fn ciphertext_vec_from_felt_blob(
+    blob: &[StarknetFieldElement],
+) -> Result<Vec<ElGamalCiphertext>, StarknetClientError> {
+    let n_bytes: u64 = blob[0]
+        .try_into()
+        .map_err(|_| StarknetClientError::Serde(ERR_INVALID_BLOB_ENCODING.to_string()))?;
+
+    // Build a byte array from the calldata blob
+    let mut byte_array: Vec<u8> = Vec::with_capacity(BYTES_PER_FELT * blob.len());
+    for felt in blob[1..].iter() {
+        let mut bytes = felt.to_bytes_be();
+        // We pack bytes into the felts in little endian order to avoid
+        // field overflows. So reverse into little endian then truncate
+        bytes.reverse();
+
+        byte_array.append(&mut bytes[..BYTES_PER_FELT].to_vec());
+    }
+
+    // Deserialize the byte array back into a ciphertext vector
+    let truncated_bytes = &byte_array[..(n_bytes as usize)];
+    serde_json::from_slice(truncated_bytes)
+        .map_err(|err| StarknetClientError::Serde(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::elgamal::ElGamalCiphertext;
+    use curve25519_dalek::scalar::Scalar;
+    use rand_core::OsRng;
+
+    use super::{ciphertext_vec_from_felt_blob, pack_bytes_into_felts};
+
+    /// Tests serializing and deserializing a ciphertext blob as a packed array
+    /// of felts
+    #[test]
+    fn test_serialize_deserialize_elgamal() {
+        let n = 50;
+        let mut rng = OsRng {};
+        let mut ciphertexts = Vec::new();
+        for _ in 0..n {
+            ciphertexts.push(ElGamalCiphertext {
+                partial_shared_secret: Scalar::random(&mut rng),
+                encrypted_message: Scalar::random(&mut rng),
+            })
+        }
+
+        // Serialize the ciphertexts
+        let bytes = serde_json::to_vec(&ciphertexts).unwrap();
+        let packed_calldata = pack_bytes_into_felts(&bytes);
+
+        // Deserialize back into ciphertexts
+        let recovered_ciphertexts = ciphertext_vec_from_felt_blob(&packed_calldata).unwrap();
+
+        assert_eq!(ciphertexts, recovered_ciphertexts);
+    }
+}

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -15,12 +15,21 @@ use crate::MERKLE_HEIGHT;
 
 pub mod client;
 pub mod error;
+mod helpers;
 pub mod types;
 
 lazy_static! {
     // -------------
     // | Selectors |
     // -------------
+
+    // -- Getters --
+
+    /// Contract view function selector to get the most recent transaction updating a given wallet
+    static ref GET_WALLET_LAST_UPDATED_SELECTOR: StarknetFieldElement = get_selector_from_name("get_wallet_update")
+        .unwrap();
+
+    // -- Setters --
 
     /// Contract function selector to create a new wallet
     static ref NEW_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("new_wallet")

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -307,7 +307,7 @@ impl NewOrderTask {
             )
             .await
             .map_err(|err| NewOrderTaskError::StarknetClient(err.to_string()))?;
-        log::info!("got tx hash: {:x}", starknet_felt_to_biguint(&tx_hash));
+        log::info!("tx hash: {:x}", starknet_felt_to_biguint(&tx_hash));
 
         // Await transaction completion
         let tx_info = self

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -297,6 +297,7 @@ impl NewOrderTask {
         let tx_hash = self
             .starknet_client
             .update_wallet(
+                self.new_wallet.public_keys.pk_view,
                 self.new_wallet.get_commitment(),
                 self.old_wallet.get_match_nullifier(),
                 self.old_wallet.get_spend_nullifier(),

--- a/core/src/tasks/create_new_order.rs
+++ b/core/src/tasks/create_new_order.rs
@@ -335,7 +335,6 @@ impl NewOrderTask {
             .await
             .map_err(|err| NewOrderTaskError::StarknetClient(err.to_string()))?;
         let new_root = authentication_path.compute_root();
-        log::info!("found merkle path in contract state");
 
         // A wallet that is compatible with circuit types
         let circuit_wallet: SizedWallet = self.new_wallet.clone().into();

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -10,10 +10,11 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use async_trait::async_trait;
 use crossbeam::channel::Sender as CrossbeamSender;
-use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
+use crypto::fields::{biguint_to_scalar, scalar_to_biguint, starknet_felt_to_biguint};
 use serde::Serialize;
 use starknet::core::types::TransactionStatus;
 use tokio::sync::oneshot;
+use tracing::log;
 
 use crate::{
     external_api::types::Wallet,
@@ -249,6 +250,7 @@ impl NewWalletTask {
             )
             .await
             .map_err(|err| NewWalletTaskError::Starknet(err.to_string()))?;
+        log::info!("tx hash: 0x{:x}", starknet_felt_to_biguint(&tx_hash));
 
         let res = self
             .starknet_client

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -241,7 +241,12 @@ impl NewWalletTask {
 
         let tx_hash = self
             .starknet_client
-            .new_wallet(wallet_commitment, wallet_ciphertext, proof)
+            .new_wallet(
+                self.wallet.public_keys.pk_view,
+                wallet_commitment,
+                wallet_ciphertext,
+                proof,
+            )
             .await
             .map_err(|err| NewWalletTaskError::Starknet(err.to_string()))?;
 

--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -15,7 +15,7 @@ use crate::state::{new_async_shared, AsyncShared};
 use super::{
     create_new_order::NewOrderTaskState, create_new_wallet::NewWalletTaskState,
     external_transfer::ExternalTransferTaskState, initialize_state::InitializeStateTaskState,
-    settle_match::SettleMatchTaskState,
+    lookup_wallet::LookupWalletTaskState, settle_match::SettleMatchTaskState,
 };
 
 /// A type alias for the identifier underlying a task
@@ -62,6 +62,8 @@ pub enum StateWrapper {
     InitializeState(InitializeStateTaskState),
     /// The state object for the deposit balance task
     ExternalTransfer(ExternalTransferTaskState),
+    /// The state object for the lookup wallet task
+    LookupWallet(LookupWalletTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
     /// The state object for the new order task

--- a/core/src/tasks/external_transfer.rs
+++ b/core/src/tasks/external_transfer.rs
@@ -328,6 +328,7 @@ impl ExternalTransferTask {
         let tx_hash = self
             .starknet_client
             .update_wallet(
+                self.new_wallet.public_keys.pk_view,
                 self.new_wallet.get_commitment(),
                 self.old_wallet.get_match_nullifier(),
                 self.old_wallet.get_spend_nullifier(),

--- a/core/src/tasks/external_transfer.rs
+++ b/core/src/tasks/external_transfer.rs
@@ -338,7 +338,7 @@ impl ExternalTransferTask {
             )
             .await
             .map_err(|err| ExternalTransferTaskError::StarknetClient(err.to_string()))?;
-        log::info!("got tx hash: {:x}", starknet_felt_to_biguint(&tx_hash));
+        log::info!("tx hash: {:x}", starknet_felt_to_biguint(&tx_hash));
 
         // Await transaction completion
         let tx_info = self

--- a/core/src/tasks/lookup_wallet.rs
+++ b/core/src/tasks/lookup_wallet.rs
@@ -1,0 +1,142 @@
+//! Defines a task that looks up a wallet in contract storage by its
+//! public view key identifier, then begins managing the wallet
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use async_trait::async_trait;
+use crossbeam::channel::Sender as CrossbeamSender;
+use serde::Serialize;
+
+use crate::{
+    external_api::types::KeyChain, proof_generation::jobs::ProofManagerJob,
+    starknet_client::client::StarknetClient, state::RelayerState,
+};
+
+use super::driver::{StateWrapper, Task};
+
+/// The task name for the lookup wallet task
+const LOOKUP_WALLET_TASK_NAME: &str = "lookup-wallet";
+
+/// Represents a task to lookup a wallet in contract storage
+pub struct LookupWalletTask {
+    /// The keychain to manage the wallet with
+    pub key_chain: KeyChain,
+    /// A starknet client for the task to submit transactions
+    pub starknet_client: StarknetClient,
+    /// A copy of the relayer-global state
+    pub global_state: RelayerState,
+    /// The work queue to add proof management jobs to
+    pub proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    /// The state of the task's execution
+    pub task_state: LookupWalletTaskState,
+}
+
+/// Represents the state of the task through its async execution
+#[derive(Clone, Debug, Serialize)]
+pub enum LookupWalletTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is finding the wallet in contract storage
+    FindingWallet,
+    /// The task is creating validity proofs for the orders in the wallet
+    CreatingValidityProofs,
+    /// The task is completed
+    Completed,
+}
+
+impl Display for LookupWalletTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+
+impl From<LookupWalletTaskState> for StateWrapper {
+    fn from(state: LookupWalletTaskState) -> Self {
+        StateWrapper::LookupWallet(state)
+    }
+}
+
+/// The error type thrown by the wallet lookup task
+#[derive(Clone, Debug)]
+pub enum LookupWalletTaskError {
+    /// Error interacting with the starknet client
+    Starknet(String),
+}
+
+impl Display for LookupWalletTaskError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+
+#[async_trait]
+impl Task for LookupWalletTask {
+    type State = LookupWalletTaskState;
+    type Error = LookupWalletTaskError;
+
+    fn completed(&self) -> bool {
+        matches!(self.state(), LookupWalletTaskState::Completed)
+    }
+
+    fn name(&self) -> String {
+        LOOKUP_WALLET_TASK_NAME.to_string()
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        // Dispatch based on task state
+        match self.task_state {
+            LookupWalletTaskState::Pending => {
+                self.task_state = LookupWalletTaskState::FindingWallet
+            }
+            LookupWalletTaskState::FindingWallet => {
+                self.find_wallet().await?;
+                self.task_state = LookupWalletTaskState::CreatingValidityProofs;
+            }
+            LookupWalletTaskState::CreatingValidityProofs => {
+                self.create_validity_proofs().await?;
+                self.task_state = LookupWalletTaskState::Completed;
+            }
+            LookupWalletTaskState::Completed => {
+                unreachable!("step called on task in Completed state")
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl LookupWalletTask {
+    /// Constructor
+    pub fn new(
+        key_chain: KeyChain,
+        starknet_client: StarknetClient,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    ) -> Self {
+        Self {
+            key_chain,
+            starknet_client,
+            global_state,
+            proof_manager_work_queue,
+            task_state: LookupWalletTaskState::Pending,
+        }
+    }
+
+    /// Find the wallet in the contract storage and create an opening for the wallet
+    async fn find_wallet(&mut self) -> Result<(), LookupWalletTaskError> {
+        unimplemented!("")
+    }
+
+    /// Prove `VALID COMMITMENTS` for all orders in the wallet
+    async fn create_validity_proofs(&self) -> Result<(), LookupWalletTaskError> {
+        unimplemented!("")
+    }
+}

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -20,6 +20,7 @@ pub mod create_new_wallet;
 pub mod driver;
 pub mod external_transfer;
 pub mod initialize_state;
+pub mod lookup_wallet;
 pub mod settle_match;
 
 /// The amount to increment the randomness each time a wallet is nullified

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -769,6 +769,7 @@ impl SettleMatchTask {
         let tx_hash = self
             .starknet_client
             .submit_settle(
+                self.new_wallet.public_keys.pk_view,
                 self.new_wallet.get_commitment(),
                 self.old_wallet.get_match_nullifier() + Scalar::random(&mut rng),
                 self.old_wallet.get_spend_nullifier() + Scalar::random(&mut rng),

--- a/crypto/src/elgamal.rs
+++ b/crypto/src/elgamal.rs
@@ -19,7 +19,7 @@ lazy_static! {
 }
 
 /// The result of creating an ElGamal encryption
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ElGamalCiphertext {
     /// The shared secret; the generator raised to the randomness
     pub partial_shared_secret: Scalar,


### PR DESCRIPTION
### Purpose
This PR adds the `/v0/wallet/lookup` implementation which takes the following task flow:
1. Call the `get_wallet_update` view function in the contract to get the last transaction hash that updated a given wallet
2. Pull the calldata from that transaction, re-structure and decrypt the ciphertext blob into a wallet
3. Find the Merkle authentication path for the wallet commitment in the contract commitment tree.
4. Prove `VALID COMMITMENTS` for all orders in the wallet

### Testing
- Created a new wallet, then shut down the relayer, started it back up and hit the endpoint. Verified that the relayer then recovered the wallet from contract storage, and hit `GET /v0/wallet/:id` to fetch the wallet, verified its fields were as expected.