### PR TITLE
core: tasks: lookup-wallet: Refactor task wrt encryption redesign

### DIFF
--- a/core/src/api_server/http/wallet.rs
+++ b/core/src/api_server/http/wallet.rs
@@ -6,6 +6,7 @@ use circuits::types::{
     transfers::{ExternalTransfer, ExternalTransferDirection},
 };
 use crossbeam::channel::Sender as CrossbeamSender;
+use crypto::fields::biguint_to_scalar;
 use hyper::{HeaderMap, StatusCode};
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -260,6 +261,8 @@ impl TypedHandler for FindWalletHandler {
         // the wallet
         let task = LookupWalletTask::new(
             req.wallet_id,
+            biguint_to_scalar(&req.blinder_seed),
+            biguint_to_scalar(&req.secret_share_seed),
             req.key_chain,
             self.starknet_client.clone(),
             self.network_sender.clone(),

--- a/core/src/chain_events/error.rs
+++ b/core/src/chain_events/error.rs
@@ -5,8 +5,6 @@ use std::fmt::Display;
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
 pub enum OnChainEventListenerError {
-    /// An error generating a proof
-    ProofGeneration(String),
     /// An RPC error with the StarkNet provider
     Rpc(String),
     /// An error sending a message to another worker in the local node

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -46,7 +46,7 @@ struct Cli {
     #[clap(long)]
     pub chain_id: ChainId,
     /// The address of the darkpool contract, defaults to the Goerli deployment
-    #[clap(long, value_parser, default_value = "0x1e7857cdd3d73838b0e053be1fa068aa15113793fea95ab663501789d3d0b51")]
+    #[clap(long, value_parser, default_value = "0x02179f01358c09410f234f1ece40d235719e05db3babca7bef0babc974333162")]
     pub contract_address: String,
 
     // ----------------------------

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -46,6 +46,10 @@ pub struct CreateWalletResponse {
 pub struct FindWalletRequest {
     /// The ID to handle the wallet by
     pub wallet_id: WalletIdentifier,
+    /// The seed for the wallet's blinder CSPRNG
+    pub blinder_seed: BigUint,
+    /// The seed for the wallet's secret share CSPRNG
+    pub secret_share_seed: BigUint,
     /// The keychain to use for management after the wallet is found
     pub key_chain: KeyChain,
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,5 +1,6 @@
 //! The entrypoint to the relayer, starts the coordinator thread which manages all other worker threads
 #![feature(const_likely)]
+#![feature(iter_advance_by)]
 #![feature(ip)]
 #![feature(generic_const_exprs)]
 #![feature(let_chains)]

--- a/core/src/starknet_client/helpers.rs
+++ b/core/src/starknet_client/helpers.rs
@@ -2,90 +2,132 @@
 
 use std::{convert::TryInto, iter};
 
-use crypto::elgamal::ElGamalCiphertext;
+use crypto::fields::starknet_felt_to_scalar;
 use itertools::Itertools;
 use starknet::core::types::FieldElement as StarknetFieldElement;
 
-use crate::starknet_client::{NEW_WALLET_SELECTOR, SETTLE_SELECTOR, UPDATE_WALLET_SELECTOR};
+use crate::{starknet_client::NEW_WALLET_SELECTOR, SizedWalletShare};
 
-use super::error::StarknetClientError;
+use super::{error::StarknetClientError, MATCH_SELECTOR, UPDATE_WALLET_SELECTOR};
 
 /// The number of bytes we can pack into a given Starknet field element
 ///
 /// The starknet field is of size 2 ** 251 + \delta, which fits at most
 /// 31 bytes cleanly into a single felt
 const BYTES_PER_FELT: usize = 31;
-/// The number of felts in an external transfer struct
-///
-/// 1 for the sender/recipient account, 1 for the mint, 2 for the amount (U256) and 1 for the direction
-const EXTERNAL_TRANSFER_N_FELTS: usize = 5;
-/// The index of the `encryption_blob_len` parameter in the `new_wallet` calldata
-const NEW_WALLET_ENCRYPTION_BLOB_IDX: usize = 2;
-/// The index of the `internal_transfer_ciphertext_len` argument in the `update_wallet` calldata
-const UPDATE_WALLET_INTERNAL_TRANSFER_IDX: usize = 4;
-/// The index of the `wallet_ciphertext_len` argument in the `settle` calldata
-const SETTLE_WALLET_CIPHERTEXT_IDX: usize = 6;
 
-/// Error thrown when a blob is not properly encoded
-const ERR_INVALID_BLOB_ENCODING: &str = "invalid blob encoding";
-/// Error thrown when an invalid selector is encountered observing a transaction's details
+/// The number of field elements used to represent an external transfer struct
+const EXTERNAL_TRANSFER_N_FELTS: usize = 5;
+/// The index of the `party0_public_blinder_share` argument in `match` calldata
+const MATCH_PARTY0_PUBLIC_BLINDER_SHARE_IDX: usize = 4;
+/// The index of the `party0_public_share_len` argument in `match` calldata
+const MATCH_PARTY0_PUBLIC_SHARES_IDX: usize = 10;
+/// The index of the `public_wallet_share_len` argument in `new_wallet` calldata
+const NEW_WALLET_SHARE_LEN_IDX: usize = 3;
+/// The index of the `external_transfers_len` argument in `update_wallet` calldata
+const UPDATE_WALLET_EXTERNAL_TRANSFER_LEN: usize = 5;
+
+/// Error message emitted when a public blinder share is not found in calldata
+const ERR_BLINDER_NOT_FOUND: &str = "public blinder share not found in calldata";
+/// Error message emitted when an invalid selector is given in the transaction's execution trace
 const ERR_INVALID_SELECTOR: &str = "invalid selector received";
 
-/// A helper to parse a ciphertext blob from transaction calldata
-pub(super) fn parse_ciphertext_from_calldata(
+/// Parse wallet public secret shares from the calldata of a transaction based on the
+/// selector invoked
+///
+/// Accept the public blinder share to disambiguate for transactions that update two sets
+/// of secret shares in their calldata
+pub(super) fn parse_shares_from_calldata(
     selector: StarknetFieldElement,
     calldata: &[StarknetFieldElement],
-) -> Result<Vec<ElGamalCiphertext>, StarknetClientError> {
-    // Parse the ciphertext blob from the calldata
-    let blob = match selector {
-        _ if selector == *NEW_WALLET_SELECTOR => parse_ciphertext_new_wallet(calldata),
-        _ if selector == *UPDATE_WALLET_SELECTOR => parse_ciphertext_update_wallet(calldata),
-        _ if selector == *SETTLE_SELECTOR => parse_ciphertext_settle(calldata),
-        _ => {
-            return Err(StarknetClientError::NotFound(
-                ERR_INVALID_SELECTOR.to_string(),
-            ));
-        }
-    };
-
-    // Parse a packed ciphertext from the calldata
-    ciphertext_vec_from_felt_blob(&blob)
+    public_blinder_share: StarknetFieldElement,
+) -> Result<SizedWalletShare, StarknetClientError> {
+    match selector {
+        _ if selector == *NEW_WALLET_SELECTOR => Ok(parse_shares_from_new_wallet(calldata)),
+        _ if selector == *UPDATE_WALLET_SELECTOR => Ok(parse_shares_from_update_wallet(calldata)),
+        _ if selector == *MATCH_SELECTOR => parse_shares_from_match(public_blinder_share, calldata),
+        _ => Err(StarknetClientError::NotFound(
+            ERR_INVALID_SELECTOR.to_string(),
+        )),
+    }
 }
 
-/// Parse a ciphertext blob from a `new_wallet` transaction
-fn parse_ciphertext_new_wallet(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
-    let blob_len: u64 = calldata[NEW_WALLET_ENCRYPTION_BLOB_IDX].try_into().unwrap();
-    let start_idx = NEW_WALLET_ENCRYPTION_BLOB_IDX + 1;
-    let end_idx = start_idx + (blob_len as usize);
-    calldata[start_idx..end_idx].to_vec()
+/// Parse wallet public shares from the calldata of a `new_wallet` transaction
+fn parse_shares_from_new_wallet(calldata: &[StarknetFieldElement]) -> SizedWalletShare {
+    let wallet_shares_len: u64 = calldata[NEW_WALLET_SHARE_LEN_IDX].try_into().unwrap();
+    let start_idx = NEW_WALLET_SHARE_LEN_IDX + 1;
+    let end_idx = start_idx + (wallet_shares_len as usize);
+
+    // Slice the calldata, cast to `Scalar`, then restructure into a wallet share
+    let calldata_slice = calldata[start_idx..end_idx].to_vec();
+    calldata_slice
+        .iter()
+        .map(starknet_felt_to_scalar)
+        .collect_vec()
+        .into()
 }
 
-/// Parse a ciphertext blob from an `update_wallet` transaction
-fn parse_ciphertext_update_wallet(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
-    // Read through the internal ciphertext
-    let mut cursor = UPDATE_WALLET_INTERNAL_TRANSFER_IDX;
-    let internal_wallet_ciphertext_len: u64 = calldata[cursor].try_into().unwrap();
-    cursor += (internal_wallet_ciphertext_len as usize) + 1;
-
-    // Read through the external transfers
+/// Parse wallet public shares from the calldata of an `update_wallet` transaction
+fn parse_shares_from_update_wallet(calldata: &[StarknetFieldElement]) -> SizedWalletShare {
+    // Scan up to the `external_transfers_len` argument to determine how far to jump past the transfer
+    let mut cursor = UPDATE_WALLET_EXTERNAL_TRANSFER_LEN;
     let external_transfers_len: u64 = calldata[cursor].try_into().unwrap();
     cursor += (external_transfers_len as usize) * EXTERNAL_TRANSFER_N_FELTS + 1;
 
-    // The next argument is the ciphertext blob length
-    let ciphertext_blob_len: u64 = calldata[cursor].try_into().unwrap();
-    let start_idx: usize = cursor + 1;
-    let end_idx: usize = start_idx + (ciphertext_blob_len as usize);
+    // The next argument is the length of the public secret shares
+    let wallet_shares_len: u64 = calldata[cursor].try_into().unwrap();
+    let start_idx = cursor + 1;
+    let end_idx = start_idx + (wallet_shares_len as usize);
 
-    calldata[start_idx..end_idx].to_vec()
+    // Slice the calldata, cast to `Scalar`, and restructure into a wallet share
+    let calldata_slice = calldata[start_idx..end_idx].to_vec();
+    calldata_slice
+        .iter()
+        .map(starknet_felt_to_scalar)
+        .collect_vec()
+        .into()
 }
 
-/// Parse a ciphertext blob from a `settle` transaction
-fn parse_ciphertext_settle(calldata: &[StarknetFieldElement]) -> Vec<StarknetFieldElement> {
-    let blob_len: u64 = calldata[SETTLE_WALLET_CIPHERTEXT_IDX].try_into().unwrap();
-    let start_idx = SETTLE_WALLET_CIPHERTEXT_IDX + 1;
-    let end_idx = start_idx + (blob_len as usize);
+/// Parse wallet public shares from the calldata of a `match` transaction
+fn parse_shares_from_match(
+    public_blinder_share: StarknetFieldElement,
+    calldata: &[StarknetFieldElement],
+) -> Result<SizedWalletShare, StarknetClientError> {
+    let mut cursor = MATCH_PARTY0_PUBLIC_BLINDER_SHARE_IDX;
+    let party0_blinder_share = calldata[cursor];
+    let party1_blinder_share = calldata[cursor];
 
-    calldata[start_idx..end_idx].to_vec()
+    let is_party0 = if public_blinder_share == party0_blinder_share {
+        true
+    } else if public_blinder_share == party1_blinder_share {
+        false
+    } else {
+        return Err(StarknetClientError::NotFound(
+            ERR_BLINDER_NOT_FOUND.to_string(),
+        ));
+    };
+
+    cursor = MATCH_PARTY0_PUBLIC_SHARES_IDX;
+    let party0_public_shares_len: u64 = calldata[cursor].try_into().unwrap();
+
+    let (start_idx, end_idx) = if is_party0 {
+        let start_idx = cursor + 1;
+        (start_idx, start_idx + (party0_public_shares_len as usize))
+    } else {
+        // Scan cursor past party 0 shares
+        cursor += party0_public_shares_len as usize;
+        let party1_public_shares_len: u64 = calldata[cursor].try_into().unwrap();
+        let start_idx = cursor + 1;
+        (start_idx, start_idx + (party1_public_shares_len as usize))
+    };
+
+    // Slice the calldata, cast to `Scalar`, and re-structure into a wallet share
+    let calldata_slice = calldata[start_idx..end_idx].to_vec();
+    Ok(calldata_slice
+        .iter()
+        .map(starknet_felt_to_scalar)
+        .collect_vec()
+        .into())
 }
 
 /// Pack bytes into Starknet field elements
@@ -113,67 +155,4 @@ pub(super) fn pack_bytes_into_felts(bytes: &[u8]) -> Vec<StarknetFieldElement> {
     }
 
     res
-}
-
-/// Deserialization from packed felts into a vector of ElGamal ciphertexts
-///
-/// When we pack the ciphertext into blob format for submission to the contract, we
-/// byte serialize the ciphertext vector, then pack the bytes into felts. The
-/// deserialization process is the opposite, chunk up the felts into byte windows,
-/// then concatenate these and deserialize explicitly into a `Vec<ElGamalCiphertext>`
-fn ciphertext_vec_from_felt_blob(
-    blob: &[StarknetFieldElement],
-) -> Result<Vec<ElGamalCiphertext>, StarknetClientError> {
-    let n_bytes: u64 = blob[0]
-        .try_into()
-        .map_err(|_| StarknetClientError::Serde(ERR_INVALID_BLOB_ENCODING.to_string()))?;
-
-    // Build a byte array from the calldata blob
-    let mut byte_array: Vec<u8> = Vec::with_capacity(BYTES_PER_FELT * blob.len());
-    for felt in blob[1..].iter() {
-        let mut bytes = felt.to_bytes_be();
-        // We pack bytes into the felts in little endian order to avoid
-        // field overflows. So reverse into little endian then truncate
-        bytes.reverse();
-
-        byte_array.append(&mut bytes[..BYTES_PER_FELT].to_vec());
-    }
-
-    // Deserialize the byte array back into a ciphertext vector
-    let truncated_bytes = &byte_array[..(n_bytes as usize)];
-    serde_json::from_slice(truncated_bytes)
-        .map_err(|err| StarknetClientError::Serde(err.to_string()))
-}
-
-#[cfg(test)]
-mod tests {
-    use crypto::elgamal::ElGamalCiphertext;
-    use curve25519_dalek::scalar::Scalar;
-    use rand_core::OsRng;
-
-    use super::{ciphertext_vec_from_felt_blob, pack_bytes_into_felts};
-
-    /// Tests serializing and deserializing a ciphertext blob as a packed array
-    /// of felts
-    #[test]
-    fn test_serialize_deserialize_elgamal() {
-        let n = 50;
-        let mut rng = OsRng {};
-        let mut ciphertexts = Vec::new();
-        for _ in 0..n {
-            ciphertexts.push(ElGamalCiphertext {
-                partial_shared_secret: Scalar::random(&mut rng),
-                encrypted_message: Scalar::random(&mut rng),
-            })
-        }
-
-        // Serialize the ciphertexts
-        let bytes = serde_json::to_vec(&ciphertexts).unwrap();
-        let packed_calldata = pack_bytes_into_felts(&bytes);
-
-        // Deserialize back into ciphertexts
-        let recovered_ciphertexts = ciphertext_vec_from_felt_blob(&packed_calldata).unwrap();
-
-        assert_eq!(ciphertexts, recovered_ciphertexts);
-    }
 }

--- a/core/src/starknet_client/mod.rs
+++ b/core/src/starknet_client/mod.rs
@@ -31,8 +31,8 @@ lazy_static! {
     /// Contract view function selector to test whether the given nullifier is used
     static ref NULLIFIER_USED_SELECTOR: StarknetFieldElement = get_selector_from_name("is_nullifier_used")
         .unwrap();
-    /// Contract view function selector to get the most recent transaction updating a given wallet
-    static ref GET_WALLET_LAST_UPDATED_SELECTOR: StarknetFieldElement = get_selector_from_name("get_wallet_update")
+    /// Contract view function selector to fetch the hash of the transaction that indexed a given public blinder share
+    static ref GET_PUBLIC_BLINDER_TRANSACTION: StarknetFieldElement = get_selector_from_name("get_public_blinder_transaction")
         .unwrap();
 
     // -- Setters --

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -247,8 +247,8 @@ impl NewWalletTask {
         let tx_hash = self
             .starknet_client
             .new_wallet(
-                self.wallet.public_shares.blinder,
                 private_share_commitment,
+                self.wallet.public_shares.clone(),
                 proof,
             )
             .await

--- a/core/src/tasks/update_wallet.rs
+++ b/core/src/tasks/update_wallet.rs
@@ -259,7 +259,6 @@ impl UpdateWalletTask {
         let tx_hash = self
             .starknet_client
             .update_wallet(
-                self.new_wallet.public_shares.blinder,
                 self.new_wallet.get_private_share_commitment(),
                 self.old_wallet.get_private_share_nullifier(),
                 self.old_wallet.get_public_share_nullifier(),


### PR DESCRIPTION
### Purpose
This PR refactors the `lookup-wallet` task to fit the encryption redesign, the specific changes are:
- Instead of looking up a direct mapping from `pk_view`, we iterate over the blinder shares generated by the csprng and lookup the most recently used `public_blinder_share`.
- We index Merkle entries for both public and private shares
- We prove `VALID REBLIND` at the wallet level, and `VALID COMMITMENT` for each order in the wallet

### Tests
- Unit tests pass
- Will test the whole system end-to-end and open a PR that fixes all bugs then.