### PR TITLE
circuits: types: Add secret share types

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -593,6 +593,15 @@ impl CommitWitness for LinkableCommitment {
     }
 }
 
+impl CommitVerifier for CompressedRistretto {
+    type VarType = Variable;
+    type ErrorType = (); // Does not error
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        Ok(verifier.commit(*self))
+    }
+}
+
 impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> SharePublic<N, S> for LinkableCommitment {
     type ErrorType = MpcError;
 

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -21,7 +21,7 @@ use crate::{
     errors::MpcError,
     mpc::SharedFabric,
     types::{biguint_from_hex_string, biguint_to_hex_string},
-    Allocate, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment,
+    Allocate, CommitPublic, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment,
 };
 
 // ---------------------
@@ -404,6 +404,24 @@ impl CommitWitness for BalanceSecretShare {
                 amount: amount_comm,
             },
         ))
+    }
+}
+
+impl CommitPublic for BalanceSecretShare {
+    type VarType = BalanceSecretShareVar;
+    type ErrorType = (); // Does not error
+
+    fn commit_public<CS: mpc_bulletproof::r1cs::RandomizableConstraintSystem>(
+        &self,
+        cs: &mut CS,
+    ) -> Result<Self::VarType, Self::ErrorType> {
+        let mint_var = self.mint.commit_public(cs).unwrap();
+        let amount_var = self.amount.commit_public(cs).unwrap();
+
+        Ok(BalanceSecretShareVar {
+            mint: mint_var,
+            amount: amount_var,
+        })
     }
 }
 

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -324,6 +324,20 @@ impl Add<BalanceSecretShare> for BalanceSecretShare {
     }
 }
 
+impl BalanceSecretShare {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.mint += blinder;
+        self.amount += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.mint -= blinder;
+        self.amount -= blinder;
+    }
+}
+
 /// A balance secret share that has been allocated in a constraint system
 #[derive(Copy, Clone, Debug)]
 pub struct BalanceSecretShareVar {
@@ -341,6 +355,20 @@ impl Add<BalanceSecretShareVar> for BalanceSecretShareVar {
             mint: self.mint + rhs.mint,
             amount: self.amount + rhs.amount,
         }
+    }
+}
+
+impl BalanceSecretShareVar {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Variable) {
+        self.mint += blinder;
+        self.amount += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Variable) {
+        self.mint -= blinder;
+        self.amount -= blinder;
     }
 }
 

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -9,7 +9,8 @@ use crate::{
         AuthenticatedCommittedFixedPoint, AuthenticatedFixedPoint, AuthenticatedFixedPointVar,
         CommittedFixedPoint, FixedPoint, FixedPointVar, LinkableFixedPointCommitment,
     },
-    Allocate, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment, SharePublic,
+    Allocate, CommitPublic, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment,
+    SharePublic,
 };
 use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
@@ -705,6 +706,28 @@ impl CommitWitness for FeeSecretShare {
                 percentage_fee: percentage_comm,
             },
         ))
+    }
+}
+
+impl CommitPublic for FeeSecretShare {
+    type VarType = FeeSecretShareVar;
+    type ErrorType = ();
+
+    fn commit_public<CS: mpc_bulletproof::r1cs::RandomizableConstraintSystem>(
+        &self,
+        cs: &mut CS,
+    ) -> Result<Self::VarType, Self::ErrorType> {
+        let settle_key_var = self.settle_key.commit_public(cs).unwrap();
+        let gas_addr_var = self.gas_addr.commit_public(cs).unwrap();
+        let gas_amount_var = self.gas_token_amount.commit_public(cs).unwrap();
+        let percentage_var = self.percentage_fee.commit_public(cs).unwrap();
+
+        Ok(FeeSecretShareVar {
+            settle_key: settle_key_var,
+            gas_addr: gas_addr_var,
+            gas_token_amount: gas_amount_var,
+            percentage_fee: percentage_var,
+        })
     }
 }
 

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -594,6 +594,24 @@ impl Add<FeeSecretShare> for FeeSecretShare {
     }
 }
 
+impl FeeSecretShare {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.settle_key += blinder;
+        self.gas_addr += blinder;
+        self.gas_token_amount += blinder;
+        self.percentage_fee += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.settle_key -= blinder;
+        self.gas_addr -= blinder;
+        self.gas_token_amount -= blinder;
+        self.percentage_fee -= blinder;
+    }
+}
+
 /// Represents a fee secret share that has been allocated in a constraint system
 #[derive(Clone, Copy, Debug)]
 pub struct FeeSecretShareVar {
@@ -619,6 +637,24 @@ impl Add<FeeSecretShareVar> for FeeSecretShareVar {
             gas_token_amount: self.gas_token_amount + rhs.gas_token_amount,
             percentage_fee: self.percentage_fee + rhs.percentage_fee,
         }
+    }
+}
+
+impl FeeSecretShareVar {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Variable) {
+        self.settle_key += blinder;
+        self.gas_addr += blinder;
+        self.gas_token_amount += blinder;
+        self.percentage_fee += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Variable) {
+        self.settle_key -= blinder;
+        self.gas_addr -= blinder;
+        self.gas_token_amount -= blinder;
+        self.percentage_fee -= blinder;
     }
 }
 

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -461,6 +461,24 @@ impl CommitWitness for PublicKeyChainSecretShare {
     }
 }
 
+impl CommitPublic for PublicKeyChainSecretShare {
+    type VarType = PublicKeyChainSecretShareVar;
+    type ErrorType = (); // Does not error
+
+    fn commit_public<CS: RandomizableConstraintSystem>(
+        &self,
+        cs: &mut CS,
+    ) -> Result<Self::VarType, Self::ErrorType> {
+        let root_var = self.pk_root.commit_public(cs).unwrap();
+        let match_var = self.pk_match.commit_public(cs).unwrap();
+
+        Ok(PublicKeyChainSecretShareVar {
+            pk_root: root_var,
+            pk_match: match_var,
+        })
+    }
+}
+
 impl CommitVerifier for PublicKeyChainSecretShareCommitment {
     type VarType = PublicKeyChainSecretShareVar;
     type ErrorType = (); // Does not error

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -390,6 +390,20 @@ impl Add<PublicKeyChainSecretShare> for PublicKeyChainSecretShare {
     }
 }
 
+impl PublicKeyChainSecretShare {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.pk_root.blind(blinder);
+        self.pk_match += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.pk_root.unblind(blinder);
+        self.pk_match -= blinder;
+    }
+}
+
 /// Represents an additive secret share of a wallet's public keychain
 /// that has been allocated in a constraint system
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -9,7 +9,7 @@ use crate::{
         AuthenticatedCommittedFixedPoint, AuthenticatedFixedPoint, AuthenticatedFixedPointVar,
         CommittedFixedPoint, FixedPoint, FixedPointVar, LinkableFixedPointCommitment,
     },
-    Allocate, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment,
+    Allocate, CommitPublic, CommitSharedProver, CommitVerifier, CommitWitness, LinkableCommitment,
 };
 use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
@@ -838,6 +838,32 @@ impl CommitWitness for OrderSecretShare {
                 timestamp: timestamp_comm,
             },
         ))
+    }
+}
+
+impl CommitPublic for OrderSecretShare {
+    type VarType = OrderSecretShareVar;
+    type ErrorType = (); // Does not error
+
+    fn commit_public<CS: mpc_bulletproof::r1cs::RandomizableConstraintSystem>(
+        &self,
+        cs: &mut CS,
+    ) -> Result<Self::VarType, Self::ErrorType> {
+        let quote_var = self.quote_mint.commit_public(cs).unwrap();
+        let base_var = self.base_mint.commit_public(cs).unwrap();
+        let side_var = self.side.commit_public(cs).unwrap();
+        let price_var = self.price.commit_public(cs).unwrap();
+        let amount_var = self.amount.commit_public(cs).unwrap();
+        let timestamp_var = self.timestamp.commit_public(cs).unwrap();
+
+        Ok(OrderSecretShareVar {
+            quote_mint: quote_var,
+            base_mint: base_var,
+            side: side_var,
+            price: price_var,
+            amount: amount_var,
+            timestamp: timestamp_var,
+        })
     }
 }
 

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -703,6 +703,28 @@ impl Add<OrderSecretShare> for OrderSecretShare {
     }
 }
 
+impl OrderSecretShare {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.quote_mint += blinder;
+        self.base_mint += blinder;
+        self.side += blinder;
+        self.price += blinder;
+        self.amount += blinder;
+        self.timestamp += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.quote_mint -= blinder;
+        self.base_mint -= blinder;
+        self.side -= blinder;
+        self.price -= blinder;
+        self.amount -= blinder;
+        self.timestamp -= blinder;
+    }
+}
+
 /// Represents an additive secret share of an order committed into a constraint system
 #[derive(Clone, Copy, Debug)]
 pub struct OrderSecretShareVar {
@@ -739,6 +761,28 @@ impl Add<OrderSecretShareVar> for OrderSecretShareVar {
             amount,
             timestamp,
         }
+    }
+}
+
+impl OrderSecretShareVar {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Variable) {
+        self.quote_mint += blinder;
+        self.base_mint += blinder;
+        self.side += blinder;
+        self.price += blinder;
+        self.amount += blinder;
+        self.timestamp += blinder;
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Variable) {
+        self.quote_mint -= blinder;
+        self.base_mint -= blinder;
+        self.side -= blinder;
+        self.price -= blinder;
+        self.amount -= blinder;
+        self.timestamp -= blinder;
     }
 }
 

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -1,9 +1,11 @@
 //! Groups type definitions for a wallet and implements traits to allocate
 //! the wallet
 
+use std::ops::Add;
+
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use itertools::Itertools;
-use mpc_bulletproof::r1cs::{Prover, Variable, Verifier};
+use mpc_bulletproof::r1cs::{LinearCombination, Prover, Variable, Verifier};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -13,11 +15,20 @@ use crate::{
 };
 
 use super::{
-    balance::{Balance, BalanceVar, CommittedBalance},
+    balance::{
+        Balance, BalanceSecretShare, BalanceSecretShareCommitment, BalanceSecretShareVar,
+        BalanceVar, CommittedBalance,
+    },
     deserialize_array,
-    fee::{CommittedFee, Fee, FeeVar},
-    keychain::{CommittedPublicKeyChain, PublicKeyChain, PublicKeyChainVar},
-    order::{CommittedOrder, Order, OrderVar},
+    fee::{CommittedFee, Fee, FeeSecretShare, FeeSecretShareCommitment, FeeSecretShareVar, FeeVar},
+    keychain::{
+        CommittedPublicKeyChain, PublicKeyChain, PublicKeyChainSecretShare,
+        PublicKeyChainSecretShareCommitment, PublicKeyChainSecretShareVar, PublicKeyChainVar,
+    },
+    order::{
+        CommittedOrder, Order, OrderSecretShare, OrderSecretShareCommitment, OrderSecretShareVar,
+        OrderVar,
+    },
     serialize_array,
 };
 
@@ -27,6 +38,10 @@ pub type WalletCommitment = Scalar;
 pub type NoteCommitment = Scalar;
 /// Nullifier type alias for readability
 pub type Nullifier = Scalar;
+
+// --------------------
+// | Wallet Base Type |
+// --------------------
 
 /// Represents the base type of a wallet holding orders, balances, fees, keys
 /// and cryptographic randomness
@@ -55,30 +70,34 @@ where
     pub fees: [Fee; MAX_FEES],
     /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
     pub keys: PublicKeyChain,
-    /// The wallet randomness used to blind commitments, nullifiers, etc
+    /// The wallet randomness used to blind secret shares
     #[serde(
         serialize_with = "scalar_to_hex_string",
         deserialize_with = "scalar_from_hex_string"
     )]
-    pub randomness: Scalar,
+    pub blinder: Scalar,
 }
 
 /// Represents a wallet that has been allocated in a constraint system
 #[derive(Clone, Debug)]
-pub struct WalletVar<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
-where
+pub struct WalletVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    L: Into<LinearCombination>,
+> where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// The list of balances in the wallet
-    pub balances: [BalanceVar; MAX_BALANCES],
+    pub balances: [BalanceVar<L>; MAX_BALANCES],
     /// The list of open orders in the wallet
-    pub orders: [OrderVar; MAX_ORDERS],
+    pub orders: [OrderVar<L>; MAX_ORDERS],
     /// The list of payable fees in the wallet
-    pub fees: [FeeVar; MAX_FEES],
+    pub fees: [FeeVar<L>; MAX_FEES],
     /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
-    pub keys: PublicKeyChainVar,
-    /// The wallet randomness used to blind commitments, nullifiers, etc
-    pub randomness: Variable,
+    pub keys: PublicKeyChainVar<L>,
+    /// The wallet randomness used to blind secret shares
+    pub blinder: Variable,
 }
 
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitWitness
@@ -87,7 +106,7 @@ where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     type CommitType = CommittedWallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, Variable>;
     type ErrorType = ();
 
     fn commit_witness<R: RngCore + CryptoRng>(
@@ -114,7 +133,7 @@ where
             .unzip();
 
         let (key_vars, key_comms) = self.keys.commit_witness(rng, prover).unwrap();
-        let (randomness_comm, randomness_var) = prover.commit(self.randomness, Scalar::random(rng));
+        let (blinder_comm, blinder_var) = prover.commit(self.randomness, Scalar::random(rng));
 
         Ok((
             WalletVar {
@@ -122,14 +141,14 @@ where
                 orders: order_vars.try_into().unwrap(),
                 fees: fee_vars.try_into().unwrap(),
                 keys: key_vars,
-                randomness: randomness_var,
+                blinder: blinder_var,
             },
             CommittedWallet {
                 balances: committed_balances.try_into().unwrap(),
                 orders: committed_orders.try_into().unwrap(),
                 fees: committed_fees.try_into().unwrap(),
                 keys: key_comms,
-                randomness: randomness_comm,
+                blinder: blinder_comm,
             },
         ))
     }
@@ -155,8 +174,8 @@ pub struct CommittedWallet<
     pub fees: [CommittedFee; MAX_FEES],
     /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
     pub keys: CommittedPublicKeyChain,
-    /// The wallet randomness used to blind commitments, nullifiers, etc
-    pub randomness: CompressedRistretto,
+    /// The wallet randomness used to blind secret shares
+    pub blinder: CompressedRistretto,
 }
 
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
@@ -164,7 +183,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> 
 where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
-    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type VarType = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, Variable>;
     type ErrorType = ();
 
     fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
@@ -185,14 +204,249 @@ where
             .collect_vec();
 
         let key_vars = self.keys.commit_verifier(verifier).unwrap();
-        let randomness_var = verifier.commit(self.randomness);
+        let blinder_var = verifier.commit(self.randomness);
 
         Ok(WalletVar {
             balances: balance_vars.try_into().unwrap(),
             orders: order_vars.try_into().unwrap(),
             fees: fee_vars.try_into().unwrap(),
             keys: key_vars,
-            randomness: randomness_var,
+            blinder: blinder_var,
+        })
+    }
+}
+
+// ----------------------------
+// | Wallet Secret Share Type |
+// ----------------------------
+
+/// Represents an additive secret share of a wallet
+#[derive(Clone, Debug)]
+pub struct WalletSecretShare<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The list of balances in the wallet
+    pub balances: [BalanceSecretShare; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [OrderSecretShare; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [FeeSecretShare; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: PublicKeyChainSecretShare,
+    /// The wallet randomness used to blind secret shares
+    pub blinder: Scalar,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    Add<WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>>
+    for WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type Output = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let balances = self
+            .balances
+            .iter()
+            .zip(rhs.balances.iter())
+            .map(|b1, b2| b1 + b2)
+            .collect_vec();
+
+        let orders = self
+            .orders
+            .iter()
+            .zip(rhs.orders.iter())
+            .map(|o1, o2| o1 + o2)
+            .collect_vec();
+
+        let fees = self
+            .fees
+            .iter()
+            .zip(rhs.fees.iter())
+            .map(|f1, f2| f1 + f2)
+            .collect_vec();
+
+        let keys = self.keys + rhs.keys;
+        let blinder = self.blinder + rhs.blinder;
+
+        Self::Output {
+            balances,
+            orders,
+            fees,
+            keys,
+            blinder,
+        }
+    }
+}
+
+/// Represents an additive secret share of a wallet that
+/// has been allocated in a constraint system
+#[derive(Clone, Debug)]
+pub struct WalletSecretShareVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The list of balances in the wallet
+    pub balances: [BalanceSecretShareVar; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [OrderSecretShareVar; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [FeeSecretShareVar; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: PublicKeyChainSecretShareVar,
+    /// The wallet randomness used to blind secret shares
+    pub blinder: Variable,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    Add<WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>>
+    for WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type Output = WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, LinearCombination>;
+
+    fn add(self, rhs: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>) -> Self::Output {
+        let balances = self
+            .balances
+            .iter()
+            .zip(rhs.balances.iter())
+            .map(|b1, b2| b1 + b2)
+            .collect_vec();
+
+        let orders = self
+            .orders
+            .iter()
+            .zip(rhs.orders.iter())
+            .map(|o1, o2| o1 + o2)
+            .collect_vec();
+
+        let fees = self
+            .fees
+            .iter()
+            .zip(rhs.fees.iter())
+            .map(|f1, f2| f1 + f2)
+            .collect_vec();
+
+        let keys = self.keys + rhs.keys;
+        let blinder = self.blinder + rhs.blinder;
+
+        Self::Output {
+            balances,
+            orders,
+            fees,
+            keys,
+            blinder,
+        }
+    }
+}
+
+/// Represents a commitment to an additive secret share of a wallet that
+/// has been allocated in a constraint system
+#[derive(Clone, Debug)]
+pub struct WalletSecretShareCommitment<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The list of balances in the wallet
+    pub balances: [BalanceSecretShareCommitment; MAX_BALANCES],
+    /// The list of open orders in the wallet
+    pub orders: [OrderSecretShareCommitment; MAX_ORDERS],
+    /// The list of payable fees in the wallet
+    pub fees: [FeeSecretShareCommitment; MAX_FEES],
+    /// The key tuple used by the wallet; i.e. (pk_root, pk_match, pk_settle, pk_view)
+    pub keys: PublicKeyChainSecretShareCommitment,
+    /// The wallet randomness used to blind secret shares
+    pub blinder: CompressedRistretto,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitWitness
+    for WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type VarType = WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type CommitType = WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = (); // Does not error
+
+    fn commit_witness<R: RngCore + CryptoRng>(
+        &self,
+        rng: &mut R,
+        prover: &mut Prover,
+    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
+        let (balance_vars, balance_comms) = self
+            .balances
+            .iter()
+            .map(|b| b.commit_witness(rng, prover).unwrap())
+            .collect();
+
+        let (order_vars, order_comms) = self
+            .orders
+            .iter()
+            .map(|o| o.commit_witness(rng, prover).unwrap())
+            .collect();
+
+        let (fee_vars, fee_comms) = self
+            .fees
+            .iter()
+            .map(|f| f.commit_witness(rng, prover).unwrap())
+            .collect();
+
+        let (key_var, key_comm) = self.keys.commit_witness(rng, prover).unwrap();
+        let (blinder_var, blinder_comm) = self.blinder.commit_witness(rng, prover).unwrap();
+
+        Ok((
+            WalletSecretShareVar {
+                balances: balance_vars,
+                orders: order_vars,
+                fees: fee_vars,
+                keys: key_var,
+                blinder: blinder_var,
+            },
+            WalletSecretShareCommitment {
+                balances: balance_comms,
+                orders: order_comms,
+                fees: fee_comms,
+                keys: key_comm,
+                blinder: blinder_comm,
+            },
+        ))
+    }
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
+    for WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type VarType = WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = (); // Does not error
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        let balance_vars = self
+            .balances
+            .iter()
+            .map(|b| b.commit_verifier(verifier).unwrap())
+            .collect_vec();
+
+        let order_vars = self
+            .orders
+            .iter()
+            .map(|o| o.commit_verifier(verifier).unwrap())
+            .collect_vec();
+
+        let fee_vars = self
+            .fees
+            .iter()
+            .map(|f| f.commit_verifier(verifier).unwrap())
+            .collect_vec();
+
+        let key_var = self.keys.commit_verifier(verifier).unwrap();
+        let blinder_var = self.blinder.commit_verifier(verifier).unwrap();
+
+        Ok(WalletSecretShareVar {
+            balances: balance_vars,
+            orders: order_vars,
+            fees: fee_vars,
+            keys: key_var,
+            blinder: blinder_var,
         })
     }
 }

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -280,6 +280,28 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
     }
 }
 
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    /// Apply the wallet blinder to the secret shares
+    pub fn blind(&mut self) {
+        self.balances.iter_mut().foreach(|b| b.blind(self.blinder));
+        self.orders.iter_mut().foreach(|o| o.blind(self.blinder));
+        self.fees.iter_mut().foreach(|f| f.blind(self.blinder));
+        self.keys.blind(self.blinder);
+    }
+
+    /// Remove the wallet blinder from the secret shares
+    pub fn unblind(&mut self) {
+        self.balances
+            .iter_mut()
+            .for_each(|b| b.unblind(self.blinder));
+        self.orders.iter_mut().foreach(|o| o.unblind(self.blinder));
+        self.fees.iter_mut().foreach(|f| f.unblind(self.blinder));
+        self.keys.unblind(self.blinder);
+    }
+}
+
 /// Represents an additive secret share of a wallet that
 /// has been allocated in a constraint system
 #[derive(Clone, Debug)]
@@ -338,6 +360,28 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
             keys,
             blinder,
         }
+    }
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    /// Apply the wallet blinder to the secret shares
+    pub fn blind(&mut self) {
+        self.balances.iter_mut().foreach(|b| b.blind(self.blinder));
+        self.orders.iter_mut().foreach(|o| o.blind(self.blinder));
+        self.fees.iter_mut().foreach(|f| f.blind(self.blinder));
+        self.keys.blind(self.blinder);
+    }
+
+    /// Remove the wallet blinder from the secret shares
+    pub fn unblind(&mut self) {
+        self.balances
+            .iter_mut()
+            .for_each(|b| b.unblind(self.blinder));
+        self.orders.iter_mut().foreach(|o| o.unblind(self.blinder));
+        self.fees.iter_mut().foreach(|f| f.unblind(self.blinder));
+        self.keys.unblind(self.blinder);
     }
 }
 

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -925,6 +925,18 @@ impl Add<NonNativeElementSecretShare> for NonNativeElementSecretShare {
     }
 }
 
+impl NonNativeElementSecretShare {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.words.iter_mut().for_each(|word| word += blinder);
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.words.iter_mut().for_each(|word| word -= blinder);
+    }
+}
+
 /// Represents an additive secret share of a non-native element that has been
 /// allocated in a constraint system
 #[derive(Clone, Debug)]
@@ -950,6 +962,18 @@ impl Add<NonNativeElementSecretShareVar> for NonNativeElementSecretShareVar {
             words: out_words,
             field_mod: self.field_mod,
         }
+    }
+}
+
+impl NonNativeElementSecretShareVar {
+    /// Apply a blinder to the secret shares
+    pub fn blind(&mut self, blinder: Variable) {
+        self.words.iter_mut().for_each(|word| word += blinder);
+    }
+
+    /// Remove a blinder from the secret shares
+    pub fn unblind(&mut self, blinder: Variable) {
+        self.words.iter_mut().for_each(|word| word -= blinder);
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds type definitions for wallet secret shares, including types that are allocated in a constrain system, and commitments to secret shares. These types will be the building blocks for the circuit redesign as a next step.

The refactored types are:
- balances
- orders
- fees
- keychain
- wallet

### Testing
- CI will fail while the refactor is in progress, no testing done.