### PR TITLE
core: Refactor types to fit encryption redesign

### DIFF
--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -288,7 +288,7 @@ where
 // ---------------------------
 
 /// The witness type for `VALID COMMITMENTS`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidCommitmentsWitness<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -22,9 +22,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::{ProverError, VerifierError},
     types::{
-        balance::{Balance, BalanceVar, CommittedBalance},
+        balance::{Balance, BalanceVar, CommittedBalance, LinkableBalanceCommitment},
         fee::{CommittedFee, Fee, FeeVar},
-        order::{CommittedOrder, Order, OrderVar},
+        order::{CommittedOrder, LinkableOrderCommitment, OrderVar},
         wallet::{WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar, WalletVar},
     },
     zk_gadgets::{
@@ -302,9 +302,9 @@ pub struct ValidCommitmentsWitness<
     /// the mint that will be received by this party upon a successful match
     pub augmented_public_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The order that the prover intends to match against with this proof
-    pub order: Order,
+    pub order: LinkableOrderCommitment,
     /// The balance that the wallet will send when the order is matched
-    pub balance_send: Balance,
+    pub balance_send: LinkableBalanceCommitment,
     /// The balance that the wallet will receive into when the order is matched
     pub balance_receive: Balance,
     /// The balance that will cover the relayer's fee when matched
@@ -672,8 +672,8 @@ mod test {
             private_secret_shares: private_shares,
             public_secret_shares: public_shares,
             augmented_public_shares,
-            order,
-            balance_send,
+            order: order.into(),
+            balance_send: balance_send.into(),
             balance_receive,
             balance_fee,
             fee,

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -263,7 +263,7 @@ where
 // ---------------------------
 
 /// The witness type for VALID REBLIND
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidReblindWitness<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -310,7 +310,7 @@ pub struct ValidReblindWitnessVar<
 
 /// A commitment to the witness type for VALID REBLIND,
 /// allocated in a constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidReblindWitnessCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -268,7 +268,7 @@ pub struct ValidSettleWitnessVar<
 
 /// A commitment to the witness type for `VALID SETTLE`,
 /// allocated in a constraint system
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidSettleWitnessCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -476,7 +476,7 @@ pub struct ValidWalletUpdateWitnessVar<
 
 /// A commitment to the witness type of `VALID WALLET UPDATE` that has been
 /// allocated in a constraint system
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidWalletUpdateWitnessCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -11,10 +11,7 @@ use std::{
     time::Duration,
 };
 
-use circuits::{
-    types::wallet::Nullifier, zk_circuits::valid_commitments::ValidCommitmentsStatement,
-    zk_gadgets::merkle::MerkleOpening,
-};
+use circuits::types::wallet::Nullifier;
 
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::{starknet_felt_to_biguint, starknet_felt_to_scalar, starknet_felt_to_u64};
@@ -24,7 +21,7 @@ use starknet::providers::jsonrpc::{
     models::{BlockId, EmittedEvent, ErrorCode, EventFilter},
     HttpTransport, JsonRpcClient, JsonRpcClientError, RpcError,
 };
-use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
 use tokio::time::{sleep_until, Instant};
 use tracing::log;
 
@@ -34,7 +31,7 @@ use crate::{
         orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
     },
     handshake::jobs::HandshakeExecutionJob,
-    proof_generation::jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle},
+    proof_generation::{jobs::ProofManagerJob, OrderValidityProofBundle},
     starknet_client::client::StarknetClient,
     state::{
         wallet::{MerkleAuthenticationPath, Wallet},
@@ -271,8 +268,8 @@ impl OnChainEventListenerExecutor {
         } else if key == *NULLIFIER_SPENT_EVENT_SELECTOR {
             // Parse the nullifier from the felt
             log::info!("Handling nullifier spent event");
-            let match_nullifier = starknet_felt_to_scalar(&event.data[0]);
-            self.handle_nullifier_spent(match_nullifier).await?;
+            let nullifier = starknet_felt_to_scalar(&event.data[0]);
+            self.handle_nullifier_spent(nullifier).await?;
         }
 
         Ok(())
@@ -286,9 +283,7 @@ impl OnChainEventListenerExecutor {
         // Send an MPC shootdown request to the handshake manager
         self.config
             .handshake_manager_job_queue
-            .send(HandshakeExecutionJob::MpcShootdown {
-                match_nullifier: nullifier,
-            })
+            .send(HandshakeExecutionJob::MpcShootdown { nullifier })
             .map_err(|err| OnChainEventListenerError::SendMessage(err.to_string()))?;
 
         // Nullify any orders that used this nullifier in their validity proof
@@ -408,59 +403,7 @@ impl OnChainEventListenerExecutor {
             return Ok(());
         }
 
-        // Generate new witness and statement variables from the freshly synced state
-        let merkle_proof = wallet.merkle_proof.clone().unwrap();
-        let new_root = merkle_proof.compute_root();
-        let new_opening: MerkleOpening = wallet.merkle_proof.clone().unwrap().into();
-        let wallet_match_nullifier = wallet.get_match_nullifier();
-
-        // Loop over orders and enqueue a proof generation job for each
-        let locked_order_book = self.global_state.read_order_book().await;
-        let mut proof_response_channels = HashMap::new();
-        for order_id in wallet.orders.keys() {
-            let stale_witness = locked_order_book.get_validity_proof_witness(order_id).await;
-            if stale_witness.is_none() {
-                log::error!("tried to update VALID COMMITMENTS for order without existing witness");
-                return Ok(());
-            }
-            let mut stale_witness = stale_witness.unwrap();
-
-            stale_witness.wallet_opening = new_opening.clone();
-
-            // Enqueue a job with the proof manager
-            let (response_sender, response_receiver) = oneshot::channel();
-            let job = ProofJob::ValidCommitments {
-                witness: stale_witness,
-                statement: ValidCommitmentsStatement {
-                    nullifier: wallet_match_nullifier,
-                    merkle_root: new_root,
-                    pk_settle: wallet.key_chain.public_keys.pk_settle,
-                },
-            };
-
-            self.config
-                .proof_generation_work_queue
-                .send(ProofManagerJob {
-                    type_: job,
-                    response_channel: response_sender,
-                })
-                .map_err(|err| OnChainEventListenerError::SendMessage(err.to_string()))?;
-
-            proof_response_channels.insert(order_id, response_receiver);
-        }
-        drop(locked_order_book); // release lock
-
-        // Await proof responses for all orders
-        // TODO: Gossip the new proof to all cluster peers
-        for (order_id, channel) in proof_response_channels.into_iter() {
-            let proof = channel
-                .await
-                .map_err(|err| OnChainEventListenerError::ProofGeneration(err.to_string()))?;
-
-            self.update_order_proof(*order_id, proof.into()).await?;
-        }
-
-        Ok(())
+        unimplemented!("Implement wallet commitment proof task in encryption redesign")
     }
 
     /// Update the order validity proof in the global state and gossip
@@ -468,11 +411,11 @@ impl OnChainEventListenerExecutor {
     async fn update_order_proof(
         &self,
         order_id: OrderIdentifier,
-        proof: ValidCommitmentsBundle,
+        proof_bundle: OrderValidityProofBundle,
     ) -> Result<(), OnChainEventListenerError> {
         // Update the locally stored proof
         self.global_state
-            .add_order_validity_proof(&order_id, proof.clone())
+            .add_order_validity_proofs(&order_id, proof_bundle.clone())
             .await;
 
         // Gossip the new validity proof onto the pubsub mesh
@@ -480,7 +423,7 @@ impl OnChainEventListenerExecutor {
         let message = OrderBookManagementMessage::OrderProofUpdated {
             order_id,
             cluster,
-            proof,
+            proof_bundle,
         };
 
         self.config

--- a/core/src/gossip/errors.rs
+++ b/core/src/gossip/errors.rs
@@ -9,6 +9,8 @@ pub enum GossipError {
     Cancelled(String),
     /// An error occurred looking up a critical state element
     MissingState(String),
+    /// A nullifier has already been used in the contract
+    NullifierUsed(String),
     /// An error parsing a gossip message
     Parse(String),
     /// An error setting up the gossip server
@@ -21,6 +23,8 @@ pub enum GossipError {
     TimerFailed(String),
     /// An error verifying a peer's proof of `VALID COMMITMENTS`
     ValidCommitmentVerification(String),
+    /// An error verifying a peer's proof of `VALID REBLIND`
+    ValidReblindVerification(String),
 }
 
 impl fmt::Display for GossipError {

--- a/core/src/gossip_api/gossip.rs
+++ b/core/src/gossip_api/gossip.rs
@@ -8,9 +8,8 @@ use uuid::Uuid;
 
 use crate::{
     gossip::types::{ClusterId, WrappedPeerId},
-    proof_generation::jobs::ValidCommitmentsBundle,
+    proof_generation::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     state::OrderIdentifier,
-    types::SizedValidCommitmentsWitness,
 };
 
 use super::{
@@ -124,24 +123,25 @@ pub enum GossipRequest {
     OrderInfo(OrderInfoRequest),
     /// A request that a peer replicate a set of wallets
     Replicate(ReplicateRequestBody),
-    /// A pushed message forwarded from the sender when a proof of `VALID COMMITMENTS` is
+    /// A pushed message forwarded from the sender when a validity proof bundle is
     /// requested, updated, or constructed for the first time
     ValidityProof {
         /// The order this proof is for
         order_id: OrderIdentifier,
-        /// The proof of `VALID COMMITMENTS` for this order
-        proof: ValidCommitmentsBundle,
+        /// The bundle of validity proofs; includes `VALID REBLIND` for the order's
+        /// wallet, and `VALID COMMITMENTS` for the order itself
+        proof_bundle: OrderValidityProofBundle,
     },
-    /// A request type that pushes the witness used in `VALID COMMITMENTS` for an order to the
-    /// receiver
+    /// A request type that pushes the witness used in the validity proofs for
+    /// an order to the receiver
     ///
     /// This may be triggered when the receiver broadcasts a pubsub message indicating that it
     /// needs a copy of the witness
     ValidityWitness {
         /// The order this witness is for
         order_id: OrderIdentifier,
-        /// The witness used to prove `VALID COMMITMENTS`
-        witness: SizedValidCommitmentsWitness,
+        /// The witness used in the validity proofs
+        witness: OrderValidityWitnessBundle,
     },
 }
 

--- a/core/src/gossip_api/orderbook_management.rs
+++ b/core/src/gossip_api/orderbook_management.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     gossip::types::ClusterId,
-    proof_generation::jobs::ValidCommitmentsBundle,
+    proof_generation::OrderValidityProofBundle,
     state::{NetworkOrder, OrderIdentifier},
 };
 
@@ -39,19 +39,20 @@ pub enum OrderBookManagementMessage {
     OrderReceived {
         /// The identifier of the new order
         order_id: OrderIdentifier,
-        /// The match nullifier of the new order
-        match_nullifier: Nullifier,
+        /// The public share nullifier of the new order's wallet
+        nullifier: Nullifier,
         /// The cluster that manages this order
         cluster: ClusterId,
     },
-    /// A new validity proof has been generated for an order, it should be placed in
+    /// A new validity proof bundle has been generated for an order, it should be placed in
     /// the `Verified` state after local peers verify the proof
     OrderProofUpdated {
         /// The identifier of the now updated order
         order_id: OrderIdentifier,
         /// The cluster that manages this order
         cluster: ClusterId,
-        /// The new proof of `VALID COMMITMENTS`
-        proof: ValidCommitmentsBundle,
+        /// The new validity proof bundle for the order, containing a proof of `VALID COMMITMENTS`
+        /// for the order, and one of `VALID REBLIND` for the wallet
+        proof_bundle: OrderValidityProofBundle,
     },
 }

--- a/core/src/handshake/jobs.rs
+++ b/core/src/handshake/jobs.rs
@@ -45,15 +45,15 @@ pub enum HandshakeExecutionJob {
         /// The net that was setup for the party
         net: QuicTwoPartyNet,
     },
-    /// Indicates that the local peer should halt any MPCs active on the given match nullifier
+    /// Indicates that the local peer should halt any MPCs active on the given nullifier
     ///
     /// This job is constructed when a nullifier is seen on chain, indicating that it is
     /// no longer valid to match on. The local party should hangup immediately to avoid
     /// leaking the order after opening
     MpcShootdown {
-        /// The match-nullifier value seen on-chain; any in-flight MPCs on this nullifier
+        /// The public share nullifier value seen on-chain; any in-flight MPCs on this nullifier
         /// are to be terminated
-        match_nullifier: Nullifier,
+        nullifier: Nullifier,
     },
     /// Indicates that a cluster replica has initiated a match on the given order pair.
     /// The local peer should not schedule this order pair for a match for some duration

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -266,9 +266,9 @@ impl HandshakeExecutor {
             }
 
             // Indicates that in-flight MPCs on the given nullifier should be terminated
-            HandshakeExecutionJob::MpcShootdown { match_nullifier } => {
+            HandshakeExecutionJob::MpcShootdown { nullifier } => {
                 self.handshake_state_index
-                    .shootdown_nullifier(match_nullifier)
+                    .shootdown_nullifier(nullifier)
                     .await
             }
         }
@@ -711,11 +711,11 @@ impl HandshakeExecutor {
         let (party0_proof, party1_proof) = {
             let locked_order_book = self.global_state.read_order_book().await;
             let local_validity_proof = locked_order_book
-                .get_validity_proof(&handshake_state.local_order_id)
+                .get_validity_proofs(&handshake_state.local_order_id)
                 .await
                 .unwrap();
             let remote_validity_proof = locked_order_book
-                .get_validity_proof(&handshake_state.peer_order_id)
+                .get_validity_proofs(&handshake_state.peer_order_id)
                 .await
                 .unwrap();
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -30,7 +30,10 @@ use std::{io::Write, process::exit, thread, time::Duration};
 
 use chrono::Local;
 use circuits::{
-    types::{keychain::PublicIdentificationKey, wallet::Wallet},
+    types::{
+        keychain::PublicIdentificationKey,
+        wallet::{Wallet, WalletSecretShare},
+    },
     zk_gadgets::fixed_point::FixedPoint,
 };
 use crossbeam::channel;
@@ -101,6 +104,8 @@ pub(crate) const MERKLE_HEIGHT: usize = 32;
 pub(crate) const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 /// A type wrapper around the wallet type that adds the default generics above
 pub(crate) type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A type wrapper around a wallet share that adds the default generics above
+pub(crate) type SizedWalletShare = WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 /// The amount of time to wait between sending teardown signals and terminating execution
 const TERMINATION_TIMEOUT_MS: u64 = 10_000; // 10 seconds
 

--- a/core/src/network_manager/manager.rs
+++ b/core/src/network_manager/manager.rs
@@ -607,14 +607,15 @@ impl NetworkManagerExecutor {
                             })
                     }
 
-                    GossipRequest::ValidityProof { order_id, proof } => {
-                        // TODO: Authenticate this
-                        self.gossip_work_queue
-                            .send(GossipServerJob::Cluster(
-                                ClusterManagementJob::UpdateValidityProof(order_id, proof),
-                            ))
-                            .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))
-                    }
+                    GossipRequest::ValidityProof {
+                        order_id,
+                        proof_bundle,
+                    } => self
+                        .gossip_work_queue
+                        .send(GossipServerJob::Cluster(
+                            ClusterManagementJob::UpdateValidityProof(order_id, proof_bundle),
+                        ))
+                        .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string())),
 
                     GossipRequest::ValidityWitness { order_id, witness } => {
                         self.gossip_work_queue
@@ -775,14 +776,14 @@ impl NetworkManagerExecutor {
             PubsubMessage::OrderBookManagement(msg) => match msg {
                 OrderBookManagementMessage::OrderReceived {
                     order_id,
-                    match_nullifier,
+                    nullifier,
                     cluster,
                 } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
                         OrderBookManagementJob::OrderReceived {
                             order_id,
-                            match_nullifier,
+                            nullifier,
                             cluster,
                         },
                     ))
@@ -791,14 +792,14 @@ impl NetworkManagerExecutor {
                 OrderBookManagementMessage::OrderProofUpdated {
                     order_id,
                     cluster,
-                    proof,
+                    proof_bundle,
                 } => self
                     .gossip_work_queue
                     .send(GossipServerJob::OrderBookManagement(
                         OrderBookManagementJob::OrderProofUpdated {
                             order_id,
                             cluster,
-                            proof,
+                            proof_bundle,
                         },
                     ))
                     .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?,

--- a/core/src/proof_generation/mod.rs
+++ b/core/src/proof_generation/mod.rs
@@ -1,6 +1,157 @@
 //! The proof generation worker handles the core of generating single-prover
 //! proofs for wallet updates
+
+<<<<<<< HEAD
+=======
+use std::sync::Arc;
+
+>>>>>>> 11da90a (temp proof-generation)
+use circuits::zk_circuits::{
+    valid_commitments::{ValidCommitments, ValidCommitmentsWitness},
+    valid_reblind::{ValidReblind, ValidReblindWitness},
+    valid_settle::{ValidSettleStatement, ValidSettleWitness},
+    valid_wallet_create::{ValidWalletCreateStatement, ValidWalletCreateWitness},
+    valid_wallet_update::{ValidWalletUpdateStatement, ValidWalletUpdateWitness},
+};
+
+use crate::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 pub mod error;
 pub mod jobs;
 pub mod proof_manager;
 pub mod worker;
+
+// ----------------------------------
+// | Circuit Default Generics Types |
+// ----------------------------------
+
+/// A witness to `VALID WALLET CREATE` with default size parameters attached
+pub type SizedValidWalletCreateWitness =
+    ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A statement for `VALID WALLET CREATE` with default size parameters attached
+pub type SizedValidWalletCreateStatement =
+    ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+/// A `VALID WALLET UPDATE` witness with default const generic sizing parameters
+pub type SizedValidWalletUpdateWitness =
+    ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A `VALID WALLET UPDATE` statement with default const generic sizing parameters
+pub type SizedValidWalletUpdateStatement =
+    ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+/// A `VALID COMMITMENTS` witness with default const generic sizing parameters
+pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// `VALID COMMITMENTS` with default state element sizing
+pub type SizedValidCommitments = ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+/// A `VALID REBLIND` circuit with default const generic sizing parameters
+pub type SizedValidReblind = ValidReblind<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A `VALID REBLIND` witness with default const generic sizing parameters
+pub type SizedValidReblindWitness = ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+/// A `VALID SETTLE` witness with default const generic sizing parameters
+pub type SizedValidSettleWitness = ValidSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+/// A `VALID SETTLE` statement with default const generic sizing parameters
+pub type SizedValidSettleStatement = ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+
+// -------------------
+// | Proof Groupings |
+// -------------------
+
+/// Wraps a proof of `VALID REBLIND` and a proof of `VALID COMMITMENTS` into
+/// a common structure so that they may be passed around easily
+///
+/// We allocate the underlying proofs on the heap to avoid excessive data movement
+#[derive(Clone, Debug)]
+pub struct OrderValidityProofBundle {
+    /// The proof of `VALID REBLIND` for the order's wallet
+    pub reblind_proof: Arc<ValidReblindBundle>,
+    /// The proof of `VALID COMMITMENTS` for the order
+    pub commitment_proof: Arc<ValidCommitmentsBundle>,
+}
+
+impl OrderValidityProofBundle {
+    /// Clone the reblind proof out from behind the reference
+    pub fn copy_reblind_proof(&self) -> ValidReblindBundle {
+        ValidReblindBundle::clone(&self.reblind_proof)
+    }
+
+    /// Clone the commitments proof out from behind the reference
+    pub fn copy_commitment_proof(&self) -> ValidCommitmentsBundle {
+        ValidCommitmentsBundle::clone(&self.commitment_proof)
+    }
+}
+
+impl Serialize for OrderValidityProofBundle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.copy_reblind_proof().serialize(serializer)?;
+        self.copy_commitment_proof().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for OrderValidityProofBundle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let reblind_proof = ValidReblindBundle::deserialize(deserializer)?;
+        let commitment_proof = ValidCommitmentsBundle::deserialize(deserializer)?;
+
+        Ok(OrderValidityProofBundle {
+            reblind_proof: Arc::new(reblind_proof),
+            commitment_proof: Arc::new(commitment_proof),
+        })
+    }
+}
+
+/// Wraps a witness to a proof of `VALID REBLIND` and a witness to a
+/// proof of `VALID COMMITMENTS` into a common structure so that they
+/// may be passed around easily
+///
+/// We allocate the underlying witnesses on the heap to avoid excessive data movement
+#[derive(Clone, Debug)]
+pub struct OrderValidityWitnessBundle {
+    /// The witness of `VALID REBLIND` for the order's wallet
+    pub reblind_witness: Arc<SizedValidReblindWitness>,
+    /// The witness of `VALID COMMITMENTS` for the order
+    pub commitment_witness: Arc<SizedValidCommitmentsWitness>,
+}
+
+impl OrderValidityWitnessBundle {
+    /// Clone the reblind witness out from behind the reference
+    pub fn copy_reblind_witness(&self) -> SizedValidReblindWitness {
+        SizedValidReblindWitness::clone(&self.reblind_witness)
+    }
+
+    /// Clone the commitment witness out from behind the reference
+    pub fn copy_commitment_witness(&self) -> SizedValidCommitmentsWitness {
+        SizedValidCommitmentsWitness::clone(&self.commitment_witness)
+    }
+}
+
+impl Serialize for OrderValidityWitnessBundle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.copy_reblind_witness().serialize(serializer)?;
+        self.copy_commitment_witness().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for OrderValidityWitnessBundle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let reblind_witness = SizedValidReblindWitness::deserialize(deserializer)?;
+        let commitment_witness = SizedValidCommitmentsWitness::deserialize(deserializer)?;
+
+        Ok(OrderValidityWitnessBundle {
+            reblind_witness: Arc::new(reblind_witness),
+            commitment_witness: Arc::new(commitment_witness),
+        })
+    }
+}

--- a/core/src/proof_generation/mod.rs
+++ b/core/src/proof_generation/mod.rs
@@ -1,11 +1,8 @@
 //! The proof generation worker handles the core of generating single-prover
 //! proofs for wallet updates
 
-<<<<<<< HEAD
-=======
 use std::sync::Arc;
 
->>>>>>> 11da90a (temp proof-generation)
 use circuits::zk_circuits::{
     valid_commitments::{ValidCommitments, ValidCommitmentsWitness},
     valid_reblind::{ValidReblind, ValidReblindWitness},
@@ -13,8 +10,11 @@ use circuits::zk_circuits::{
     valid_wallet_create::{ValidWalletCreateStatement, ValidWalletCreateWitness},
     valid_wallet_update::{ValidWalletUpdateStatement, ValidWalletUpdateWitness},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
+
+use self::jobs::{ValidCommitmentsBundle, ValidReblindBundle};
 pub mod error;
 pub mod jobs;
 pub mod proof_manager;

--- a/core/src/starknet_client/client.rs
+++ b/core/src/starknet_client/client.rs
@@ -561,11 +561,11 @@ impl StarknetClient {
         &self,
         public_blinder_share: Scalar,
     ) -> Result<TransactionHash, StarknetClientError> {
-        let reduced_pk_view = Self::reduce_scalar_to_felt(&public_blinder_share.into());
+        let reduced_blinder_share = Self::reduce_scalar_to_felt(&public_blinder_share.into());
         let call = CallFunction {
             contract_address: self.contract_address,
             entry_point_selector: *GET_WALLET_LAST_UPDATED_SELECTOR,
-            calldata: vec![reduced_pk_view],
+            calldata: vec![reduced_blinder_share],
         };
 
         self.call_contract(call)

--- a/core/src/state/wallet.rs
+++ b/core/src/state/wallet.rs
@@ -230,7 +230,7 @@ pub struct Wallet {
     pub metadata: WalletMetadata,
     /// The private secret shares of the wallet
     pub private_shares: SizedWalletShare,
-    /// THe public secret shares of the wallet
+    /// The public secret shares of the wallet
     pub public_shares: SizedWalletShare,
     /// The authentication path for the wallet
     #[serde(default)]

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -49,9 +49,12 @@ use crate::{
         orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
     },
     handshake::{r#match::HandshakeResult, state::HandshakeState},
-    proof_generation::jobs::{
-        ProofJob, ProofManagerJob, ValidCommitmentsBundle, ValidMatchEncryptBundle,
-        ValidSettleBundle,
+    proof_generation::{
+        jobs::{
+            ProofJob, ProofManagerJob, ValidCommitmentsBundle, ValidMatchEncryptBundle,
+            ValidSettleBundle,
+        },
+        OrderValidityProofBundle,
     },
     starknet_client::client::StarknetClient,
     state::{wallet::Wallet, NetworkOrder, NetworkOrderState, OrderIdentifier, RelayerState},
@@ -93,10 +96,10 @@ pub struct SettleMatchTask {
     pub handshake_state: HandshakeState,
     /// The result of the match process
     pub handshake_result: Box<HandshakeResult>,
-    /// The proof of `VALID COMMITMENTS` submitted by the first party
-    pub party0_validity_proof: ValidCommitmentsBundle,
-    /// The proof of `VALID COMMITMENTS` submitted by the second party
-    pub party1_validity_proof: ValidCommitmentsBundle,
+    /// The validity proofs submitted by the first party
+    pub party0_validity_proof: OrderValidityProofBundle,
+    /// The validity proofs submitted by the second party
+    pub party1_validity_proof: OrderValidityProofBundle,
     /// The notes that result from the match
     pub match_notes: MatchNotes,
     /// The note that settles into the local wallet
@@ -261,8 +264,8 @@ impl SettleMatchTask {
     pub async fn new(
         handshake_state: HandshakeState,
         handshake_result: Box<HandshakeResult>,
-        party0_validity_proof: ValidCommitmentsBundle,
-        party1_validity_proof: ValidCommitmentsBundle,
+        party0_validity_proof: OrderValidityProofBundle,
+        party1_validity_proof: OrderValidityProofBundle,
         starknet_client: StarknetClient,
         network_sender: TokioSender<GossipOutbound>,
         global_state: RelayerState,

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,10 +1,5 @@
 //! Groups type definitions relevant to all modules and at the top level
 
-use circuits::zk_circuits::{
-    valid_commitments::{ValidCommitments, ValidCommitmentsWitness},
-    valid_settle::{ValidSettleStatement, ValidSettleWitness},
-    valid_wallet_update::ValidWalletUpdateWitness,
-};
 use serde::Serialize;
 
 use crate::{
@@ -12,24 +7,7 @@ use crate::{
     price_reporter::reporter::PriceReport,
     state::{wallet::WalletIdentifier, OrderIdentifier},
     tasks::driver::{StateWrapper as TaskStatus, TaskIdentifier},
-    MAX_BALANCES, MAX_FEES, MAX_ORDERS,
 };
-
-// ----------------------------------
-// | Circuit Default Generics Types |
-// ----------------------------------
-
-/// `VALID COMMITMENTS` with default state element sizing
-pub type SizedValidCommitments = ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-/// A `VALID COMMITMENTS` witness with default const generic sizing parameters
-pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-/// A `VALID WALLET UPDATE` witness with default const generic sizing parameters
-pub type SizedValidWalletUpdateWitness =
-    ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-/// A `VALID SETTLE` statement with default const generic sizing parameters
-pub type SizedValidSettleStatement = ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-/// A `VALID SETTLE` witness with default const generic sizing parameters
-pub type SizedValidSettleWitness = ValidSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
 // ----------------------
 // | Pubsub Topic Names |


### PR DESCRIPTION
### Purpose
This PR makes the initial changes to bring the `core` crate into compatibility with the redesigned circuits. Specifically, it changes the types, interfaces, state, and messages of the `core` crate to fit the new paradigm of secret shares as the primary state element.

As well, this PR refactors the gossip protocol to consider validity proofs in a tuple of `(ValidReblind, ValidCommitments)`.

### Todo
- Refactor the `tasks` crate
- Add in new commitment links between proofs
- Remove dead code

### Testing
- `core` does not yet build so unit tests fail
- Clippy returns no errors on all modules except `tasks`