### PR TITLE
core: Use `PENDING` state for finality, rather than `ACCEPTED_ON_L2`

### DIFF
--- a/core/src/chain_events/listener.rs
+++ b/core/src/chain_events/listener.rs
@@ -19,10 +19,13 @@ use circuits::{
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::{starknet_felt_to_biguint, starknet_felt_to_scalar, starknet_felt_to_u64};
 use curve25519_dalek::scalar::Scalar;
-use starknet::core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name};
 use starknet::providers::jsonrpc::{
     models::{BlockId, EmittedEvent, ErrorCode, EventFilter},
     HttpTransport, JsonRpcClient, JsonRpcClientError, RpcError,
+};
+use starknet::{
+    core::{types::FieldElement as StarknetFieldElement, utils::get_selector_from_name},
+    providers::jsonrpc::models::BlockTag,
 };
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
 use tokio::time::{sleep_until, Instant};
@@ -209,7 +212,7 @@ impl OnChainEventListenerExecutor {
     ) -> Result<(Vec<EmittedEvent>, bool), OnChainEventListenerError> {
         let filter = EventFilter {
             from_block: Some(BlockId::Number(self.start_block)),
-            to_block: None,
+            to_block: Some(BlockId::Tag(BlockTag::Pending)),
             address: Some(self.contract_address()),
             keys: None,
         };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -114,12 +114,12 @@ struct Cli {
     /// The HTTP addressable StarkNet JSON-RPC node
     #[clap(long = "starknet-gateway", value_parser)]
     pub starknet_jsonrpc_node: Option<String>,
-    /// The StarkNet address corresponding to the given key
-    #[clap(long = "starknet-account-addr", value_parser, requires = "starknet-private-key")]
-    pub starknet_account_address: Option<String>,
-    /// The StarkNet private key used to send transactions
-    #[clap(long = "starknet-account-pkey", value_parser, requires = "starknet-account-address")]
-    pub starknet_private_key: Option<String>,
+    /// The StarkNet addresses corresponding to the given private keys
+    #[clap(long = "starknet-account-addr", value_parser, requires = "starknet-private-keys")]
+    pub starknet_account_addresses: Option<Vec<String>>,
+    /// The StarkNet private keys used to send transactions
+    #[clap(long = "starknet-account-pkey", value_parser, requires = "starknet-account-addresses")]
+    pub starknet_private_keys: Option<Vec<String>>,
     /// A file holding a json representation of the wallets the local node
     /// should manage
     #[clap(short, long, value_parser)]
@@ -186,10 +186,10 @@ pub struct RelayerConfig {
     pub coinbase_api_secret: Option<String>,
     /// The StarkNet JSON-RPC API gateway
     pub starknet_jsonrpc_node: Option<String>,
-    /// The StarkNet address corresponding to the given key
-    pub starknet_account_address: Option<String>,
-    /// The StarkNet private key used for signing transactions
-    pub starknet_private_key: Option<String>,
+    /// The StarkNet addresses corresponding to the given private keys
+    pub starknet_account_addresses: Option<Vec<String>>,
+    /// The StarkNet private keys used for signing transactions
+    pub starknet_private_keys: Option<Vec<String>>,
     /// The Ethereum RPC node websocket address to dial for on-chain data
     pub eth_websocket_addr: Option<String>,
 }
@@ -216,8 +216,8 @@ impl Clone for RelayerConfig {
             coinbase_api_key: self.coinbase_api_key.clone(),
             coinbase_api_secret: self.coinbase_api_secret.clone(),
             starknet_jsonrpc_node: self.starknet_jsonrpc_node.clone(),
-            starknet_account_address: self.starknet_account_address.clone(),
-            starknet_private_key: self.starknet_private_key.clone(),
+            starknet_account_addresses: self.starknet_account_addresses.clone(),
+            starknet_private_keys: self.starknet_private_keys.clone(),
             eth_websocket_addr: self.eth_websocket_addr.clone(),
             debug: self.debug,
         }
@@ -303,8 +303,8 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         coinbase_api_key: cli_args.coinbase_api_key,
         coinbase_api_secret: cli_args.coinbase_api_secret,
         starknet_jsonrpc_node: cli_args.starknet_jsonrpc_node,
-        starknet_account_address: cli_args.starknet_account_address,
-        starknet_private_key: cli_args.starknet_private_key,
+        starknet_account_addresses: cli_args.starknet_account_addresses,
+        starknet_private_keys: cli_args.starknet_private_keys,
         eth_websocket_addr: cli_args.eth_websocket_addr,
         debug: cli_args.debug,
     };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -116,10 +116,10 @@ struct Cli {
     pub starknet_jsonrpc_node: Option<String>,
     /// The StarkNet addresses corresponding to the given private keys
     #[clap(long = "starknet-account-addr", value_parser, requires = "starknet-private-keys")]
-    pub starknet_account_addresses: Option<Vec<String>>,
+    pub starknet_account_addresses: Vec<String>,
     /// The StarkNet private keys used to send transactions
     #[clap(long = "starknet-account-pkey", value_parser, requires = "starknet-account-addresses")]
-    pub starknet_private_keys: Option<Vec<String>>,
+    pub starknet_private_keys: Vec<String>,
     /// A file holding a json representation of the wallets the local node
     /// should manage
     #[clap(short, long, value_parser)]
@@ -187,9 +187,9 @@ pub struct RelayerConfig {
     /// The StarkNet JSON-RPC API gateway
     pub starknet_jsonrpc_node: Option<String>,
     /// The StarkNet addresses corresponding to the given private keys
-    pub starknet_account_addresses: Option<Vec<String>>,
+    pub starknet_account_addresses: Vec<String>,
     /// The StarkNet private keys used for signing transactions
-    pub starknet_private_keys: Option<Vec<String>>,
+    pub starknet_private_keys: Vec<String>,
     /// The Ethereum RPC node websocket address to dial for on-chain data
     pub eth_websocket_addr: Option<String>,
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -181,8 +181,8 @@ async fn main() -> Result<(), CoordinatorError> {
         contract_addr: args.contract_address.clone(),
         infura_api_key: None,
         starknet_json_rpc_addr: args.starknet_jsonrpc_node.clone(),
-        starknet_account_address: args.starknet_account_address,
-        starknet_pkey: args.starknet_private_key,
+        starknet_account_addresses: args.starknet_account_addresses,
+        starknet_pkeys: args.starknet_private_keys,
     });
 
     // Build a task driver that may be used to spawn long-lived asynchronous tasks that

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -225,7 +225,7 @@ impl NewWalletTask {
     }
 
     /// Submit the newly created wallet on-chain with proof of validity
-    async fn submit_wallet_tx(&self) -> Result<(), NewWalletTaskError> {
+    async fn submit_wallet_tx(&mut self) -> Result<(), NewWalletTaskError> {
         let proof = if let NewWalletTaskState::SubmittingTx { proof_bundle } = self.state() {
             proof_bundle
         } else {

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -620,7 +620,7 @@ impl SettleMatchTask {
 
     /// Submit the match transaction to the contract
     async fn submit_match(
-        &self,
+        &mut self,
         proof: ValidMatchEncryptBundle,
     ) -> Result<(), SettleMatchTaskError> {
         // Build commitments to the notes
@@ -790,7 +790,10 @@ impl SettleMatchTask {
     }
 
     /// Submit the settle transaction to the contract
-    async fn submit_settle(&self, proof: ValidSettleBundle) -> Result<(), SettleMatchTaskError> {
+    async fn submit_settle(
+        &mut self,
+        proof: ValidSettleBundle,
+    ) -> Result<(), SettleMatchTaskError> {
         let note_commitment = compute_note_commitment(
             &self.my_note,
             self.old_wallet.key_chain.public_keys.pk_settle,

--- a/core/src/tasks/update_wallet.rs
+++ b/core/src/tasks/update_wallet.rs
@@ -273,7 +273,7 @@ impl UpdateWalletTask {
     }
 
     /// Submit the `update_wallet` transaction to the contract and await finality
-    async fn submit_tx(&self) -> Result<(), UpdateWalletTaskError> {
+    async fn submit_tx(&mut self) -> Result<(), UpdateWalletTaskError> {
         let proof = if let UpdateWalletTaskState::SubmittingTx { proof_bundle } = self.state() {
             proof_bundle
         } else {
@@ -322,6 +322,11 @@ impl UpdateWalletTask {
                 ERR_TRANSACTION_FAILED.to_string(),
             ));
         }
+
+        // Update the wallet in the global state
+        self.global_state
+            .update_wallet(self.new_wallet.clone())
+            .await;
 
         Ok(())
     }
@@ -401,11 +406,6 @@ impl UpdateWalletTask {
             self.update_order_state(order_id, proof.into(), witness)
                 .await?;
         }
-
-        // Update the wallet in the global state
-        self.global_state
-            .update_wallet(self.new_wallet.clone())
-            .await;
 
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR aims to use `PENDING` state for confirmation, rather than `ACCEPTED_ON_L2`. These two states are equivalent while StarkNet is still single-sequencer, and we get significantly better time-to-confirmation by using `PENDING`.

Main changes:
* Use `PENDING` everywhere, including in events streaming and transaction polling.
* Add support for multi-account rotation when submitting transactions. The StarkNet sequencer has a nonce check bug, such that multiple transactions from a single account are not possible within a single `PENDING` block, so we rotate between accounts for each tx.
* Stream a WalletUpdate event immediately after the transaction is confirmed as `PENDING`, rather than after `VALID_COMMITMENTS` proofs are generated.