### PR TITLE
core: api-server: http: Add API authentication via `sk_root` signature

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -11,6 +11,7 @@ bitvec = "1.0"
 circuit-macros = { path = "../circuit-macros" }
 crypto = { path = "../crypto" }
 curve25519-dalek = "2"
+ed25519-dalek = { version = "1.0.1" }
 itertools = "0.10"
 lazy_static = "1.4"
 merlin = "2.0"

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -1,6 +1,7 @@
 //! Defines the constraint system types for the set of keys a wallet holds
 
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use ed25519_dalek::PublicKey as DalekKey;
 use mpc_bulletproof::r1cs::{Prover, RandomizableConstraintSystem, Variable, Verifier};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -207,6 +208,20 @@ impl From<PublicSigningKey> for Vec<Scalar> {
         };
 
         elem.into()
+    }
+}
+
+impl From<&PublicSigningKey> for DalekKey {
+    fn from(key: &PublicSigningKey) -> Self {
+        let key_bytes = key.0.to_bytes_le();
+        DalekKey::from_bytes(&key_bytes).unwrap()
+    }
+}
+
+impl From<DalekKey> for PublicSigningKey {
+    fn from(key: DalekKey) -> Self {
+        let key_bytes = key.as_bytes();
+        Self(BigUint::from_bytes_le(key_bytes))
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ crossterm = { version = "0.26", optional = true }
 create2 = "0.0.2"
 crypto = { path = "../crypto" }
 curve25519-dalek = "2"
-ed25519-dalek = { version = "1.0.1" }
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 env_logger = "0.10"
 futures = { version = "0.3.26" }
 futures-util = { version = "0.3" }

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use hyper::{
     server::conn::AddrStream,
     service::{make_service_fn, service_fn},
-    Body, Error as HyperError, Method, Request, Response, Server, StatusCode,
+    Body, Error as HyperError, HeaderMap, Method, Request, Response, Server, StatusCode,
 };
 use num_bigint::BigUint;
 use num_traits::Num;
@@ -461,6 +461,7 @@ impl TypedHandler for PingHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/http/network.rs
+++ b/core/src/api_server/http/network.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use hyper::StatusCode;
+use hyper::{HeaderMap, StatusCode};
 use itertools::Itertools;
 
 use crate::{
@@ -64,6 +64,7 @@ impl TypedHandler for GetNetworkTopologyHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -113,6 +114,7 @@ impl TypedHandler for GetClusterInfoHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -162,6 +164,7 @@ impl TypedHandler for GetPeerInfoHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/http/order_book.rs
+++ b/core/src/api_server/http/order_book.rs
@@ -5,7 +5,7 @@
 // ---------------
 
 use async_trait::async_trait;
-use hyper::StatusCode;
+use hyper::{HeaderMap, StatusCode};
 use itertools::Itertools;
 
 use crate::{
@@ -64,6 +64,7 @@ impl TypedHandler for GetNetworkOrdersHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -103,6 +104,7 @@ impl TypedHandler for GetNetworkOrderByIdHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/http/price_report.rs
+++ b/core/src/api_server/http/price_report.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use crossbeam::channel;
+use hyper::HeaderMap;
 
 use crate::{
     api_server::{
@@ -48,6 +49,7 @@ impl TypedHandler for ExchangeHealthStatesHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/http/task.rs
+++ b/core/src/api_server/http/task.rs
@@ -5,7 +5,7 @@
 // ---------------
 
 use async_trait::async_trait;
-use hyper::StatusCode;
+use hyper::{HeaderMap, StatusCode};
 
 use crate::{
     api_server::{
@@ -52,6 +52,7 @@ impl TypedHandler for GetTaskStatusHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -6,7 +6,7 @@ use circuits::types::{
     transfers::{ExternalTransfer, ExternalTransferDirection, InternalTransfer},
 };
 use crossbeam::channel::Sender as CrossbeamSender;
-use hyper::StatusCode;
+use hyper::{HeaderMap, StatusCode};
 use num_traits::ToPrimitive;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
 
@@ -114,6 +114,7 @@ impl TypedHandler for GetWalletHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -192,6 +193,7 @@ impl TypedHandler for CreateWalletHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -253,6 +255,7 @@ impl TypedHandler for FindWalletHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -300,6 +303,7 @@ impl TypedHandler for GetOrdersHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -345,6 +349,7 @@ impl TypedHandler for GetOrderByIdHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -415,6 +420,7 @@ impl TypedHandler for CreateOrderHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -512,6 +518,7 @@ impl TypedHandler for CancelOrderHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -583,6 +590,7 @@ impl TypedHandler for GetBalancesHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -628,6 +636,7 @@ impl TypedHandler for GetBalanceByMintHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -702,6 +711,7 @@ impl TypedHandler for DepositBalanceHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -796,6 +806,7 @@ impl TypedHandler for WithdrawBalanceHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -891,6 +902,7 @@ impl TypedHandler for InternalTransferHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -969,6 +981,7 @@ impl TypedHandler for GetFeesHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -1033,6 +1046,7 @@ impl TypedHandler for AddFeeHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
@@ -1128,6 +1142,7 @@ impl TypedHandler for RemoveFeeHandler {
 
     async fn handle_typed(
         &self,
+        _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {

--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -7,7 +7,6 @@ use circuits::types::keychain::PublicSigningKey;
 use ed25519_dalek::{Digest, PublicKey, Sha512, Signature};
 use hyper::{HeaderMap, StatusCode};
 use serde::Serialize;
-use tracing::log;
 
 use self::error::ApiServerError;
 pub mod error;
@@ -33,7 +32,7 @@ const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiratio
 const ERR_SIG_VERIFICATION_FAILED: &str = "signature verification failed";
 
 /// A helper to authenticate a request via expiring signatures using the method below
-pub(self) fn authenticate_request_from_headers<T>(
+pub(self) fn authenticate_wallet_request<T>(
     headers: HeaderMap,
     body: &T,
     pk_root: &PublicSigningKey,
@@ -114,15 +113,6 @@ where
     }
 
     // Hash the body and the expiration timestamp into a digest to check the signature against
-    let mut hasher = Sha512::default();
-    let body_bytes = serde_json::to_vec(&body).unwrap();
-    log::info!("body bytes: {body_bytes:?}");
-    hasher.update(&body_bytes);
-    hasher.update(expiration_timestamp.to_le_bytes());
-
-    let out = hasher.finalize();
-    log::info!("out: {out:?}");
-
     let mut hasher = Sha512::default();
     let body_bytes = serde_json::to_vec(&body).unwrap();
     hasher.update(&body_bytes);

--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -1,7 +1,139 @@
 //! Defines the server for the publicly facing API (both HTTP and websocket)
 //! that the relayer exposes
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use circuits::types::keychain::PublicSigningKey;
+use ed25519_dalek::{Digest, PublicKey, Sha512, Signature};
+use hyper::{HeaderMap, StatusCode};
+use serde::Serialize;
+use tracing::log;
+
+use self::error::ApiServerError;
 pub mod error;
 mod http;
 mod router;
 mod websocket;
 pub mod worker;
+
+/// Header name for the HTTP auth signature
+const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
+/// Header name for the expiration timestamp of a signature
+const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
+
+/// Error displayed when the signature format is invalid
+const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
+/// Error displayed when the signature header is missing
+const ERR_SIG_HEADER_MISSING: &str = "signature missing from request";
+/// Error displayed when the signature expiration header is missing
+const ERR_SIG_EXPIRATION_MISSING: &str = "signature expiration missing from headers";
+/// Error displayed when the expiration format is invalid
+const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiration timestamp";
+/// Error displayed when signature verification fails on a request
+const ERR_SIG_VERIFICATION_FAILED: &str = "signature verification failed";
+
+/// A helper to authenticate a request via expiring signatures using the method below
+pub(self) fn authenticate_request_from_headers<T>(
+    headers: HeaderMap,
+    body: &T,
+    pk_root: &PublicSigningKey,
+) -> Result<(), ApiServerError>
+where
+    T: Serialize,
+{
+    // Parse the signature and the expiration timestamp from the header
+    let signature = headers
+        .get(RENEGADE_AUTH_HEADER_NAME)
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_SIG_HEADER_MISSING.to_string(),
+            )
+        })?
+        .as_bytes();
+    let sig_expiration = headers
+        .get(RENEGADE_SIG_EXPIRATION_HEADER_NAME)
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_SIG_EXPIRATION_MISSING.to_string(),
+            )
+        })?;
+
+    // Parse the expiration into a timestamp
+    let expiration = sig_expiration
+        .to_str()
+        .map_err(|_| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_EXPIRATION_FORMAT_INVALID.to_string(),
+            )
+        })
+        .and_then(|s| {
+            s.parse::<u64>().map_err(|_| {
+                ApiServerError::HttpStatusCode(
+                    StatusCode::BAD_REQUEST,
+                    ERR_EXPIRATION_FORMAT_INVALID.to_string(),
+                )
+            })
+        })?;
+
+    // Recover a public key from the byte packed scalar representing the public key
+    let root_key: PublicKey = pk_root.into();
+    if !validate_expiring_signature(body, expiration, signature, root_key)? {
+        Err(ApiServerError::HttpStatusCode(
+            StatusCode::UNAUTHORIZED,
+            ERR_SIG_VERIFICATION_FAILED.to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// A helper to verify a signature on a request body
+///
+/// The signature should be a sponge hash of the serialized request body
+/// and a unix timestamp representing the expiration of the signature. A
+/// call to this method after the expiration timestamp should return false
+pub(self) fn validate_expiring_signature<T>(
+    body: &T,
+    expiration_timestamp: u64,
+    signature: &[u8],
+    pk_root: PublicKey,
+) -> Result<bool, ApiServerError>
+where
+    T: Serialize,
+{
+    // Check the expiration timestamp
+    let now = SystemTime::now();
+    let target_duration = Duration::from_millis(expiration_timestamp);
+    let target_time = UNIX_EPOCH + target_duration;
+
+    if now >= target_time {
+        return Ok(false);
+    }
+
+    // Hash the body and the expiration timestamp into a digest to check the signature against
+    let mut hasher = Sha512::default();
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    log::info!("body bytes: {body_bytes:?}");
+    hasher.update(&body_bytes);
+    hasher.update(expiration_timestamp.to_le_bytes());
+
+    let out = hasher.finalize();
+    log::info!("out: {out:?}");
+
+    let mut hasher = Sha512::default();
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    hasher.update(&body_bytes);
+    hasher.update(expiration_timestamp.to_le_bytes());
+
+    // Check the signature
+    let sig: Signature = serde_json::from_slice(signature).map_err(|_| {
+        ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_SIG_FORMAT_INVALID.to_string())
+    })?;
+
+    Ok(pk_root
+        .verify_prehashed(hasher, None /* context */, &sig)
+        .is_ok())
+}

--- a/core/src/external_api/mod.rs
+++ b/core/src/external_api/mod.rs
@@ -11,7 +11,7 @@ pub mod websocket;
 
 /// An empty request/response type
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct EmptyRequestResponse;
+pub struct EmptyRequestResponse {}
 
 /// A helper to serialize a BigUint to a hex string
 pub fn biguint_to_hex_string<S>(val: &BigUint, s: S) -> Result<S::Ok, S::Error>
@@ -33,4 +33,21 @@ where
     BigUint::from_str_radix(hex_string, 16 /* radix */).map_err(|e| {
         DeserializeError::custom(format!("error deserializing BigUint from hex string: {e}"))
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::EmptyRequestResponse;
+
+    /// Tests empty request/response serialization, expected behavior is that it serializes to and from
+    /// an empty json struct
+    #[test]
+    fn test_serde_empty() {
+        let req = EmptyRequestResponse {};
+        let serialized_str = serde_json::to_string(&req).unwrap();
+        assert_eq!(serialized_str, "{}");
+
+        // Test deserialization from empty json struct encoded as a string
+        let _req: EmptyRequestResponse = serde_json::from_str("{}").unwrap();
+    }
 }


### PR DESCRIPTION
### Purpose
This PR adds authentication to endpoints returning or modifying wallet-private data. The authentication requires a signature and signature expiration UNIX timestamp to be attached as headers `renegade-auth` and `renegade-auth-expiration` respectively.

The signature is the signature of the request body concatenated with the expiration timestamp with `sk_root`.

### Testing
- Tested the various wallet flows through the API with signatures attached