### PR TITLE
core: api-server: http: Add fee creation/removal APIs

### DIFF
--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -35,13 +35,13 @@ use self::{
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     task::{GetTaskStatusHandler, GET_TASK_STATUS_ROUTE},
     wallet::{
-        CancelOrderHandler, CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler,
-        FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler, GetFeesHandler,
-        GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler, InternalTransferHandler,
-        WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE,
-        FIND_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_FEES_ROUTE,
-        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, INTERNAL_TRANSFER_ROUTE, WALLET_ORDERS_ROUTE,
-        WITHDRAW_BALANCE_ROUTE,
+        AddFeeHandler, CancelOrderHandler, CreateOrderHandler, CreateWalletHandler,
+        DepositBalanceHandler, FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
+        GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler,
+        InternalTransferHandler, WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE,
+        DEPOSIT_BALANCE_ROUTE, FEES_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE,
+        GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+        INTERNAL_TRANSFER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
     },
 };
 
@@ -327,11 +327,24 @@ impl HttpServer {
             ),
         );
 
-        // The "/wallet/:id/fees" route
+        // The GET "/wallet/:id/fees" route
         router.add_route(
             Method::GET,
-            GET_FEES_ROUTE.to_string(),
+            FEES_ROUTE.to_string(),
             GetFeesHandler::new(global_state.clone()),
+        );
+
+        // The POST "/wallet/:id/fees" route
+        router.add_route(
+            Method::POST,
+            FEES_ROUTE.to_string(),
+            AddFeeHandler::new(
+                config.starknet_client.clone(),
+                config.network_sender.clone(),
+                global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
+            ),
         );
 
         // The "/order_book/orders" route

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -224,3 +224,24 @@ pub struct GetFeesResponse {
     /// The fees in a given wallet
     pub fees: Vec<Fee>,
 }
+
+/// The request type to add a fee to a wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AddFeeRequest {
+    /// The fee to add to the wallet
+    pub fee: Fee,
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type to a request to add a fee to a wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AddFeeResponse {
+    /// The ID of the task allocated on behalf of this request
+    pub task_id: TaskIdentifier,
+}

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -245,3 +245,24 @@ pub struct AddFeeResponse {
     /// The ID of the task allocated on behalf of this request
     pub task_id: TaskIdentifier,
 }
+
+/// The request type to remove a fee from a wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RemoveFeeRequest {
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    ///
+    /// TODO: For now this is just a blob, we will add this feature in
+    /// a follow up
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type for a request to remove a fee from a wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RemoveFeeResponse {
+    /// The ID of the task allocated for this request
+    pub task_id: TaskIdentifier,
+    /// The fee that was removed
+    pub fee: Fee,
+}


### PR DESCRIPTION
### Purpose
This PR adds two API endpoints:
- `POST /wallet/:id/fees`: Add a fee to the fee list of a wallet
- `POST /wallet/:id/fees/:index/remove`: Remove a fee from the fee list of a wallet

### Testing
- Tested both APIs on my Goerli darkpool wallet