### PR TITLE
core: tasks: intialize-state: Refactor task to fit encryption redesign

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -770,7 +770,7 @@ pub mod native_helpers {
     /// Reblind a wallet given its secret shares
     ///
     /// Returns the reblinded private and public shares
-    pub(crate) fn reblind_wallet<
+    pub fn reblind_wallet<
         const MAX_BALANCES: usize,
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
@@ -829,7 +829,7 @@ pub mod native_helpers {
     ///
     /// The return type is a tuple containing the private and public shares. Note
     /// that the private shares returned are exactly those passed in
-    pub(crate) fn create_wallet_shares_from_private<
+    pub fn create_wallet_shares_from_private<
         const MAX_BALANCES: usize,
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -13,9 +13,7 @@ mod test_helpers {
 
     use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use crypto::{
-        fields::{
-            biguint_to_scalar, prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField,
-        },
+        fields::{prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField},
         hash::default_poseidon_params,
     };
     use curve25519_dalek::scalar::Scalar;
@@ -25,21 +23,17 @@ mod test_helpers {
     use rand_core::{CryptoRng, OsRng, RngCore};
 
     use crate::{
-        native_helpers::compute_poseidon_hash,
+        native_helpers::{
+            compute_poseidon_hash, create_wallet_shares_with_randomness, reblind_wallet,
+        },
         types::{
-            balance::{Balance, BalanceSecretShare},
-            fee::{Fee, FeeSecretShare},
-            keychain::{PublicKeyChain, PublicKeyChainSecretShare, NUM_KEYS},
-            order::{Order, OrderSecretShare, OrderSide},
+            balance::Balance,
+            fee::Fee,
+            keychain::{PublicKeyChain, NUM_KEYS},
+            order::{Order, OrderSide},
             wallet::{Wallet, WalletSecretShare},
         },
-        zk_gadgets::{
-            fixed_point::FixedPoint,
-            merkle::MerkleOpening,
-            nonnative::{
-                biguint_to_scalar_words, NonNativeElementSecretShare, TWO_TO_256_FIELD_MOD,
-            },
-        },
+        zk_gadgets::{fixed_point::FixedPoint, merkle::MerkleOpening},
     };
 
     // --------------
@@ -114,58 +108,20 @@ mod test_helpers {
     // | Helpers |
     // -----------
 
-    /// Reblind a wallet given its secret shares
-    ///
-    /// Returns the reblinded private and public shares
-    pub(crate) fn reblind_wallet(
-        private_secret_shares: SizedWalletShare,
-        wallet: &SizedWallet,
-    ) -> (SizedWalletShare, SizedWalletShare) {
-        // Sample new wallet blinders from the `blinder` CSPRNG
-        // See the comments in `valid_reblind.rs` for an explanation of the two CSPRNGs
-        let mut blinder_samples =
-            evaluate_hash_chain(private_secret_shares.blinder, 2 /* length */);
-        let mut blinder_drain = blinder_samples.drain(..);
-        let new_blinder = blinder_drain.next().unwrap();
-        let new_blinder_private_share = blinder_drain.next().unwrap();
-
-        // Sample new secret shares for the wallet
-        let shares_serialized: Vec<Scalar> = private_secret_shares.into();
-        let serialized_len = shares_serialized.len();
-        let secret_shares =
-            evaluate_hash_chain(shares_serialized[serialized_len - 2], serialized_len - 1);
-
-        create_wallet_shares_with_randomness(
-            wallet,
-            new_blinder,
-            new_blinder_private_share,
-            secret_shares,
-        )
-    }
-
-    /// Compute a chained Poseidon hash of the given length from the given seed
-    pub(crate) fn evaluate_hash_chain(seed: Scalar, length: usize) -> Vec<Scalar> {
-        let mut seed = scalar_to_prime_field(&seed);
-        let mut res = Vec::with_capacity(length);
-
-        let poseidon_config = default_poseidon_params();
-        for _ in 0..length {
-            // New hasher every time to reset the hash state, Arkworks sponges don't natively
-            // support resets, so we pay the small re-initialization overhead
-            let mut hasher = PoseidonSponge::new(&poseidon_config);
-            hasher.absorb(&seed);
-            seed = hasher.squeeze_field_elements(1 /* num_elements */)[0];
-
-            res.push(prime_field_to_scalar(&seed));
-        }
-
-        res
-    }
-
     /// Construct secret shares of a wallet for testing
-    pub(crate) fn create_wallet_shares(
-        wallet: &SizedWallet,
-    ) -> (SizedWalletShare, SizedWalletShare) {
+    pub(crate) fn create_wallet_shares<
+        const MAX_BALANCES: usize,
+        const MAX_ORDERS: usize,
+        const MAX_FEES: usize,
+    >(
+        wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    ) -> (
+        WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    )
+    where
+        [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+    {
         // Sample a random secret share for the blinder
         let mut rng = OsRng {};
         let blinder_share = Scalar::random(&mut rng);
@@ -176,164 +132,6 @@ mod test_helpers {
             blinder_share,
             from_fn(|| Some(Scalar::random(&mut rng))),
         )
-    }
-
-    /// Construct public shares of a wallet given the private shares and blinder
-    ///
-    /// The return type is a tuple containing the private and public shares. Note
-    /// that the private shares returned are exactly those passed in
-    pub(crate) fn create_wallet_shares_from_private(
-        wallet: &SizedWallet,
-        private_shares: &SizedWalletShare,
-        blinder: Scalar,
-    ) -> (SizedWalletShare, SizedWalletShare) {
-        // Serialize the wallet's private shares and use this as the secret share stream
-        let private_shares_ser: Vec<Scalar> = private_shares.clone().into();
-        create_wallet_shares_with_randomness(
-            wallet,
-            blinder,
-            private_shares.blinder,
-            private_shares_ser,
-        )
-    }
-
-    /// Create a secret sharing of a wallet given the secret shares and blinders
-    fn create_wallet_shares_with_randomness<T>(
-        wallet: &SizedWallet,
-        blinder: Scalar,
-        private_blinder_share: Scalar,
-        secret_shares: T,
-    ) -> (SizedWalletShare, SizedWalletShare)
-    where
-        T: IntoIterator<Item = Scalar>,
-    {
-        // Cast to iter and create a shorthand notation
-        let mut share_iter = secret_shares.into_iter();
-        macro_rules! next_share {
-            () => {
-                share_iter.next().unwrap()
-            };
-        }
-
-        // Secret share the balances
-        let mut balances1 = Vec::with_capacity(MAX_BALANCES);
-        let mut balances2 = Vec::with_capacity(MAX_BALANCES);
-        for balance in wallet.balances.iter() {
-            let mint_share = next_share!();
-            let amount_share = next_share!();
-            balances1.push(BalanceSecretShare {
-                mint: mint_share,
-                amount: amount_share,
-            });
-
-            balances2.push(BalanceSecretShare {
-                mint: biguint_to_scalar(&balance.mint) - mint_share,
-                amount: Scalar::from(balance.amount) - amount_share,
-            });
-        }
-
-        // Secret share the orders
-        let mut orders1 = Vec::with_capacity(MAX_ORDERS);
-        let mut orders2 = Vec::with_capacity(MAX_ORDERS);
-        for order in wallet.orders.iter() {
-            let quote_share = next_share!();
-            let base_share = next_share!();
-            let side_share = next_share!();
-            let price_share = next_share!();
-            let amount_share = next_share!();
-            let timestamp_share = next_share!();
-
-            orders1.push(OrderSecretShare {
-                quote_mint: quote_share,
-                base_mint: base_share,
-                side: side_share,
-                price: price_share,
-                amount: amount_share,
-                timestamp: timestamp_share,
-            });
-
-            orders2.push(OrderSecretShare {
-                quote_mint: biguint_to_scalar(&order.quote_mint) - quote_share,
-                base_mint: biguint_to_scalar(&order.base_mint) - base_share,
-                side: Scalar::from(order.side) - side_share,
-                price: order.price.repr - price_share,
-                amount: Scalar::from(order.amount) - amount_share,
-                timestamp: Scalar::from(order.timestamp) - timestamp_share,
-            });
-        }
-
-        // Secret share the fees
-        let mut fees1 = Vec::with_capacity(MAX_FEES);
-        let mut fees2 = Vec::with_capacity(MAX_FEES);
-        for fee in wallet.fees.iter() {
-            let settle_key_share = next_share!();
-            let gas_addr_share = next_share!();
-            let gas_amount_share = next_share!();
-            let percentage_share = next_share!();
-
-            fees1.push(FeeSecretShare {
-                settle_key: settle_key_share,
-                gas_addr: gas_addr_share,
-                gas_token_amount: gas_amount_share,
-                percentage_fee: percentage_share,
-            });
-
-            fees2.push(FeeSecretShare {
-                settle_key: biguint_to_scalar(&fee.settle_key) - settle_key_share,
-                gas_addr: biguint_to_scalar(&fee.gas_addr) - gas_addr_share,
-                gas_token_amount: Scalar::from(fee.gas_token_amount) - gas_amount_share,
-                percentage_fee: fee.percentage_fee.repr - percentage_share,
-            })
-        }
-
-        // Secret share the keychain
-        let root_key_words = biguint_to_scalar_words(wallet.keys.pk_root.0.clone());
-        let root_shares1 = (0..root_key_words.len())
-            .map(|_| next_share!())
-            .collect_vec();
-        let root_shares2 = root_key_words
-            .iter()
-            .zip(root_shares1.iter())
-            .map(|(w1, w2)| w1 - w2)
-            .collect_vec();
-
-        let match_share = next_share!();
-
-        let keychain1 = PublicKeyChainSecretShare {
-            pk_root: NonNativeElementSecretShare {
-                words: root_shares1,
-                field_mod: TWO_TO_256_FIELD_MOD.clone(),
-            },
-            pk_match: match_share,
-        };
-        let keychain2 = PublicKeyChainSecretShare {
-            pk_root: NonNativeElementSecretShare {
-                words: root_shares2,
-                field_mod: TWO_TO_256_FIELD_MOD.clone(),
-            },
-            pk_match: wallet.keys.pk_match.0 - match_share,
-        };
-
-        // Construct the secret shares of the wallet
-        let wallet1 = SizedWalletShare {
-            balances: balances1.try_into().unwrap(),
-            orders: orders1.try_into().unwrap(),
-            fees: fees1.try_into().unwrap(),
-            keys: keychain1,
-            blinder: private_blinder_share,
-        };
-        let mut wallet2 = SizedWalletShare {
-            balances: balances2.try_into().unwrap(),
-            orders: orders2.try_into().unwrap(),
-            fees: fees2.try_into().unwrap(),
-            keys: keychain2,
-            blinder: blinder - private_blinder_share,
-        };
-
-        // Blind the public shares
-        wallet2.blind(blinder);
-
-        (wallet1, wallet2)
     }
 
     /// Create a multi-item opening in a Merkle tree, do so by constructing the Merkle tree

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -581,14 +581,14 @@ mod test {
     use rand_core::OsRng;
 
     use crate::{
+        native_helpers::create_wallet_shares_from_private,
         types::{
             balance::{Balance, BalanceSecretShare},
             fee::FeeSecretShare,
             order::{OrderSecretShare, OrderSide},
         },
         zk_circuits::test_helpers::{
-            create_wallet_shares, create_wallet_shares_from_private, SizedWallet, INITIAL_WALLET,
-            MAX_BALANCES, MAX_FEES, MAX_ORDERS,
+            create_wallet_shares, SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
         },
         CommitPublic, CommitWitness,
     };

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -580,11 +580,13 @@ mod test {
     use rand_core::OsRng;
 
     use crate::{
-        native_helpers::{compute_wallet_share_commitment, compute_wallet_share_nullifier},
+        native_helpers::{
+            compute_wallet_share_commitment, compute_wallet_share_nullifier, reblind_wallet,
+        },
         types::keychain::SecretIdentificationKey,
         zk_circuits::test_helpers::{
-            create_multi_opening, create_wallet_shares, reblind_wallet, SizedWallet,
-            SizedWalletShare, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS, PRIVATE_KEYS,
+            create_multi_opening, create_wallet_shares, SizedWallet, SizedWalletShare,
+            INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS, PRIVATE_KEYS,
         },
         CommitPublic, CommitWitness,
     };

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -201,7 +201,8 @@ async fn main() -> Result<(), CoordinatorError> {
         starknet_client.clone(),
         proof_generation_worker_sender.clone(),
         network_sender.clone(),
-    );
+    )
+    .await;
     task_driver.start_task(task).await;
 
     // ----------------

--- a/core/src/tasks/helpers.rs
+++ b/core/src/tasks/helpers.rs
@@ -1,9 +1,47 @@
 //! Helpers for common functionality across tasks
 
+use circuits::{
+    native_helpers::{
+        compute_wallet_share_commitment, create_wallet_shares_from_private, reblind_wallet,
+    },
+    types::{
+        balance::Balance,
+        order::{Order, OrderSide},
+    },
+    zk_circuits::{
+        valid_commitments::{ValidCommitmentsStatement, ValidCommitmentsWitness},
+        valid_reblind::{ValidReblindStatement, ValidReblindWitness},
+    },
+};
+use crossbeam::channel::Sender as CrossbeamSender;
+use crypto::fields::biguint_to_scalar;
+use num_bigint::BigUint;
+use tokio::sync::oneshot::{self, Receiver as TokioReceiver};
+
 use crate::{
+    proof_generation::{
+        jobs::{ProofBundle, ProofJob, ProofManagerJob},
+        SizedValidCommitmentsWitness, SizedValidReblindWitness,
+    },
     starknet_client::{client::StarknetClient, error::StarknetClientError},
     state::wallet::{Wallet, WalletAuthenticationPath},
+    SizedWallet,
 };
+
+// -------------
+// | Constants |
+// -------------
+
+/// Error message emitted when enqueuing a job with the proof manager fails
+const ERR_ENQUEUING_JOB: &str = "error enqueuing job with proof manager";
+/// Error message emitted when a balance cannot be found for an order
+const ERR_BALANCE_NOT_FOUND: &str = "cannot find balance for order";
+/// Error message emitted when an order cannot be found in a wallet
+const ERR_ORDER_NOT_FOUND: &str = "cannot find order in wallet";
+
+// -----------
+// | Helpers |
+// -----------
 
 /// Find the merkle authentication path of a wallet
 pub(super) async fn find_merkle_path(
@@ -24,4 +62,181 @@ pub(super) async fn find_merkle_path(
         public_share_path: public_merkle_auth_path,
         private_share_path: private_merkle_auth_path,
     })
+}
+
+/// Re-blind the wallet and prove `VALID REBLIND` for the wallet
+pub(super) fn construct_wallet_reblind_proof(
+    wallet: &Wallet,
+    wallet_openings: WalletAuthenticationPath,
+    proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+) -> Result<(SizedValidReblindWitness, TokioReceiver<ProofBundle>), String> {
+    // Reblind the wallet
+    let circuit_wallet: SizedWallet = wallet.clone().into();
+    let (reblinded_private_shares, reblinded_public_shares) =
+        reblind_wallet(wallet.private_shares.clone(), &circuit_wallet);
+
+    let merkle_root = wallet_openings.public_share_path.compute_root();
+    let private_reblinded_commitment =
+        compute_wallet_share_commitment(reblinded_private_shares.clone());
+
+    // Construct the witness and statement
+    let statement = ValidReblindStatement {
+        original_private_share_nullifier: wallet.get_private_share_nullifier(),
+        original_public_share_nullifier: wallet.get_public_share_nullifier(),
+        reblinded_private_share_commitment: private_reblinded_commitment,
+        merkle_root,
+    };
+    let witness = ValidReblindWitness {
+        original_wallet_private_shares: wallet.private_shares.clone(),
+        original_wallet_public_shares: wallet.public_shares.clone(),
+        reblinded_wallet_private_shares: reblinded_private_shares,
+        reblinded_wallet_public_shares: reblinded_public_shares,
+        private_share_opening: wallet_openings.private_share_path.into(),
+        public_share_opening: wallet_openings.public_share_path.into(),
+        sk_match: wallet.key_chain.secret_keys.sk_match,
+    };
+
+    // Forward a job to the proof manager
+    let (proof_sender, proof_receiver) = oneshot::channel();
+    proof_manager_work_queue
+        .send(ProofManagerJob {
+            type_: ProofJob::ValidReblind {
+                witness: witness.clone(),
+                statement,
+            },
+            response_channel: proof_sender,
+        })
+        .map_err(|_| ERR_ENQUEUING_JOB.to_string())?;
+
+    Ok((witness, proof_receiver))
+}
+
+/// Prove `VALID COMMITMENTS` for an order within a wallet
+///
+/// Returns a copy of the witness for indexing
+pub(super) fn construct_wallet_commitment_proof(
+    wallet: Wallet,
+    order: Order,
+    proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+) -> Result<(SizedValidCommitmentsWitness, TokioReceiver<ProofBundle>), String> {
+    // Choose the first fee
+    let fee = wallet.fees.get(0).unwrap().clone();
+
+    // Build an augmented wallet and find balances to update
+    let mut augmented_wallet: SizedWallet = wallet.clone().into();
+
+    let (send_mint, receive_mint) = match order.side {
+        OrderSide::Buy => (order.quote_mint.clone(), order.base_mint.clone()),
+        OrderSide::Sell => (order.base_mint.clone(), order.quote_mint.clone()),
+    };
+
+    let (send_index, send_balance) =
+        find_or_augment_balance(send_mint, &mut augmented_wallet, false /* augment */)
+            .ok_or_else(|| ERR_BALANCE_NOT_FOUND.to_string())?;
+    let (receive_index, receive_balance) =
+        find_or_augment_balance(receive_mint, &mut augmented_wallet, true /* augment */)
+            .ok_or_else(|| ERR_BALANCE_NOT_FOUND.to_string())?;
+
+    // Find a balance to cover the fee
+    let (_, fee_balance) = find_or_augment_balance(
+        fee.gas_addr.clone(),
+        &mut augmented_wallet,
+        false, /* augment */
+    )
+    .ok_or_else(|| ERR_BALANCE_NOT_FOUND.to_string())?;
+
+    // Find the order in the wallet
+    let order_index = find_order(&order.base_mint, &order.quote_mint, &augmented_wallet)
+        .ok_or_else(|| ERR_ORDER_NOT_FOUND.to_string())?;
+
+    // Create new augmented public secret shares
+    let (_, augmented_public_shares) = create_wallet_shares_from_private(
+        &augmented_wallet,
+        &wallet.private_shares,
+        biguint_to_scalar(&wallet.blinder),
+    );
+
+    // Build the witness and statement
+    let statement = ValidCommitmentsStatement {
+        balance_send_index: send_index,
+        balance_receive_index: receive_index,
+        order_index,
+    };
+    let witness = ValidCommitmentsWitness {
+        private_secret_shares: wallet.private_shares,
+        public_secret_shares: wallet.public_shares,
+        augmented_public_shares,
+        order: order.into(),
+        balance_send: send_balance.into(),
+        balance_receive: receive_balance,
+        balance_fee: fee_balance,
+        fee,
+    };
+
+    // Dispatch a job to the proof manager to prove `VALID COMMITMENTS`
+    let (proof_sender, proof_receiver) = oneshot::channel();
+    proof_manager_work_queue
+        .send(ProofManagerJob {
+            response_channel: proof_sender,
+            type_: ProofJob::ValidCommitments {
+                witness: witness.clone(),
+                statement,
+            },
+        })
+        .map_err(|_| ERR_ENQUEUING_JOB.to_string())?;
+
+    Ok((witness, proof_receiver))
+}
+
+/// Find a balance in the wallet
+///
+/// If the balance is not found and the `augment` flag is set, the method
+/// will find an empty balance and add a zero'd balance in its place
+///
+/// Returns the index at which the balance was found or augmented, if possible
+fn find_or_augment_balance(
+    mint: BigUint,
+    wallet: &mut SizedWallet,
+    augment: bool,
+) -> Option<(usize, Balance)> {
+    let index = wallet
+        .balances
+        .iter()
+        .enumerate()
+        .find(|(_ind, balance)| mint.eq(&balance.mint));
+    match index {
+        Some((index, balance)) => Some((index, balance.clone())),
+        None => {
+            if !augment {
+                return None;
+            }
+
+            // Find an empty balance and augment it
+            let empty_balance_ind = wallet
+                .balances
+                .iter()
+                .enumerate()
+                .find(|(_ind, balance)| balance.mint.eq(&BigUint::from(0u8)))
+                .map(|(ind, _balance)| ind)?;
+
+            wallet.balances[empty_balance_ind] = Balance {
+                mint: mint.clone(),
+                amount: 0,
+            };
+            Some((
+                empty_balance_ind,
+                wallet.balances[empty_balance_ind].clone(),
+            ))
+        }
+    }
+}
+
+/// Find an order in the wallet, returns the index at which the order was found
+fn find_order(base_mint: &BigUint, quote_mint: &BigUint, wallet: &SizedWallet) -> Option<usize> {
+    wallet
+        .orders
+        .iter()
+        .enumerate()
+        .find(|(_ind, order)| order.quote_mint.eq(quote_mint) && order.base_mint.eq(base_mint))
+        .map(|(ind, _order)| ind)
 }

--- a/core/src/tasks/mod.rs
+++ b/core/src/tasks/mod.rs
@@ -11,6 +11,3 @@ pub mod initialize_state;
 pub mod lookup_wallet;
 pub mod settle_match;
 pub mod update_wallet;
-
-/// The amount to increment the randomness each time a wallet is nullified
-pub(self) const RANDOMNESS_INCREMENT: u8 = 2;


### PR DESCRIPTION
### Purpose
This PR refactors the `initialize-state` task to fit the secret share pattern in the encryption redesign.

At a high level, the changes are:
- Find merkle authentication paths for both the public and private wallet shares separately
- Prove both `VALID REBLIND` once for each wallet and `VALID COMMITMENTS` for each order in the wallet. Store both of these (heap allocated) proofs in the global state.

### Testing
- Unit tests pass
- Will defer testing concrete functionality until the rest of the tasks are refactored, easier to test the whole flow end-to-end.