### PR TITLE
core, circuits: Link witness elements between `VALID COMMITMENT`, `VALID REBLIND`, `VALID SETTLE`

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -24,6 +24,7 @@ rand = { version = "0.8" }
 rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_arrays = "0.1"
+serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -612,7 +612,7 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> SharePublic<N, S> for L
     ) -> Result<Self, Self::ErrorType> {
         let shared_values = fabric
             .borrow_fabric()
-            .batch_shared_plaintext_scalars(owning_party, &[self.val, self.randomness])
+            .batch_share_plaintext_scalars(owning_party, &[self.val, self.randomness])
             .map_err(|err| MpcError::SharingError(err.to_string()))?;
 
         Ok(Self {

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -94,7 +94,7 @@ impl CommitWitness for Balance {
 }
 
 /// Represents the committed type of the balance tuple
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommittedBalance {
     /// the mint (erc-20 token address) of the token in the balance
     pub mint: CompressedRistretto,
@@ -412,7 +412,7 @@ impl<L: Into<LinearCombination>> From<Vec<L>> for BalanceSecretShareVar {
 }
 
 /// A commitment to a balance allocate within a constraint system
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BalanceSecretShareCommitment {
     /// The mint (ERC20 token addr) of the balance
     pub mint: CompressedRistretto,

--- a/circuits/src/types/balance.rs
+++ b/circuits/src/types/balance.rs
@@ -479,25 +479,38 @@ impl CommitVerifier for BalanceSecretShareCommitment {
     }
 }
 
+// -----------------------------------
+// | Commitment Linked Secret Shares |
+// -----------------------------------
+
 /// A balance secret share type that may be linked across multiple proofs
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LinkableBalanceShareCommitment {
+pub struct LinkableBalanceShare {
     /// The mint (ERC20 token addr) of the balance
     pub mint: LinkableCommitment,
     /// The amount of the balance held
     pub amount: LinkableCommitment,
 }
 
-impl From<BalanceSecretShare> for LinkableBalanceShareCommitment {
+impl From<BalanceSecretShare> for LinkableBalanceShare {
     fn from(balance: BalanceSecretShare) -> Self {
-        LinkableBalanceShareCommitment {
+        LinkableBalanceShare {
             mint: balance.mint.into(),
             amount: balance.amount.into(),
         }
     }
 }
 
-impl CommitWitness for LinkableBalanceShareCommitment {
+impl From<LinkableBalanceShare> for BalanceSecretShare {
+    fn from(balance: LinkableBalanceShare) -> Self {
+        BalanceSecretShare {
+            mint: balance.mint.val,
+            amount: balance.amount.val,
+        }
+    }
+}
+
+impl CommitWitness for LinkableBalanceShare {
     type VarType = BalanceSecretShareVar;
     type CommitType = BalanceSecretShareCommitment;
     type ErrorType = (); // Does not error

--- a/circuits/src/types/fee.rs
+++ b/circuits/src/types/fee.rs
@@ -715,7 +715,7 @@ impl<L: Into<LinearCombination>> From<Vec<L>> for FeeSecretShareVar {
 }
 
 /// Represents a commitment to a fee secret share that has been allocated in a constraint system
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeeSecretShareCommitment {
     /// The public settle key of the cluster collecting fees
     pub settle_key: CompressedRistretto,

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -575,23 +575,40 @@ impl CommitVerifier for PublicKeyChainSecretShareCommitment {
 
 /// A public key chain share that may be linked across proofs
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LinkablePublicKeyChainShareCommitment {
+pub struct LinkablePublicKeyChainShare {
     /// The public root key
     pub pk_root: LinkableNonNativeElementShare,
     /// The public match key
     pub pk_match: LinkableCommitment,
 }
 
-impl From<PublicKeyChainSecretShare> for LinkablePublicKeyChainShareCommitment {
+impl From<PublicKeyChainSecretShare> for LinkablePublicKeyChainShare {
     fn from(keychain: PublicKeyChainSecretShare) -> Self {
-        LinkablePublicKeyChainShareCommitment {
+        LinkablePublicKeyChainShare {
             pk_root: keychain.pk_root.into(),
             pk_match: keychain.pk_match.into(),
         }
     }
 }
 
-impl CommitWitness for LinkablePublicKeyChainShareCommitment {
+impl From<LinkablePublicKeyChainShare> for PublicKeyChainSecretShare {
+    fn from(keychain: LinkablePublicKeyChainShare) -> Self {
+        PublicKeyChainSecretShare {
+            pk_root: NonNativeElementSecretShare {
+                words: keychain
+                    .pk_root
+                    .words
+                    .into_iter()
+                    .map(|word| word.val)
+                    .collect_vec(),
+                field_mod: keychain.pk_root.field_mod,
+            },
+            pk_match: keychain.pk_match.val,
+        }
+    }
+}
+
+impl CommitWitness for LinkablePublicKeyChainShare {
     type VarType = PublicKeyChainSecretShareVar;
     type CommitType = PublicKeyChainSecretShareCommitment;
     type ErrorType = (); // Does not error

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -146,7 +146,7 @@ impl From<SecretIdentificationKey> for Scalar {
 /// The type is committed to as a NonNativeVar to support keys larger than the
 /// proof system's field size
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PublicSigningKey(pub(crate) BigUint);
+pub struct PublicSigningKey(pub BigUint);
 impl Serialize for PublicSigningKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/circuits/src/types/keychain.rs
+++ b/circuits/src/types/keychain.rs
@@ -506,7 +506,7 @@ impl<L: Into<LinearCombination>> From<Vec<L>> for PublicKeyChainSecretShareVar {
 
 /// Represents a commitment to an additive secret share of a wallet's public keychain
 /// that has been allocated in a constraint system
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PublicKeyChainSecretShareCommitment {
     /// The public root key
     pub pk_root: NonNativeElementSecretShareCommitment,

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -220,7 +220,7 @@ impl CommitWitness for Order {
 }
 
 /// An order that has been committed to by a prover
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommittedOrder {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: CompressedRistretto,
@@ -829,7 +829,7 @@ impl<L: Into<LinearCombination>> From<Vec<L>> for OrderSecretShareVar {
 }
 
 /// Represents a commitment to an additive secret share of an order committed into a constraint system
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderSecretShareCommitment {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: CompressedRistretto,

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -934,7 +934,7 @@ impl CommitVerifier for OrderSecretShareCommitment {
 
 /// An order secret share type that may be linked between proofs
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LinkableOrderShareCommitment {
+pub struct LinkableOrderShare {
     /// The mint (ERC-20 contract address) of the quote token
     pub quote_mint: LinkableCommitment,
     /// The mint (ERC-20 contract address) of the base token
@@ -949,9 +949,9 @@ pub struct LinkableOrderShareCommitment {
     pub timestamp: LinkableCommitment,
 }
 
-impl From<OrderSecretShare> for LinkableOrderShareCommitment {
+impl From<OrderSecretShare> for LinkableOrderShare {
     fn from(order: OrderSecretShare) -> Self {
-        LinkableOrderShareCommitment {
+        LinkableOrderShare {
             quote_mint: order.quote_mint.into(),
             base_mint: order.base_mint.into(),
             side: order.side.into(),
@@ -962,7 +962,20 @@ impl From<OrderSecretShare> for LinkableOrderShareCommitment {
     }
 }
 
-impl CommitWitness for LinkableOrderShareCommitment {
+impl From<LinkableOrderShare> for OrderSecretShare {
+    fn from(order: LinkableOrderShare) -> Self {
+        OrderSecretShare {
+            quote_mint: order.quote_mint.val,
+            base_mint: order.base_mint.val,
+            side: order.side.val,
+            price: order.price.val,
+            amount: order.amount.val,
+            timestamp: order.timestamp.val,
+        }
+    }
+}
+
+impl CommitWitness for LinkableOrderShare {
     type VarType = OrderSecretShareVar;
     type CommitType = OrderSecretShareCommitment;
     type ErrorType = (); // Does not error

--- a/circuits/src/types/wallet.rs
+++ b/circuits/src/types/wallet.rs
@@ -586,7 +586,7 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
 
 /// Represents a commitment to an additive secret share of a wallet that
 /// has been allocated in a constraint system
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WalletSecretShareCommitment<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,

--- a/circuits/src/zk_circuits/commitment_links.rs
+++ b/circuits/src/zk_circuits/commitment_links.rs
@@ -1,0 +1,109 @@
+//! Groups helpers that validate commitment links between proofs
+//!
+//! When we wish to guarantee input consistency between two proofs; we share the
+//! commitment to each consistent variable between the proofs. Checking that two
+//! proofs are input consistent then amounts to checking that the relevant witness elements
+//! use the same commitment between proofs
+
+use merlin::Transcript;
+use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+use rand_core::OsRng;
+
+use crate::{types::wallet::LinkableWalletSecretShare, CommitWitness};
+
+use super::{
+    valid_commitments::ValidCommitmentsWitnessCommitment, valid_match_mpc::ValidMatchCommitment,
+    valid_reblind::ValidReblindWitnessCommitment,
+};
+
+/// Verify that a proof of `VALID REBLIND` and a proof of `VALID COMMITMENTS` are linked properly
+///
+/// The linked elements are simply the reblinded secret shares of the wallet
+#[rustfmt::skip]
+pub fn verify_reblind_commitments_link<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    reblind_commitment: &ValidReblindWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    commitments_commitment: &ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+) -> bool
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    reblind_commitment.reblinded_wallet_private_shares == commitments_commitment.private_secret_shares &&
+    reblind_commitment.reblinded_wallet_public_shares == commitments_commitment.public_secret_shares
+}
+
+/// Verify that a proof of `VALID COMMITMENTS` and a proof of `VALID MATCH MPC` are linked properly
+///
+/// The linked elements are the orders and balances used as input to the matching engine
+pub fn verify_commitment_match_link<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    party0_commitments_commitment: &ValidCommitmentsWitnessCommitment<
+        MAX_BALANCES,
+        MAX_ORDERS,
+        MAX_FEES,
+    >,
+    party1_commitments_commitment: &ValidCommitmentsWitnessCommitment<
+        MAX_BALANCES,
+        MAX_ORDERS,
+        MAX_FEES,
+    >,
+    match_commitment: &ValidMatchCommitment,
+) -> bool
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    party0_commitments_commitment.balance_send == match_commitment.balance1
+        && party0_commitments_commitment.order == match_commitment.order1
+        && party1_commitments_commitment.balance_send == match_commitment.balance2
+        && party1_commitments_commitment.order == match_commitment.order2
+}
+
+/// Verify that a given set of opened augmented public shares are the same as those in
+/// the two parties' proofs of `VALID COMMITMENTS`
+pub fn verify_augmented_shares_commitments<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    party0_augmented_shares: &LinkableWalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    party1_augmented_shares: &LinkableWalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    party0_validity_commitments: &ValidCommitmentsWitnessCommitment<
+        MAX_BALANCES,
+        MAX_ORDERS,
+        MAX_FEES,
+    >,
+    party1_validity_commitments: &ValidCommitmentsWitnessCommitment<
+        MAX_BALANCES,
+        MAX_ORDERS,
+        MAX_FEES,
+    >,
+) -> bool
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    // Create a dummy prover for simplicity
+    // We can work around this an implement a more direct commitment if this
+    // path becomes a bottleneck
+    let pc_gens = PedersenGens::default();
+    let mut transcript = Transcript::new(b"");
+    let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+    // Commit to the linked augmented shares and verify that the commitments are the same
+    // as the commitments in the validity proofs
+    let mut rng = OsRng {};
+    let (_, party0_shares_comm) = party0_augmented_shares
+        .commit_witness(&mut rng, &mut prover)
+        .unwrap();
+    let (_, party1_shares_comm) = party1_augmented_shares
+        .commit_witness(&mut rng, &mut prover)
+        .unwrap();
+
+    party0_shares_comm == party0_validity_commitments.augmented_public_shares
+        && party1_shares_comm == party1_validity_commitments.augmented_public_shares
+}

--- a/circuits/src/zk_circuits/commitment_links.rs
+++ b/circuits/src/zk_circuits/commitment_links.rs
@@ -88,7 +88,7 @@ where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     // Create a dummy prover for simplicity
-    // We can work around this an implement a more direct commitment if this
+    // We can work around this and implement a more direct commitment if this
     // path becomes a bottleneck
     let pc_gens = PedersenGens::default();
     let mut transcript = Transcript::new(b"");

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -1,5 +1,6 @@
 //! Groups circuitry for full zero knowledge circuits that we are interested
 //! in proving knowledge of witness for throughout the network
+pub mod commitment_links;
 pub mod valid_commitments;
 pub mod valid_match_mpc;
 pub mod valid_reblind;

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -15,7 +15,10 @@ use crate::{
     errors::{ProverError, VerifierError},
     types::{
         r#match::{CommittedMatchResult, LinkableMatchResultCommitment, MatchResultVar},
-        wallet::{WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar},
+        wallet::{
+            LinkableWalletSecretShare, WalletSecretShare, WalletSecretShareCommitment,
+            WalletSecretShareVar,
+        },
     },
     zk_gadgets::{
         comparators::{EqGadget, EqVecGadget},
@@ -246,9 +249,9 @@ pub struct ValidSettleWitness<
     /// The match result to be applied to the wallet shares
     pub match_res: LinkableMatchResultCommitment,
     /// The public secret shares of the first party before the match is applied
-    pub party0_public_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub party0_public_shares: LinkableWalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The public secret shares of the second party before the match is applied
-    pub party1_public_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub party1_public_shares: LinkableWalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
 }
 
 /// The witness type for `VALID SETTLE`, allocated in a constraint system
@@ -650,8 +653,8 @@ mod test {
 
         let witness = ValidSettleWitness {
             match_res: match_res.into(),
-            party0_public_shares,
-            party1_public_shares,
+            party0_public_shares: party0_public_shares.into(),
+            party1_public_shares: party1_public_shares.into(),
         };
         let statement = ValidSettleStatement {
             party0_modified_shares,

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -287,7 +287,7 @@ pub struct FixedPointVar {
 }
 
 /// A commitment to a fixed-precision variable
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommittedFixedPoint {
     /// The underlying scalar representing the fixed point variable
     pub(crate) repr: CompressedRistretto,

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -990,7 +990,7 @@ impl NonNativeElementSecretShareVar {
 
 /// Represents a commitment to an additive secret share of a non-native element that has been
 /// allocated in a constraint system
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NonNativeElementSecretShareCommitment {
     /// The scalar words underlying the value
     pub(crate) words: Vec<CompressedRistretto>,

--- a/core/src/handshake/match.rs
+++ b/core/src/handshake/match.rs
@@ -9,13 +9,13 @@ use circuits::{
     multiprover_prove,
     types::{
         balance::LinkableBalanceCommitment,
-        fee::Fee,
+        fee::LinkableFeeCommitment,
         order::{LinkableOrderCommitment, Order},
         r#match::{
             AuthenticatedLinkableMatchResultCommitment, AuthenticatedMatchResult,
             LinkableMatchResultCommitment,
         },
-        wallet::Nullifier,
+        wallet::{LinkableWalletSecretShare, Nullifier},
     },
     verify_collaborative_proof,
     zk_circuits::valid_match_mpc::{
@@ -37,10 +37,13 @@ use uuid::Uuid;
 
 use crate::{
     proof_generation::{jobs::ValidMatchMpcBundle, OrderValidityWitnessBundle},
-    SizedWalletShare,
+    MAX_BALANCES, MAX_FEES, MAX_ORDERS,
 };
 
 use super::{error::HandshakeManagerError, manager::HandshakeExecutor, state::HandshakeState};
+
+/// A type alias for a linkable wallet share with default sizing parameters
+pub type SizedLinkableWalletShare = LinkableWalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
 /// The type returned by the match process, including the result, the validity proof bundle,
 /// and all witness/statement variables that must be revealed to complete the match
@@ -53,15 +56,15 @@ pub struct HandshakeResult {
     /// The second party's public wallet share nullifier,
     pub party1_share_nullifier: Nullifier,
     /// The first party's public reblinded secret shares
-    pub party0_reblinded_shares: SizedWalletShare,
+    pub party0_reblinded_shares: SizedLinkableWalletShare,
     /// The second party's public reblinded secret shares
-    pub party1_reblinded_shares: SizedWalletShare,
+    pub party1_reblinded_shares: SizedLinkableWalletShare,
     /// The proof of `VALID MATCH MPC` along with associated commitments
     pub match_proof: ValidMatchMpcBundle,
     /// The first party's fee
-    pub party0_fee: Fee,
+    pub party0_fee: LinkableFeeCommitment,
     /// The second party's fee
-    pub party1_fee: Fee,
+    pub party1_fee: LinkableFeeCommitment,
 }
 
 impl HandshakeResult {

--- a/core/src/starknet_client/helpers.rs
+++ b/core/src/starknet_client/helpers.rs
@@ -19,13 +19,13 @@ const BYTES_PER_FELT: usize = 31;
 /// The number of field elements used to represent an external transfer struct
 const EXTERNAL_TRANSFER_N_FELTS: usize = 5;
 /// The index of the `party0_public_blinder_share` argument in `match` calldata
-const MATCH_PARTY0_PUBLIC_BLINDER_SHARE_IDX: usize = 4;
+const MATCH_PARTY0_PUBLIC_BLINDER_SHARE_IDX: usize = 2;
 /// The index of the `party0_public_share_len` argument in `match` calldata
-const MATCH_PARTY0_PUBLIC_SHARES_IDX: usize = 10;
+const MATCH_PARTY0_PUBLIC_SHARES_IDX: usize = 8;
 /// The index of the `public_wallet_share_len` argument in `new_wallet` calldata
 const NEW_WALLET_SHARE_LEN_IDX: usize = 3;
 /// The index of the `external_transfers_len` argument in `update_wallet` calldata
-const UPDATE_WALLET_EXTERNAL_TRANSFER_LEN: usize = 5;
+const UPDATE_WALLET_EXTERNAL_TRANSFER_LEN: usize = 4;
 
 /// Error message emitted when a public blinder share is not found in calldata
 const ERR_BLINDER_NOT_FOUND: &str = "public blinder share not found in calldata";

--- a/core/src/tasks/initialize_state.rs
+++ b/core/src/tasks/initialize_state.rs
@@ -243,6 +243,7 @@ impl InitializeStateTask {
                 let (commitments_witness, response_channel) = construct_wallet_commitment_proof(
                     wallet.clone(),
                     order.clone(),
+                    &wallet_reblind_witness,
                     self.proof_manager_work_queue.clone(),
                 )
                 .map_err(InitializeStateTaskError::ProveValidCommitments)?;

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -220,8 +220,10 @@ impl SettleMatchTask {
     /// Apply the match to the wallets and prove `VALID SETTLE`
     async fn prove_settle(&self) -> Result<ValidSettleBundle, SettleMatchTaskError> {
         // Modify the secret shares
-        let mut party0_modified_shares = self.handshake_result.party0_reblinded_shares.clone();
-        let mut party1_modified_shares = self.handshake_result.party1_reblinded_shares.clone();
+        let mut party0_modified_shares: SizedWalletShare =
+            self.handshake_result.party0_reblinded_shares.clone().into();
+        let mut party1_modified_shares: SizedWalletShare =
+            self.handshake_result.party1_reblinded_shares.clone().into();
         let party0_commit_proof = self.party0_validity_proof.commitment_proof.clone();
         let party1_commit_proof = self.party1_validity_proof.commitment_proof.clone();
 

--- a/integration-helpers/src/mpc_network/mocks.rs
+++ b/integration-helpers/src/mpc_network/mocks.rs
@@ -88,6 +88,14 @@ impl MpcNetwork for MockMpcNet {
         0
     }
 
+    async fn send_bytes(&mut self, _bytes: &[u8]) -> Result<(), MpcNetworkError> {
+        Ok(())
+    }
+
+    async fn receive_bytes(&mut self, _num_expected: usize) -> Result<Vec<u8>, MpcNetworkError> {
+        Err(MpcNetworkError::RecvError)
+    }
+
     async fn send_scalars(&mut self, _: &[Scalar]) -> Result<(), MpcNetworkError> {
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR adds commitment linking between elements of the proofs used in the match process -- `VALID REBLIND`, `VALID COMMITMENTS`, and `VALID MATCH MPC`, and `VALID SETTLE`.

The linked elements are:
- re-blinded wallet shares between `VALID REBLIND` and `VALID COMMITMENTS`.
- augmented wallet shares between `VALID COMMITMENTS` and `VALID SETTLE`
- balances, orders, and fees between `VALID COMMITMENTS` and `VALID MATCH MPC`

### Testing
- Unit tests pass