### PR TITLE
core: tasks: update-wallet: Refactor to fit encryption redesign

### DIFF
--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -37,11 +37,11 @@ use self::{
     wallet::{
         AddFeeHandler, CancelOrderHandler, CreateOrderHandler, CreateWalletHandler,
         DepositBalanceHandler, FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
-        GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler,
-        InternalTransferHandler, RemoveFeeHandler, WithdrawBalanceHandler, CANCEL_ORDER_ROUTE,
-        CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, FEES_ROUTE, FIND_WALLET_ROUTE,
-        GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
-        INTERNAL_TRANSFER_ROUTE, REMOVE_FEE_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
+        GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler, RemoveFeeHandler,
+        WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE,
+        FEES_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE,
+        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, REMOVE_FEE_ROUTE, WALLET_ORDERS_ROUTE,
+        WITHDRAW_BALANCE_ROUTE,
     },
 };
 
@@ -370,20 +370,6 @@ impl HttpServer {
             WITHDRAW_BALANCE_ROUTE.to_string(),
             true, /* auth_required */
             WithdrawBalanceHandler::new(
-                config.starknet_client.clone(),
-                config.network_sender.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
-        );
-
-        // The "/wallet/:id/balances/:mint/internal_transfer" route
-        router.add_route(
-            Method::POST,
-            INTERNAL_TRANSFER_ROUTE.to_string(),
-            true, /* auth_required */
-            InternalTransferHandler::new(
                 config.starknet_client.clone(),
                 config.network_sender.clone(),
                 global_state.clone(),

--- a/core/src/proof_generation/jobs.rs
+++ b/core/src/proof_generation/jobs.rs
@@ -170,6 +170,16 @@ impl From<ProofBundle> for ValidWalletCreateBundle {
     }
 }
 
+impl From<ProofBundle> for ValidReblindBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidReblind(b) = bundle {
+            b
+        } else {
+            panic!("Proof bundle is not of type ValidReblind: {:?}", bundle);
+        }
+    }
+}
+
 impl From<ProofBundle> for ValidCommitmentsBundle {
     fn from(bundle: ProofBundle) -> Self {
         if let ProofBundle::ValidCommitments(b) = bundle {

--- a/core/src/starknet_client/client.rs
+++ b/core/src/starknet_client/client.rs
@@ -58,7 +58,7 @@ use crate::{
         VALUE_INSERTED_EVENT_SELECTOR,
     },
     state::{wallet::MerkleAuthenticationPath, MerkleTreeCoords},
-    MERKLE_HEIGHT,
+    SizedWalletShare, MERKLE_HEIGHT,
 };
 
 use super::{
@@ -614,28 +614,19 @@ impl StarknetClient {
     pub async fn update_wallet(
         &self,
         public_blinder_share: Scalar,
-        new_wallet_commitment: WalletShareCommitment,
-        old_match_nullifier: Nullifier,
-        old_spend_nullifier: Nullifier,
+        new_private_shares_commitment: WalletShareCommitment,
+        old_private_shares_nullifier: Nullifier,
+        old_public_shares_nullifier: Nullifier,
         external_transfer: Option<ExternalTransfer>,
-        internal_transfer_ciphertext: Option<Vec<ElGamalCiphertext>>,
-        wallet_ciphertext: Vec<ElGamalCiphertext>,
+        new_public_shares: SizedWalletShare,
         valid_wallet_update: ValidWalletUpdateBundle,
     ) -> Result<TransactionHash, StarknetClientError> {
         let mut calldata = vec![
             Self::reduce_scalar_to_felt(&public_blinder_share),
-            Self::reduce_scalar_to_felt(&new_wallet_commitment),
-            Self::reduce_scalar_to_felt(&old_match_nullifier),
-            Self::reduce_scalar_to_felt(&old_spend_nullifier),
+            Self::reduce_scalar_to_felt(&new_private_shares_commitment),
+            Self::reduce_scalar_to_felt(&old_private_shares_nullifier),
+            Self::reduce_scalar_to_felt(&old_public_shares_nullifier),
         ];
-
-        // Append the internal transfer ciphertext if there is one
-        if let Some(internal_transfer) = internal_transfer_ciphertext {
-            calldata.append(&mut pack_serializable!(internal_transfer));
-        } else {
-            // Otherwise, push 0 to the calldata to indicate a zero-length ciphertext blob
-            calldata.push(0u8.into());
-        }
 
         // Add the external transfer tuple to the calldata
         if let Some(transfer) = external_transfer {
@@ -645,8 +636,8 @@ impl StarknetClient {
             calldata.push(0u8.into() /* external_transfers_len */);
         }
 
-        // Append the packed wallet ciphertext and proof of `VALID WALLET UPDATE`
-        calldata.append(&mut pack_serializable!(wallet_ciphertext));
+        // Append the packed wallet shares and proof of `VALID WALLET UPDATE`
+        calldata.append(&mut pack_serializable!(new_public_shares));
         calldata.append(&mut pack_serializable!(valid_wallet_update));
 
         // Call the `update_wallet` function in the contract

--- a/core/src/state/orderbook.rs
+++ b/core/src/state/orderbook.rs
@@ -289,11 +289,9 @@ impl NetworkOrderBook {
 
     /// Get the public share nullifier for a given order
     pub async fn get_nullifier(&self, order_id: &OrderIdentifier) -> Option<Nullifier> {
-        if let Some(order_info_locked) = self.read_order(order_id).await {
-            Some(order_info_locked.public_share_nullifier)
-        } else {
-            None
-        }
+        self.read_order(order_id)
+            .await
+            .map(|order_info_locked| order_info_locked.public_share_nullifier)
     }
 
     /// Fetch all orders under a given nullifier

--- a/core/src/tasks/helpers.rs
+++ b/core/src/tasks/helpers.rs
@@ -238,5 +238,9 @@ fn find_order(base_mint: &BigUint, quote_mint: &BigUint, wallet: &SizedWallet) -
         .iter()
         .enumerate()
         .find(|(_ind, order)| order.quote_mint.eq(quote_mint) && order.base_mint.eq(base_mint))
+<<<<<<< HEAD
         .map(|(ind, _order)| ind)
+=======
+        .map(|(ind, _balance)| ind)
+>>>>>>> 181e771 (core: tasks: initialize-state: Refactor task after encryption redesign)
 }

--- a/core/src/tasks/update_wallet.rs
+++ b/core/src/tasks/update_wallet.rs
@@ -3,52 +3,31 @@
 //!
 //! This involves proving `VALID WALLET UPDATE`, submitting on-chain, and re-indexing state
 
-use std::{
-    collections::HashMap,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use async_trait::async_trait;
-use circuits::{
-    native_helpers::compute_poseidon_hash,
-    types::{
-        keychain::SecretIdentificationKey,
-        order::Order as CircuitOrder,
-        transfers::{ExternalTransfer, InternalTransfer},
-    },
-    zk_circuits::{
-        valid_commitments::ValidCommitmentsStatement,
-        valid_wallet_update::ValidWalletUpdateStatement,
-    },
-    zk_gadgets::merkle::MerkleOpening,
-};
+use circuits::types::transfers::ExternalTransfer;
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::starknet_felt_to_biguint;
-use curve25519_dalek::scalar::Scalar;
 use serde::Serialize;
 use starknet::core::types::TransactionStatus;
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
 use tracing::log;
 
 use crate::{
-    gossip_api::{
-        gossip::{GossipOutbound, PubsubMessage},
-        orderbook_management::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
-    },
-    price_reporter::exchanges::get_current_time,
-    proof_generation::jobs::{
-        ProofJob, ProofManagerJob, ValidCommitmentsBundle, ValidWalletUpdateBundle,
+    gossip_api::gossip::GossipOutbound,
+    proof_generation::{
+        jobs::{ProofJob, ProofManagerJob, ValidWalletUpdateBundle},
+        SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
     },
     starknet_client::client::StarknetClient,
-    state::{wallet::Wallet, NetworkOrder, NetworkOrderState, OrderIdentifier, RelayerState},
-    tasks::{encrypt_internal_transfer, encrypt_wallet},
-    types::{SizedValidCommitmentsWitness, SizedValidWalletUpdateWitness},
-    SizedWallet,
+    state::{wallet::Wallet, NetworkOrder, RelayerState},
+    tasks::helpers::get_current_timestamp,
 };
 
 use super::{
     driver::{StateWrapper, Task},
-    RANDOMNESS_INCREMENT,
+    helpers::update_wallet_validity_proofs,
 };
 
 /// The human-readable name of the the task
@@ -66,8 +45,6 @@ const ERR_TRANSACTION_FAILED: &str = "transaction failed";
 pub struct UpdateWalletTask {
     /// The external transfer, if one exists
     pub external_transfer: Option<ExternalTransfer>,
-    /// The internal transfer, if one exists
-    pub internal_transfer: Option<InternalTransfer>,
     /// The old wallet before update
     pub old_wallet: Wallet,
     /// The new wallet after update
@@ -89,12 +66,12 @@ pub struct UpdateWalletTask {
 pub enum UpdateWalletTaskError {
     /// Error generating a proof of `VALID WALLET UPDATE`
     ProofGeneration(String),
-    /// An error enqueuing a message for another worker
-    SendMessage(String),
     /// An error occurred interacting with Starknet
     StarknetClient(String),
     /// A state element was not found that is necessary for task execution
     StateMissing(String),
+    /// An error while updating validity proofs for a wallet
+    UpdatingValidityProofs(String),
 }
 
 /// Defines the state of the deposit balance task
@@ -109,7 +86,7 @@ pub enum UpdateWalletTaskState {
     /// The task is submitting the transaction to the contract and awaiting
     /// transaction finality
     SubmittingTx {
-        /// The proof of `VALID WALLET UPDATE` submitted to the contract
+        /// The proof of VALID WALLET UPDATE created in the previous step
         proof_bundle: ValidWalletUpdateBundle,
     },
     /// The task is updating the validity proofs for all orders in the
@@ -156,10 +133,8 @@ impl Task for UpdateWalletTask {
             }
             UpdateWalletTaskState::Proving => {
                 // Begin the proof of `VALID WALLET UPDATE`
-                let proof = self.generate_proof().await?;
-                self.task_state = UpdateWalletTaskState::SubmittingTx {
-                    proof_bundle: proof,
-                };
+                let proof_bundle = self.generate_proof().await?;
+                self.task_state = UpdateWalletTaskState::SubmittingTx { proof_bundle };
             }
             UpdateWalletTaskState::SubmittingTx { .. } => {
                 // Submit the proof and transaction info to the contract and await
@@ -205,19 +180,15 @@ impl UpdateWalletTask {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         external_transfer: Option<ExternalTransfer>,
-        internal_transfer: Option<InternalTransfer>,
         old_wallet: Wallet,
-        mut new_wallet: Wallet,
+        new_wallet: Wallet,
         starknet_client: StarknetClient,
         network_sender: TokioSender<GossipOutbound>,
         global_state: RelayerState,
         proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
     ) -> Self {
-        // Increment the randomness
-        new_wallet.randomness = &old_wallet.randomness + RANDOMNESS_INCREMENT;
         Self {
             external_transfer,
-            internal_transfer,
             old_wallet,
             new_wallet,
             starknet_client,
@@ -230,43 +201,47 @@ impl UpdateWalletTask {
 
     /// Generate a proof of `VALID WALLET UPDATE` for the wallet with added balance
     async fn generate_proof(&self) -> Result<ValidWalletUpdateBundle, UpdateWalletTaskError> {
-        let timestamp: Scalar = get_current_time().into();
+        let timestamp = get_current_timestamp();
         let merkle_opening =
             self.old_wallet.merkle_proof.clone().ok_or_else(|| {
                 UpdateWalletTaskError::StateMissing(ERR_NO_MERKLE_PROOF.to_string())
             })?;
+        let merkle_root = merkle_opening.public_share_path.compute_root();
 
-        // Build the statement
-        let statement = ValidWalletUpdateStatement {
-            timestamp,
-            pk_root: self.old_wallet.key_chain.public_keys.pk_root.clone(),
-            new_wallet_commitment: self.new_wallet.get_commitment(),
-            match_nullifier: self.old_wallet.get_match_nullifier(),
-            spend_nullifier: self.old_wallet.get_spend_nullifier(),
-            merkle_root: merkle_opening.compute_root(),
+        // Build a witness and statement
+        let private_share_nullifier = self.old_wallet.get_private_share_nullifier();
+        let public_share_nullifier = self.old_wallet.get_public_share_nullifier();
+        let new_private_share_commitment = self.new_wallet.get_private_share_commitment();
+
+        let statement = SizedValidWalletUpdateStatement {
+            old_private_shares_nullifier: private_share_nullifier,
+            old_public_shares_nullifier: public_share_nullifier,
+            new_private_shares_commitment: new_private_share_commitment,
+            new_public_shares: self.new_wallet.public_shares.clone(),
+            merkle_root,
             external_transfer: self.external_transfer.clone().unwrap_or_default(),
+            old_pk_root: self.old_wallet.key_chain.public_keys.pk_root.clone(),
+            timestamp,
         };
 
-        // Construct the witness
-        let old_circuit_wallet: SizedWallet = self.old_wallet.clone().into();
-        let new_circuit_wallet: SizedWallet = self.new_wallet.clone().into();
         let witness = SizedValidWalletUpdateWitness {
-            wallet1: old_circuit_wallet,
-            wallet2: new_circuit_wallet,
-            wallet1_opening: merkle_opening.into(),
-            internal_transfer: InternalTransfer::default(),
+            old_wallet_private_shares: self.old_wallet.private_shares.clone(),
+            old_wallet_public_shares: self.old_wallet.public_shares.clone(),
+            private_shares_opening: merkle_opening.private_share_path.into(),
+            public_shares_opening: merkle_opening.public_share_path.into(),
+            new_wallet_private_shares: self.new_wallet.private_shares.clone(),
         };
 
-        // Send a job to the proof manager and await completion
-        let (response_sender, response_receiver) = oneshot::channel();
+        // Dispatch a job to the proof manager, and await the job's result
+        let (proof_sender, proof_receiver) = oneshot::channel();
         self.proof_manager_work_queue
             .send(ProofManagerJob {
+                response_channel: proof_sender,
                 type_: ProofJob::ValidWalletUpdate { witness, statement },
-                response_channel: response_sender,
             })
-            .map_err(|err| UpdateWalletTaskError::SendMessage(err.to_string()))?;
+            .map_err(|err| UpdateWalletTaskError::ProofGeneration(err.to_string()))?;
 
-        response_receiver
+        proof_receiver
             .await
             .map(|bundle| bundle.into())
             .map_err(|err| UpdateWalletTaskError::ProofGeneration(err.to_string()))
@@ -280,30 +255,18 @@ impl UpdateWalletTask {
             unreachable!("submit_tx may only be called from a SubmittingTx task state")
         };
 
-        // Encrypt the new wallet and internal transfer under the public view key
-        // TODO: This will eventually come directly from the user as they sign the encryption
-        let encrypted_internal_transfer = self
-            .internal_transfer
-            .clone()
-            .map(|transfer| encrypt_internal_transfer(&transfer));
-        let encrypted_wallet = encrypt_wallet(
-            self.new_wallet.clone().into(),
-            self.old_wallet.key_chain.public_keys.pk_view,
-        );
-
         // Submit on-chain
         let tx_hash = self
             .starknet_client
             .update_wallet(
-                self.new_wallet.key_chain.public_keys.pk_view,
-                self.new_wallet.get_commitment(),
-                self.old_wallet.get_match_nullifier(),
-                self.old_wallet.get_spend_nullifier(),
+                self.new_wallet.public_shares.blinder,
+                self.new_wallet.get_private_share_commitment(),
+                self.old_wallet.get_private_share_nullifier(),
+                self.old_wallet.get_public_share_nullifier(),
                 self.external_transfer
                     .clone()
                     .map(|transfer| transfer.into()),
-                encrypted_internal_transfer,
-                encrypted_wallet,
+                self.new_wallet.public_shares.clone(),
                 proof,
             )
             .await
@@ -323,172 +286,51 @@ impl UpdateWalletTask {
             ));
         }
 
-        Ok(())
-    }
-
-    /// After a wallet update has been submitted on-chain, find its authentication
-    /// path, and re-prove `VALID COMMITMENTS` for all orders in the wallet
-    async fn update_validity_proofs(&self) -> Result<(), UpdateWalletTaskError> {
-        // Find the new wallet in the Merkle state
-        let authentication_path = self
-            .starknet_client
-            .find_merkle_authentication_path(self.new_wallet.get_commitment())
-            .await
-            .map_err(|err| UpdateWalletTaskError::StarknetClient(err.to_string()))?;
-        let new_root = authentication_path.compute_root();
-
-        // A wallet that is compatible with circuit types
-        let circuit_wallet: SizedWallet = self.new_wallet.clone().into();
-        let randomness_hash = compute_poseidon_hash(&[circuit_wallet.randomness]);
-        let wallet_opening: MerkleOpening = authentication_path.into();
-
-        // The statement in `VALID COMMITMENTS` is only parameterized by wallet-specific variables;
-        // so we construct it once and use it for all order commitment proofs
-        let new_statement = ValidCommitmentsStatement {
-            nullifier: self.new_wallet.get_match_nullifier(),
-            merkle_root: new_root,
-            pk_settle: self.new_wallet.key_chain.public_keys.pk_settle,
-        };
-
-        // Request that the proof manager prove `VALID COMMITMENTS` for each order
-        let mut proof_response_channels = HashMap::new();
-        for (order_id, order) in self.new_wallet.orders.clone().into_iter() {
-            // Skip default orders
-            if order.is_default() {
-                continue;
-            }
-
-            // Build a witness for this order's validity proof
-            let witness = if let Some(witness) = self
-                .get_witness_for_order(
-                    order,
-                    circuit_wallet.clone(),
-                    wallet_opening.clone(),
-                    randomness_hash,
-                    self.new_wallet.key_chain.secret_keys.sk_match,
-                )
-                .await
-            {
-                witness
-            } else {
-                log::error!("could not find witness for order {order_id}, skipping...");
-                continue;
-            };
-
-            // Send a job to the proof manager to prove `VALID COMMITMENTS` for this wallet
-            let (response_sender, response_receiver) = oneshot::channel();
-            self.proof_manager_work_queue
-                .send(ProofManagerJob {
-                    type_: ProofJob::ValidCommitments {
-                        witness: witness.clone(),
-                        statement: new_statement,
-                    },
-                    response_channel: response_sender,
-                })
-                .map_err(|err| UpdateWalletTaskError::SendMessage(err.to_string()))?;
-
-            proof_response_channels.insert(order_id, (response_receiver, witness));
-        }
-
-        // Await proofs for all orders
-        for (order_id, (proof_channel, witness)) in proof_response_channels.into_iter() {
-            let proof = proof_channel
-                .await
-                .map_err(|err| UpdateWalletTaskError::ProofGeneration(err.to_string()))?;
-            log::info!("got proof for order {order_id}");
-
-            // Update the global state of the order
-            self.update_order_state(order_id, proof.into(), witness)
-                .await?;
-        }
-
-        // Update the wallet in the global state
+        // After the state is finalized on-chain, add new orders to the book and
+        // re-index the wallet in the global state
+        self.add_new_orders_to_book().await;
         self.global_state
             .update_wallet(self.new_wallet.clone())
             .await;
-
         Ok(())
     }
 
-    /// Generate a `VALID COMMITMENTS` witness for the given order
-    ///
-    /// This will use the old witness -- modifying it appropriately -- if one exists,
-    /// otherwise, it will create a brand new witness
-    #[allow(clippy::too_many_arguments)]
-    async fn get_witness_for_order(
-        &self,
-        order: CircuitOrder,
-        wallet: SizedWallet,
-        wallet_opening: MerkleOpening,
-        randomness_hash: Scalar,
-        sk_match: SecretIdentificationKey,
-    ) -> Option<SizedValidCommitmentsWitness> {
-        // Always recreate the witness anew, even if a witness previously existed
-        // The balances used in a witness may have changes so it is easier to just
-        // recreate the witness
-        let (balance, fee, fee_balance) = self.new_wallet.get_balance_and_fee_for_order(&order)?;
-        Some(SizedValidCommitmentsWitness {
-            wallet,
-            order: order.into(),
-            balance: balance.into(),
-            fee: fee.into(),
-            fee_balance: fee_balance.into(),
-            wallet_opening,
-            randomness_hash: randomness_hash.into(),
-            sk_match,
-        })
-    }
+    /// Add new orders to the network order book
+    async fn add_new_orders_to_book(&self) {
+        let local_cluster_id = self.global_state.local_cluster_id.clone();
+        let wallet_public_share_nullifier = self.new_wallet.get_public_share_nullifier();
 
-    /// Update the order in the state
-    async fn update_order_state(
-        &self,
-        order_id: OrderIdentifier,
-        proof: ValidCommitmentsBundle,
-        witness: SizedValidCommitmentsWitness,
-    ) -> Result<(), UpdateWalletTaskError> {
-        // If the order does not currently exist in the book, add it
-        if !self
-            .global_state
-            .read_order_book()
-            .await
-            .contains_order(&order_id)
-        {
-            self.global_state
-                .add_order(NetworkOrder {
-                    id: order_id,
-                    match_nullifier: self.new_wallet.get_match_nullifier(),
-                    local: true,
-                    cluster: self.global_state.local_cluster_id.clone(),
-                    state: NetworkOrderState::Verified,
-                    valid_commit_proof: Some(proof.clone()),
-                    valid_commit_witness: Some(witness),
-                })
-                .await;
-        } else {
-            // Otherwise, update the existing proof
-            self.global_state
-                .add_order_validity_proof(&order_id, proof.clone())
-                .await;
-            self.global_state
+        for order_id in self.new_wallet.orders.keys() {
+            if !self
+                .global_state
                 .read_order_book()
                 .await
-                .attach_validity_proof_witness(&order_id, witness)
-                .await;
+                .contains_order(order_id)
+            {
+                self.global_state
+                    .add_order(NetworkOrder::new(
+                        *order_id,
+                        wallet_public_share_nullifier,
+                        local_cluster_id.clone(),
+                        true, /* local */
+                    ))
+                    .await
+            }
         }
+    }
 
-        // Broadcast the new order's validity proof to the network
-        let cluster = self.global_state.local_cluster_id.clone();
-        let message = OrderBookManagementMessage::OrderProofUpdated {
-            order_id,
-            cluster,
-            proof,
-        };
-
-        self.network_sender
-            .send(GossipOutbound::Pubsub {
-                topic: ORDER_BOOK_TOPIC.to_string(),
-                message: PubsubMessage::OrderBookManagement(message),
-            })
-            .map_err(|err| UpdateWalletTaskError::SendMessage(err.to_string()))
+    /// After a wallet update has been submitted on-chain, find its authentication
+    /// path, and re-prove `VALID REBLIND` for the wallet and `VALID COMMITMENTS`
+    /// for all orders in the wallet
+    async fn update_validity_proofs(&self) -> Result<(), UpdateWalletTaskError> {
+        update_wallet_validity_proofs(
+            &self.new_wallet,
+            &self.starknet_client,
+            self.proof_manager_work_queue.clone(),
+            self.global_state.clone(),
+            self.network_sender.clone(),
+        )
+        .await
+        .map_err(UpdateWalletTaskError::UpdatingValidityProofs)
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the `update-wallet` task to fit the secret sharing scheme of the encryption redesign. Specifically, this involves:
- Change the proofs of `VALID WALLET UPDATE` to fit the new design
- Change the post-tx logic to prove both `VALID REBLIND` as well as `VALID COMMITMENTS`
- Change the wallet update to index both the public and private share Merkle openings

### Testing
- Unit tests pass
- Did not test the functionality in goerli; will wait til all tasks are done.