### PR TITLE
circuits: zk-circuits: `VALID WALLET UPDATE`: Implement new design

### DIFF
--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -36,7 +36,7 @@ use super::{
 };
 
 /// Commitment type alias for readability
-pub type WalletCommitment = Scalar;
+pub type WalletShareCommitment = Scalar;
 /// Commitment type alias for readability
 pub type NoteCommitment = Scalar;
 /// Nullifier type alias for readability

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -2,6 +2,7 @@
 //! in proving knowledge of witness for throughout the network
 pub mod valid_match_mpc;
 pub mod valid_wallet_create;
+pub mod valid_wallet_update;
 
 #[cfg(test)]
 mod test_helpers {

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -324,12 +324,11 @@ mod test_helpers {
     fn test_split_wallet_into_shares() {
         // Split into secret shares
         let wallet = INITIAL_WALLET.clone();
-        let (mut share1, mut share2) = create_wallet_shares(&wallet);
+        let (private_share, mut public_share) = create_wallet_shares(&wallet);
 
-        // Recover from shares
-        share1.unblind();
-        share2.unblind();
-        let recovered_wallet = share1 + share2;
+        // Unblind the public shares, recover from shares
+        public_share.unblind(wallet.blinder);
+        let recovered_wallet = private_share + public_share;
 
         assert_eq!(wallet, recovered_wallet);
     }

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -1,0 +1,294 @@
+//! Defines the `VALID WALLET UPDATE` circuit
+//!
+//! This circuit proves that a user-generated update to a wallet is valid, and that
+//! the state nullification/creation is computed correctly
+
+// ----------------------
+// | Circuit Definition |
+// ----------------------
+
+use curve25519_dalek::scalar::Scalar;
+use mpc_bulletproof::r1cs::{Prover, RandomizableConstraintSystem, Variable, Verifier};
+use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    types::{
+        keychain::PublicSigningKey,
+        transfers::{ExternalTransfer, ExternalTransferVar},
+        wallet::{
+            Nullifier, WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar,
+            WalletShareCommitment,
+        },
+    },
+    zk_gadgets::{
+        merkle::{MerkleOpening, MerkleOpeningCommitment, MerkleOpeningVar, MerkleRoot},
+        nonnative::NonNativeElementVar,
+    },
+    CommitPublic, CommitVerifier, CommitWitness,
+};
+
+/// The `VALID WALLET UPDATE` circuit
+pub struct ValidWalletUpdate<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>;
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    /// Apply the circuit constraints to a given constraint system
+    pub fn circuit<CS: RandomizableConstraintSystem>(
+        statement: ValidWalletUpdateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        witness: ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut CS,
+    ) {
+        unimplemented!("")
+    }
+}
+
+// ---------------------------
+// | Witness Type Definition |
+// ---------------------------
+
+/// The witness type for `VALID WALLET UPDATE`
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateWitness<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The private secret shares of the existing wallet
+    pub old_wallet_private_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The public secret shares of the existing wallet
+    pub old_wallet_public_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The Merkle opening of the old wallet's private secret shares
+    pub private_shares_opening: MerkleOpening,
+    /// The Merkle opening of the old wallet's public secret shares
+    pub public_shares_opening: MerkleOpening,
+    /// The new wallet's private secret shares
+    pub new_wallet_private_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+}
+
+/// The witness type for `VALID WALLET UPDATE` allocated in a constraint system
+#[derive(Clone)]
+pub struct ValidWalletUpdateWitnessVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The private secret shares of the existing wallet
+    pub old_wallet_private_shares: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The public secret shares of the existing wallet
+    pub old_wallet_public_shares: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The Merkle opening of the old wallet's private secret shares
+    pub private_shares_opening: MerkleOpeningVar,
+    /// The Merkle opening of the old wallet's public secret shares
+    pub public_shares_opening: MerkleOpeningVar,
+    /// The new wallet's private secret shares
+    pub new_wallet_private_shares: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+}
+
+/// A commitment to the witness type of `VALID WALLET UPDATE` that has been
+/// allocated in a constraint system
+#[derive(Clone)]
+pub struct ValidWalletUpdateWitnessCommitment<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The private secret shares of the existing wallet
+    pub old_wallet_private_shares: WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The public secret shares of the existing wallet
+    pub old_wallet_public_shares: WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The Merkle opening of the old wallet's private secret shares
+    pub private_shares_opening: MerkleOpeningCommitment,
+    /// The Merkle opening of the old wallet's public secret shares
+    pub public_shares_opening: MerkleOpeningCommitment,
+    /// The new wallet's private secret shares
+    pub new_wallet_private_shares: WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitWitness
+    for ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type VarType = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type CommitType = ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = (); // Does not error
+
+    fn commit_witness<R: RngCore + CryptoRng>(
+        &self,
+        rng: &mut R,
+        prover: &mut Prover,
+    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
+        // Old wallet state
+        let (old_private_share_vars, old_private_share_comms) = self
+            .old_wallet_private_shares
+            .commit_witness(rng, prover)
+            .unwrap();
+        let (old_public_share_vars, old_public_share_comms) = self
+            .old_wallet_public_shares
+            .commit_witness(rng, prover)
+            .unwrap();
+        let (private_opening_vars, private_opening_comms) = self
+            .private_shares_opening
+            .commit_witness(rng, prover)
+            .unwrap();
+        let (public_opening_vars, public_opening_comms) = self
+            .public_shares_opening
+            .commit_witness(rng, prover)
+            .unwrap();
+
+        // New wallet state
+        let (new_private_share_vars, new_private_share_comms) = self
+            .new_wallet_private_shares
+            .commit_witness(rng, prover)
+            .unwrap();
+
+        Ok((
+            ValidWalletUpdateWitnessVar {
+                old_wallet_private_shares: old_private_share_vars,
+                old_wallet_public_shares: old_public_share_vars,
+                private_shares_opening: private_opening_vars,
+                public_shares_opening: public_opening_vars,
+                new_wallet_private_shares: new_private_share_vars,
+            },
+            ValidWalletUpdateWitnessCommitment {
+                old_wallet_private_shares: old_private_share_comms,
+                old_wallet_public_shares: old_public_share_comms,
+                private_shares_opening: private_opening_comms,
+                public_shares_opening: public_opening_comms,
+                new_wallet_private_shares: new_private_share_comms,
+            },
+        ))
+    }
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
+    for ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type VarType = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = (); // Does not error
+
+    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
+        let old_private_share_vars = self
+            .old_wallet_private_shares
+            .commit_verifier(verifier)
+            .unwrap();
+        let old_public_share_vars = self
+            .old_wallet_public_shares
+            .commit_verifier(verifier)
+            .unwrap();
+        let private_opening_vars = self
+            .private_shares_opening
+            .commit_verifier(verifier)
+            .unwrap();
+        let public_opening_vars = self
+            .public_shares_opening
+            .commit_verifier(verifier)
+            .unwrap();
+        let new_private_share_vars = self
+            .new_wallet_private_shares
+            .commit_verifier(verifier)
+            .unwrap();
+
+        Ok(ValidWalletUpdateWitnessVar {
+            old_wallet_private_shares: old_private_share_vars,
+            old_wallet_public_shares: old_public_share_vars,
+            private_shares_opening: private_opening_vars,
+            public_shares_opening: public_opening_vars,
+            new_wallet_private_shares: new_private_share_vars,
+        })
+    }
+}
+
+// -----------------------------
+// | Statement Type Definition |
+// -----------------------------
+
+/// The statement type for `VALID WALLET UPDATE`
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidWalletUpdateStatement<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The nullifier of the old wallet's private secret shares
+    pub old_private_shares_nullifier: Nullifier,
+    /// The nullifier of the old wallet's public secret shares
+    pub old_public_shares_nullifier: Nullifier,
+    /// A commitment to the new wallet's private secret shares
+    pub new_private_shares_commitment: WalletShareCommitment,
+    /// The public secret shares of the new wallet
+    pub new_public_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The global Merkle root that the wallet share proofs open to
+    pub merkle_root: MerkleRoot,
+    /// The external transfer tuple
+    pub external_transfer: ExternalTransfer,
+    /// The public root key of the old wallet, rotated out after update
+    pub old_pk_root: PublicSigningKey,
+    /// The timestamp this update is at
+    pub timestamp: u64,
+}
+
+/// The statement type for `VALID WALLET UPDATE` allocated in a constraint system
+#[derive(Clone, Debug)]
+pub struct ValidWalletUpdateStatementVar<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+> {
+    /// The nullifier of the old wallet's private secret shares
+    pub old_private_shares_nullifier: Variable,
+    /// The nullifier of the old wallet's public secret shares
+    pub old_public_shares_nullifier: Variable,
+    /// A commitment to the new wallet's private secret shares
+    pub new_private_shares_commitment: Variable,
+    /// The public secret shares of the new wallet
+    pub new_public_shares: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    /// The global Merkle root that the wallet share proofs open to
+    pub merkle_root: Variable,
+    /// The external transfer tuple
+    pub external_transfer: ExternalTransferVar,
+    /// The public root key of the old wallet, rotated out after update
+    pub old_pk_root: NonNativeElementVar,
+    /// The timestamp this update is at
+    pub timestamp: Variable,
+}
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitPublic
+    for ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+{
+    type VarType = ValidWalletUpdateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type ErrorType = (); // Does not error
+
+    fn commit_public<CS: RandomizableConstraintSystem>(
+        &self,
+        cs: &mut CS,
+    ) -> Result<Self::VarType, Self::ErrorType> {
+        let old_private_nullifier_var =
+            self.old_private_shares_nullifier.commit_public(cs).unwrap();
+        let old_public_nullifier_var = self.old_public_shares_nullifier.commit_public(cs).unwrap();
+        let new_private_commitment_var = self
+            .new_private_shares_commitment
+            .commit_public(cs)
+            .unwrap();
+        let new_public_share_vars = self.new_public_shares.commit_public(cs).unwrap();
+
+        let merkle_root_var = self.merkle_root.commit_public(cs).unwrap();
+        let external_transfer_var = self.external_transfer.commit_public(cs).unwrap();
+        let pk_root_var = self.old_pk_root.commit_public(cs).unwrap();
+        let timestamp_var = Scalar::from(self.timestamp).commit_public(cs).unwrap();
+
+        Ok(ValidWalletUpdateStatementVar {
+            old_private_shares_nullifier: old_private_nullifier_var,
+            old_public_shares_nullifier: old_public_nullifier_var,
+            new_private_shares_commitment: new_private_commitment_var,
+            new_public_shares: new_public_share_vars,
+            merkle_root: merkle_root_var,
+            external_transfer: external_transfer_var,
+            old_pk_root: pk_root_var,
+            timestamp: timestamp_var,
+        })
+    }
+}

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -1,18 +1,11 @@
 //! Groups logic for computing wallet commitments and nullifiers inside of a circuit
 
-use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
+    r1cs::{LinearCombination, RandomizableConstraintSystem},
     r1cs_mpc::R1CSError,
 };
 
-use crate::{
-    mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    types::{
-        note::NoteVar,
-        wallet::{WalletSecretShareVar, WalletShareCommitment},
-    },
-};
+use crate::{mpc_gadgets::poseidon::PoseidonSpongeParameters, types::wallet::WalletSecretShareVar};
 
 use super::poseidon::PoseidonHashGadget;
 

--- a/circuits/src/zk_gadgets/commitments.rs
+++ b/circuits/src/zk_gadgets/commitments.rs
@@ -39,7 +39,7 @@ where
     }
 }
 
-/// A gadget for computing the nullifier of a wallet
+/// A gadget for computing the nullifier of secret share to a wallet
 #[derive(Clone, Debug)]
 pub struct NullifierGadget {}
 impl NullifierGadget {

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -36,7 +36,7 @@ impl OrGate {
         L: Into<LinearCombination> + Clone,
         CS: RandomizableConstraintSystem,
     {
-        // Dispatch to the single or gate
+        // Dispatch to the single OR gate
         a.iter().fold(Variable::Zero().into(), |acc, val| {
             Self::or(acc, val.clone().into(), cs)
         })

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -9,10 +9,10 @@ use mpc_bulletproof::{
 };
 use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
 
-use crate::errors::ProverError;
+use crate::{errors::ProverError, zk_gadgets::comparators::EqGadget};
 
 /// Represents an OR gate in a single-prover constraint system
-pub struct OrGate {}
+pub struct OrGate;
 impl OrGate {
     /// Computes the logical OR of the two arguments
     ///
@@ -20,11 +20,26 @@ impl OrGate {
     /// constrained elsewhere in the calling circuit
     pub fn or<L, CS>(a: L, b: L, cs: &mut CS) -> LinearCombination
     where
-        L: Into<LinearCombination> + Clone,
+        L: Into<LinearCombination>,
         CS: RandomizableConstraintSystem,
     {
         let (a, b, a_times_b) = cs.multiply(a.into(), b.into());
         a + b - a_times_b
+    }
+
+    /// Computes the logical OR of `n` arguments: out = a_1 || a_2 || .. || a_n
+    ///
+    /// The arguments are assumed to be binary (0 or 1), but this assumption should be
+    /// constrained elsewhere in the calling circuit
+    pub fn multi_or<L, CS>(a: &[L], cs: &mut CS) -> LinearCombination
+    where
+        L: Into<LinearCombination> + Clone,
+        CS: RandomizableConstraintSystem,
+    {
+        // Dispatch to the single or gate
+        a.iter().fold(Variable::Zero().into(), |acc, val| {
+            Self::or(acc, val.clone().into(), cs)
+        })
     }
 }
 
@@ -53,7 +68,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> Multiprov
 
 /// Represents an AND gate in the constraint system
 #[derive(Clone, Debug)]
-pub struct AndGate {}
+pub struct AndGate;
 impl AndGate {
     /// Computes the logical AND of the two inputs: out = a & b
     ///
@@ -67,6 +82,39 @@ impl AndGate {
         // For binary values, and is reduced to multiplication
         // Multiply the values and return their output wire
         cs.multiply(a.into(), b.into()).2
+    }
+
+    /// Computes the logical AND of `n` inputs: out = a_1 & a_2 & ... & a_n
+    ///
+    /// The arguments are assumed to be binary (0 or 1), but this assumption should be
+    /// constrained elsewhere in the calling circuit
+    pub fn multi_and<L, CS>(a: &[L], cs: &mut CS) -> Variable
+    where
+        L: Into<LinearCombination> + Clone,
+        CS: RandomizableConstraintSystem,
+    {
+        let sum: LinearCombination = a
+            .iter()
+            .cloned()
+            .fold(Variable::Zero().into(), |acc, val| acc + val);
+        EqGadget::eq(sum, Scalar::from(a.len() as u32).into(), cs)
+    }
+}
+
+/// Inverts a boolean assumed to be constrained binary
+#[derive(Clone, Debug)]
+pub struct NotGate;
+impl NotGate {
+    /// Computes the logical NOT of an input boolean: out = !a
+    ///
+    /// The argument is assumed to be binary (0 or 1), but this assumption should be
+    /// constrained elsewhere in the calling circuit
+    pub fn not<L, CS>(a: L, _cs: &mut CS) -> LinearCombination
+    where
+        L: Into<LinearCombination>,
+        CS: RandomizableConstraintSystem,
+    {
+        Variable::One() - a.into()
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR implements the new design of `VALID WALLET UPDATE` which checks that:
- Previous wallet shares are valid entries in the state tree
- The previous wallet share nullifiers were correctly computed
- The commitment to the new private wallet shares is correctly computed
- The wallet has a `pk_root` value equal to one given in the statement
- The wallet transition is valid:
    - Updates to balances are the correct application of an external transfer
    - Updates to orders are correctly timestamped

### Testing
- Unit tests pass; verified many different cases:
    - Valid order placement and cancellation
    - Invalid order updates with incorrect timestamps
    - Valid deposit/withdrawal
    - Invalid deposit/withdrawal with maliciously engineered balance updates