### PR TITLE
core: api-server: websocket: Refactor into router/handler model

### DIFF
--- a/core/src/api_server/websocket/handler.rs
+++ b/core/src/api_server/websocket/handler.rs
@@ -12,8 +12,8 @@ use crate::{
     types::SystemBusMessage,
 };
 
-/// The main trait that route handlers hold for their topic, handles any custom logic
-/// required to handle a websocket subscribe/unsubscribe
+/// The main trait that route handlers implement for their topic, handles any custom logic
+/// required to process a websocket subscribe/unsubscribe request
 pub trait WebsocketTopicHandler: Send + Sync {
     /// Handle a request to subscribe to the topic
     fn handle_subscribe_message(

--- a/core/src/api_server/websocket/price_report.rs
+++ b/core/src/api_server/websocket/price_report.rs
@@ -1,0 +1,134 @@
+//! Handlers for price reporting websocket topics
+
+use hyper::StatusCode;
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
+use tokio::sync::oneshot::channel;
+
+use crate::{
+    api_server::{error::ApiServerError, router::UrlParams},
+    price_reporter::{jobs::PriceReporterManagerJob, price_report_topic_name, tokens::Token},
+    system_bus::{SystemBus, TopicReader},
+    types::SystemBusMessage,
+};
+
+use super::handler::WebsocketTopicHandler;
+
+// ------------------
+// | Error Messages |
+// ------------------
+
+/// The error emitted when a route is missing parameters
+const ERR_MISSING_PARAMS: &str = "route missing parameters";
+/// The error message given when communication with the price reporter fails
+const ERR_SENDING_MESSAGE: &str = "error sending message to price reporter";
+
+// ----------------
+// | URL Captures |
+// ----------------
+
+/// The source to fetch a price report from
+const PRICE_SOURCE_URL_PARAM: &str = "source";
+/// The base mint url param to fetch a price report for
+const BASE_MINT_URL_PARAM: &str = "base";
+/// The quote mint url param to fetch a price report for
+const QUOTE_MINT_URL_PARAM: &str = "quote";
+
+/// Parse a price report source from a set of URL params
+fn parse_source_from_url_params(params: &UrlParams) -> Result<String, ApiServerError> {
+    params
+        .get(&PRICE_SOURCE_URL_PARAM.to_string())
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_MISSING_PARAMS.to_string())
+        })
+        .cloned()
+}
+
+/// Parse a base mint from a URL param
+fn parse_base_mint_from_url_params(params: &UrlParams) -> Result<String, ApiServerError> {
+    params
+        .get(&BASE_MINT_URL_PARAM.to_string())
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_MISSING_PARAMS.to_string())
+        })
+        .cloned()
+}
+
+/// Parse a quote mint from a URL param
+fn parse_quote_mint_from_url_params(params: &UrlParams) -> Result<String, ApiServerError> {
+    params
+        .get(&QUOTE_MINT_URL_PARAM.to_string())
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_MISSING_PARAMS.to_string())
+        })
+        .cloned()
+}
+
+// -----------
+// | Handler |
+// -----------
+
+/// The handler that manages a subscription to a price report
+#[derive(Clone)]
+pub struct PriceReporterHandler {
+    /// A sender to the price reporter's work queue
+    price_reporter_work_queue: TokioSender<PriceReporterManagerJob>,
+    /// A reference to the relayer-global system bus    
+    system_bus: SystemBus<SystemBusMessage>,
+}
+
+impl PriceReporterHandler {
+    /// Constructor
+    pub fn new(
+        price_reporter_work_queue: TokioSender<PriceReporterManagerJob>,
+        system_bus: SystemBus<SystemBusMessage>,
+    ) -> Self {
+        Self {
+            price_reporter_work_queue,
+            system_bus,
+        }
+    }
+}
+
+impl WebsocketTopicHandler for PriceReporterHandler {
+    /// Handle a subscription to a price report
+    ///
+    /// Send a message to the price reporter indicating that it should
+    /// open websockets to the reporting exchanges
+    fn handle_subscribe_message(
+        &self,
+        _topic: String,
+        route_params: &UrlParams,
+    ) -> Result<TopicReader<SystemBusMessage>, ApiServerError> {
+        // Parse the source, base mint, and quote mint from the route
+        let source = parse_source_from_url_params(route_params)?;
+        let base = Token::from_addr(&parse_base_mint_from_url_params(route_params)?);
+        let quote = Token::from_addr(&parse_quote_mint_from_url_params(route_params)?);
+
+        // Start a price reporting stream in the manager
+        let (channel, _) = channel();
+        self.price_reporter_work_queue
+            .send(PriceReporterManagerJob::StartPriceReporter {
+                base_token: base.clone(),
+                quote_token: quote.clone(),
+                id: None,
+                channel, /* unused here */
+            })
+            .map_err(|_| ApiServerError::WebsocketServerFailure(ERR_SENDING_MESSAGE.to_string()))?;
+
+        Ok(self
+            .system_bus
+            .subscribe(price_report_topic_name(&source, base, quote)))
+    }
+
+    /// Handle an unsubscribe message from the price reporter
+    ///
+    /// TODO: Cleanup unused websocket connections after this happens
+    /// for now, this does nothing
+    fn handle_unsubscribe_message(
+        &self,
+        _topic: String,
+        _route_params: &UrlParams,
+    ) -> Result<(), ApiServerError> {
+        Ok(())
+    }
+}

--- a/core/src/api_server/worker.rs
+++ b/core/src/api_server/worker.rs
@@ -19,7 +19,7 @@ use crate::{
 use super::{error::ApiServerError, http::HttpServer, websocket::WebsocketServer};
 
 /// The number of threads backing the HTTP server
-const API_SERVER_NUM_THREADS: usize = 2;
+const API_SERVER_NUM_THREADS: usize = 4;
 
 /// Accepts inbound HTTP requests and websocket subscriptions and
 /// serves requests from those connections
@@ -97,8 +97,7 @@ impl Worker for ApiServer {
         });
 
         // Build the websocket server
-        let websocket_server =
-            WebsocketServer::new(self.config.clone(), self.config.system_bus.clone());
+        let websocket_server = WebsocketServer::new(self.config.clone());
         let websocket_thread_handle = tokio_runtime.spawn_blocking(move || {
             let err = block_on(websocket_server.execution_loop()).err().unwrap();
             ApiServerError::WebsocketServerFailure(err.to_string())

--- a/core/src/price_reporter/jobs.rs
+++ b/core/src/price_reporter/jobs.rs
@@ -1,8 +1,8 @@
 //! Defines all possible jobs for the PriceReporterManager.
 #![allow(dead_code)]
-use crossbeam::channel::Sender;
 use ring_channel::RingReceiver;
 use std::collections::{HashMap, HashSet};
+use tokio::sync::oneshot::Sender as TokioSender;
 
 use super::{
     exchanges::{Exchange, ExchangeConnectionState},
@@ -31,7 +31,7 @@ pub enum PriceReporterManagerJob {
         /// The ID of the listener
         id: Option<PriceReporterListenerID>,
         /// The channel to send a response after completion
-        channel: Sender<()>,
+        channel: TokioSender<()>,
     },
     /// Drop the specified id from the listeners
     DropListenerID {
@@ -42,7 +42,7 @@ pub enum PriceReporterManagerJob {
         /// The ID of the listener to drop
         id: PriceReporterListenerID,
         /// The channel to send a response after completion
-        channel: Sender<()>,
+        channel: TokioSender<()>,
     },
     /// Peek at the median price report
     PeekMedian {
@@ -51,7 +51,7 @@ pub enum PriceReporterManagerJob {
         /// The quote Token
         quote_token: Token,
         /// The return channel for the price report
-        channel: Sender<PriceReporterState>,
+        channel: TokioSender<PriceReporterState>,
     },
     /// Peek at each ExchangeConnectionState
     PeekAllExchanges {
@@ -60,7 +60,7 @@ pub enum PriceReporterManagerJob {
         /// The quote Token
         quote_token: Token,
         /// The return channel for the ExchangeConnectionStates
-        channel: Sender<HashMap<Exchange, ExchangeConnectionState>>,
+        channel: TokioSender<HashMap<Exchange, ExchangeConnectionState>>,
     },
     /// Create a forked median receiver
     CreateNewMedianReceiver {
@@ -69,7 +69,7 @@ pub enum PriceReporterManagerJob {
         /// The quote Token
         quote_token: Token,
         /// The return channel for the new receiver
-        channel: Sender<RingReceiver<PriceReport>>,
+        channel: TokioSender<RingReceiver<PriceReport>>,
     },
     /// Get all the exchanges that this price reporter supports
     GetSupportedExchanges {
@@ -78,7 +78,7 @@ pub enum PriceReporterManagerJob {
         /// The quote Token
         quote_token: Token,
         /// The return channel for the supported exchanges
-        channel: Sender<HashSet<Exchange>>,
+        channel: TokioSender<HashSet<Exchange>>,
     },
     /// Get all the supported exchanges that are in a healthy state
     GetHealthyExchanges {
@@ -87,6 +87,6 @@ pub enum PriceReporterManagerJob {
         /// The quote Token
         quote_token: Token,
         /// The return channel for the healthy exchanges
-        channel: Sender<HashSet<Exchange>>,
+        channel: TokioSender<HashSet<Exchange>>,
     },
 }

--- a/core/src/price_reporter/manager.rs
+++ b/core/src/price_reporter/manager.rs
@@ -251,7 +251,9 @@ impl PriceReporterManagerExecutor {
 
         // If there is no specified listener ID, we do not register any new IDs
         if id.is_none() {
-            channel.send(()).unwrap();
+            if !channel.is_closed() {
+                channel.send(()).unwrap();
+            }
             return Ok(());
         }
 
@@ -273,7 +275,9 @@ impl PriceReporterManagerExecutor {
         }
 
         // Send a response that we have handled the job
-        channel.send(()).unwrap();
+        if !channel.is_closed() {
+            channel.send(()).unwrap()
+        };
 
         Ok(())
     }

--- a/core/src/price_reporter/mod.rs
+++ b/core/src/price_reporter/mod.rs
@@ -1,6 +1,8 @@
 //! The price reporter module manages all external price feeds, including PriceReporter spin-up and
 //! tear-down, websocket connections to all exchanges (both centralized and decentralized), and
 //! aggregation of individual PriceReports into medians.
+
+use self::tokens::Token;
 pub mod errors;
 pub mod exchanges;
 pub mod jobs;
@@ -8,3 +10,13 @@ pub mod manager;
 pub mod reporter;
 pub mod tokens;
 pub mod worker;
+
+/// Get the topic name for a price report
+pub fn price_report_topic_name(source: &str, base: Token, quote: Token) -> String {
+    format!(
+        "{}-price-report-{}-{}",
+        source,
+        base.get_addr(),
+        quote.get_addr()
+    )
+}

--- a/core/src/price_reporter/tokens.rs
+++ b/core/src/price_reporter/tokens.rs
@@ -33,7 +33,7 @@ enum ExchangeTicker {
 }
 
 // We populate three global heap-allocated structs for convenience and metadata lookup. The first is
-// a bidirectinal map between the ERC-20 contract address and the ERC-20 ticker. The second is a
+// a bidirectional map between the ERC-20 contract address and the ERC-20 ticker. The second is a
 // HashMap between the ERC-20 contract address and the number of decimals (fixed-point offset). The
 // third is a HashMap between the ERC-20 ticker and each Exchange's expected name for each ticker.
 


### PR DESCRIPTION
### Purpose
This PR makes a refactor of the websocket API server into a router/handler based approach. The idea being that this allows us to cleanly build topic-specific logic for subscribing and unsubscribing (e.g. the price report topics must allocate jobs in the `PriceReportManager`).

This PR also implements the initial routes for price reports and handshake status updates.

The rest of the route implementations will come in a follow up.

### Testing
- Unit tests pass
- Tested price reporting websocket topics locally