### PR TITLE
core: api-server: websocket: Add websocket API authentication

### DIFF
--- a/core/src/api_server/mod.rs
+++ b/core/src/api_server/mod.rs
@@ -1,8 +1,122 @@
 //! Defines the server for the publicly facing API (both HTTP and websocket)
 //! that the relayer exposes
 
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use circuits::types::keychain::PublicSigningKey;
+use ed25519_dalek::{Digest, PublicKey, Sha512, Signature};
+use hyper::{HeaderMap, StatusCode};
+
+use self::error::ApiServerError;
+
 pub mod error;
 mod http;
 mod router;
 mod websocket;
 pub mod worker;
+
+/// Header name for the HTTP auth signature
+const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
+/// Header name for the expiration timestamp of a signature
+const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
+
+/// Error displayed when the signature format is invalid
+const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
+/// Error displayed when the signature header is missing
+const ERR_SIG_HEADER_MISSING: &str = "signature missing from request";
+/// Error displayed when the signature expiration header is missing
+const ERR_SIG_EXPIRATION_MISSING: &str = "signature expiration missing from headers";
+/// Error displayed when the expiration format is invalid
+const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiration timestamp";
+/// Error displayed when signature verification fails on a request
+const ERR_SIG_VERIFICATION_FAILED: &str = "signature verification failed";
+
+/// A helper to authenticate a request via expiring signatures using the method below
+pub(self) fn authenticate_wallet_request(
+    headers: HeaderMap,
+    body: &[u8],
+    pk_root: &PublicSigningKey,
+) -> Result<(), ApiServerError> {
+    // Parse the signature and the expiration timestamp from the header
+    let signature = headers
+        .get(RENEGADE_AUTH_HEADER_NAME)
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_SIG_HEADER_MISSING.to_string(),
+            )
+        })?
+        .as_bytes();
+    let sig_expiration = headers
+        .get(RENEGADE_SIG_EXPIRATION_HEADER_NAME)
+        .ok_or_else(|| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_SIG_EXPIRATION_MISSING.to_string(),
+            )
+        })?;
+
+    // Parse the expiration into a timestamp
+    let expiration = sig_expiration
+        .to_str()
+        .map_err(|_| {
+            ApiServerError::HttpStatusCode(
+                StatusCode::BAD_REQUEST,
+                ERR_EXPIRATION_FORMAT_INVALID.to_string(),
+            )
+        })
+        .and_then(|s| {
+            s.parse::<u64>().map_err(|_| {
+                ApiServerError::HttpStatusCode(
+                    StatusCode::BAD_REQUEST,
+                    ERR_EXPIRATION_FORMAT_INVALID.to_string(),
+                )
+            })
+        })?;
+
+    // Recover a public key from the byte packed scalar representing the public key
+    let root_key: PublicKey = pk_root.into();
+    if !validate_expiring_signature(body, expiration, signature, root_key)? {
+        Err(ApiServerError::HttpStatusCode(
+            StatusCode::UNAUTHORIZED,
+            ERR_SIG_VERIFICATION_FAILED.to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// A helper to verify a signature on a request body
+///
+/// The signature should be a sponge hash of the serialized request body
+/// and a unix timestamp representing the expiration of the signature. A
+/// call to this method after the expiration timestamp should return false
+pub(self) fn validate_expiring_signature(
+    body: &[u8],
+    expiration_timestamp: u64,
+    signature: &[u8],
+    pk_root: PublicKey,
+) -> Result<bool, ApiServerError> {
+    // Check the expiration timestamp
+    let now = SystemTime::now();
+    let target_duration = Duration::from_millis(expiration_timestamp);
+    let target_time = UNIX_EPOCH + target_duration;
+
+    if now >= target_time {
+        return Ok(false);
+    }
+
+    // Hash the body and the expiration timestamp into a digest to check the signature against
+    let mut hasher = Sha512::default();
+    hasher.update(body);
+    hasher.update(expiration_timestamp.to_le_bytes());
+
+    // Check the signature
+    let sig: Signature = serde_json::from_slice(signature).map_err(|_| {
+        ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_SIG_FORMAT_INVALID.to_string())
+    })?;
+
+    Ok(pk_root
+        .verify_prehashed(hasher, None /* context */, &sig)
+        .is_ok())
+}

--- a/core/src/api_server/websocket/handler.rs
+++ b/core/src/api_server/websocket/handler.rs
@@ -29,11 +29,16 @@ pub trait WebsocketTopicHandler: Send + Sync {
         topic: String,
         route_params: &UrlParams,
     ) -> Result<(), ApiServerError>;
+
+    /// Whether or not the route requires wallet auth
+    fn requires_wallet_auth(&self) -> bool;
 }
 
 /// The default handler directly subscribes and unsubscribes from the topic
 #[derive(Clone)]
 pub struct DefaultHandler {
+    /// Whether or not the endpoint is authenticated
+    authenticated: bool,
     /// A reference to the relayer-global system bus
     system_bus: SystemBus<SystemBusMessage>,
     /// The bus topic to subscribe to on a subscription message
@@ -44,8 +49,13 @@ pub struct DefaultHandler {
 
 impl DefaultHandler {
     /// Constructor
-    pub fn new_with_remap(topic_remap: String, system_bus: SystemBus<SystemBusMessage>) -> Self {
+    pub fn new_with_remap(
+        authenticated: bool,
+        topic_remap: String,
+        system_bus: SystemBus<SystemBusMessage>,
+    ) -> Self {
         Self {
+            authenticated,
             system_bus,
             topic_remap: Some(topic_remap),
         }
@@ -76,5 +86,9 @@ impl WebsocketTopicHandler for DefaultHandler {
         _route_params: &UrlParams,
     ) -> Result<(), ApiServerError> {
         Ok(())
+    }
+
+    fn requires_wallet_auth(&self) -> bool {
+        self.authenticated
     }
 }

--- a/core/src/api_server/websocket/price_report.rs
+++ b/core/src/api_server/websocket/price_report.rs
@@ -133,4 +133,8 @@ impl WebsocketTopicHandler for PriceReporterHandler {
     ) -> Result<(), ApiServerError> {
         Ok(())
     }
+
+    fn requires_wallet_auth(&self) -> bool {
+        false
+    }
 }

--- a/core/src/api_server/websocket/task.rs
+++ b/core/src/api_server/websocket/task.rs
@@ -71,4 +71,8 @@ impl WebsocketTopicHandler for TaskStatusHandler {
     ) -> Result<(), ApiServerError> {
         Ok(())
     }
+
+    fn requires_wallet_auth(&self) -> bool {
+        false
+    }
 }

--- a/core/src/api_server/websocket/wallet.rs
+++ b/core/src/api_server/websocket/wallet.rs
@@ -79,4 +79,8 @@ impl WebsocketTopicHandler for WalletTopicHandler {
     ) -> Result<(), ApiServerError> {
         Ok(())
     }
+
+    fn requires_wallet_auth(&self) -> bool {
+        true
+    }
 }

--- a/core/src/external_api/websocket.rs
+++ b/core/src/external_api/websocket.rs
@@ -1,12 +1,23 @@
 //! Groups API definitions for the websocket API
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+
+/// The wrapper websocket message type that contains both a header and body
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientWebsocketMessage {
+    /// The headers associated with the client message
+    pub headers: HashMap<String, String>,
+    /// The body of the request
+    pub body: WebsocketMessage,
+}
 
 /// A message type that indicates the client would like to either subscribe or unsubscribe
 /// from a given topic
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum SubscriptionMessage {
+#[serde(tag = "method", rename_all = "lowercase")]
+pub enum WebsocketMessage {
     /// Indicates that the client would like to subscribe to the given topic
     Subscribe {
         /// The topic being subscribed to
@@ -19,7 +30,7 @@ pub enum SubscriptionMessage {
     },
 }
 
-/// A message that is sent in response to a SubscriptionMessage, notifies the client
+/// A message that is sent in response to a subscribe/unsubscribe message, notifies the client
 /// of the now active subscriptions after a subscribe/unsubscribe message is applied
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubscriptionResponse {


### PR DESCRIPTION
### Purpose
This PR implements authentication for the websocket API. This involves checking that the client has signed the request body with `sk_root` -- just as in the HTTP api.

Auth is only attached to the wallet update topic for the moment.

### Testing
- Unit tests
- Tested both unauthenticated and authenticated (with and without valid signatures) routes.