### PR TITLE
circuits: zk-circuits: `VALID WALLET CREATE`: Implement refactored circuit

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -808,13 +808,10 @@ pub mod native_helpers {
         // Hash the keys into the state
         let mut key_scalars = Vec::<Scalar>::from(wallet.keys.pk_root.clone());
         key_scalars.push(wallet.keys.pk_match.into());
-        key_scalars.push(wallet.keys.pk_settle.into());
-        key_scalars.push(wallet.keys.pk_view.into());
-
         hasher.absorb(&key_scalars.iter().map(scalar_to_prime_field).collect_vec());
 
         // Hash the randomness into the state
-        hasher.absorb(&scalar_to_prime_field(&wallet.randomness));
+        hasher.absorb(&scalar_to_prime_field(&wallet.blinder));
 
         hasher.squeeze_field_elements(1 /* num_elements */)[0]
     }
@@ -857,7 +854,7 @@ pub mod native_helpers {
         [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
     {
         let mut hasher = PoseidonSponge::new(&default_poseidon_params());
-        hasher.absorb(&vec![commitment, scalar_to_prime_field(&wallet.randomness)]);
+        hasher.absorb(&vec![commitment, scalar_to_prime_field(&wallet.blinder)]);
         hasher.squeeze_field_elements(1 /* num_elements */)[0]
     }
 
@@ -877,7 +874,7 @@ pub mod native_helpers {
         let mut hasher = PoseidonSponge::new(&default_poseidon_params());
         hasher.absorb(&vec![
             commitment,
-            scalar_to_prime_field(&(wallet.randomness + Scalar::one())),
+            scalar_to_prime_field(&(wallet.blinder + Scalar::one())),
         ]);
         hasher.squeeze_field_elements(1 /* num_elements */)[0]
     }

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -747,17 +747,9 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        share: &WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        share: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> Scalar {
-        let mut hash_input = Vec::new();
-        for balance in share.balances.iter() {
-            hash_input.append(&mut vec![balance.mint, balance.amount])
-        }
-
-        for order in share.orders.iter() {
-            hash_input.append(&mut vec![])
-        }
-
+        let hash_input: Vec<Scalar> = share.into();
         compute_poseidon_hash(&hash_input)
     }
 

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -1,5 +1,5 @@
 //! Groups the base type and derived types for the `Fee` entity
-use std::{ops::Add, os::unix::fs::DirBuilderExt};
+use std::ops::Add;
 
 use crate::{
     errors::{MpcError, TypeConversionError},

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -14,7 +14,6 @@ use crate::{
         fee::SCALARS_PER_FEE, order::SCALARS_PER_ORDER, scalar_from_hex_string,
         scalar_to_hex_string,
     },
-    zk_gadgets::commitments::WalletShareCommitGadget,
     CommitPublic, CommitVerifier, CommitWitness,
 };
 
@@ -495,7 +494,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
             .for_each(|f| wallet_shares.append(&mut f.into()));
 
         wallet_shares.append(&mut wallet.keys.into());
-        wallet_shares.push(wallet.blinder.into());
+        wallet_shares.push(wallet.blinder);
 
         wallet_shares
     }

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -249,21 +249,19 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
     WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
 {
     /// Apply the wallet blinder to the secret shares
-    pub fn blind(&mut self) {
-        self.balances.iter_mut().for_each(|b| b.blind(self.blinder));
-        self.orders.iter_mut().for_each(|o| o.blind(self.blinder));
-        self.fees.iter_mut().for_each(|f| f.blind(self.blinder));
-        self.keys.blind(self.blinder);
+    pub fn blind(&mut self, blinder: Scalar) {
+        self.balances.iter_mut().for_each(|b| b.blind(blinder));
+        self.orders.iter_mut().for_each(|o| o.blind(blinder));
+        self.fees.iter_mut().for_each(|f| f.blind(blinder));
+        self.keys.blind(blinder);
     }
 
     /// Remove the wallet blinder from the secret shares
-    pub fn unblind(&mut self) {
-        self.balances
-            .iter_mut()
-            .for_each(|b| b.unblind(self.blinder));
-        self.orders.iter_mut().for_each(|o| o.unblind(self.blinder));
-        self.fees.iter_mut().for_each(|f| f.unblind(self.blinder));
-        self.keys.unblind(self.blinder);
+    pub fn unblind(&mut self, blinder: Scalar) {
+        self.balances.iter_mut().for_each(|b| b.unblind(blinder));
+        self.orders.iter_mut().for_each(|o| o.unblind(blinder));
+        self.fees.iter_mut().for_each(|f| f.unblind(blinder));
+        self.keys.unblind(blinder);
     }
 }
 
@@ -401,31 +399,29 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
     WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
 {
     /// Apply the wallet blinder to the secret shares
-    pub fn blind(&mut self) {
+    pub fn blind(&mut self, blinder: LinearCombination) {
         self.balances
             .iter_mut()
-            .for_each(|b| b.blind(self.blinder.clone()));
+            .for_each(|b| b.blind(blinder.clone()));
         self.orders
             .iter_mut()
-            .for_each(|o| o.blind(self.blinder.clone()));
-        self.fees
-            .iter_mut()
-            .for_each(|f| f.blind(self.blinder.clone()));
-        self.keys.blind(self.blinder.clone());
+            .for_each(|o| o.blind(blinder.clone()));
+        self.fees.iter_mut().for_each(|f| f.blind(blinder.clone()));
+        self.keys.blind(blinder);
     }
 
     /// Remove the wallet blinder from the secret shares
-    pub fn unblind(&mut self) {
+    pub fn unblind(&mut self, blinder: LinearCombination) {
         self.balances
             .iter_mut()
-            .for_each(|b| b.unblind(self.blinder.clone()));
+            .for_each(|b| b.unblind(blinder.clone()));
         self.orders
             .iter_mut()
-            .for_each(|o| o.unblind(self.blinder.clone()));
+            .for_each(|o| o.unblind(blinder.clone()));
         self.fees
             .iter_mut()
-            .for_each(|f| f.unblind(self.blinder.clone()));
-        self.keys.unblind(self.blinder.clone());
+            .for_each(|f| f.unblind(blinder.clone()));
+        self.keys.unblind(blinder);
     }
 }
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -39,8 +39,6 @@ mod test_helpers {
         pub(crate) static ref PUBLIC_KEYS: PublicKeyChain = PublicKeyChain {
             pk_root: BigUint::from(1u8).into(),
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
-            pk_settle: compute_poseidon_hash(&[PRIVATE_KEYS[2]]).into(),
-            pk_view: Scalar::one().into(),
         };
         pub(crate) static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
             Balance { mint: 1u8.into(), amount: 5 },
@@ -78,7 +76,7 @@ mod test_helpers {
             orders: INITIAL_ORDERS.clone(),
             fees: INITIAL_FEES.clone(),
             keys: PUBLIC_KEYS.clone(),
-            randomness: Scalar::from(42u64)
+            blinder: Scalar::from(42u64)
         };
     }
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -216,7 +216,7 @@ mod test_helpers {
         };
 
         // Construct the secret shares of the wallet
-        let mut wallet1 = SizedWalletShare {
+        let wallet1 = SizedWalletShare {
             balances: balances1.try_into().unwrap(),
             orders: orders1.try_into().unwrap(),
             fees: fees1.try_into().unwrap(),
@@ -231,9 +231,8 @@ mod test_helpers {
             blinder: wallet.blinder - blinder_share,
         };
 
-        // Blind the shares
-        wallet1.blind();
-        wallet2.blind();
+        // Blind the public shares
+        wallet2.blind(wallet.blinder);
 
         (wallet1, wallet2)
     }

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -8,9 +8,13 @@
 //! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.1
 //! for a formal specification
 
+use std::char::MAX;
+
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
-    r1cs::{Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
+    r1cs::{
+        LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+    },
     r1cs_mpc::R1CSError,
     BulletproofGens,
 };
@@ -19,14 +23,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ProverError, VerifierError},
-    mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    types::{
-        fee::{CommittedFee, Fee, FeeVar},
-        keychain::{CommittedPublicKeyChain, PublicKeyChain, PublicKeyChainVar},
-        serialize_array,
-        wallet::{WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar},
+    types::wallet::{
+        WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar, WalletVar,
     },
-    zk_gadgets::poseidon::PoseidonHashGadget,
+    zk_gadgets::commitments::WalletShareCommitGadget,
     CommitPublic, CommitVerifier, CommitWitness, SingleProverCircuit, MAX_BALANCES, MAX_FEES,
     MAX_ORDERS,
 };
@@ -56,65 +56,54 @@ pub struct ValidWalletCreate<
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
     ValidWalletCreate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
 where
-    [(); MAX_BALANCES * BALANCE_ZEROS + MAX_ORDERS * ORDER_ZEROS]: Sized,
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// Applies constraints to the constraint system specifying the statement of
     /// VALID WALLET CREATE
     fn circuit<CS>(
-        statement: ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        witness: ValidWalletCreateVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        mut statement: ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        mut witness: ValidWalletCreateVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<(), R1CSError>
     where
         CS: RandomizableConstraintSystem,
     {
-        // Check that the commitment is to an empty wallet with the given randomness
-        // keys, and fees
+        // Validate the commitment given in the statement is a valid commitment to the private secret shares
+        let commitment =
+            WalletShareCommitGadget::compute_commitment(&witness.private_wallet_share, cs)?;
+        cs.constrain(commitment - statement.private_shares_commitment);
+
+        // Unblind the shares then reconstruct the wallet
+        witness.private_wallet_share.unblind();
+        statement.public_wallet_shares.unblind();
+        let wallet = witness.private_wallet_share + statement.public_wallet_shares;
+
+        // Verify that the orders and balances are zero'd
+        Self::verify_zero_wallet(wallet, cs);
+
         Ok(())
     }
 
-    /// Validates
-    fn check_commitment<CS>(
+    /// Constrains a wallet to have all zero'd out orders and balances
+    fn verify_zero_wallet<CS: RandomizableConstraintSystem>(
+        wallet: WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, LinearCombination>,
         cs: &mut CS,
-        expected_commit: Variable,
-        witness: ValidWalletCreateVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-    ) -> Result<(), R1CSError>
-    where
-        CS: RandomizableConstraintSystem,
-    {
-        let hash_params = PoseidonSpongeParameters::default();
-        let mut hasher = PoseidonHashGadget::new(hash_params);
-
-        // This wallet should have empty orders and balances, hash zeros into the state
-        // to represent an empty orders list
-        let zeros = [Scalar::zero(); MAX_BALANCES * BALANCE_ZEROS + MAX_ORDERS * ORDER_ZEROS];
-        hasher.batch_absorb(&zeros, cs)?;
-
-        // Hash the fees into the state
-        for fee in witness.fees.iter() {
-            hasher.batch_absorb(
-                &[
-                    fee.settle_key.into(),
-                    fee.gas_addr.into(),
-                    fee.gas_token_amount.into(),
-                    fee.percentage_fee.repr.clone(),
-                ],
-                cs,
-            )?;
+    ) {
+        // Constrain balances to be zero
+        for balance in wallet.balances.into_iter() {
+            cs.constrain(balance.mint);
+            cs.constrain(balance.amount);
         }
 
-        // Hash the keys into the state
-        let mut key_vars = witness.keys.pk_root.words();
-        key_vars.push(witness.keys.pk_match.into());
-        key_vars.push(witness.keys.pk_settle.into());
-        key_vars.push(witness.keys.pk_view.into());
-
-        hasher.batch_absorb(&key_vars, cs)?;
-        hasher.absorb(witness.wallet_randomness, cs)?;
-
-        // Enforce that the result is equal to the expected commitment
-        hasher.constrained_squeeze(expected_commit, cs)?;
-        Ok(())
+        // Constrain orders to be zero
+        for order in wallet.orders.into_iter() {
+            cs.constrain(order.base_mint);
+            cs.constrain(order.quote_mint);
+            cs.constrain(order.side);
+            cs.constrain(order.price.repr);
+            cs.constrain(order.amount);
+            cs.constrain(order.timestamp);
+        }
     }
 }
 
@@ -141,7 +130,7 @@ pub struct ValidWalletCreateVar<
     const MAX_FEES: usize,
 > {
     /// The private secret shares of the new wallet
-    pub private_wallet_share: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub private_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
 }
 
 /// The committed witness for the VALID WALLET CREATE proof
@@ -201,7 +190,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> 
 // -----------------------------
 
 /// The statement type for the `VALID WALLET CREATE` circuit
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletCreateStatement<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
@@ -214,7 +203,7 @@ pub struct ValidWalletCreateStatement<
 }
 
 /// The statement type for the `VALID WALLET CREATE` circuit, allocated in a constraint system
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct ValidWalletCreateStatementVar<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
@@ -253,7 +242,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> 
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> SingleProverCircuit
     for ValidWalletCreate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
 where
-    [(); MAX_BALANCES * BALANCE_ZEROS + MAX_ORDERS * ORDER_ZEROS]: Sized,
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     type Statement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Witness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
@@ -304,109 +293,3 @@ where
 // ---------
 // | Tests |
 // ---------
-
-#[cfg(test)]
-mod test_valid_wallet_create {
-    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
-    use crypto::{
-        fields::{
-            biguint_to_scalar, prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField,
-        },
-        hash::default_poseidon_params,
-    };
-    use curve25519_dalek::scalar::Scalar;
-    use itertools::Itertools;
-    use num_bigint::BigUint;
-    use rand_core::{CryptoRng, OsRng, RngCore};
-
-    use crate::{
-        test_helpers::bulletproof_prove_and_verify, types::fee::Fee,
-        zk_circuits::test_helpers::PUBLIC_KEYS, zk_gadgets::fixed_point::FixedPoint,
-    };
-
-    use super::{
-        ValidWalletCreate, ValidWalletCreateStatement, ValidWalletCreateWitness, BALANCE_ZEROS,
-        ORDER_ZEROS,
-    };
-
-    /// Set to smaller values for testing
-    /// The maximum balances allowed in a wallet
-    const MAX_BALANCES: usize = 2;
-    /// The maximum orders allowed in a wallet
-    const MAX_ORDERS: usize = 2;
-    /// The maximum fees allowed in a wallet
-    const MAX_FEES: usize = 2;
-
-    /// Generates a random fee for testing
-    fn random_fee<R: RngCore + CryptoRng>(rng: &mut R) -> Fee {
-        Fee {
-            settle_key: BigUint::from(rng.next_u64()),
-            gas_addr: BigUint::from(rng.next_u64()),
-            gas_token_amount: rng.next_u64(),
-            percentage_fee: FixedPoint::from(0.01),
-        }
-    }
-
-    /// Compute the commitment to an empty wallet given a witness variable
-    fn compute_commitment(witness: &ValidWalletCreateWitness<MAX_FEES>) -> Scalar {
-        let arkworks_params = default_poseidon_params();
-        let mut arkworks_hasher = PoseidonSponge::new(&arkworks_params);
-
-        // Hash zeros into the sponge for each order and balance
-        for _ in 0..(MAX_ORDERS * ORDER_ZEROS + MAX_BALANCES * BALANCE_ZEROS) {
-            arkworks_hasher.absorb(&DalekRistrettoField::from(0u64));
-        }
-
-        // Absorb the fees into the hasher state
-        for fee in witness.fees.iter() {
-            arkworks_hasher.absorb(&scalar_to_prime_field(&biguint_to_scalar(&fee.settle_key)));
-            arkworks_hasher.absorb(&scalar_to_prime_field(&biguint_to_scalar(&fee.gas_addr)));
-            arkworks_hasher.absorb(&DalekRistrettoField::from(fee.gas_token_amount));
-            arkworks_hasher.absorb(&DalekRistrettoField::from(Into::<u64>::into(
-                fee.percentage_fee,
-            )));
-        }
-
-        // Absorb the public keys into the hasher state
-        let pk_root_words: Vec<Scalar> = witness.keys.pk_root.clone().into();
-        arkworks_hasher.absorb(
-            &pk_root_words
-                .iter()
-                .map(scalar_to_prime_field)
-                .collect_vec(),
-        );
-        arkworks_hasher.absorb(&scalar_to_prime_field(&witness.keys.pk_match.into()));
-        arkworks_hasher.absorb(&scalar_to_prime_field(&witness.keys.pk_settle.into()));
-        arkworks_hasher.absorb(&scalar_to_prime_field(&witness.keys.pk_view.into()));
-
-        // Absorb the wallet randomness into the hasher state
-        arkworks_hasher.absorb(&scalar_to_prime_field(&witness.wallet_randomness));
-
-        prime_field_to_scalar::<DalekRistrettoField>(
-            &arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0],
-        )
-    }
-
-    /// Tests the VALID WALLET CREATE with a valid witness (empty wallet)
-    #[test]
-    fn test_valid_wallet() {
-        let mut rng = OsRng {};
-        let n_fees = MAX_FEES;
-        let fees = (0..n_fees).map(|_| random_fee(&mut rng)).collect_vec();
-
-        let witness = ValidWalletCreateWitness {
-            fees: fees.try_into().unwrap(),
-            keys: PUBLIC_KEYS.clone(),
-            wallet_randomness: Scalar::random(&mut rng),
-        };
-        let statement = ValidWalletCreateStatement {
-            wallet_commitment: compute_commitment(&witness),
-        };
-
-        // Prove and verify on a smaller (for testing speed) version of the circuit
-        let res = bulletproof_prove_and_verify::<
-            ValidWalletCreate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        >(witness, statement);
-        assert!(res.is_ok());
-    }
-}

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -53,7 +53,7 @@ where
     /// VALID WALLET CREATE
     fn circuit<CS>(
         mut statement: ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        mut witness: ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        witness: ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<(), R1CSError>
     where
@@ -64,9 +64,10 @@ where
             WalletShareCommitGadget::compute_commitment(&witness.private_wallet_share, cs)?;
         cs.constrain(commitment - statement.private_shares_commitment);
 
-        // Unblind the shares then reconstruct the wallet
-        witness.private_wallet_share.unblind();
-        statement.public_wallet_shares.unblind();
+        // Unblind the public shares then reconstruct the wallet
+        let blinder = witness.private_wallet_share.blinder.clone()
+            + statement.public_wallet_shares.blinder.clone();
+        statement.public_wallet_shares.unblind(blinder);
         let wallet = witness.private_wallet_share + statement.public_wallet_shares;
 
         // Verify that the orders and balances are zero'd

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -25,7 +25,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
 where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
-    /// Compute the commitment to a wallet
+    /// Compute the commitment to a wallet share
     pub fn compute_commitment<CS: RandomizableConstraintSystem>(
         wallet_share: &WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -8,26 +8,26 @@ use mpc_bulletproof::{
 
 use crate::{
     mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    types::{note::NoteVar, wallet::WalletVar},
+    types::{note::NoteVar, wallet::WalletSecretShareVar},
 };
 
 use super::poseidon::PoseidonHashGadget;
 
-/// A gadget for computing wallet commitments
+/// A gadget for computing the commitment to a secret share of a wallet
 #[derive(Clone, Debug)]
-pub struct WalletCommitGadget<
+pub struct WalletShareCommitGadget<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
     const MAX_FEES: usize,
 > {}
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
-    WalletCommitGadget<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+    WalletShareCommitGadget<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
 where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// Compute the commitment to a wallet
-    pub fn wallet_commit<CS: RandomizableConstraintSystem>(
-        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub fn compute_commitment<CS: RandomizableConstraintSystem>(
+        wallet_share: &WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
         // Create a new hash gadget


### PR DESCRIPTION
### Purpose
This PR adds in the new definition of the `VALID WALLET CREATE` circuit to the refactor. This circuit validates that:
1. The commitment to the private wallet shares is correctly computed. This commitment is given as a public variable.
2. The underlying wallet, constructed as a combination of secret shares, is a valid, zero'd out wallet.

### Testing
- Unit tests pass, tested cases for cheating prover on invalid commitment, non-zero order, and non-zero balance.