### PR TITLE
circuits: zk_circuits, zk_gadgets: add `apply_constraints` method to `SingleProverCircuit` trait

### DIFF
--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -12,7 +12,8 @@
 use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
     r1cs::{
-        LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+        LinearCombination, Prover, R1CSError, R1CSProof, RandomizableConstraintSystem, Variable,
+        Verifier,
     },
     BulletproofGens,
 };
@@ -532,8 +533,20 @@ where
     type Statement = ValidCommitmentsStatement;
     type Witness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type WitnessVar = ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type StatementVar = ValidCommitmentsStatementVar;
 
     const BP_GENS_CAPACITY: usize = 1024;
+
+    fn apply_constraints<CS: RandomizableConstraintSystem>(
+        witness_var: Self::WitnessVar,
+        statement_var: Self::StatementVar,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        // Apply the constraints over the allocated witness & statement
+        Self::circuit(statement_var, witness_var, cs);
+        Ok(())
+    }
 
     fn prove(
         witness: Self::Witness,
@@ -545,8 +558,8 @@ where
         let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
         let statement_var = statement.commit_public(&mut prover).unwrap();
 
-        // Apply the constraints
-        Self::circuit(statement_var, witness_var, &mut prover);
+        Self::apply_constraints(witness_var, statement_var, &mut prover)
+            .map_err(ProverError::R1CS)?;
 
         // Prove the relation
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -565,8 +578,8 @@ where
         let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
         let statement_var = statement.commit_public(&mut verifier).unwrap();
 
-        // Apply the constrains
-        Self::circuit(statement_var, witness_var, &mut verifier);
+        Self::apply_constraints(witness_var, statement_var, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
 
         // Verify the proof
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -533,14 +533,12 @@ where
     type Statement = ValidCommitmentsStatement;
     type Witness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidCommitmentsWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type WitnessVar = ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type StatementVar = ValidCommitmentsStatementVar;
 
     const BP_GENS_CAPACITY: usize = 1024;
 
     fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: Self::WitnessVar,
-        statement_var: Self::StatementVar,
+        witness_var: <Self::Witness as CommitWitness>::VarType,
+        statement_var: <Self::Statement as CommitPublic>::VarType,
         cs: &mut CS,
     ) -> Result<(), R1CSError> {
         // Apply the constraints over the allocated witness & statement
@@ -558,8 +556,7 @@ where
         let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
         let statement_var = statement.commit_public(&mut prover).unwrap();
 
-        Self::apply_constraints(witness_var, statement_var, &mut prover)
-            .map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut prover).unwrap();
 
         // Prove the relation
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -578,8 +575,7 @@ where
         let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
         let statement_var = statement.commit_public(&mut verifier).unwrap();
 
-        Self::apply_constraints(witness_var, statement_var, &mut verifier)
-            .map_err(VerifierError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut verifier).unwrap();
 
         // Verify the proof
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -692,7 +692,6 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
             .unwrap();
 
         // Check that the matches value is properly formed
-        // TODO(andrew): This seems like the place to look at re: apply_constraints
         Self::matching_engine_check_single_prover(
             &mut verifier,
             party0_order,

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -692,6 +692,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
             .unwrap();
 
         // Check that the matches value is properly formed
+        // TODO(andrew): This seems like the place to look at re: apply_constraints
         Self::matching_engine_check_single_prover(
             &mut verifier,
             party0_order,

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -481,14 +481,12 @@ where
     type Witness = ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidReblindWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Statement = ValidReblindStatement;
-    type WitnessVar = ValidReblindWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type StatementVar = ValidReblindStatementVar;
 
     const BP_GENS_CAPACITY: usize = 65536;
 
     fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: Self::WitnessVar,
-        statement_var: Self::StatementVar,
+        witness_var: <Self::Witness as CommitWitness>::VarType,
+        statement_var: <Self::Statement as CommitPublic>::VarType,
         cs: &mut CS,
     ) -> Result<(), R1CSError> {
         // Apply the constraints over the allocated witness & statement

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -450,14 +450,12 @@ where
     type Witness = ValidSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Statement = ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidSettleWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type WitnessVar = ValidSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type StatementVar = ValidSettleStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 1024;
 
     fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: Self::WitnessVar,
-        statement_var: Self::StatementVar,
+        witness_var: <Self::Witness as CommitWitness>::VarType,
+        statement_var: <Self::Statement as CommitPublic>::VarType,
         cs: &mut CS,
     ) -> Result<(), R1CSError> {
         // Apply the constraints over the allocated witness & statement
@@ -475,8 +473,7 @@ where
         let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
         let statement_var = statement.commit_public(&mut prover).unwrap();
 
-        Self::apply_constraints(witness_var, statement_var, &mut prover)
-            .map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut prover).unwrap();
 
         // Prove the relation
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -495,8 +492,7 @@ where
         let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
         let statement_var = statement.commit_public(&mut verifier).unwrap();
 
-        Self::apply_constraints(witness_var, statement_var, &mut verifier)
-            .map_err(VerifierError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut verifier).unwrap();
 
         // Verify the proof
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -241,14 +241,12 @@ where
     type Statement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Witness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type WitnessVar = ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type StatementVar = ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 10000;
 
     fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: Self::WitnessVar,
-        statement_var: Self::StatementVar,
+        witness_var: <Self::Witness as CommitWitness>::VarType,
+        statement_var: <Self::Statement as CommitPublic>::VarType,
         cs: &mut CS,
     ) -> Result<(), R1CSError> {
         // Apply the constraints over the allocated witness & statement

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -241,8 +241,19 @@ where
     type Statement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Witness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type WitnessVar = ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type StatementVar = ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 10000;
+
+    fn apply_constraints<CS: RandomizableConstraintSystem>(
+        witness_var: Self::WitnessVar,
+        statement_var: Self::StatementVar,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        // Apply the constraints over the allocated witness & statement
+        Self::circuit(statement_var, witness_var, cs)
+    }
 
     fn prove(
         witness: Self::Witness,
@@ -255,7 +266,8 @@ where
         let statement_var = statement.commit_public(&mut prover).unwrap();
 
         // Apply the constraints
-        Self::circuit(statement_var, witness_var, &mut prover).map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut prover)
+            .map_err(ProverError::R1CS)?;
 
         // Prove the statement
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -275,7 +287,8 @@ where
         let statement_var = statement.commit_public(&mut verifier).unwrap();
 
         // Apply the constraints
-        Self::circuit(statement_var, witness_var, &mut verifier).map_err(VerifierError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
 
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         verifier

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -655,14 +655,12 @@ where
     type Witness = ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Statement = ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type WitnessVar = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type StatementVar = ValidWalletUpdateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 65536;
 
     fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: Self::WitnessVar,
-        statement_var: Self::StatementVar,
+        witness_var: <Self::Witness as CommitWitness>::VarType,
+        statement_var: <Self::Statement as CommitPublic>::VarType,
         cs: &mut CS,
     ) -> Result<(), R1CSError> {
         // Apply the constraints over the allocated witness & statement

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -655,8 +655,19 @@ where
     type Witness = ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Statement = ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type WitnessCommitment = ValidWalletUpdateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type WitnessVar = ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    type StatementVar = ValidWalletUpdateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 65536;
+
+    fn apply_constraints<CS: RandomizableConstraintSystem>(
+        witness_var: Self::WitnessVar,
+        statement_var: Self::StatementVar,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        // Apply the constraints over the allocated witness & statement
+        Self::circuit(statement_var, witness_var, cs)
+    }
 
     fn prove(
         witness: Self::Witness,
@@ -668,8 +679,8 @@ where
         let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
         let statement_var = statement.commit_public(&mut prover).unwrap();
 
-        // Apply the constraints
-        Self::circuit(statement_var, witness_var, &mut prover).map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut prover)
+            .map_err(ProverError::R1CS)?;
 
         // Prove the circuit
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -688,8 +699,8 @@ where
         let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
         let statement_var = statement.commit_public(&mut verifier).unwrap();
 
-        // Apply the constraints
-        Self::circuit(statement_var, witness_var, &mut verifier).map_err(VerifierError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
 
         // Verify the proof
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -359,8 +359,25 @@ impl SingleProverCircuit for PoseidonMerkleHashGadget {
     type Statement = MerkleStatement;
     type Witness = MerkleWitness;
     type WitnessCommitment = MerkleWitnessCommitment;
+    type WitnessVar = MerkleWitnessVar;
+    // The only statement variable that gets allocated is the Merkle root
+    type StatementVar = Variable;
 
     const BP_GENS_CAPACITY: usize = 8192;
+
+    fn apply_constraints<CS: RandomizableConstraintSystem>(
+        witness_var: Self::WitnessVar,
+        statement_var: Self::StatementVar,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError> {
+        // Apply the constraints over the allocated witness & statement
+        PoseidonMerkleHashGadget::compute_and_constrain_root(
+            witness_var.leaf_data,
+            witness_var.opening,
+            statement_var,
+            cs,
+        )
+    }
 
     fn prove(
         witness: Self::Witness,
@@ -374,14 +391,7 @@ impl SingleProverCircuit for PoseidonMerkleHashGadget {
         // Commit to the expected root
         let root_var = prover.commit_public(statement.expected_root);
 
-        // Apply the constraints
-        PoseidonMerkleHashGadget::compute_and_constrain_root(
-            witness_var.leaf_data,
-            witness_var.opening,
-            root_var,
-            &mut prover,
-        )
-        .map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, root_var, &mut prover).map_err(ProverError::R1CS)?;
 
         // Prove the statement
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
@@ -400,14 +410,8 @@ impl SingleProverCircuit for PoseidonMerkleHashGadget {
         let witness_vars = witness_commitments.commit_verifier(&mut verifier).unwrap();
         let root_var = verifier.commit_public(statement.expected_root);
 
-        // Apply constraints
-        PoseidonMerkleHashGadget::compute_and_constrain_root(
-            witness_vars.leaf_data,
-            witness_vars.opening,
-            root_var,
-            &mut verifier,
-        )
-        .map_err(VerifierError::R1CS)?;
+        Self::apply_constraints(witness_vars, root_var, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
 
         // Verify the proof
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_gadgets/nonnative.rs
+++ b/circuits/src/zk_gadgets/nonnative.rs
@@ -1144,7 +1144,7 @@ mod nonnative_tests {
         CommitPublic, CommitVerifier, CommitWitness, SingleProverCircuit,
     };
 
-    use super::{biguint_to_scalar_words, FieldMod, NonNativeElementVar};
+    use super::{biguint_to_scalar_words, FieldMod, NonNativeElement, NonNativeElementVar};
 
     // -------------
     // | Constants |
@@ -1291,33 +1291,10 @@ mod nonnative_tests {
         }
     }
 
-    impl CommitPublic for (BigUint, FieldMod) {
-        type VarType = NonNativeElementVar;
-        type ErrorType = ();
-
-        fn commit_public<CS: RandomizableConstraintSystem>(
-            &self,
-            cs: &mut CS,
-        ) -> Result<Self::VarType, Self::ErrorType> {
-            let expected_words = biguint_to_scalar_words(self.0.clone());
-            let statement_word_vars = expected_words
-                .iter()
-                .map(|word| cs.commit_public(*word))
-                .collect_vec();
-
-            let statement_word_lcs: Vec<LinearCombination> = statement_word_vars
-                .into_iter()
-                .map(Into::into)
-                .collect_vec();
-
-            Ok(NonNativeElementVar::new(statement_word_lcs, self.1.clone()))
-        }
-    }
-
     pub struct AdderCircuit {}
     impl SingleProverCircuit for AdderCircuit {
         type Witness = FanIn2Witness;
-        type Statement = (BigUint, FieldMod);
+        type Statement = NonNativeElement;
         type WitnessCommitment = FanIn2WitnessCommitment;
 
         const BP_GENS_CAPACITY: usize = 64;
@@ -1383,7 +1360,7 @@ mod nonnative_tests {
     #[derive(Clone, Debug)]
     pub struct MulCircuit {}
     impl SingleProverCircuit for MulCircuit {
-        type Statement = (BigUint, FieldMod);
+        type Statement = NonNativeElement;
         type Witness = FanIn2Witness;
         type WitnessCommitment = FanIn2WitnessCommitment;
 
@@ -1449,7 +1426,7 @@ mod nonnative_tests {
 
     pub struct SubCircuit {}
     impl SingleProverCircuit for SubCircuit {
-        type Statement = (BigUint, FieldMod);
+        type Statement = NonNativeElement;
         type Witness = FanIn2Witness;
         type WitnessCommitment = FanIn2WitnessCommitment;
 
@@ -1740,7 +1717,10 @@ mod nonnative_tests {
                 field_mod: field_mod.clone(),
             };
 
-            let statement = (expected_bigint, field_mod);
+            let statement = NonNativeElement {
+                val: expected_bigint,
+                field_mod,
+            };
 
             // Prove and verify a valid member of the relation
             let res = bulletproof_prove_and_verify::<AdderCircuit>(witness, statement);
@@ -1800,7 +1780,10 @@ mod nonnative_tests {
                 field_mod: field_mod.clone(),
             };
 
-            let statement = (expected_bigint, field_mod);
+            let statement = NonNativeElement {
+                val: expected_bigint,
+                field_mod,
+            };
 
             // Prove and verify a valid member of the relation
             let res = bulletproof_prove_and_verify::<MulCircuit>(witness, statement);
@@ -1865,7 +1848,10 @@ mod nonnative_tests {
                 field_mod: field_mod.clone(),
             };
 
-            let statement = (expected_bigint.to_biguint().unwrap(), field_mod);
+            let statement = NonNativeElement {
+                val: expected_bigint.to_biguint().unwrap(),
+                field_mod,
+            };
 
             // Prove and verify a valid member of the relation
             let res = bulletproof_prove_and_verify::<SubCircuit>(witness, statement);


### PR DESCRIPTION
Adds a method `apply_constraints` to the `SingleProverCircuit` trait, which encapsulates the logic of building the actual constraints in the system given the allocated witness and statement variables.

This will be used in the constraint intermediate representation / export tool to build circuit weight matrices in a manner that is generic over the circuit itself