### PR TITLE
core: api-server: http: Add `/wallet/:id/balances/:mint/internal_transfer`

### DIFF
--- a/circuits/src/types/transfers.rs
+++ b/circuits/src/types/transfers.rs
@@ -157,6 +157,11 @@ impl CommitVerifier for ExternalTransferCommitment {
 /// Represents an internal transfer tuple, not allocated in any constraint system
 #[derive(Clone, Debug, Default)]
 pub struct InternalTransfer {
+    /// The public settle key of the recipient
+    ///
+    /// This is not used in the circuits, so it is not present in the
+    /// allocated structures below
+    pub recipient_key: BigUint,
     /// The mint to transfer
     pub mint: BigUint,
     /// The amount to transfer

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -1100,6 +1100,7 @@ mod valid_wallet_update_tests {
                 indices: mock_opening_indices,
             },
             internal_transfer: InternalTransfer {
+                recipient_key: BigUint::default(),
                 mint: internal_transfer_mint,
                 amount: internal_transfer_volume.into(),
             },
@@ -1166,6 +1167,7 @@ mod valid_wallet_update_tests {
                 indices: mock_opening_indices,
             },
             internal_transfer: InternalTransfer {
+                recipient_key: BigUint::default(),
                 mint: internal_transfer_mint,
                 amount: internal_transfer_volume.into(),
             },
@@ -1562,6 +1564,7 @@ mod valid_wallet_update_tests {
                 indices: mock_opening_indices,
             },
             internal_transfer: InternalTransfer {
+                recipient_key: BigUint::default(),
                 mint: internal_transfer_mint.into(),
                 amount: internal_transfer_volume.into(),
             },

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -37,10 +37,11 @@ use self::{
     wallet::{
         CancelOrderHandler, CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler,
         FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler,
-        GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler, WithdrawBalanceHandler,
-        CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE,
-        GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE, GET_ORDER_BY_ID_ROUTE,
-        GET_WALLET_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
+        GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler, InternalTransferHandler,
+        WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE,
+        FIND_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE,
+        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, INTERNAL_TRANSFER_ROUTE, WALLET_ORDERS_ROUTE,
+        WITHDRAW_BALANCE_ROUTE,
     },
 };
 
@@ -305,6 +306,19 @@ impl HttpServer {
             Method::POST,
             WITHDRAW_BALANCE_ROUTE.to_string(),
             WithdrawBalanceHandler::new(
+                config.starknet_client.clone(),
+                config.network_sender.clone(),
+                global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
+            ),
+        );
+
+        // The "/wallet/:id/balances/:mint/internal_transfer" route
+        router.add_route(
+            Method::POST,
+            INTERNAL_TRANSFER_ROUTE.to_string(),
+            InternalTransferHandler::new(
                 config.starknet_client.clone(),
                 config.network_sender.clone(),
                 global_state.clone(),

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -445,6 +445,7 @@ impl TypedHandler for CreateOrderHandler {
         // Spawn a task to handle the order creation flow
         let task = UpdateWalletTask::new(
             None, /* external_transfer */
+            None, /* internal_transfer */
             old_wallet,
             new_wallet,
             self.starknet_client.clone(),
@@ -528,6 +529,7 @@ impl TypedHandler for CancelOrderHandler {
         // Spawn a task to handle the order creation flow
         let task = UpdateWalletTask::new(
             None, /* external_transfer */
+            None, /* internal_transfer */
             old_wallet,
             new_wallet,
             self.starknet_client.clone(),
@@ -727,6 +729,7 @@ impl TypedHandler for DepositBalanceHandler {
                 amount: req.amount,
                 direction: ExternalTransferDirection::Deposit,
             }),
+            None, /* internal_transfer */
             old_wallet,
             new_wallet,
             self.starknet_client.clone(),
@@ -821,6 +824,7 @@ impl TypedHandler for WithdrawBalanceHandler {
                 amount: req.amount,
                 direction: ExternalTransferDirection::Withdrawal,
             }),
+            None, /* internal_transfer */
             old_wallet,
             new_wallet,
             self.starknet_client.clone(),

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -187,6 +187,33 @@ pub struct WithdrawBalanceResponse {
     pub task_id: TaskIdentifier,
 }
 
+/// The request type to create an internal transfer to another darkpool wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InternalTransferRequest {
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+    /// The recipient's settle key
+    #[serde(
+        serialize_with = "biguint_to_hex_string",
+        deserialize_with = "biguint_from_hex_string"
+    )]
+    pub recipient_key: BigUint,
+    /// The amount to transfer
+    pub amount: BigUint,
+}
+
+/// The response type to a request to create an internal transfer
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InternalTransferResponse {
+    /// The ID of the task that was allocated on behalf of this request
+    pub task_id: TaskIdentifier,
+}
+
 // -------------------------
 // | Wallet Fees API Types |
 // -------------------------

--- a/core/src/starknet_client/client.rs
+++ b/core/src/starknet_client/client.rs
@@ -616,8 +616,6 @@ impl StarknetClient {
     /// and handle internal/external transfers
     ///
     /// Returns the transaction hash of the `update_wallet` call
-    ///
-    /// TODO: Add internal
     #[allow(clippy::too_many_arguments)]
     pub async fn update_wallet(
         &self,
@@ -626,6 +624,7 @@ impl StarknetClient {
         old_match_nullifier: Nullifier,
         old_spend_nullifier: Nullifier,
         external_transfer: Option<ExternalTransfer>,
+        internal_transfer_ciphertext: Option<Vec<ElGamalCiphertext>>,
         wallet_ciphertext: Vec<ElGamalCiphertext>,
         valid_wallet_update: ValidWalletUpdateBundle,
     ) -> Result<TransactionHash, StarknetClientError> {
@@ -634,8 +633,15 @@ impl StarknetClient {
             Self::reduce_scalar_to_felt(&new_wallet_commitment),
             Self::reduce_scalar_to_felt(&old_match_nullifier),
             Self::reduce_scalar_to_felt(&old_spend_nullifier),
-            0u8.into(), // TODO: add internal transfer tuple
         ];
+
+        // Append the internal transfer ciphertext if there is one
+        if let Some(internal_transfer) = internal_transfer_ciphertext {
+            calldata.append(&mut pack_serializable!(internal_transfer));
+        } else {
+            // Otherwise, push 0 to the calldata to indicate a zero-length ciphertext blob
+            calldata.push(0u8.into());
+        }
 
         // Add the external transfer tuple to the calldata
         if let Some(transfer) = external_transfer {

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -8,6 +8,7 @@ use std::convert::TryInto;
 
 use circuits::types::{
     balance::Balance, fee::Fee, keychain::KeyChain as CircuitKeyChain, note::Note, order::Order,
+    transfers::InternalTransfer,
 };
 use crypto::{
     elgamal::{decrypt_scalar, encrypt_scalar, ElGamalCiphertext},
@@ -143,4 +144,12 @@ pub(self) fn encrypt_note(note: Note, pk_settle: &BigUint) -> Vec<ElGamalCiphert
         .map(|val| encrypt_scalar(val, pk_settle))
         .map(|(cipher, _)| cipher)
         .collect_vec()
+}
+
+/// Helper to encrypt an internal transfer under a given key
+pub(self) fn encrypt_internal_transfer(transfer: &InternalTransfer) -> Vec<ElGamalCiphertext> {
+    vec![
+        encrypt_scalar(biguint_to_scalar(&transfer.mint), &transfer.recipient_key).0,
+        encrypt_scalar(biguint_to_scalar(&transfer.amount), &transfer.recipient_key).0,
+    ]
 }


### PR DESCRIPTION
### Purpose
This PR adds internal transfer support to the public API through the `update_wallet` flow.

The changes to the task are minimal, essentially just requiring that we encrypt the internal transfer if one is present.

### Testing
- Tested the new endpoint, verified its functionality