### PR TITLE
circuits: zk_circuits, zk_gadgets: add `apply_constraints` method to `MultiProverCircuit` trait

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -17,8 +17,7 @@ lazy_static = "1.4"
 merlin = "2.0"
 miller_rabin = "1.1.1"
 mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
-# TODO: REMOVE BRANCH FIELD BEFORE MERGING
-mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof", branch = "andrew/constraint-intermediate-repr" }
+mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
 rand = { version = "0.8" }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -17,7 +17,8 @@ lazy_static = "1.4"
 merlin = "2.0"
 miller_rabin = "1.1.1"
 mpc-ristretto = { git = "https://github.com/renegade-fi/MPC-Ristretto" }
-mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
+# TODO: REMOVE BRANCH FIELD BEFORE MERGING
+mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof", branch = "andrew/constraint-intermediate-repr" }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
 rand = { version = "0.8" }

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -1,7 +1,9 @@
 //! Groups integration tests for the circuitry that converts between scalars and their
 //! bit representations
 
-use circuits::zk_gadgets::bits::{MultiproverToBitsGadget, ToBitsStatement};
+use circuits::zk_gadgets::bits::{
+    MultiProverToBitsWitness, MultiproverToBitsGadget, ToBitsStatement,
+};
 use crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{mpc_network::batch_share_plaintext_scalar, types::IntegrationTest};
@@ -36,7 +38,7 @@ fn test_to_bits(test_args: &IntegrationTestArgs) -> Result<(), String> {
     };
 
     multiprover_prove_and_verify::<'_, _, _, MultiproverToBitsGadget<'_, 64 /* bits */, _, _>>(
-        shared_scalar,
+        MultiProverToBitsWitness { a: shared_scalar },
         statement,
         test_args.mpc_fabric.clone(),
     )

--- a/circuits/integration/zk_gadgets/mod.rs
+++ b/circuits/integration/zk_gadgets/mod.rs
@@ -4,7 +4,7 @@ pub mod bits;
 mod comparators;
 mod poseidon;
 
-use circuits::{mpc::SharedFabric, MultiProverCircuit, Open};
+use circuits::{mpc::SharedFabric, CommitVerifier, MultiProverCircuit, Open};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use mpc_bulletproof::{
@@ -31,6 +31,8 @@ where
     N: MpcNetwork + Send,
     S: SharedValueSource<Scalar>,
     C: MultiProverCircuit<'a, N, S>,
+    <<C as MultiProverCircuit<'a, N, S>>::WitnessCommitment as Open<N, S>>::OpenOutput:
+        CommitVerifier,
 {
     let mut transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
     let pc_gens = PedersenGens::default();

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -548,11 +548,11 @@ where
     /// Applies all the verifier-side constraints embodied by the circuit over
     /// the entire committed witness & statement,
     /// building them into the given constraint system
-    // fn apply_constraints_single_prover<CS: RandomizableConstraintSystem>(
-    //     witness_var: <Self::Witness as CommitWitness>::VarType,
-    //     statement_var: <Self::Statement as CommitPublic>::VarType,
-    //     cs: &mut CS,
-    // ) -> Result<(), R1CSError>;
+    fn apply_constraints_single_prover<CS: RandomizableConstraintSystem>(
+        witness_var: <<Self::WitnessCommitment as Open<N, S>>::OpenOutput as CommitVerifier>::VarType,
+        statement: Self::Statement,
+        cs: &mut CS,
+    ) -> Result<(), R1CSError>;
 
     /// Generate a proof of the statement represented by the circuit
     ///

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -530,11 +530,12 @@ pub trait MultiProverCircuit<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueS
     /// Applies all the prover-side constraints embodied by the circuit over
     /// the allocated witness, secret shares of the counterparty's witness, & statement,
     /// building them into the given constraint system
-    // fn apply_constraints_multi_prover<CS: RandomizableConstraintSystem>(
-    //     witness_var: <Self::Witness as CommitWitness>::VarType,
-    //     statement_var: Self::Statement,
-    //     cs: &mut CS,
-    // ) -> Result<(), R1CSError>;
+    fn apply_constraints_multi_prover(
+        witness_var: <Self::Witness as CommitSharedProver<N, S>>::SharedVarType,
+        statement: Self::Statement,
+        prover: &mut MpcProver<'a, '_, '_, N, S>,
+        fabric: SharedFabric<N, S>,
+    ) -> Result<(), ProverError>;
 
     /// Applies all the verifier-side constraints embodied by the circuit over
     /// the entire committed witness & statement,

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -510,7 +510,7 @@ pub trait SingleProverCircuit {
 pub trait MultiProverCircuit<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> {
     /// The witness type, given only to the prover, which generates a blinding commitment
     /// that can be given to the verifier
-    type Witness;
+    type Witness: CommitSharedProver<N, S>;
     /// The statement type, given to both the prover and verifier, parameterizes the underlying
     /// NP statement being proven
     type Statement: Clone;
@@ -526,6 +526,24 @@ pub trait MultiProverCircuit<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueS
     /// This is a function of circuit depth, one generator is needed per
     /// multiplication gate (roughly)
     const BP_GENS_CAPACITY: usize;
+
+    /// Applies all the prover-side constraints embodied by the circuit over
+    /// the allocated witness, secret shares of the counterparty's witness, & statement,
+    /// building them into the given constraint system
+    // fn apply_constraints_multi_prover<CS: RandomizableConstraintSystem>(
+    //     witness_var: <Self::Witness as CommitWitness>::VarType,
+    //     statement_var: Self::Statement,
+    //     cs: &mut CS,
+    // ) -> Result<(), R1CSError>;
+
+    /// Applies all the verifier-side constraints embodied by the circuit over
+    /// the entire committed witness & statement,
+    /// building them into the given constraint system
+    // fn apply_constraints_single_prover<CS: RandomizableConstraintSystem>(
+    //     witness_var: <Self::Witness as CommitWitness>::VarType,
+    //     statement_var: <Self::Statement as CommitPublic>::VarType,
+    //     cs: &mut CS,
+    // ) -> Result<(), R1CSError>;
 
     /// Generate a proof of the statement represented by the circuit
     ///

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -675,6 +675,15 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
 
     const BP_GENS_CAPACITY: usize = 256;
 
+    fn apply_constraints_multi_prover(
+        witness_var: <Self::Witness as CommitSharedProver<N, S>>::SharedVarType,
+        _statement: Self::Statement,
+        prover: &mut MpcProver<'a, '_, '_, N, S>,
+        fabric: SharedFabric<N, S>,
+    ) -> Result<(), ProverError> {
+        Self::matching_engine_check(prover, witness_var, fabric)
+    }
+
     fn prove(
         witness: Self::Witness,
         _statement: Self::Statement,
@@ -688,7 +697,12 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
             .commit(u64::MAX /* unused */, &mut rng, &mut prover)
             .map_err(ProverError::Mpc)?;
 
-        Self::matching_engine_check(&mut prover, witness_var, fabric)?;
+        Self::apply_constraints_multi_prover(
+            witness_var,
+            ValidMatchMpcStatement {},
+            &mut prover,
+            fabric,
+        )?;
 
         // Prove the statement
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -492,8 +492,8 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> CommitSharedProver<N, S
     ) -> Result<(Self::SharedVarType, Self::CommitType), Self::ErrorType> {
         let (party0_vars, party0_comm) = (self.my_order.clone(), self.my_balance.clone())
             .commit(0 /* owning_party */, rng, prover)?;
-        let (party1_vars, party1_comm) =
-            (self.my_order.clone(), self.my_balance.clone()).commit(1 /* owning_party */, rng, prover)?;
+        let (party1_vars, party1_comm) = (self.my_order.clone(), self.my_balance.clone())
+            .commit(1 /* owning_party */, rng, prover)?;
 
         let (match_var, match_commit) =
             self.match_res.commit(0 /* owning_party */, rng, prover)?;

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -290,7 +290,7 @@ pub struct FixedPointVar {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommittedFixedPoint {
     /// The underlying scalar representing the fixed point variable
-    pub(crate) repr: CompressedRistretto,
+    pub repr: CompressedRistretto,
 }
 
 impl CommitWitness for FixedPoint {


### PR DESCRIPTION
Similar to #99, this adds an `apply_constraints` method, now to the `MultiProverCircuit` trait, to encapsulate the logic of building the constraint system given the allocated witness (and counterparty witness shares) and statement