### PR TITLE
circuits: zk-gadgets, zk-circuits: Refactor implementation after type refactor

### DIFF
--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -4,12 +4,12 @@
 //! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.5
 //! for a formal specification
 
-use std::{borrow::Borrow, marker::PhantomData};
+use std::marker::PhantomData;
 
+use circuit_macros::circuit_type;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
-use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
+    r1cs::{LinearCombination, R1CSProof, RandomizableConstraintSystem, Variable, Verifier},
     r1cs_mpc::{
         MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable, R1CSError,
         SharedR1CSProof,
@@ -17,47 +17,37 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use mpc_ristretto::{
-    authenticated_ristretto::AuthenticatedCompressedRistretto, beaver::SharedValueSource,
-    network::MpcNetwork,
+    authenticated_ristretto::AuthenticatedCompressedRistretto,
+    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
 };
 use rand_core::OsRng;
+use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    errors::{MpcError, ProverError, VerifierError},
+    errors::{ProverError, VerifierError},
     mpc::SharedFabric,
-    mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    types::{
-        balance::{
-            AuthenticatedBalanceVar, AuthenticatedCommittedBalance, BalanceVar, CommittedBalance,
-        },
-        order::{AuthenticatedCommittedOrder, AuthenticatedOrderVar, CommittedOrder, OrderVar},
-        r#match::{
-            AuthenticatedCommittedMatchResult, AuthenticatedMatchResultVar, CommittedMatchResult,
-            MatchResultVar,
-        },
+    traits::{
+        BaseType, CircuitBaseType, CircuitCommitmentType, CircuitVarType, LinearCombinationLike,
+        MpcBaseType, MpcLinearCombinationLike, MpcType, MultiproverCircuitBaseType,
+        MultiproverCircuitCommitmentType, MultiproverCircuitVariableType,
     },
-    zk_gadgets::poseidon::MultiproverPoseidonHashGadget,
-    CommitSharedProver, CommitVerifier, MultiProverCircuit, Open,
+    types::r#match::LinkableMatchResult,
+    zk_gadgets::fixed_point::AuthenticatedFixedPointVar,
+    zk_gadgets::select::{
+        CondSelectGadget, CondSelectVectorGadget, MultiproverCondSelectGadget,
+        MultiproverCondSelectVectorGadget,
+    },
+    MultiProverCircuit,
 };
 use crate::{
-    types::r#match::AuthenticatedLinkableMatchResultCommitment,
-    zk_gadgets::{
-        fixed_point::AuthenticatedFixedPointVar,
-        select::{
-            CondSelectGadget, CondSelectVectorGadget, MultiproverCondSelectGadget,
-            MultiproverCondSelectVectorGadget,
-        },
-    },
-};
-use crate::{
-    types::{balance::LinkableBalanceCommitment, order::LinkableOrderCommitment},
+    types::{balance::LinkableBalance, order::LinkableOrder},
     zk_gadgets::{
         comparators::{
             GreaterThanEqGadget, GreaterThanEqZeroGadget, MultiproverGreaterThanEqGadget,
             MultiproverGreaterThanEqZeroGadget,
         },
-        fixed_point::{CommittedFixedPoint, FixedPointVar},
+        fixed_point::FixedPointVar,
     },
 };
 
@@ -75,65 +65,49 @@ pub struct ValidMatchMpcCircuit<'a, N: MpcNetwork + Send, S: SharedValueSource<S
     _phantom: &'a PhantomData<(N, S)>,
 }
 
-impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
+impl<'a, N: 'a + MpcNetwork + Send + Clone, S: 'a + SharedValueSource<Scalar> + Clone>
     ValidMatchMpcCircuit<'a, N, S>
 {
-    /// Assert that the hash of an input equals the expected public value
-    ///
-    /// This is used throughout the statement to assert input consistency with
-    /// linked proofs
-    pub fn input_consistency_check<L, CS>(
-        cs: &mut CS,
-        input: &[L],
-        expected_out: &L,
-        fabric: SharedFabric<N, S>,
-    ) -> Result<(), ProverError>
-    where
-        L: Into<MpcLinearCombination<N, S>> + Clone,
-        CS: MpcRandomizableConstraintSystem<'a, N, S>,
-    {
-        // Build a hasher and constrain the hash of the input to equal the expected output
-        let hash_params = PoseidonSpongeParameters::default();
-        let mut hasher = MultiproverPoseidonHashGadget::new(hash_params, fabric);
-        hasher.hash(input, expected_out, cs)
-    }
-
     /// The order crossing check, verifies that the matches result is valid given the orders
     /// and balances of the two parties
     pub fn matching_engine_check<CS>(
-        cs: &mut CS,
-        order1: AuthenticatedOrderVar<N, S>,
-        order2: AuthenticatedOrderVar<N, S>,
-        balance1: AuthenticatedBalanceVar<N, S>,
-        balance2: AuthenticatedBalanceVar<N, S>,
-        matches: AuthenticatedMatchResultVar<N, S>,
+        witness: AuthenticatedValidMatchMpcWitnessVar<N, S, MpcVariable<N, S>>,
         fabric: SharedFabric<N, S>,
+        cs: &mut CS,
     ) -> Result<(), ProverError>
     where
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
     {
         // Check that both orders are for the matched asset pair
-        cs.constrain(&order1.quote_mint - &matches.quote_mint);
-        cs.constrain(&order1.base_mint - &matches.base_mint);
-        cs.constrain(&order2.quote_mint - &matches.quote_mint);
-        cs.constrain(&order2.base_mint - &matches.base_mint);
+        cs.constrain(witness.order1.quote_mint - witness.match_res.quote_mint.clone());
+        cs.constrain(witness.order1.base_mint - witness.match_res.base_mint.clone());
+        cs.constrain(witness.order2.quote_mint - witness.match_res.quote_mint.clone());
+        cs.constrain(witness.order2.base_mint - witness.match_res.base_mint.clone());
 
         // Check that the direction of the match is the same as the first party's direction
-        cs.constrain(&matches.direction - &order1.side);
+        cs.constrain(witness.match_res.direction.clone() - witness.order1.side.clone());
 
         // Check that the orders are on opposite sides of the market. It is assumed that order
         // sides are already constrained to be binary when they are submitted. More broadly it
         // is assumed that orders are well formed, checking this amounts to checking their inclusion
         // in the state tree, which is done in `input_consistency_check`
-        cs.constrain(&order1.side + order2.side - MpcVariable::one(fabric.0.clone()));
+        cs.constrain(
+            witness.order1.side + witness.order2.side - MpcVariable::one(fabric.0.clone()),
+        );
 
         // Check that the prices of the orders overlap
         // 1. Mux buy/sell side based on the direction of the match
         let prices = MultiproverCondSelectVectorGadget::select(
             cs,
-            &[order2.price.repr.clone(), order1.price.repr.clone()],
-            &[order1.price.repr.clone(), order2.price.repr.clone()],
-            matches.direction.clone().into(),
+            &[
+                witness.order2.price.repr.clone(),
+                witness.order1.price.repr.clone(),
+            ],
+            &[
+                witness.order1.price.repr.clone(),
+                witness.order2.price.repr.clone(),
+            ],
+            witness.match_res.direction.clone(),
             fabric.clone(),
         )?;
         let buy_side_price = AuthenticatedFixedPointVar {
@@ -153,22 +127,23 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 
         // Check that price is correctly computed to be the midpoint
         // i.e. price1 + price2 = 2 * execution_price
-        let double_execution_price: AuthenticatedFixedPointVar<_, _> = matches
+        let double_execution_price = witness
+            .match_res
             .execution_price
             .mul_integer(
                 MpcLinearCombination::from_scalar(Scalar::from(2u64), fabric.0.clone()),
                 cs,
             )
             .map_err(ProverError::Collaborative)?;
-        double_execution_price.constrain_equal(&(&order1.price + &order2.price), cs);
+        double_execution_price.constrain_equal(&(witness.order1.price + witness.order2.price), cs);
 
         // Constrain the min_amount_order_index to be binary
         // i.e. 0 === min_amount_order_index * (1 - min_amount_order_index)
         let (_, _, mul_out) = cs
             .multiply(
-                &matches.min_amount_order_index.clone().into(),
+                &witness.match_res.min_amount_order_index.clone().into(),
                 &(MpcLinearCombination::from_scalar(Scalar::one(), fabric.0.clone())
-                    - &matches.min_amount_order_index),
+                    - &witness.match_res.min_amount_order_index),
             )
             .map_err(ProverError::Collaborative)?;
         cs.constrain(mul_out.into());
@@ -178,16 +153,16 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 
         // 1. Constraint he max_minus_min_amount to be correctly computed with respect to the argmin
         // witness variable min_amount_order_index
-        let max_minus_min1 = &order1.amount - &order2.amount;
-        let max_minus_min2 = &order2.amount - &order1.amount;
+        let max_minus_min1 = &witness.order1.amount - &witness.order2.amount;
+        let max_minus_min2 = &witness.order2.amount - &witness.order1.amount;
         let max_minus_min_expected = MultiproverCondSelectGadget::select(
             max_minus_min1,
             max_minus_min2,
-            matches.min_amount_order_index.into(),
+            witness.match_res.min_amount_order_index.into(),
             fabric.clone(),
             cs,
         )?;
-        cs.constrain(&max_minus_min_expected - &matches.max_minus_min_amount);
+        cs.constrain(&max_minus_min_expected - &witness.match_res.max_minus_min_amount);
 
         // 2. Constrain the max_minus_min_amount value to be positive
         // This, along with the previous check, constrain `max_minus_min_amount` to be computed correctly.
@@ -195,7 +170,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         // or min(amounts) - max(amounts).
         // Constraining the value to be positive forces it to be equal to max(amounts) - min(amounts)
         MultiproverGreaterThanEqZeroGadget::<'_, 32 /* bitlength */, _, _>::constrain_greater_than_zero(
-            matches.max_minus_min_amount.clone(),
+            witness.match_res.max_minus_min_amount.clone(),
             fabric.clone(),
             cs,
         )?;
@@ -205,16 +180,18 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         //      min(a, b) = 1/2 * (a + b - [max(a, b) - min(a, b)])
         // Above we are given max(a, b) - min(a, b), so we can enforce the constraint
         //      2 * executed_amount = amount1 + amount2 - max_minus_min_amount
-        let lhs = Scalar::from(2u64) * &matches.base_amount;
-        let rhs = &order1.amount + &order2.amount - &matches.max_minus_min_amount;
+        let lhs = Scalar::from(2u64) * &witness.match_res.base_amount;
+        let rhs = &witness.order1.amount + &witness.order2.amount
+            - &witness.match_res.max_minus_min_amount;
         cs.constrain(lhs - rhs);
 
         // The quote amount should then equal the price multiplied by the base amount
-        let expected_quote_amount = matches
+        let expected_quote_amount = witness
+            .match_res
             .execution_price
-            .mul_integer(&matches.base_amount, cs)
+            .mul_integer(witness.match_res.base_amount.clone(), cs)
             .map_err(ProverError::Collaborative)?;
-        expected_quote_amount.constrain_equal_integer(&matches.quote_amount, cs);
+        expected_quote_amount.constrain_equal_integer(&witness.match_res.quote_amount, cs);
 
         // Ensure the balances cover the orders
         // 1. Mux between the (mint, amount) pairs that the parties are expected to cover by the
@@ -222,24 +199,24 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 
         // The selections in the case that party 0 is on the buy side of the match
         let party0_buy_side_selection = vec![
-            matches.base_mint.clone(),
-            matches.base_amount.clone(),
-            matches.quote_mint.clone(),
-            matches.quote_amount.clone(),
+            witness.match_res.base_mint.clone(),
+            witness.match_res.base_amount.clone(),
+            witness.match_res.quote_mint.clone(),
+            witness.match_res.quote_amount.clone(),
         ];
 
         let party1_buy_side_selection = vec![
-            matches.quote_mint.clone(),
-            matches.quote_amount.clone(),
-            matches.base_mint.clone(),
-            matches.base_amount.clone(),
+            witness.match_res.quote_mint.clone(),
+            witness.match_res.quote_amount.clone(),
+            witness.match_res.base_mint.clone(),
+            witness.match_res.base_amount.clone(),
         ];
 
         let selected_values = MultiproverCondSelectVectorGadget::select(
             cs,
             &party0_buy_side_selection,
             &party1_buy_side_selection,
-            matches.direction,
+            witness.match_res.direction,
             fabric.clone(),
         )?;
 
@@ -250,19 +227,19 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         let party1_buy_amount = selected_values[3].to_owned();
 
         // Constrain the mints on the balances to be correct
-        cs.constrain(&party0_buy_mint - &balance1.mint);
-        cs.constrain(&party1_buy_mint - &balance2.mint);
+        cs.constrain(&party0_buy_mint - &witness.balance1.mint);
+        cs.constrain(&party1_buy_mint - &witness.balance2.mint);
 
         // Constrain the amounts of the balances to subsume the obligations from the match
         MultiproverGreaterThanEqGadget::<'_, 64 /* bitlength */, N, S>::constrain_greater_than_eq(
-            balance1.amount.into(),
+            witness.balance1.amount.into(),
             party0_buy_amount,
             fabric.clone(),
             cs,
         )?;
 
         MultiproverGreaterThanEqGadget::<'_, 64 /* bitlength */, N, S>::constrain_greater_than_eq(
-            balance2.amount.into(),
+            witness.balance2.amount.into(),
             party1_buy_amount,
             fabric,
             cs,
@@ -275,34 +252,33 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
     ///
     /// Used to apply constraints to the verifier
     pub fn matching_engine_check_single_prover<CS>(
+        witness: ValidMatchMpcWitnessVar<Variable>,
         cs: &mut CS,
-        order1: OrderVar<Variable>,
-        order2: OrderVar<Variable>,
-        balance1: BalanceVar<Variable>,
-        balance2: BalanceVar<Variable>,
-        matches: MatchResultVar,
     ) -> Result<(), R1CSError>
     where
         CS: RandomizableConstraintSystem,
     {
-        // Check that both of the orders are for the matched asset pair
-        cs.constrain(order1.quote_mint - matches.quote_mint);
-        cs.constrain(order1.base_mint - matches.base_mint);
-        cs.constrain(order2.quote_mint - matches.quote_mint);
-        cs.constrain(order2.base_mint - matches.base_mint);
+        // Check that both orders are for the matched asset pair
+        cs.constrain(witness.order1.quote_mint - witness.match_res.quote_mint);
+        cs.constrain(witness.order1.base_mint - witness.match_res.base_mint);
+        cs.constrain(witness.order2.quote_mint - witness.match_res.quote_mint);
+        cs.constrain(witness.order2.base_mint - witness.match_res.base_mint);
 
-        // Constrain the direction of the match to the direction of the first party's order
-        cs.constrain(matches.direction - order1.side);
+        // Check that the direction of the match is the same as the first party's direction
+        cs.constrain(witness.match_res.direction - witness.order1.side);
 
-        // Check that the orders are in opposite directions
-        cs.constrain(order1.side + order2.side - Scalar::one());
+        // Check that the orders are on opposite sides of the market. It is assumed that order
+        // sides are already constrained to be binary when they are submitted. More broadly it
+        // is assumed that orders are well formed, checking this amounts to checking their inclusion
+        // in the state tree, which is done in `input_consistency_check`
+        cs.constrain(witness.order1.side + witness.order2.side - Variable::One());
 
         // Check that the prices of the orders overlap
         // 1. Mux buy/sell side based on the direction of the match
-        let prices = CondSelectVectorGadget::select(
-            &[order2.price.repr.clone(), order1.price.repr.clone()],
-            &[order1.price.repr.clone(), order2.price.repr.clone()],
-            matches.direction.into(),
+        let prices = CondSelectVectorGadget::select::<Variable, Variable, _>(
+            &[witness.order2.price.repr, witness.order1.price.repr],
+            &[witness.order1.price.repr, witness.order2.price.repr],
+            witness.match_res.direction,
             cs,
         );
         let buy_side_price = FixedPointVar {
@@ -319,17 +295,19 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
             cs,
         );
 
-        // Constrain the execution price to the midpoint of the two order prices
-        let double_execution_price = matches
+        // Check that price is correctly computed to be the midpoint
+        // i.e. price1 + price2 = 2 * execution_price
+        let double_execution_price = witness
+            .match_res
             .execution_price
-            .mul_integer(Scalar::from(2u64) * Variable::One(), cs);
-        double_execution_price.constraint_equal(order1.price + order2.price, cs);
+            .mul_integer::<LinearCombination, _>(Scalar::from(2u8).into(), cs);
+        cs.constrain(double_execution_price - (witness.order1.price + witness.order2.price));
 
         // Constrain the min_amount_order_index to be binary
         // i.e. 0 === min_amount_order_index * (1 - min_amount_order_index)
         let (_, _, mul_out) = cs.multiply(
-            matches.min_amount_order_index.into(),
-            Scalar::one() - matches.min_amount_order_index,
+            witness.match_res.min_amount_order_index.into(),
+            LinearCombination::from(Scalar::one()) - witness.match_res.min_amount_order_index,
         );
         cs.constrain(mul_out.into());
 
@@ -338,15 +316,15 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 
         // 1. Constraint he max_minus_min_amount to be correctly computed with respect to the argmin
         // witness variable min_amount_order_index
-        let max_minus_min1 = order1.amount - order2.amount;
-        let max_minus_min2 = order2.amount - order1.amount;
-        let max_minus_min_expected = CondSelectGadget::select(
+        let max_minus_min1 = witness.order1.amount - witness.order2.amount;
+        let max_minus_min2 = witness.order2.amount - witness.order1.amount;
+        let max_minus_min_expected = CondSelectGadget::select::<LinearCombination, Variable, _>(
             max_minus_min1,
             max_minus_min2,
-            matches.min_amount_order_index.into(),
+            witness.match_res.min_amount_order_index,
             cs,
         );
-        cs.constrain(max_minus_min_expected - matches.max_minus_min_amount);
+        cs.constrain(max_minus_min_expected - witness.match_res.max_minus_min_amount);
 
         // 2. Constrain the max_minus_min_amount value to be positive
         // This, along with the previous check, constrain `max_minus_min_amount` to be computed correctly.
@@ -354,7 +332,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         // or min(amounts) - max(amounts).
         // Constraining the value to be positive forces it to be equal to max(amounts) - min(amounts)
         GreaterThanEqZeroGadget::<32 /* bitlength */>::constrain_greater_than_zero(
-            matches.max_minus_min_amount,
+            witness.match_res.max_minus_min_amount,
             cs,
         );
 
@@ -363,37 +341,41 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         //      min(a, b) = 1/2 * (a + b - [max(a, b) - min(a, b)])
         // Above we are given max(a, b) - min(a, b), so we can enforce the constraint
         //      2 * executed_amount = amount1 + amount2 - max_minus_min_amount
-        let lhs = Scalar::from(2u64) * matches.base_amount;
-        let rhs = order1.amount + order2.amount - matches.max_minus_min_amount;
+        let lhs = Scalar::from(2u64) * witness.match_res.base_amount;
+        let rhs =
+            witness.order1.amount + witness.order2.amount - witness.match_res.max_minus_min_amount;
         cs.constrain(lhs - rhs);
 
         // The quote amount should then equal the price multiplied by the base amount
-        let expected_quote_amount = matches.execution_price.mul_integer(matches.base_amount, cs);
-        expected_quote_amount.constraint_equal_integer(matches.quote_amount, cs);
+        let expected_quote_amount = witness
+            .match_res
+            .execution_price
+            .mul_integer(witness.match_res.base_amount, cs);
+        expected_quote_amount.constraint_equal_integer(witness.match_res.quote_amount, cs);
 
-        // Ensure that the balances cover the obligations from the match
+        // Ensure the balances cover the orders
         // 1. Mux between the (mint, amount) pairs that the parties are expected to cover by the
         // direction of the order
 
         // The selections in the case that party 0 is on the buy side of the match
         let party0_buy_side_selection = vec![
-            matches.base_mint,
-            matches.base_amount,
-            matches.quote_mint,
-            matches.quote_amount,
+            witness.match_res.base_mint,
+            witness.match_res.base_amount,
+            witness.match_res.quote_mint,
+            witness.match_res.quote_amount,
         ];
 
         let party1_buy_side_selection = vec![
-            matches.quote_mint,
-            matches.quote_amount,
-            matches.base_mint,
-            matches.base_amount,
+            witness.match_res.quote_mint,
+            witness.match_res.quote_amount,
+            witness.match_res.base_mint,
+            witness.match_res.base_amount,
         ];
 
         let selected_values = CondSelectVectorGadget::select(
             &party0_buy_side_selection,
             &party1_buy_side_selection,
-            matches.direction,
+            witness.match_res.direction,
             cs,
         );
 
@@ -404,18 +386,18 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
         let party1_buy_amount = selected_values[3].to_owned();
 
         // Constrain the mints on the balances to be correct
-        cs.constrain(party0_buy_mint - balance1.mint);
-        cs.constrain(party1_buy_mint - balance2.mint);
+        cs.constrain(party0_buy_mint - witness.balance1.mint);
+        cs.constrain(party1_buy_mint - witness.balance2.mint);
 
         // Constrain the amounts of the balances to subsume the obligations from the match
         GreaterThanEqGadget::<64 /* bitlength */>::constrain_greater_than_eq(
-            balance1.amount.into(),
+            witness.balance1.amount.into(),
             party0_buy_amount,
             cs,
         );
 
         GreaterThanEqGadget::<64 /* bitlength */>::constrain_greater_than_eq(
-            balance2.amount.into(),
+            witness.balance2.amount.into(),
             party1_buy_amount,
             cs,
         );
@@ -428,161 +410,24 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 // | Witness Type Definition |
 // ---------------------------
 
-/// The witness type for the circuit proving the VALID MATCH MPC statement
-///
-/// Note that the witness structure does not include both orders or balances.
-/// This is because the witness is distributed (neither party knows both sides)
-/// and is realized during the commit phase of the collaborative proof.
-#[derive(Debug)]
-pub struct ValidMatchMpcWitness<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
-    /// The local party's order that was matched by MPC
-    pub my_order: LinkableOrderCommitment,
-    /// A balance known by the local party that covers the position
-    /// expressed in their order
-    pub my_balance: LinkableBalanceCommitment,
+/// The full witness, recovered by opening the witness commitment, but never realized in
+/// the plaintext by either party
+#[circuit_type(singleprover_circuit, mpc, multiprover_circuit)]
+#[derive(Clone, Debug)]
+pub struct ValidMatchMpcWitness {
+    /// The first party's order
+    pub order1: LinkableOrder,
+    /// The first party's balance
+    pub balance1: LinkableBalance,
+    /// The second party's order
+    pub order2: LinkableOrder,
+    /// The second party's balance
+    pub balance2: LinkableBalance,
     /// The result of running a match MPC on the given orders
     ///
     /// We do not open this value before proving so that we can avoid leaking information
     /// before the collaborative proof has finished
-    pub match_res: AuthenticatedLinkableMatchResultCommitment<N, S>,
-}
-
-impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Clone for ValidMatchMpcWitness<N, S> {
-    fn clone(&self) -> Self {
-        Self {
-            my_order: self.my_order.clone(),
-            my_balance: self.my_balance.clone(),
-            match_res: self.match_res.clone(),
-        }
-    }
-}
-
-/// Represents a commitment to the VALID MATCH MPC witness
-#[derive(Clone, Debug)]
-pub struct ValidMatchCommitmentShared<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
-    /// A commitment to the first party's order
-    pub order1: AuthenticatedCommittedOrder<N, S>,
-    /// A commitment to the first party's balance
-    pub balance1: AuthenticatedCommittedBalance<N, S>,
-    /// A commitment to the second party's order
-    pub order2: AuthenticatedCommittedOrder<N, S>,
-    /// A commitment to the second party's balance
-    pub balance2: AuthenticatedCommittedBalance<N, S>,
-    /// A commitment to the match result from the MPC
-    pub match_result: AuthenticatedCommittedMatchResult<N, S>,
-}
-
-impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> From<ValidMatchCommitmentShared<N, S>>
-    for Vec<AuthenticatedCompressedRistretto<N, S>>
-{
-    fn from(commit: ValidMatchCommitmentShared<N, S>) -> Self {
-        let order1_vec = Into::<Vec<_>>::into(commit.order1);
-        let balance1_vec = Into::<Vec<_>>::into(commit.balance1);
-        let order2_vec = Into::<Vec<_>>::into(commit.order2);
-        let balance2_vec = Into::<Vec<_>>::into(commit.balance2);
-        let match_vec = Into::<Vec<_>>::into(commit.match_result);
-
-        order1_vec
-            .into_iter()
-            .chain(balance1_vec.into_iter())
-            .chain(order2_vec.into_iter())
-            .chain(balance2_vec.into_iter())
-            .chain(match_vec.into_iter())
-            .collect_vec()
-    }
-}
-
-/// An opened commitment to the VALID MATCH MPC witness
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ValidMatchCommitment {
-    /// A commitment to the first party's order
-    pub order1: CommittedOrder,
-    /// A commitment to the first party's balance
-    pub balance1: CommittedBalance,
-    /// A commitment to the second party's order
-    pub order2: CommittedOrder,
-    /// A commitment to the second party's balance
-    pub balance2: CommittedBalance,
-    /// A commitment to the match result
-    pub match_result: CommittedMatchResult,
-}
-
-impl From<&[CompressedRistretto]> for ValidMatchCommitment {
-    fn from(commitments: &[CompressedRistretto]) -> Self {
-        Self {
-            order1: CommittedOrder {
-                quote_mint: commitments[0],
-                base_mint: commitments[1],
-                side: commitments[2],
-                price: CommittedFixedPoint {
-                    repr: commitments[3],
-                },
-                amount: commitments[4],
-                timestamp: commitments[5],
-            },
-            balance1: CommittedBalance {
-                mint: commitments[6],
-                amount: commitments[7],
-            },
-            order2: CommittedOrder {
-                quote_mint: commitments[8],
-                base_mint: commitments[9],
-                side: commitments[10],
-                price: CommittedFixedPoint {
-                    repr: commitments[11],
-                },
-                amount: commitments[12],
-                timestamp: commitments[13],
-            },
-            balance2: CommittedBalance {
-                mint: commitments[14],
-                amount: commitments[15],
-            },
-            match_result: CommittedMatchResult {
-                quote_mint: commitments[16],
-                base_mint: commitments[17],
-                quote_amount: commitments[18],
-                base_amount: commitments[19],
-                direction: commitments[20],
-                execution_price: CommittedFixedPoint {
-                    repr: commitments[21],
-                },
-                max_minus_min_amount: commitments[22],
-                min_amount_order_index: commitments[23],
-            },
-        }
-    }
-}
-
-impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Open<N, S>
-    for ValidMatchCommitmentShared<N, S>
-{
-    type OpenOutput = ValidMatchCommitment;
-    type Error = MpcError;
-
-    fn open(self, _: SharedFabric<N, S>) -> Result<Self::OpenOutput, Self::Error> {
-        let all_commitments: Vec<AuthenticatedCompressedRistretto<N, S>> = self.into();
-        let opened_values: Vec<CompressedRistretto> =
-            AuthenticatedCompressedRistretto::batch_open(&all_commitments)
-                .map_err(|err| MpcError::SharingError(err.to_string()))?
-                .into_iter()
-                .map(|val| val.value())
-                .collect();
-
-        Ok(Into::<ValidMatchCommitment>::into(opened_values.borrow()))
-    }
-
-    fn open_and_authenticate(self, _: SharedFabric<N, S>) -> Result<Self::OpenOutput, Self::Error> {
-        let all_commitments: Vec<AuthenticatedCompressedRistretto<_, _>> = self.into();
-        let opened_values: Vec<CompressedRistretto> =
-            AuthenticatedCompressedRistretto::batch_open_and_authenticate(&all_commitments)
-                .map_err(|err| MpcError::SharingError(err.to_string()))?
-                .into_iter()
-                .map(|val| val.value())
-                .collect();
-
-        Ok(Into::<ValidMatchCommitment>::into(opened_values.borrow()))
-    }
+    pub match_res: LinkableMatchResult,
 }
 
 // -----------------------------
@@ -590,8 +435,6 @@ impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> Open<N, S>
 // -----------------------------
 
 /// The parameterization for the VALID MATCH MPC statement
-///
-/// TODO: Add in midpoint oracle prices
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidMatchMpcStatement {}
 
@@ -600,12 +443,11 @@ pub struct ValidMatchMpcStatement {}
 // ---------------------
 
 /// Prover implementation of the Valid Match circuit
-impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCircuit<'a, N, S>
-    for ValidMatchMpcCircuit<'a, N, S>
+impl<'a, N: 'a + MpcNetwork + Send + Clone, S: SharedValueSource<Scalar> + Clone>
+    MultiProverCircuit<'a, N, S> for ValidMatchMpcCircuit<'a, N, S>
 {
-    type Statement = ValidMatchMpcStatement;
-    type Witness = ValidMatchMpcWitness<N, S>;
-    type WitnessCommitment = ValidMatchCommitmentShared<N, S>;
+    type Statement = ();
+    type Witness = AuthenticatedValidMatchMpcWitness<N, S>;
 
     const BP_GENS_CAPACITY: usize = 256;
 
@@ -614,93 +456,40 @@ impl<'a, N: 'a + MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCir
         _statement: Self::Statement,
         mut prover: MpcProver<'a, '_, '_, N, S>,
         fabric: SharedFabric<N, S>,
-    ) -> Result<(ValidMatchCommitmentShared<N, S>, SharedR1CSProof<N, S>), ProverError> {
+    ) -> Result<
+        (
+            AuthenticatedValidMatchMpcWitnessCommitment<N, S>,
+            SharedR1CSProof<N, S>,
+        ),
+        ProverError,
+    > {
         // Commit to party 0's inputs first, then party 1's inputs
         let mut rng = OsRng {};
-
-        let (party0_vars, party0_comm) = (witness.my_order.clone(), witness.my_balance.clone())
-            .commit(0 /* owning_party */, &mut rng, &mut prover)
-            .map_err(ProverError::Mpc)?;
-        let (party1_vars, party1_comm) = (witness.my_order, witness.my_balance)
-            .commit(1 /* owning_party */, &mut rng, &mut prover)
+        let (witness_var, witness_comm) = witness
+            .commit_shared(&mut rng, &mut prover)
             .map_err(ProverError::Mpc)?;
 
-        let (match_var, match_commit) = witness
-            .match_res
-            .commit(0 /* owning_party */, &mut rng, &mut prover)
-            .map_err(ProverError::Mpc)?;
-
-        // Destructure the committed values
-        let party0_order = party0_vars.0;
-        let party0_balance = party0_vars.1;
-        let party1_order = party1_vars.0;
-        let party1_balance = party1_vars.1;
-
-        Self::matching_engine_check(
-            &mut prover,
-            party0_order,
-            party1_order,
-            party0_balance,
-            party1_balance,
-            match_var,
-            fabric,
-        )?;
+        Self::matching_engine_check(witness_var, fabric, &mut prover)?;
 
         // Prove the statement
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
 
-        Ok((
-            ValidMatchCommitmentShared {
-                order1: party0_comm.0,
-                balance1: party0_comm.1,
-                order2: party1_comm.0,
-                balance2: party1_comm.1,
-                match_result: match_commit,
-            },
-            proof,
-        ))
+        Ok((witness_comm, proof))
     }
 
     fn verify(
-        witness_commitment: ValidMatchCommitment,
+        witness_commitment: ValidMatchMpcWitnessCommitment,
         _statement: Self::Statement,
         proof: R1CSProof,
         mut verifier: Verifier,
     ) -> Result<(), VerifierError> {
-        // Commit to the input variables from the provers
-        let party0_order = witness_commitment
-            .order1
-            .commit_verifier(&mut verifier)
-            .unwrap();
-        let party0_balance = witness_commitment
-            .balance1
-            .commit_verifier(&mut verifier)
-            .unwrap();
-        let party1_order = witness_commitment
-            .order2
-            .commit_verifier(&mut verifier)
-            .unwrap();
-        let party1_balance = witness_commitment
-            .balance2
-            .commit_verifier(&mut verifier)
-            .unwrap();
-
-        let match_res_var = witness_commitment
-            .match_result
-            .commit_verifier(&mut verifier)
-            .unwrap();
+        // Allocate the witness in the constraint system
+        let witness_vars = witness_commitment.commit_verifier(&mut verifier);
 
         // Check that the matches value is properly formed
-        Self::matching_engine_check_single_prover(
-            &mut verifier,
-            party0_order,
-            party1_order,
-            party0_balance,
-            party1_balance,
-            match_res_var,
-        )
-        .map_err(VerifierError::R1CS)?;
+        Self::matching_engine_check_single_prover(witness_vars, &mut verifier)
+            .map_err(VerifierError::R1CS)?;
 
         let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         verifier

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -8,7 +8,8 @@
 //! See the whitepaper (https://renegade.fi/whitepaper.pdf) appendix A.1
 //! for a formal specification
 
-use curve25519_dalek::scalar::Scalar;
+use circuit_macros::circuit_type;
+use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use mpc_bulletproof::{
     r1cs::{
         LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
@@ -17,16 +18,16 @@ use mpc_bulletproof::{
     BulletproofGens,
 };
 use rand_core::OsRng;
-use serde::{Deserialize, Serialize};
+use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     errors::{ProverError, VerifierError},
-    types::wallet::{
-        WalletSecretShare, WalletSecretShareCommitment, WalletSecretShareVar, WalletVar,
+    traits::{
+        BaseType, CircuitBaseType, CircuitCommitmentType, CircuitVarType, LinearCombinationLike,
     },
+    types::wallet::{WalletShare, WalletVar},
     zk_gadgets::wallet_operations::WalletShareCommitGadget,
-    CommitPublic, CommitVerifier, CommitWitness, SingleProverCircuit, MAX_BALANCES, MAX_FEES,
-    MAX_ORDERS,
+    SingleProverCircuit, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
 };
 
 /// A type alias for an instantiation of this circuit with default generics
@@ -52,8 +53,8 @@ where
     /// Applies constraints to the constraint system specifying the statement of
     /// VALID WALLET CREATE
     fn circuit<CS>(
-        mut statement: ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        witness: ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        statement: ValidWalletCreateStatementVar<Variable, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        witness: ValidWalletCreateWitnessVar<Variable, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<(), R1CSError>
     where
@@ -67,10 +68,9 @@ where
         cs.constrain(commitment - statement.private_shares_commitment);
 
         // Unblind the public shares then reconstruct the wallet
-        let blinder = witness.private_wallet_share.blinder.clone()
-            + statement.public_wallet_shares.blinder.clone();
-        statement.public_wallet_shares.unblind(blinder);
-        let wallet = witness.private_wallet_share + statement.public_wallet_shares;
+        let blinder = witness.private_wallet_share.blinder + statement.public_wallet_shares.blinder;
+        let unblinded_public_shares = statement.public_wallet_shares.unblind_shares(blinder);
+        let wallet = witness.private_wallet_share + unblinded_public_shares;
 
         // Verify that the orders and balances are zero'd
         Self::verify_zero_wallet(wallet, cs);
@@ -80,7 +80,7 @@ where
 
     /// Constrains a wallet to have all zero'd out orders and balances
     fn verify_zero_wallet<CS: RandomizableConstraintSystem>(
-        wallet: WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, LinearCombination>,
+        wallet: WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) {
         // Constrain balances to be zero
@@ -106,77 +106,17 @@ where
 // ---------------------------
 
 /// The witness for the VALID WALLET CREATE statement
+#[circuit_type(singleprover_circuit)]
 #[derive(Clone, Debug)]
 pub struct ValidWalletCreateWitness<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
     const MAX_FEES: usize,
-> {
-    /// The private secret shares of the new wallet
-    pub private_wallet_share: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-}
-
-/// The proof-system allocated witness for VALID WALLET CREATE
-#[derive(Clone, Debug)]
-pub struct ValidWalletCreateWitnessVar<
-    const MAX_BALANCES: usize,
-    const MAX_ORDERS: usize,
-    const MAX_FEES: usize,
-> {
-    /// The private secret shares of the new wallet
-    pub private_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-}
-
-/// The committed witness for the VALID WALLET CREATE proof
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ValidWalletCreateWitnessCommitment<
-    const MAX_BALANCES: usize,
-    const MAX_ORDERS: usize,
-    const MAX_FEES: usize,
-> {
-    /// The private secret shares of the new wallet
-    pub private_wallet_share: WalletSecretShareCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-}
-
-impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitWitness
-    for ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
-    type CommitType = ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type VarType = ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type ErrorType = ();
-
-    fn commit_witness<R: rand_core::RngCore + rand_core::CryptoRng>(
-        &self,
-        rng: &mut R,
-        prover: &mut Prover,
-    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
-        let (wallet_share_var, wallet_share_comm) = self
-            .private_wallet_share
-            .commit_witness(rng, prover)
-            .unwrap();
-        Ok((
-            ValidWalletCreateWitnessVar {
-                private_wallet_share: wallet_share_var,
-            },
-            ValidWalletCreateWitnessCommitment {
-                private_wallet_share: wallet_share_comm,
-            },
-        ))
-    }
-}
-
-impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitVerifier
-    for ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
-{
-    type VarType = ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type ErrorType = ();
-
-    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
-        let wallet_share_var = self.private_wallet_share.commit_verifier(verifier).unwrap();
-        Ok(ValidWalletCreateWitnessVar {
-            private_wallet_share: wallet_share_var,
-        })
-    }
+    /// The private secret shares of the new wallet
+    pub private_wallet_share: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
 }
 
 // -----------------------------
@@ -184,49 +124,19 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> 
 // -----------------------------
 
 /// The statement type for the `VALID WALLET CREATE` circuit
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[circuit_type(singleprover_circuit)]
+#[derive(Clone, Debug)]
 pub struct ValidWalletCreateStatement<
     const MAX_BALANCES: usize,
     const MAX_ORDERS: usize,
     const MAX_FEES: usize,
-> {
+> where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     /// The commitment to the private secret shares of the wallet
     pub private_shares_commitment: Scalar,
     /// The public secret shares of the wallet
-    pub public_wallet_shares: WalletSecretShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-}
-
-/// The statement type for the `VALID WALLET CREATE` circuit, allocated in a constraint system
-#[derive(Clone, Debug)]
-pub struct ValidWalletCreateStatementVar<
-    const MAX_BALANCES: usize,
-    const MAX_ORDERS: usize,
-    const MAX_FEES: usize,
-> {
-    /// The commitment to the private secret shares of the wallet
-    pub private_shares_commitment: Variable,
-    /// The public secret shares of the wallet
-    pub public_wallet_shares: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-}
-
-impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize> CommitPublic
-    for ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
-{
-    type VarType = ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type ErrorType = (); // Does not error
-
-    fn commit_public<CS: RandomizableConstraintSystem>(
-        &self,
-        cs: &mut CS,
-    ) -> Result<Self::VarType, Self::ErrorType> {
-        let private_commitment_var = self.private_shares_commitment.commit_public(cs).unwrap();
-        let public_shares_var = self.public_wallet_shares.commit_public(cs).unwrap();
-
-        Ok(ValidWalletCreateStatementVar {
-            private_shares_commitment: private_commitment_var,
-            public_wallet_shares: public_shares_var,
-        })
-    }
+    pub public_wallet_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
 }
 
 // ---------------------
@@ -240,7 +150,6 @@ where
 {
     type Statement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Witness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
-    type WitnessCommitment = ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     const BP_GENS_CAPACITY: usize = 10000;
 
@@ -248,11 +157,17 @@ where
         witness: Self::Witness,
         statement: Self::Statement,
         mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
+    ) -> Result<
+        (
+            ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+            R1CSProof,
+        ),
+        ProverError,
+    > {
         // Commit to the witness and statement
         let mut rng = OsRng {};
-        let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
-        let statement_var = statement.commit_public(&mut prover).unwrap();
+        let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover);
+        let statement_var = statement.commit_public(&mut prover);
 
         // Apply the constraints
         Self::circuit(statement_var, witness_var, &mut prover).map_err(ProverError::R1CS)?;
@@ -265,14 +180,14 @@ where
     }
 
     fn verify(
-        witness_commitment: Self::WitnessCommitment,
+        witness_commitment: ValidWalletCreateWitnessCommitment<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement: Self::Statement,
         proof: R1CSProof,
         mut verifier: Verifier,
     ) -> Result<(), VerifierError> {
         // Commit to the witness and statement
-        let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
-        let statement_var = statement.commit_public(&mut verifier).unwrap();
+        let witness_var = witness_commitment.commit_verifier(&mut verifier);
+        let statement_var = statement.commit_public(&mut verifier);
 
         // Apply the constraints
         Self::circuit(statement_var, witness_var, &mut verifier).map_err(VerifierError::R1CS)?;
@@ -298,6 +213,7 @@ mod test {
     use crate::{
         native_helpers::compute_wallet_private_share_commitment,
         test_helpers::bulletproof_prove_and_verify,
+        traits::CircuitBaseType,
         types::{balance::Balance, order::Order},
         zk_circuits::{
             test_helpers::{
@@ -308,7 +224,6 @@ mod test {
                 ValidWalletCreate, ValidWalletCreateStatement, ValidWalletCreateWitness,
             },
         },
-        CommitPublic, CommitWitness,
     };
 
     /// Witness with default size parameters
@@ -344,7 +259,7 @@ mod test {
     fn create_witness_statement_from_wallet(
         wallet: &SizedWallet,
     ) -> (SizedWitness, SizedStatement) {
-        let (private_shares, public_shares) = create_wallet_shares(wallet);
+        let (private_shares, public_shares) = create_wallet_shares(wallet.clone());
 
         // Build a commitment to the private secret shares
         let commitment = compute_wallet_private_share_commitment(private_shares.clone());
@@ -370,8 +285,8 @@ mod test {
 
         // Allocate the witness and statement in the constraint system
         let mut rng = OsRng {};
-        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover).unwrap();
-        let statement_var = statement.commit_public(&mut prover).unwrap();
+        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
+        let statement_var = statement.commit_public(&mut prover);
 
         // Apply the constraints
         ValidWalletCreate::circuit(statement_var, witness_var, &mut prover).unwrap();

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -5,27 +5,17 @@ use std::marker::PhantomData;
 use ark_ff::Zero;
 use circuit_macros::circuit_trace;
 use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
-use curve25519_dalek::ristretto::CompressedRistretto;
+
 use curve25519_dalek::scalar::Scalar;
-use mpc_bulletproof::r1cs::{
-    ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable,
-    Verifier,
-};
-use mpc_bulletproof::r1cs_mpc::{
-    MpcConstraintSystem, MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem,
-    R1CSError, SharedR1CSProof,
-};
-use mpc_bulletproof::BulletproofGens;
-use mpc_ristretto::authenticated_ristretto::AuthenticatedCompressedRistretto;
-use mpc_ristretto::authenticated_scalar::AuthenticatedScalar;
+use mpc_bulletproof::r1cs::{LinearCombination, RandomizableConstraintSystem, Variable};
+use mpc_bulletproof::r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, R1CSError};
 use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
 use num_bigint::BigUint;
 use num_integer::Integer;
-use rand_core::OsRng;
 
-use crate::errors::{MpcError, ProverError, VerifierError};
+use crate::errors::ProverError;
 use crate::mpc::SharedFabric;
-use crate::{MultiProverCircuit, SingleProverCircuit};
+use crate::traits::{LinearCombinationLike, MpcLinearCombinationLike};
 
 use super::bits::ToBitsGadget;
 use super::comparators::{EqZeroGadget, LessThanGadget};
@@ -45,7 +35,7 @@ impl<const D: usize> DivRemGadget<D> {
     /// Return (q, r) such that a = bq + r and r < b
     pub fn div_rem<L, CS>(a: L, b: L, cs: &mut CS) -> (Variable, Variable)
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         let a_lc: LinearCombination = a.into();
@@ -88,7 +78,7 @@ impl ExpGadget {
     #[circuit_trace(latency)]
     pub fn exp<L, CS>(x: L, alpha: u64, cs: &mut CS) -> LinearCombination
     where
-        L: Into<LinearCombination>,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         if alpha == 0 {
@@ -107,105 +97,11 @@ impl ExpGadget {
             out_var2.into()
         }
     }
-
-    /// Generate the constraints for the ExpGadget statement
-    #[circuit_trace(latency)]
-    fn generate_exp_constraints<CS: RandomizableConstraintSystem>(
-        x_var: Variable,
-        y_var: Variable,
-        alpha: u64,
-        cs: &mut CS,
-    ) {
-        // Commit to the inputs and output
-        let res = Self::exp(x_var, alpha, cs);
-        cs.constrain(res - y_var);
-    }
-}
-
-/// The witness type to the ExpGadget Circuit implementation
-///
-/// This circuit represents a proof of knowledge of some base that when raised to the
-/// statement's exponent yields the statement's result.
-///
-/// This statement is not particularly useful and is moreso useful for testing the
-/// gadget itself
-#[derive(Clone, Debug)]
-pub struct ExpGadgetWitness {
-    /// Exponentiation base
-    pub x: Scalar,
-}
-
-/// The statement type for the ExpGadget circuit implementation
-///
-/// Both the exponent and the expected output are considered public inputs
-/// to the proof.
-#[derive(Copy, Clone, Debug)]
-pub struct ExpGadgetStatement {
-    /// Exponent
-    pub alpha: u64,
-    /// Expected result
-    pub expected_out: Scalar,
-}
-
-impl SingleProverCircuit for ExpGadget {
-    type Witness = ExpGadgetWitness;
-    type Statement = ExpGadgetStatement;
-    type WitnessCommitment = CompressedRistretto;
-
-    const BP_GENS_CAPACITY: usize = 64;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the input and expected output
-        let mut rng = OsRng {};
-        let blinding_factor = Scalar::random(&mut rng);
-
-        let (x_commit, x_var) = prover.commit(witness.x, blinding_factor);
-        let out_var = prover.commit_public(statement.expected_out);
-
-        // Generate the constraints for the circuit
-        Self::generate_exp_constraints(x_var, out_var, statement.alpha, &mut prover);
-
-        let bp_gens = BulletproofGens::new(
-            Self::BP_GENS_CAPACITY, /* gens_capacity */
-            1,                      /* party_capacity */
-        );
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        // Only return the commitment to the witness, the verifier will separately commit to the statement input
-        Ok((x_commit, proof))
-    }
-
-    fn verify(
-        witness_commitment: CompressedRistretto,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the result in the verifier
-        let x_var = verifier.commit(witness_commitment); // The input `x`
-        let out_var = verifier.commit_public(statement.expected_out);
-
-        // Generate the constraints for the circuit
-        Self::generate_exp_constraints(x_var, out_var, statement.alpha, &mut verifier);
-
-        let bp_gens = BulletproofGens::new(
-            Self::BP_GENS_CAPACITY, /* gens_capacity */
-            1,                      /* party_capacity */
-        );
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
 }
 
 /// An exponentiation gadget on a private exponent; compute x^\alpha
 #[derive(Clone, Debug)]
 pub struct PrivateExpGadget<const ALPHA_BITS: usize> {}
-
 impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
     /// Compute x^\alpha where `x` is public and alpha is private
     pub fn exp_private_fixed_base<L, CS>(
@@ -214,7 +110,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError>
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // Bit decompose the exponent, this removes the need to check `is_odd` at every
@@ -226,7 +122,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
     /// Compute x^\alpha where both x and alpha are private values
     pub fn exp_private<L, CS>(x: L, alpha: L, cs: &mut CS) -> Result<LinearCombination, R1CSError>
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // Bit decompose the exponent, this removes the need to check `is_odd` at every
@@ -245,7 +141,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError>
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         if alpha_bits.is_empty() {
@@ -264,20 +160,12 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         let recursive_plus_one = x * recursive_doubled;
 
         // Mux between the two results depending on whether the current exponent is odd or even
-        let odd_bit_selection = CondSelectGadget::select(
-            recursive_plus_one,
-            recursive_doubled.into(),
-            is_odd.into(),
-            cs,
-        );
+        let odd_bit_selection =
+            CondSelectGadget::select(recursive_plus_one, recursive_doubled.into(), is_odd, cs);
 
         // Mask the value of the output if alpha is already zero
-        let zero_mask = CondSelectGadget::select(
-            Variable::One().into(),
-            odd_bit_selection,
-            alpha_zero.into(),
-            cs,
-        );
+        let zero_mask =
+            CondSelectGadget::select(Variable::One().into(), odd_bit_selection, alpha_zero, cs);
 
         Ok(zero_mask)
     }
@@ -289,7 +177,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError>
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         if alpha_bits.is_empty() {
@@ -314,12 +202,8 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
             CondSelectGadget::select(recursive_plus_one, recursive_doubled, is_odd, cs);
 
         // Mask the value of the output if alpha is already zero
-        let zero_mask = CondSelectGadget::select(
-            Variable::One().into(),
-            odd_bit_selection,
-            alpha_zero.into(),
-            cs,
-        );
+        let zero_mask =
+            CondSelectGadget::select(Variable::One().into(), odd_bit_selection, alpha_zero, cs);
 
         Ok(zero_mask)
     }
@@ -328,7 +212,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
     /// are constrained to be binary elsewhere in the circuit
     fn all_bits_zero<L, CS>(bits: &[L], cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // Add all the bits
@@ -344,78 +228,17 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
     }
 }
 
-impl<const ALPHA_SIZE: usize> SingleProverCircuit for PrivateExpGadget<ALPHA_SIZE> {
-    /// Expected output
-    type Statement = Scalar;
-    /// (x, \alpha)
-    type Witness = (Scalar, Scalar);
-    type WitnessCommitment = (CompressedRistretto, CompressedRistretto);
-
-    const BP_GENS_CAPACITY: usize = 4096;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to `x` and `\alpha`
-        let mut rng = OsRng {};
-        let (x_comm, x_var) = prover.commit(witness.0, Scalar::random(&mut rng));
-        let (alpha_comm, alpha_var) = prover.commit(witness.1, Scalar::random(&mut rng));
-
-        // Commit to the expected output
-        let expected_out = prover.commit_public(statement);
-
-        // Apply the constraints
-        let res = Self::exp_private(x_var, alpha_var, &mut prover).map_err(ProverError::R1CS)?;
-        prover.constrain(res - expected_out);
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok(((x_comm, alpha_comm), proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to `x` and `\alpha`
-        let x_var = verifier.commit(witness_commitment.0);
-        let alpha_var = verifier.commit(witness_commitment.1);
-
-        // Commit to the expected output
-        let expected_out = verifier.commit_public(statement);
-
-        // Apply the constraints
-        let res =
-            Self::exp_private(x_var, alpha_var, &mut verifier).map_err(VerifierError::R1CS)?;
-        verifier.constrain(res - expected_out);
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
-}
-
 // -----------------------
 // | Multiprover Gadgets |
 // -----------------------
 
 /// A multiprover implementation of the exp gadget
-///
-/// TODO: Implementation
 pub struct MultiproverExpGadget<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> {
     /// Phantom
     _phantom: PhantomData<&'a (N, S)>,
 }
 
-impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
+impl<'a, N: 'a + MpcNetwork + Send + Clone, S: 'a + SharedValueSource<Scalar> + Clone>
     MultiproverExpGadget<'a, N, S>
 {
     /// Apply the gadget to the input
@@ -427,7 +250,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
     ) -> Result<MpcLinearCombination<N, S>, ProverError>
     where
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
-        L: Into<MpcLinearCombination<N, S>>,
+        L: MpcLinearCombinationLike<N, S>,
     {
         if alpha == 0 {
             Ok(MpcLinearCombination::from_scalar(Scalar::one(), fabric.0))
@@ -454,72 +277,6 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
     }
 }
 
-/// The witness type for the ExpGadget in the multiprover setting
-///
-/// This type is essentially the same witness type as the witness for
-/// the single prover setting, but using the authenticated, secret shared
-/// field
-#[derive(Clone, Debug)]
-pub struct MultiproverExpWitness<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
-    /// Exponentiation base
-    pub x: AuthenticatedScalar<N, S>,
-}
-
-impl<'a, N: MpcNetwork + Send, S: SharedValueSource<Scalar>> MultiProverCircuit<'a, N, S>
-    for MultiproverExpGadget<'a, N, S>
-{
-    /// Witness is the secret shared version of the single-prover witness, and the
-    /// statement is the same as the single-prover case
-    type Witness = MultiproverExpWitness<N, S>;
-    type WitnessCommitment = AuthenticatedCompressedRistretto<N, S>;
-    type Statement = ExpGadgetStatement;
-
-    const BP_GENS_CAPACITY: usize = 2048;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: MpcProver<'a, '_, '_, N, S>,
-        fabric: SharedFabric<N, S>,
-    ) -> Result<
-        (
-            AuthenticatedCompressedRistretto<N, S>,
-            SharedR1CSProof<N, S>,
-        ),
-        ProverError,
-    > {
-        // Commit to the input
-        let mut rng = OsRng {};
-        let blinder = Scalar::random(&mut rng);
-        let (witness_commit, witness_var) = prover
-            .commit_preshared(&witness.x, blinder)
-            .map_err(|err| ProverError::Mpc(MpcError::SharingError(err.to_string())))?;
-
-        // Commit to the public expected hash output
-        // TODO: update this with a correct commit_public impl
-        let (_, output_var) = prover.commit_public(statement.expected_out);
-
-        // Apply the constraints to the prover
-        let res = Self::exp(witness_var, statement.alpha, fabric, &mut prover)?;
-        prover.constrain(res - output_var);
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
-
-        Ok((witness_commit, proof))
-    }
-
-    fn verify(
-        witness_commitments: CompressedRistretto,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        ExpGadget::verify(witness_commitments, statement, proof, verifier)
-    }
-}
-
 #[cfg(test)]
 mod arithmetic_tests {
     use crypto::fields::{bigint_to_scalar, biguint_to_scalar, scalar_to_biguint};
@@ -534,9 +291,9 @@ mod arithmetic_tests {
     use num_integer::Integer;
     use rand_core::{OsRng, RngCore};
 
-    use crate::test_helpers::bulletproof_prove_and_verify;
+    use crate::traits::CircuitBaseType;
 
-    use super::{DivRemGadget, ExpGadget, ExpGadgetStatement, ExpGadgetWitness, PrivateExpGadget};
+    use super::{DivRemGadget, ExpGadget, PrivateExpGadget};
 
     /// Tests the single prover exponentiation gadget
     #[test]
@@ -551,35 +308,17 @@ mod arithmetic_tests {
             random_bigint.modpow(&BigUint::from(alpha), &get_ristretto_group_modulus());
         let expected_scalar = bigint_to_scalar(&expected_res.into());
 
+        // Build a constraint system
+        let mut prover_transcript = Transcript::new("test".as_bytes());
+        let pc_gens = PedersenGens::default();
+        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
         // Create the circuit
-        bulletproof_prove_and_verify::<ExpGadget>(
-            ExpGadgetWitness { x: random_value },
-            ExpGadgetStatement {
-                alpha: alpha as u64,
-                expected_out: expected_scalar,
-            },
-        )
-        .unwrap();
-    }
+        let base_var = random_bigint.commit_public(&mut prover);
+        let res = ExpGadget::exp(base_var, alpha as u64, &mut prover);
 
-    /// Tests that a single prover exp does not verify for incorrect values
-    #[test]
-    fn test_single_prover_exp_failure() {
-        // Generate a random input
-        let mut rng = OsRng {};
-        let alpha = rng.next_u32();
-        let random_value = Scalar::random(&mut rng);
-        let random_out = Scalar::random(&mut rng);
-
-        let res = bulletproof_prove_and_verify::<ExpGadget>(
-            ExpGadgetWitness { x: random_value },
-            ExpGadgetStatement {
-                alpha: alpha as u64,
-                expected_out: random_out,
-            },
-        );
-
-        assert!(res.is_err());
+        // Check the result
+        assert_eq!(expected_scalar, prover.eval(&res));
     }
 
     /// Tests the single prover exponent gadget on a private exponent
@@ -596,14 +335,21 @@ mod arithmetic_tests {
         // Compute the expected exponentiation result
         let x_bigint = scalar_to_biguint(&x);
         let alpha_bigint = scalar_to_biguint(&alpha);
-
         let expected = x_bigint.modpow(&alpha_bigint, &get_ristretto_group_modulus());
 
-        let res = bulletproof_prove_and_verify::<PrivateExpGadget<64>>(
-            (x, alpha),
-            biguint_to_scalar(&expected),
-        );
-        assert!(res.is_ok())
+        // Build a constraint system
+        let mut prover_transcript = Transcript::new("test".as_bytes());
+        let pc_gens = PedersenGens::default();
+        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
+        let x_var = x_bigint.commit_public(&mut prover);
+        let alpha_var = alpha_bigint.commit_public(&mut prover);
+        let res =
+            PrivateExpGadget::<64 /* ALPHA_BITS */>::exp_private(x_var, alpha_var, &mut prover)
+                .unwrap();
+
+        // Check the result
+        assert_eq!(biguint_to_scalar(&expected), prover.eval(&res));
     }
 
     /// Tests the div_rem gadget

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -2,45 +2,29 @@
 use std::marker::PhantomData;
 
 use crypto::fields::bigint_to_scalar;
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
-use itertools::Itertools;
+use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
-    r1cs::{
-        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
-        Variable, Verifier,
-    },
-    r1cs_mpc::{
-        MpcConstraintSystem, MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem,
-        R1CSError, SharedR1CSProof,
-    },
-    BulletproofGens,
+    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
+    r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, R1CSError},
 };
-use mpc_ristretto::{
-    authenticated_ristretto::AuthenticatedCompressedRistretto,
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
-};
+use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
 use num_bigint::BigInt;
-use rand_core::OsRng;
 
 use crate::{
-    errors::{MpcError, ProverError, VerifierError},
+    errors::ProverError,
     mpc::SharedFabric,
     mpc_gadgets::bits::{scalar_to_bits_le, to_bits_le},
-    MultiProverCircuit, Open, SingleProverCircuit,
+    traits::{LinearCombinationLike, MpcLinearCombinationLike},
 };
 
-/**
- * Single prover implementation
- */
-
+/// Singleprover implementation of the `ToBits` gadget
 pub struct ToBitsGadget<const D: usize> {}
-
 impl<const D: usize> ToBitsGadget<D> {
     /// Converts a value to its bitwise representation in a single-prover constraint system
     pub fn to_bits<L, CS>(a: L, cs: &mut CS) -> Result<Vec<Variable>, R1CSError>
     where
         CS: RandomizableConstraintSystem,
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
     {
         let a_scalar = cs.eval(&a.clone().into());
         let bits = &scalar_to_bits_le(&a_scalar)[..D];
@@ -60,80 +44,6 @@ impl<const D: usize> ToBitsGadget<D> {
     }
 }
 
-/// The statement proved here is trivial, we prove the bit-decomposition of a given witness
-/// scalar. This is, of course, not useful in practice, but is used for testing.
-#[derive(Clone, Debug)]
-pub struct ToBitsStatement {
-    /// The expected bits from the decomposition
-    pub bits: Vec<Scalar>,
-}
-
-impl<const D: usize> SingleProverCircuit for ToBitsGadget<D> {
-    type Statement = ToBitsStatement;
-    type Witness = Scalar;
-    type WitnessCommitment = CompressedRistretto;
-
-    const BP_GENS_CAPACITY: usize = 256;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (witness_comm, witness_var) = prover.commit(witness, Scalar::random(&mut rng));
-
-        // Commit to the statement
-        let statement_vars = statement
-            .bits
-            .iter()
-            .map(|bit| prover.commit_public(*bit))
-            .collect_vec();
-
-        // Get the bits result and constrain the output
-        let res_bits = Self::to_bits(witness_var, &mut prover).map_err(ProverError::R1CS)?;
-
-        for (statement_bit, res_bit) in statement_vars.into_iter().zip(res_bits.into_iter()) {
-            prover.constrain(statement_bit - res_bit)
-        }
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((witness_comm, proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the witness and statement
-        let witness_var = verifier.commit(witness_commitment);
-        let bit_vars = statement
-            .bits
-            .into_iter()
-            .map(|bit| verifier.commit_public(bit))
-            .collect_vec();
-
-        // Apply the constraints using the single-prover gadget
-        let computed_bits =
-            ToBitsGadget::<D>::to_bits(witness_var, &mut verifier).map_err(VerifierError::R1CS)?;
-        for (statement_bit, computed_bit) in bit_vars.into_iter().zip(computed_bits.into_iter()) {
-            verifier.constrain(statement_bit - computed_bit);
-        }
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
-}
-
 /// Takes a scalar and returns its bit representation, constrained to be correct
 ///
 /// D is the bitlength of the input vector to bitify
@@ -147,8 +57,12 @@ pub struct MultiproverToBitsGadget<
     _phantom: &'a PhantomData<(N, S)>,
 }
 
-impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
-    MultiproverToBitsGadget<'a, D, N, S>
+impl<
+        'a,
+        const D: usize,
+        N: 'a + MpcNetwork + Send + Clone,
+        S: 'a + SharedValueSource<Scalar> + Clone,
+    > MultiproverToBitsGadget<'a, D, N, S>
 {
     /// Converts a value into its bitwise representation
     pub fn to_bits<L, CS>(
@@ -158,7 +72,7 @@ impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Sc
     ) -> Result<Vec<MpcLinearCombination<N, S>>, ProverError>
     where
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
-        L: Into<MpcLinearCombination<N, S>> + Clone,
+        L: MpcLinearCombinationLike<N, S>,
     {
         // Evaluate the linear combination so that we can use a raw MPC to get the bits
         let a_scalar = cs
@@ -186,61 +100,20 @@ impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Sc
     }
 }
 
-impl<'a, const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>
-    MultiProverCircuit<'a, N, S> for MultiproverToBitsGadget<'a, D, N, S>
-{
-    type Statement = ToBitsStatement;
-    type Witness = AuthenticatedScalar<N, S>;
-    type WitnessCommitment = AuthenticatedCompressedRistretto<N, S>;
-
-    const BP_GENS_CAPACITY: usize = 512;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: MpcProver<'a, '_, '_, N, S>,
-        fabric: SharedFabric<N, S>,
-    ) -> Result<(Self::WitnessCommitment, SharedR1CSProof<N, S>), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (witness_comm, witness_var) = prover
-            .commit_preshared(&witness, Scalar::random(&mut rng))
-            .map_err(|err| ProverError::Mpc(MpcError::SharingError(err.to_string())))?;
-
-        let (_, bit_vars) = prover.batch_commit_public(&statement.bits);
-
-        // Apply the constraints
-        let bits = Self::to_bits(witness_var, fabric, &mut prover)?;
-        for (statement_bit, computed_bit) in bit_vars.into_iter().zip(bits.into_iter()) {
-            prover.constrain(statement_bit - computed_bit);
-        }
-
-        // Generate a proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
-
-        Ok((witness_comm, proof))
-    }
-
-    fn verify(
-        witness_commitments: <Self::WitnessCommitment as Open<N, S>>::OpenOutput,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        ToBitsGadget::<D>::verify(witness_commitments, statement, proof, verifier)
-    }
-}
-
 #[cfg(test)]
 mod bits_test {
     use crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
     use curve25519_dalek::scalar::Scalar;
+    use merlin::Transcript;
+    use mpc_bulletproof::{
+        r1cs::{ConstraintSystem, Prover},
+        PedersenGens,
+    };
     use rand_core::{OsRng, RngCore};
 
-    use crate::test_helpers::bulletproof_prove_and_verify;
+    use crate::traits::CircuitBaseType;
 
-    use super::{ToBitsGadget, ToBitsStatement};
+    use super::ToBitsGadget;
 
     /// Test that the to_bits single-prover gadget functions correctly
     #[test]
@@ -249,14 +122,21 @@ mod bits_test {
         let mut rng = OsRng {};
         let random_value = rng.next_u64();
 
-        let witness = Scalar::from(random_value);
-
         // Create the statement by bitifying the input
-        let bits = bigint_to_scalar_bits::<64 /* bits */>(&scalar_to_bigint(&witness));
-        let statement = ToBitsStatement { bits };
+        let witness = Scalar::from(random_value);
+        let mut bits = bigint_to_scalar_bits::<64 /* bits */>(&scalar_to_bigint(&witness));
 
-        assert!(
-            bulletproof_prove_and_verify::<ToBitsGadget<64 /* bits */>>(witness, statement).is_ok()
-        );
+        // Create a constraint system
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        // Bitify the input
+        let input_var = witness.commit_public(&mut prover);
+        let res = ToBitsGadget::<64 /* bits */>::to_bits(input_var, &mut prover).unwrap();
+
+        for bit in res.into_iter().rev().map(|v| prover.eval(&v.into())) {
+            assert_eq!(bit, bits.pop().unwrap());
+        }
     }
 }

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -177,10 +177,12 @@ impl EqVecGadget {
 pub struct NotEqualGadget {}
 impl NotEqualGadget {
     /// Computes a != b
-    pub fn not_equal<L1, L2, CS>(a: L1, b: L2, cs: &mut CS) -> LinearCombination
+    pub fn not_equal<L1, L2, V1, V2, CS>(a: V1, b: V2, cs: &mut CS) -> LinearCombination
     where
         L1: LinearCombinationLike,
         L2: LinearCombinationLike,
+        V1: CircuitVarType<L1>,
+        V2: CircuitVarType<L2>,
         CS: RandomizableConstraintSystem,
     {
         let eq_zero = EqZeroGadget::eq_zero(a.into() - b.into(), cs);

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -2,24 +2,20 @@
 
 use std::marker::PhantomData;
 
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{
-        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
-        Variable, Verifier,
-    },
+    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem},
-    BulletproofGens,
 };
 use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
-use rand_core::OsRng;
 
 use crate::{
-    errors::{ProverError, VerifierError},
+    errors::ProverError,
     mpc::SharedFabric,
     mpc_gadgets::bits::{scalar_to_bits_le, to_bits_le},
-    SingleProverCircuit, POSITIVE_SCALAR_MAX_BITS,
+    traits::{CircuitVarType, LinearCombinationLike, MpcLinearCombinationLike},
+    POSITIVE_SCALAR_MAX_BITS,
 };
 
 /// A gadget that returns whether a value is equal to zero
@@ -35,7 +31,7 @@ impl EqZeroGadget {
     /// have a valid multiplicative inverse
     pub fn eq_zero<L, CS>(val: L, cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // Compute the inverse of the value outside the constraint
@@ -68,71 +64,42 @@ impl EqZeroGadget {
     }
 }
 
-impl SingleProverCircuit for EqZeroGadget {
-    type Statement = bool;
-    type Witness = Scalar;
-    type WitnessCommitment = CompressedRistretto;
-
-    const BP_GENS_CAPACITY: usize = 32;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (witness_comm, witness_var) = prover.commit(witness, Scalar::random(&mut rng));
-
-        // Commit to the statement
-        let expected_var = prover.commit_public(Scalar::from(statement as u8));
-
-        // Test equality to zero and constrain this to be expected
-        let eq_zero = EqZeroGadget::eq_zero(witness_var, &mut prover);
-        prover.constrain(eq_zero - expected_var);
-
-        // Prover the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((witness_comm, proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the witness
-        let witness_var = verifier.commit(witness_commitment);
-
-        // Commit to the statement
-        let expected_var = verifier.commit_public(Scalar::from(statement as u8));
-
-        // Test equality to zero and constrain this to be expected
-        let eq_zero = EqZeroGadget::eq_zero(witness_var, &mut verifier);
-        verifier.constrain(eq_zero - expected_var);
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
-}
-
 /// Returns 1 if a == b otherwise 0
 #[derive(Clone, Debug)]
 pub struct EqGadget {}
 impl EqGadget {
     /// Computes a == b
-    pub fn eq<L, CS>(a: L, b: L, cs: &mut CS) -> Variable
+    pub fn eq<L1, L2, V1, V2, CS>(a: V1, b: V2, cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L1: LinearCombinationLike,
+        L2: LinearCombinationLike,
+        V1: CircuitVarType<L1>,
+        V2: CircuitVarType<L2>,
         CS: RandomizableConstraintSystem,
     {
-        EqZeroGadget::eq_zero(a.into() - b.into(), cs)
+        let a_vars = a.to_vars();
+        let b_vars = b.to_vars();
+
+        EqVecGadget::eq_vec(&a_vars, &b_vars, cs)
+    }
+
+    /// Constraints a == b
+    pub fn constrain_eq<L1, L2, V1, V2, CS>(a: V1, b: V2, cs: &mut CS)
+    where
+        L1: LinearCombinationLike,
+        L2: LinearCombinationLike,
+        V1: CircuitVarType<L1>,
+        V2: CircuitVarType<L2>,
+        CS: RandomizableConstraintSystem,
+    {
+        let a_vars = a.to_vars();
+        let b_vars = b.to_vars();
+        assert!(
+            a_vars.len() == b_vars.len(),
+            "a and b must have the same length"
+        );
+
+        EqVecGadget::constrain_eq_vec(&a_vars, &b_vars, cs)
     }
 }
 
@@ -141,16 +108,29 @@ impl EqGadget {
 pub struct EqVecGadget {}
 impl EqVecGadget {
     /// Returns 1 if \vec{a} = \vec{b}, otherwise 0
-    pub fn eq_vec<L, CS>(a: &[L], b: &[L], cs: &mut CS) -> Variable
+    pub fn eq_vec<L1, L2, V1, V2, CS>(a: &[V1], b: &[V2], cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L1: LinearCombinationLike,
+        L2: LinearCombinationLike,
+        V1: CircuitVarType<L1>,
+        V2: CircuitVarType<L2>,
         CS: RandomizableConstraintSystem,
     {
         assert_eq!(a.len(), b.len(), "eq_vec expects equal length vectors");
+        let a_vals = a
+            .iter()
+            .cloned()
+            .flat_map(|a_val| a_val.to_vars())
+            .collect_vec();
+        let b_vals = b
+            .iter()
+            .cloned()
+            .flat_map(|b_val| b_val.to_vars())
+            .collect_vec();
 
         // Compare each vector element
         let mut not_equal_values = Vec::with_capacity(a.len());
-        for (a_val, b_val) in a.iter().zip(b.iter()) {
+        for (a_val, b_val) in a_vals.into_iter().zip(b_vals.into_iter()) {
             not_equal_values.push(NotEqualGadget::not_equal(a_val.clone(), b_val.clone(), cs));
         }
 
@@ -164,16 +144,27 @@ impl EqVecGadget {
     }
 
     /// Constraints the two vectors to be equal
-    ///
-    /// TODO: This may be optimized with a randomized constraint
-    pub fn constrain_eq_vec<L, CS>(a: &[L], b: &[L], cs: &mut CS)
+    pub fn constrain_eq_vec<L1, L2, V1, V2, CS>(a: &[V1], b: &[V2], cs: &mut CS)
     where
-        L: Into<LinearCombination> + Clone,
+        L1: LinearCombinationLike,
+        L2: LinearCombinationLike,
+        V1: CircuitVarType<L1>,
+        V2: CircuitVarType<L2>,
         CS: RandomizableConstraintSystem,
     {
         assert_eq!(a.len(), b.len(), "eq_vec expects equal length vectors");
+        let a_vars = a
+            .iter()
+            .cloned()
+            .flat_map(|a_val| a_val.to_vars())
+            .collect_vec();
+        let b_vars = b
+            .iter()
+            .cloned()
+            .flat_map(|b_val| b_val.to_vars())
+            .collect_vec();
 
-        for (a_val, b_val) in a.iter().cloned().zip(b.iter().cloned()) {
+        for (a_val, b_val) in a_vars.into_iter().zip(b_vars) {
             let a_lc: LinearCombination = a_val.into();
             let b_lc: LinearCombination = b_val.into();
             cs.constrain(a_lc - b_lc);
@@ -184,12 +175,12 @@ impl EqVecGadget {
 /// Returns a boolean representing a != b where 1 is true and 0 is false
 #[derive(Debug)]
 pub struct NotEqualGadget {}
-
 impl NotEqualGadget {
     /// Computes a != b
-    pub fn not_equal<L, CS>(a: L, b: L, cs: &mut CS) -> LinearCombination
+    pub fn not_equal<L1, L2, CS>(a: L1, b: L2, cs: &mut CS) -> LinearCombination
     where
-        L: Into<LinearCombination> + Clone,
+        L1: LinearCombinationLike,
+        L2: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         let eq_zero = EqZeroGadget::eq_zero(a.into() - b.into(), cs);
@@ -204,7 +195,7 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
     /// Evaluate the condition x >= 0; returns 1 if true, otherwise 0
     pub fn greater_than_zero<L, CS>(x: L, cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // If we can reconstruct the value without the highest bit, the value is non-negative
@@ -215,7 +206,7 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
     /// Constrain the value to be greater than zero
     pub fn constrain_greater_than_zero<L, CS>(x: L, cs: &mut CS)
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // If we can reconstruct the value without the highest bit, the value is non-negative
@@ -231,7 +222,7 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
     /// non-negative
     fn bit_decompose_reconstruct<L, CS>(x: L, cs: &mut CS) -> LinearCombination
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         assert!(
@@ -259,58 +250,6 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
     }
 }
 
-/// The witness for the statement that a hidden value is greater than zero
-#[derive(Clone, Debug)]
-pub struct GreaterThanEqZeroWitness {
-    /// The value attested to that must be greater than zero
-    val: Scalar,
-}
-impl<const D: usize> SingleProverCircuit for GreaterThanEqZeroGadget<D> {
-    type Statement = ();
-    type Witness = GreaterThanEqZeroWitness;
-    type WitnessCommitment = CompressedRistretto;
-
-    const BP_GENS_CAPACITY: usize = 256;
-
-    fn prove(
-        witness: Self::Witness,
-        _: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (witness_commit, witness_var) = prover.commit(witness.val, Scalar::random(&mut rng));
-
-        // Apply the constraints
-        Self::constrain_greater_than_zero(witness_var, &mut prover);
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((witness_commit, proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        _: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the witness
-        let witness_var = verifier.commit(witness_commitment);
-
-        // Apply the constraints
-        Self::constrain_greater_than_zero(witness_var, &mut verifier);
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
-}
-
 /// A multiprover version of the greater than or equal to zero gadget
 pub struct MultiproverGreaterThanEqZeroGadget<
     'a,
@@ -322,8 +261,12 @@ pub struct MultiproverGreaterThanEqZeroGadget<
     _phantom: &'a PhantomData<(N, S)>,
 }
 
-impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
-    MultiproverGreaterThanEqZeroGadget<'a, D, N, S>
+impl<
+        'a,
+        const D: usize,
+        N: 'a + MpcNetwork + Send + Clone,
+        S: 'a + SharedValueSource<Scalar> + Clone,
+    > MultiproverGreaterThanEqZeroGadget<'a, D, N, S>
 {
     /// Constrains the input value to be greater than or equal to zero implicitly
     /// by bit-decomposing the value and re-composing it thereafter
@@ -333,7 +276,7 @@ impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Sc
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where
-        L: Into<MpcLinearCombination<N, S>> + Clone,
+        L: MpcLinearCombinationLike<N, S>,
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
     {
         let reconstructed_res = Self::bit_decompose_reconstruct(x.clone(), fabric, cs)?;
@@ -353,7 +296,7 @@ impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Sc
         cs: &mut CS,
     ) -> Result<MpcLinearCombination<N, S>, ProverError>
     where
-        L: Into<MpcLinearCombination<N, S>> + Clone,
+        L: MpcLinearCombinationLike<N, S>,
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
     {
         // Evaluate the assignment of the value in the underlying constraint system
@@ -385,7 +328,7 @@ impl<const D: usize> GreaterThanEqGadget<D> {
     /// Evaluates the comparator a >= b; returns 1 if true, otherwise 0
     pub fn greater_than_eq<L, CS>(a: L, b: L, cs: &mut CS) -> Variable
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         GreaterThanEqZeroGadget::<D>::greater_than_zero(a.into() - b.into(), cs)
@@ -394,68 +337,10 @@ impl<const D: usize> GreaterThanEqGadget<D> {
     /// Constrains the values to satisfy a >= b
     pub fn constrain_greater_than_eq<L, CS>(a: L, b: L, cs: &mut CS)
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         GreaterThanEqZeroGadget::<D>::constrain_greater_than_zero(a.into() - b.into(), cs);
-    }
-}
-
-/// The witness for the statement a >= b; used for testing
-///
-/// Here, both `a` and `b` are private variables
-#[allow(missing_docs, clippy::missing_docs_in_private_items)]
-#[derive(Clone, Debug)]
-pub struct GreaterThanEqWitness {
-    pub a: Scalar,
-    pub b: Scalar,
-}
-
-impl<const D: usize> SingleProverCircuit for GreaterThanEqGadget<D> {
-    type Statement = ();
-    type Witness = GreaterThanEqWitness;
-    type WitnessCommitment = Vec<CompressedRistretto>;
-
-    const BP_GENS_CAPACITY: usize = 64;
-
-    fn prove(
-        witness: Self::Witness,
-        _: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (a_comm, a_var) = prover.commit(witness.a, Scalar::random(&mut rng));
-        let (b_comm, b_var) = prover.commit(witness.b, Scalar::random(&mut rng));
-
-        // Apply the constraints
-        Self::constrain_greater_than_eq(a_var, b_var, &mut prover);
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((vec![a_comm, b_comm], proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        _: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the witness
-        let a_var = verifier.commit(witness_commitment[0]);
-        let b_var = verifier.commit(witness_commitment[1]);
-
-        // Apply the constraints
-        Self::constrain_greater_than_eq(a_var, b_var, &mut verifier);
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
     }
 }
 
@@ -468,7 +353,7 @@ impl<const D: usize> LessThanGadget<D> {
     /// Compute the boolean a < b; returns 1 if true, otherwise 0
     pub fn less_than<L, CS>(a: L, b: L, cs: &mut CS) -> LinearCombination
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         let a_geq_b = GreaterThanEqGadget::<D>::greater_than_eq(a, b, cs);
@@ -478,14 +363,13 @@ impl<const D: usize> LessThanGadget<D> {
     /// Constrain a to be less than b
     pub fn constrain_less_than<L, CS>(a: L, b: L, cs: &mut CS)
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         let lt_result = Self::less_than(a, b, cs);
         cs.constrain(Variable::One() - lt_result);
     }
 }
-
 /// A multiprover variant of the GreaterThanEqGadget
 ///
 /// `D` is the bitlength of the input values
@@ -499,8 +383,12 @@ pub struct MultiproverGreaterThanEqGadget<
     _phantom: &'a PhantomData<(N, S)>,
 }
 
-impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
-    MultiproverGreaterThanEqGadget<'a, D, N, S>
+impl<
+        'a,
+        const D: usize,
+        N: 'a + MpcNetwork + Send + Clone,
+        S: 'a + SharedValueSource<Scalar> + Clone,
+    > MultiproverGreaterThanEqGadget<'a, D, N, S>
 {
     /// Constrain the relation a >= b
     pub fn constrain_greater_than_eq<L, CS>(
@@ -510,7 +398,7 @@ impl<'a, const D: usize, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Sc
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where
-        L: Into<MpcLinearCombination<N, S>> + Clone,
+        L: MpcLinearCombinationLike<N, S>,
         CS: MpcRandomizableConstraintSystem<'a, N, S>,
     {
         MultiproverGreaterThanEqZeroGadget::<'a, D, N, S>::constrain_greater_than_zero(
@@ -526,83 +414,84 @@ mod comparators_test {
     use std::{cmp, ops::Neg};
 
     use curve25519_dalek::scalar::Scalar;
+    use merlin::Transcript;
+    use mpc_bulletproof::{
+        r1cs::{ConstraintSystem, Prover},
+        PedersenGens,
+    };
     use rand_core::{OsRng, RngCore};
 
-    use crate::{errors::VerifierError, test_helpers::bulletproof_prove_and_verify};
+    use crate::traits::CircuitBaseType;
 
-    use super::{
-        EqZeroGadget, GreaterThanEqGadget, GreaterThanEqWitness, GreaterThanEqZeroGadget,
-        GreaterThanEqZeroWitness,
-    };
+    use super::{EqZeroGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget};
 
     /// Test the equal zero gadget
     #[test]
     fn test_eq_zero() {
+        // Build a constraint system
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
         // First tests with a non-zero value
         let mut rng = OsRng {};
-        let mut witness = Scalar::random(&mut rng);
-        let mut statement = false; /* non-zero */
+        let val = Scalar::random(&mut rng).commit_public(&mut prover);
 
-        let res = bulletproof_prove_and_verify::<EqZeroGadget>(witness, statement);
-        assert!(res.is_ok());
+        let res = EqZeroGadget::eq_zero(val, &mut prover);
+        assert_eq!(Scalar::zero(), prover.eval(&res.into()));
 
         // Now test with the zero value
-        witness = Scalar::zero();
-        statement = true; /* zero */
+        let val = Scalar::zero().commit_public(&mut prover);
+        let res = EqZeroGadget::eq_zero(val, &mut prover);
 
-        let res = bulletproof_prove_and_verify::<EqZeroGadget>(witness, statement);
-        assert!(res.is_ok());
+        assert_eq!(Scalar::one(), prover.eval(&res.into()));
     }
 
     /// Test the greater than zero constraint
     #[test]
     fn test_greater_than_zero() {
         let mut rng = OsRng {};
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
 
         // Test first with a positive value
-        let value1 = Scalar::from(rng.next_u64());
-        let witness = GreaterThanEqZeroWitness { val: value1 };
-
-        bulletproof_prove_and_verify::<GreaterThanEqZeroGadget<64 /* bitlength */>>(witness, ())
-            .unwrap();
+        let value1 = Scalar::from(rng.next_u64()).commit_public(&mut prover);
+        let res = GreaterThanEqZeroGadget::<64 /* bits */>::greater_than_zero(value1, &mut prover);
+        assert_eq!(Scalar::one(), prover.eval(&res.into()));
 
         // Test with a negative value
-        let value2 = value1.neg();
-        let witness = GreaterThanEqZeroWitness { val: value2 };
-        assert!(matches!(
-            bulletproof_prove_and_verify::<GreaterThanEqZeroGadget<64 /* bitlength */>>(
-                witness,
-                ()
-            ),
-            Err(VerifierError::R1CS(_))
-        ));
+        let value2 = Scalar::from(rng.next_u64())
+            .neg()
+            .commit_public(&mut prover);
+        let res = GreaterThanEqZeroGadget::<64 /* bits */>::greater_than_zero(value2, &mut prover);
+        assert_eq!(Scalar::zero(), prover.eval(&res.into()));
     }
 
     /// Test the greater than or equal to constraint
     #[test]
     fn test_greater_than_eq() {
         let mut rng = OsRng {};
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
         let a = rng.next_u64();
         let b = rng.next_u64();
 
-        let max = Scalar::from(cmp::max(a, b));
-        let min = Scalar::from(cmp::min(a, b));
+        let max = Scalar::from(cmp::max(a, b)).commit_public(&mut prover);
+        let min = Scalar::from(cmp::min(a, b)).commit_public(&mut prover);
 
-        // Test first with a valid witness
-        let witness = GreaterThanEqWitness { a: max, b: min };
-        bulletproof_prove_and_verify::<GreaterThanEqGadget<64 /* bitlength */>>(witness, ())
-            .unwrap();
+        // Test with a > b = false
+        let res = GreaterThanEqGadget::<64 /* bits */>::greater_than_eq(min, max, &mut prover);
+        assert_eq!(Scalar::zero(), prover.eval(&res.into()));
 
         // Test with equal values
-        let witness = GreaterThanEqWitness { a: max, b: max };
-        bulletproof_prove_and_verify::<GreaterThanEqGadget<64 /* bitlength */>>(witness, ())
-            .unwrap();
+        let res = GreaterThanEqGadget::<64 /* bits */>::greater_than_eq(min, min, &mut prover);
+        assert_eq!(Scalar::one(), prover.eval(&res.into()));
 
-        // Test with an invalid witness
-        let witness = GreaterThanEqWitness { a: min, b: max };
-        assert!(matches!(
-            bulletproof_prove_and_verify::<GreaterThanEqGadget<64 /* bitlength */>>(witness, ()),
-            Err(VerifierError::R1CS(_))
-        ));
+        // Test with a > b = true
+        let res = GreaterThanEqGadget::<64 /* bits */>::greater_than_eq(max, min, &mut prover);
+        assert_eq!(Scalar::one(), prover.eval(&res.into()));
     }
 }

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -1,21 +1,17 @@
 //! Implements the ZK gadgetry for ElGamal encryption
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-use crypto::elgamal::ElGamalCiphertext;
+use circuit_macros::circuit_type;
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use lazy_static::lazy_static;
 use mpc_bulletproof::{
-    r1cs::{
-        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
-        Variable, Verifier,
-    },
+    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::R1CSError,
-    BulletproofGens,
 };
-use rand_core::OsRng;
+use rand_core::{CryptoRng, RngCore};
 
-use crate::{
-    errors::{ProverError, VerifierError},
-    CommitPublic, CommitVerifier, CommitWitness, SingleProverCircuit,
+use crate::traits::{
+    BaseType, CircuitBaseType, CircuitCommitmentType, CircuitVarType, LinearCombinationLike,
 };
 
 use super::arithmetic::PrivateExpGadget;
@@ -42,267 +38,39 @@ impl<const SCALAR_BITS: usize> ElGamalGadget<SCALAR_BITS> {
         plaintext: L,
         pub_key: L,
         cs: &mut CS,
-    ) -> Result<(LinearCombination, LinearCombination), R1CSError>
+    ) -> Result<ElGamalCiphertextVar<LinearCombination>, R1CSError>
     where
-        L: Into<LinearCombination> + Clone,
+        L: LinearCombinationLike,
         CS: RandomizableConstraintSystem,
     {
         // Take the generator raised to the randomness, so that the secret key holder may
         // reconstruct the shared secret
-        let ciphertext1 = PrivateExpGadget::<SCALAR_BITS>::exp_private_fixed_base(
+        let partial_shared_secret = PrivateExpGadget::<SCALAR_BITS>::exp_private_fixed_base(
             generator,
             randomness.clone(),
             cs,
         )?;
 
         // Raise the public key to the randomness and use this to encrypt the value
-        let partial_shared_secret =
-            PrivateExpGadget::<SCALAR_BITS>::exp_private(pub_key, randomness, cs)?;
+        let shared_secret = PrivateExpGadget::<SCALAR_BITS>::exp_private(pub_key, randomness, cs)?;
 
         // Blind the plaintext using the shared secret
-        let (_, _, blinded_plaintext) = cs.multiply(partial_shared_secret, plaintext.into());
-
-        Ok((ciphertext1, blinded_plaintext.into()))
-    }
-}
-
-/// An ElGamal ciphertext that has been allocated in a constraint system
-#[derive(Copy, Clone, Debug)]
-pub struct ElGamalCiphertextVar {
-    /// The shared secret; the generator raised to the randomness
-    pub partial_shared_secret: Variable,
-    /// The encrypted value; the pubkey raised to the randomness, multiplied with the message
-    pub encrypted_message: Variable,
-}
-
-/// An ElGamal ciphertext that has been committed to by a prover
-#[derive(Clone, Debug)]
-pub struct ElGamalCiphertextCommitment {
-    /// The shared secret; the generator raised to the randomness
-    pub partial_shared_secret: CompressedRistretto,
-    /// The encrypted value; the pubkey raised to the randomness, multiplied with the message
-    pub encrypted_message: CompressedRistretto,
-}
-
-impl CommitWitness for ElGamalCiphertext {
-    type VarType = ElGamalCiphertextVar;
-    type CommitType = ElGamalCiphertextCommitment;
-    type ErrorType = ();
-
-    fn commit_witness<R: rand_core::RngCore + rand_core::CryptoRng>(
-        &self,
-        rng: &mut R,
-        prover: &mut Prover,
-    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
-        let (partial_shared_secret_comm, partial_shared_secret_var) =
-            prover.commit(self.partial_shared_secret, Scalar::random(rng));
-        let (encrypted_message_comm, encrypted_message_var) =
-            prover.commit(self.encrypted_message, Scalar::random(rng));
-
-        Ok((
-            ElGamalCiphertextVar {
-                partial_shared_secret: partial_shared_secret_var,
-                encrypted_message: encrypted_message_var,
-            },
-            ElGamalCiphertextCommitment {
-                partial_shared_secret: partial_shared_secret_comm,
-                encrypted_message: encrypted_message_comm,
-            },
-        ))
-    }
-}
-
-impl CommitPublic for ElGamalCiphertext {
-    type VarType = ElGamalCiphertextVar;
-    type ErrorType = (); // Does not error
-
-    fn commit_public<CS: RandomizableConstraintSystem>(
-        &self,
-        cs: &mut CS,
-    ) -> Result<Self::VarType, Self::ErrorType> {
-        let partial_shared_secret_var = self.partial_shared_secret.commit_public(cs).unwrap();
-        let encrypted_message_var = self.encrypted_message.commit_public(cs).unwrap();
-
+        let (_, _, blinded_plaintext) = cs.multiply(shared_secret, plaintext.into());
         Ok(ElGamalCiphertextVar {
-            partial_shared_secret: partial_shared_secret_var,
-            encrypted_message: encrypted_message_var,
+            partial_shared_secret,
+            encrypted_message: blinded_plaintext.into(),
         })
     }
 }
 
-impl CommitVerifier for ElGamalCiphertextCommitment {
-    type VarType = ElGamalCiphertextVar;
-    type ErrorType = ();
-
-    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
-        let partial_shared_secret_var = verifier.commit(self.partial_shared_secret);
-        let encrypted_message_var = verifier.commit(self.encrypted_message);
-
-        Ok(ElGamalCiphertextVar {
-            partial_shared_secret: partial_shared_secret_var,
-            encrypted_message: encrypted_message_var,
-        })
-    }
-}
-
-/// A witness for the ElGamal encryption circuit; containing the randomness and the plaintext
-#[derive(Clone, Debug)]
-pub struct ElGamalWitness {
-    /// The randomness used to create the shared secret
-    pub randomness: Scalar,
-    /// The plaintext message encrypted under the key
-    pub plaintext: Scalar,
-}
-
-/// A statement for the ElGamal encryption circuit; holds the group parameterization and the
-/// expected ciphertext
-#[derive(Clone, Debug)]
-pub struct ElGamalStatement {
-    /// The public key that the value is encrypted under
-    pub pub_key: Scalar,
-    /// The generator of the group that the circuit is defined over
-    pub generator: Scalar,
-    /// The expected result of encrypting the secret under the pubkey
-    pub expected_ciphertext: (Scalar, Scalar),
-}
-
-/// An ElGamal witness that has been allocated within a constraint system
-#[derive(Clone, Debug)]
-pub struct ElGamalWitnessVar {
-    /// The randomness used to create the shared secret
-    pub randomness: Variable,
-    /// The plaintext message encrypted under the key
-    pub plaintext: Variable,
-}
-
-/// A commitment to an ElGamal witness
-#[derive(Clone, Debug)]
-pub struct ElGamalWitnessCommitment {
-    /// The randomness used to create the shared secret
-    pub randomness: CompressedRistretto,
-    /// The plaintext message encrypted under the key
-    pub plaintext: CompressedRistretto,
-}
-
-impl CommitWitness for ElGamalWitness {
-    type CommitType = ElGamalWitnessCommitment;
-    type VarType = ElGamalWitnessVar;
-    type ErrorType = ();
-
-    fn commit_witness<R: rand_core::RngCore + rand_core::CryptoRng>(
-        &self,
-        rng: &mut R,
-        prover: &mut Prover,
-    ) -> Result<(Self::VarType, Self::CommitType), Self::ErrorType> {
-        let (randomness_comm, randomness_var) = prover.commit(self.randomness, Scalar::random(rng));
-        let (plaintext_comm, plaintext_var) = prover.commit(self.plaintext, Scalar::random(rng));
-
-        Ok((
-            ElGamalWitnessVar {
-                randomness: randomness_var,
-                plaintext: plaintext_var,
-            },
-            ElGamalWitnessCommitment {
-                randomness: randomness_comm,
-                plaintext: plaintext_comm,
-            },
-        ))
-    }
-}
-
-impl CommitVerifier for ElGamalWitnessCommitment {
-    type VarType = ElGamalWitnessVar;
-    type ErrorType = ();
-
-    fn commit_verifier(&self, verifier: &mut Verifier) -> Result<Self::VarType, Self::ErrorType> {
-        let randomness_var = verifier.commit(self.randomness);
-        let plaintext_var = verifier.commit(self.plaintext);
-
-        Ok(ElGamalWitnessVar {
-            randomness: randomness_var,
-            plaintext: plaintext_var,
-        })
-    }
-}
-
-impl<const SCALAR_BITS: usize> SingleProverCircuit for ElGamalGadget<SCALAR_BITS> {
-    type Witness = ElGamalWitness;
-    type WitnessCommitment = ElGamalWitnessCommitment;
-    type Statement = ElGamalStatement;
-
-    const BP_GENS_CAPACITY: usize = 1024;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Self::WitnessCommitment, R1CSProof), ProverError> {
-        // Commit to the witness
-        let mut rng = OsRng {};
-        let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover).unwrap();
-
-        // Commit to the statement
-        let pub_key_var = prover.commit_public(statement.pub_key);
-        let expected_ciphertext_var = (
-            prover.commit_public(statement.expected_ciphertext.0),
-            prover.commit_public(statement.expected_ciphertext.1),
-        );
-
-        // Apply the constraints
-        let res = Self::encrypt(
-            statement.generator,
-            witness_var.randomness,
-            witness_var.plaintext,
-            pub_key_var,
-            &mut prover,
-        )
-        .map_err(ProverError::R1CS)?;
-
-        prover.constrain(res.0 - expected_ciphertext_var.0);
-        prover.constrain(res.1 - expected_ciphertext_var.1);
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((witness_comm, proof))
-    }
-
-    fn verify(
-        witness_commitment: Self::WitnessCommitment,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the witness
-        let witness_var = witness_commitment.commit_verifier(&mut verifier).unwrap();
-
-        // Commit to the statement
-        let pub_key_var = verifier.commit_public(statement.pub_key);
-        let expected_ciphertext_var = (
-            verifier.commit_public(statement.expected_ciphertext.0),
-            verifier.commit_public(statement.expected_ciphertext.1),
-        );
-
-        // Apply the constraints
-        let res = Self::encrypt(
-            statement.generator,
-            witness_var.randomness,
-            witness_var.plaintext,
-            pub_key_var,
-            &mut verifier,
-        )
-        .map_err(VerifierError::R1CS)?;
-
-        verifier.constrain(res.0 - expected_ciphertext_var.0);
-        verifier.constrain(res.1 - expected_ciphertext_var.1);
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
+/// The result of creating an ElGamal encryption
+#[circuit_type(singleprover_circuit)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ElGamalCiphertext {
+    /// The parital shared secret; the generator raised to the randomness
+    pub partial_shared_secret: Scalar,
+    /// The encrypted value; the pubkey raised to the randomness, multiplied with the message
+    pub encrypted_message: Scalar,
 }
 
 #[cfg(test)]
@@ -310,16 +78,18 @@ mod elgamal_tests {
     use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
     use curve25519_dalek::scalar::Scalar;
     use integration_helpers::mpc_network::field::get_ristretto_group_modulus;
+    use merlin::Transcript;
+    use mpc_bulletproof::{r1cs::Prover, PedersenGens};
     use num_bigint::BigUint;
     use rand_core::{OsRng, RngCore};
 
-    use crate::test_helpers::bulletproof_prove_and_verify;
+    use crate::{traits::CircuitBaseType, zk_gadgets::comparators::EqGadget};
 
-    use super::{ElGamalGadget, ElGamalStatement, ElGamalWitness};
+    use super::{ElGamalCiphertext, ElGamalGadget};
 
     /// Test the ElGamal encryption gadget on a valid ciphertext
     #[test]
-    fn test_valid_ciphertext() {
+    fn test_encrypt() {
         // Create a random cipher
         let mut rng = OsRng {};
         let randomness_bitlength = 16;
@@ -341,56 +111,35 @@ mod elgamal_tests {
 
         let ciphertext_1 = generator_bigint.modpow(&randomness_bigint, &field_mod);
         let partial_shared_secret = pubkey_bigint.modpow(&randomness_bigint, &field_mod);
-        let ciphertext_2 = (partial_shared_secret * plaintext_bigint) % &field_mod;
+        let ciphertext_2 = (&partial_shared_secret * &plaintext_bigint) % &field_mod;
 
-        // Prove the statement
-        let witness = ElGamalWitness {
-            randomness,
-            plaintext,
+        let expected_ciphertext = ElGamalCiphertext {
+            partial_shared_secret: biguint_to_scalar(&ciphertext_1),
+            encrypted_message: biguint_to_scalar(&ciphertext_2),
         };
-        let statement = ElGamalStatement {
-            pub_key: pubkey,
+
+        // Create a constraint system
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        let randomness_var = randomness.commit_public(&mut prover);
+        let plaintext_var = plaintext.commit_public(&mut prover);
+        let pubkey_var = pubkey.commit_public(&mut prover);
+
+        let res = ElGamalGadget::<16 /* SCALAR_BITS */>::encrypt(
             generator,
-            expected_ciphertext: (
-                biguint_to_scalar(&ciphertext_1),
-                biguint_to_scalar(&ciphertext_2),
-            ),
-        };
+            randomness_var,
+            plaintext_var,
+            pubkey_var,
+            &mut prover,
+        )
+        .unwrap();
 
-        let res = bulletproof_prove_and_verify::<ElGamalGadget<16>>(witness, statement);
-        assert!(res.is_ok());
-    }
+        // Check that the result equals the expected
+        let expected = expected_ciphertext.commit_public(&mut prover);
 
-    /// Tests the ElGamal gadget with an invalid ciphertext
-    #[test]
-    fn test_invalid_ciphertext() {
-        // Create a random cipher
-        let mut rng = OsRng {};
-        let randomness_bitlength = 16;
-        let mut randomness_bytes = vec![0u8; randomness_bitlength / 8];
-        rng.fill_bytes(&mut randomness_bytes);
-
-        let randomness = biguint_to_scalar(&BigUint::from_bytes_le(&randomness_bytes));
-        let plaintext = Scalar::random(&mut rng);
-
-        let pubkey = Scalar::random(&mut rng);
-        let generator = Scalar::from(3u64);
-
-        // Generate the expected encryption
-        let expected_ciphertext = (Scalar::random(&mut rng), Scalar::random(&mut rng));
-
-        // Prove the statement
-        let witness = ElGamalWitness {
-            randomness,
-            plaintext,
-        };
-        let statement = ElGamalStatement {
-            pub_key: pubkey,
-            generator,
-            expected_ciphertext,
-        };
-
-        let res = bulletproof_prove_and_verify::<ElGamalGadget<16>>(witness, statement);
-        assert!(res.is_err());
+        EqGadget::constrain_eq(res, expected, &mut prover);
+        assert!(prover.constraints_satisfied());
     }
 }

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -95,15 +95,6 @@ impl FixedPoint {
         }
     }
 
-    /// Commit to the fixed point variable as a public input in a given constraint system
-    pub fn commit_public<CS: RandomizableConstraintSystem>(
-        &self,
-        cs: &mut CS,
-    ) -> FixedPointVar<Variable> {
-        let repr = cs.commit_public(self.repr);
-        FixedPointVar { repr }
-    }
-
     /// Return the represented value as an f64
     pub fn to_f64(&self) -> f64 {
         let mut dec = BigDecimal::from(scalar_to_bigint(&self.repr));

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -251,11 +251,7 @@ pub(crate) mod merkle_test {
     {
         let mut res = Vec::with_capacity(HEIGHT);
         for _ in 0..HEIGHT {
-            res.push(match leaf_index % 2 {
-                val @ 0..=1 => Scalar::from(val as u64),
-                _ => unreachable!("impossible evaluation mod 2"),
-            });
-
+            res.push(Scalar::from((leaf_index % 2) as u64));
             leaf_index >>= 1;
         }
 

--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -2,12 +2,10 @@
 pub mod arithmetic;
 pub mod bits;
 pub mod comparators;
-pub mod edwards;
 pub mod elgamal;
 pub mod fixed_point;
 pub mod gates;
 pub mod merkle;
-pub mod nonnative;
 pub mod poseidon;
 pub mod select;
 pub mod wallet_operations;

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -3,37 +3,23 @@
 
 use std::marker::PhantomData;
 
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use curve25519_dalek::scalar::Scalar;
 use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{
-        ConstraintSystem, LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem,
-        Variable, Verifier,
-    },
-    r1cs_mpc::{
-        MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable, R1CSError,
-        SharedR1CSProof,
-    },
-    BulletproofGens,
+    r1cs::{LinearCombination, RandomizableConstraintSystem},
+    r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, MpcVariable, R1CSError},
 };
-use mpc_ristretto::{
-    authenticated_ristretto::AuthenticatedCompressedRistretto,
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
-};
-use rand_core::OsRng;
+use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
 
 use crate::{
-    errors::{MpcError, ProverError, VerifierError},
-    mpc::SharedFabric,
-    mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    MultiProverCircuit, SingleProverCircuit,
+    errors::ProverError, mpc::SharedFabric, mpc_gadgets::poseidon::PoseidonSpongeParameters,
 };
 
 use super::arithmetic::{ExpGadget, MultiproverExpGadget};
 
-/**
- * Single prover gadget
- */
+// -----------------------
+// | Singleprover Gadget |
+// -----------------------
 
 /// A hash gadget that applies a Poseidon hash function to the given constraint system
 ///
@@ -268,94 +254,9 @@ impl PoseidonHashGadget {
     }
 }
 
-/// The witness input to a Poseidon pre-image argument of knowledge
-///
-/// This circuit encodes the statement that the prover knows a correct
-/// Poseidon pre-image to the given hash output
-#[derive(Clone, Debug)]
-pub struct PoseidonGadgetWitness {
-    /// Preimage
-    pub preimage: Vec<Scalar>,
-}
-
-/// The statement variable (public variable) for the argument, consisting
-/// of the expected hash output and the hash parameters
-#[derive(Clone, Debug)]
-pub struct PoseidonGadgetStatement {
-    /// Expected output of applying the Poseidon hash to the preimage
-    pub expected_out: Scalar,
-    /// The hash parameters that parameterize the Poseidon permutation
-    pub params: PoseidonSpongeParameters,
-}
-
-impl SingleProverCircuit for PoseidonHashGadget {
-    type Witness = PoseidonGadgetWitness;
-    type WitnessCommitment = Vec<CompressedRistretto>;
-    type Statement = PoseidonGadgetStatement;
-
-    const BP_GENS_CAPACITY: usize = 2048;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: Prover,
-    ) -> Result<(Vec<CompressedRistretto>, R1CSProof), ProverError> {
-        // Commit to the preimage
-        let mut rng = OsRng {};
-        let (preimage_commits, preimage_vars): (Vec<CompressedRistretto>, Vec<Variable>) = witness
-            .preimage
-            .into_iter()
-            .map(|val| prover.commit(val, Scalar::random(&mut rng)))
-            .unzip();
-
-        // Commit publicly to the expected result
-        let out_var = prover.commit_public(statement.expected_out);
-
-        // Apply the constraints to the proof system
-        let mut hasher = PoseidonHashGadget::new(statement.params);
-        hasher
-            .hash(&preimage_vars, out_var, &mut prover)
-            .map_err(ProverError::R1CS)?;
-
-        // Prove the statement
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((preimage_commits, proof))
-    }
-
-    fn verify(
-        witness_commitments: Vec<CompressedRistretto>,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Commit to the preimage from the existing witness commitments
-        let witness_vars = witness_commitments
-            .iter()
-            .map(|comm| verifier.commit(*comm))
-            .collect_vec();
-
-        // Commit to the public expected output
-        let output_var = verifier.commit_public(statement.expected_out);
-
-        // Build a hasher and apply the constraints
-        let mut hasher = PoseidonHashGadget::new(statement.params);
-        hasher
-            .hash(&witness_vars, output_var, &mut verifier)
-            .map_err(VerifierError::R1CS)?;
-
-        // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        verifier
-            .verify(&proof, &bp_gens)
-            .map_err(VerifierError::R1CS)
-    }
-}
-
-/**
- * Multiprover Gadget
- */
+// ----------------------
+// | Multiprover Gadget |
+// ----------------------
 
 /// A hash gadget that applies a Poseidon hash function to the given constraint system
 ///
@@ -381,7 +282,7 @@ pub struct MultiproverPoseidonHashGadget<
     _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
+impl<'a, N: 'a + MpcNetwork + Send + Clone, S: 'a + SharedValueSource<Scalar> + Clone>
     MultiproverPoseidonHashGadget<'a, N, S>
 {
     /// Construct a new hash gadget with the given parameterization
@@ -608,71 +509,6 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
     }
 }
 
-/// The witness type for the multiprover Poseidon gadget
-#[derive(Clone, Debug)]
-pub struct MultiproverPoseidonWitness<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
-    /// The preimage (input) to the hash function
-    pub preimage: Vec<AuthenticatedScalar<N, S>>,
-}
-
-impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> MultiProverCircuit<'a, N, S>
-    for MultiproverPoseidonHashGadget<'a, N, S>
-{
-    /// Witness is as the witness in the single prover case, except for the facts that hte underlying scalar
-    /// field is the authenticated and shared Ristretto scalar field.
-    ///
-    /// The Statement, on the other hand, is entirely public; and therefore the same type as the single prover.
-    type Witness = MultiproverPoseidonWitness<N, S>;
-    type WitnessCommitment = Vec<AuthenticatedCompressedRistretto<N, S>>;
-    type Statement = PoseidonGadgetStatement;
-
-    const BP_GENS_CAPACITY: usize = 2048;
-
-    fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
-        mut prover: MpcProver<'a, '_, '_, N, S>,
-        fabric: SharedFabric<N, S>,
-    ) -> Result<
-        (
-            Vec<AuthenticatedCompressedRistretto<N, S>>,
-            SharedR1CSProof<N, S>,
-        ),
-        ProverError,
-    > {
-        // Commit to the hash input and expected output
-        let mut rng = OsRng {};
-        let blinders = (0..witness.preimage.len())
-            .map(|_| Scalar::random(&mut rng))
-            .collect_vec();
-
-        let (witness_commits, witness_vars) = prover
-            .batch_commit_preshared(&witness.preimage, &blinders)
-            .map_err(|err| ProverError::Mpc(MpcError::SharingError(err.to_string())))?;
-
-        let (_, out_var) = prover.commit_public(statement.expected_out);
-
-        // Create a hasher and apply the constraints
-        let mut hasher = MultiproverPoseidonHashGadget::new(statement.params, fabric);
-        hasher.hash(&witness_vars, &out_var, &mut prover)?;
-
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
-
-        Ok((witness_commits, proof))
-    }
-
-    fn verify(
-        witness_commitments: Vec<CompressedRistretto>,
-        statement: Self::Statement,
-        proof: R1CSProof,
-        verifier: Verifier,
-    ) -> Result<(), VerifierError> {
-        // Forward to the single prover gadget
-        PoseidonHashGadget::verify(witness_commitments, statement, proof, verifier)
-    }
-}
-
 #[cfg(test)]
 mod single_prover_test {
     use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
@@ -682,13 +518,13 @@ mod single_prover_test {
     };
     use curve25519_dalek::scalar::Scalar;
     use itertools::Itertools;
+    use merlin::Transcript;
+    use mpc_bulletproof::{r1cs::Prover, PedersenGens};
     use rand_core::{OsRng, RngCore};
 
-    use crate::{
-        mpc_gadgets::poseidon::PoseidonSpongeParameters, test_helpers::bulletproof_prove_and_verify,
-    };
+    use crate::{mpc_gadgets::poseidon::PoseidonSpongeParameters, traits::CircuitBaseType};
 
-    use super::{PoseidonGadgetStatement, PoseidonGadgetWitness, PoseidonHashGadget};
+    use super::PoseidonHashGadget;
 
     #[test]
     fn test_single_prover_hash() {
@@ -707,19 +543,25 @@ mod single_prover_test {
 
         let expected_result: DalekRistrettoField =
             arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0];
-
         let expected_scalar = prime_field_to_scalar(&expected_result);
 
-        bulletproof_prove_and_verify::<PoseidonHashGadget>(
-            PoseidonGadgetWitness {
-                preimage: random_elems.into_iter().map(Scalar::from).collect_vec(),
-            },
-            PoseidonGadgetStatement {
-                expected_out: expected_scalar,
-                params: PoseidonSpongeParameters::default(),
-            },
-        )
-        .unwrap();
+        // Build a constraint system
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        let preimage_vars = random_elems
+            .into_iter()
+            .map(|elem| elem.commit_public(&mut prover))
+            .collect_vec();
+        let expected_out_var = expected_scalar.commit_public(&mut prover);
+
+        let mut hasher = PoseidonHashGadget::new(PoseidonSpongeParameters::default());
+        hasher
+            .hash(&preimage_vars, expected_out_var, &mut prover)
+            .unwrap();
+
+        assert!(prover.constraints_satisfied());
     }
 
     /// Tests the case in which the pre-image is not correct
@@ -730,16 +572,22 @@ mod single_prover_test {
         let random_elems = (0..n).map(|_| Scalar::random(&mut rng)).collect_vec();
         let random_expected = Scalar::random(&mut rng);
 
-        let res = bulletproof_prove_and_verify::<PoseidonHashGadget>(
-            PoseidonGadgetWitness {
-                preimage: random_elems,
-            },
-            PoseidonGadgetStatement {
-                expected_out: random_expected,
-                params: PoseidonSpongeParameters::default(),
-            },
-        );
+        // Build a constraint system
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"test");
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
 
-        assert!(res.is_err());
+        let preimage_vars = random_elems
+            .into_iter()
+            .map(|elem| elem.commit_public(&mut prover))
+            .collect_vec();
+        let expected_out_var = random_expected.commit_public(&mut prover);
+
+        let mut hasher = PoseidonHashGadget::new(PoseidonSpongeParameters::default());
+        hasher
+            .hash(&preimage_vars, expected_out_var, &mut prover)
+            .unwrap();
+
+        assert!(!prover.constraints_satisfied());
     }
 }

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -1,16 +1,18 @@
 //! Groups logic for computing wallet commitments and nullifiers inside of a circuit
 
+use itertools::Itertools;
 use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
+    r1cs::{LinearCombination, RandomizableConstraintSystem},
     r1cs_mpc::R1CSError,
 };
 
 use crate::{
     mpc_gadgets::poseidon::PoseidonSpongeParameters,
-    types::{balance::BalanceVar, fee::FeeVar, order::OrderVar, wallet::WalletSecretShareVar},
+    traits::{CircuitVarType, LinearCombinationLike},
+    types::wallet::WalletShareVar,
 };
 
-use super::{comparators::EqVecGadget, poseidon::PoseidonHashGadget};
+use super::poseidon::PoseidonHashGadget;
 
 // ------------------------
 // | Public State Gadgets |
@@ -29,8 +31,11 @@ where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// Compute the commitment to the private wallet shares
-    pub fn compute_private_commitment<CS: RandomizableConstraintSystem>(
-        private_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub fn compute_private_commitment<
+        L: LinearCombinationLike,
+        CS: RandomizableConstraintSystem,
+    >(
+        private_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
         // Create a new hash gadget
@@ -38,7 +43,7 @@ where
         let mut hasher = PoseidonHashGadget::new(hash_params);
 
         // Serialize the wallet and hash it into the hasher's state
-        let serialized_wallet: Vec<LinearCombination> = private_wallet_share.into();
+        let serialized_wallet: Vec<L> = private_wallet_share.to_vars();
         hasher.batch_absorb(&serialized_wallet, cs)?;
 
         // Squeeze an element out of the state
@@ -46,8 +51,11 @@ where
     }
 
     /// Compute the commitment to the full wallet given a commitment to the private shares
-    pub fn compute_wallet_commitment_from_private<CS: RandomizableConstraintSystem>(
-        blinded_public_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub fn compute_wallet_commitment_from_private<
+        L: LinearCombinationLike,
+        CS: RandomizableConstraintSystem,
+    >(
+        blinded_public_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         private_commitment: LinearCombination,
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
@@ -57,16 +65,25 @@ where
 
         // The public shares are added directly to a sponge H(private_commit || public shares)
         let mut hash_input = vec![private_commitment];
-        hash_input.append(&mut blinded_public_wallet_share.into());
+        hash_input.append(
+            &mut blinded_public_wallet_share
+                .to_vars()
+                .into_iter()
+                .map(|var| var.into())
+                .collect_vec(),
+        );
 
         hasher.batch_absorb(&hash_input, cs)?;
         hasher.squeeze(cs)
     }
 
     /// Compute the full commitment of a wallet's shares given both the public and private shares
-    pub fn compute_wallet_share_commitment<CS: RandomizableConstraintSystem>(
-        public_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        private_wallet_share: WalletSecretShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub fn compute_wallet_share_commitment<
+        L: LinearCombinationLike,
+        CS: RandomizableConstraintSystem,
+    >(
+        public_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
         // First compute the private half, then absorb in the public
@@ -95,146 +112,5 @@ impl NullifierGadget {
 
         hasher.batch_absorb(&[share_commitment, wallet_blinder], cs)?;
         hasher.squeeze(cs)
-    }
-}
-
-// -----------------------------
-// | Wallet Comparison Gadgets |
-// -----------------------------
-
-/// Compares two balances
-pub struct BalanceComparatorGadget;
-impl BalanceComparatorGadget {
-    /// Compare two balances returning 1 if they are equal, 0 otherwise
-    pub fn compare_eq<L1, L2, CS>(b1: BalanceVar<L1>, b2: BalanceVar<L2>, cs: &mut CS) -> Variable
-    where
-        L1: Into<LinearCombination> + Clone,
-        L2: Into<LinearCombination> + Clone,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::eq_vec(
-            &[b1.mint.into(), b1.amount.into()],
-            &[b2.mint.into(), b2.amount.into()],
-            cs,
-        )
-    }
-
-    /// Constrain two balances to be equal
-    pub fn constrain_eq<L, CS>(b1: BalanceVar<L>, b2: BalanceVar<L>, cs: &mut CS)
-    where
-        L: Into<LinearCombination> + Clone,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::constrain_eq_vec(&[b1.mint, b1.amount], &[b2.mint, b2.amount], cs);
-    }
-}
-
-/// Compares two orders
-pub struct OrderComparatorGadget;
-impl OrderComparatorGadget {
-    /// Compare two orders, returning 1 if they are equal, 0 otherwise
-    pub fn compare_eq<L1, L2, CS>(o1: OrderVar<L1>, o2: OrderVar<L2>, cs: &mut CS) -> Variable
-    where
-        L1: Into<LinearCombination>,
-        L2: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::eq_vec(
-            &[
-                o1.quote_mint.into(),
-                o1.base_mint.into(),
-                o1.side.into(),
-                o1.price.repr,
-                o1.amount.into(),
-                o1.timestamp.into(),
-            ],
-            &[
-                o2.quote_mint.into(),
-                o2.base_mint.into(),
-                o2.side.into(),
-                o2.price.repr,
-                o2.amount.into(),
-                o2.timestamp.into(),
-            ],
-            cs,
-        )
-    }
-
-    /// Constrain two orders to equal one another
-    pub fn constrain_eq<L, CS>(o1: OrderVar<L>, o2: OrderVar<L>, cs: &mut CS)
-    where
-        L: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::constrain_eq_vec(
-            &[
-                o1.quote_mint.into(),
-                o1.base_mint.into(),
-                o1.side.into(),
-                o1.price.repr,
-                o1.amount.into(),
-                o1.timestamp.into(),
-            ],
-            &[
-                o2.quote_mint.into(),
-                o2.base_mint.into(),
-                o2.side.into(),
-                o2.price.repr,
-                o2.amount.into(),
-                o2.timestamp.into(),
-            ],
-            cs,
-        )
-    }
-}
-
-/// Compares two fees
-pub struct FeeComparatorGadget;
-impl FeeComparatorGadget {
-    /// Compare two fees, returning 1 if they are equal, 0 otherwise
-    pub fn compare_eq<L1, L2, CS>(f1: FeeVar<L1>, f2: FeeVar<L2>, cs: &mut CS) -> Variable
-    where
-        L1: Into<LinearCombination>,
-        L2: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::eq_vec(
-            &[
-                f1.settle_key.into(),
-                f1.gas_addr.into(),
-                f1.gas_token_amount.into(),
-                f1.percentage_fee.repr,
-            ],
-            &[
-                f2.settle_key.into(),
-                f2.gas_addr.into(),
-                f2.gas_token_amount.into(),
-                f2.percentage_fee.repr,
-            ],
-            cs,
-        )
-    }
-
-    /// Constrain two fees to equal one another
-    pub fn constrain_eq<L, CS>(f1: FeeVar<L>, f2: FeeVar<L>, cs: &mut CS)
-    where
-        L: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
-        EqVecGadget::constrain_eq_vec(
-            &[
-                f1.settle_key.into(),
-                f1.gas_addr.into(),
-                f1.gas_token_amount.into(),
-                f1.percentage_fee.repr,
-            ],
-            &[
-                f2.settle_key.into(),
-                f2.gas_addr.into(),
-                f2.gas_token_amount.into(),
-                f2.percentage_fee.repr,
-            ],
-            cs,
-        )
     }
 }


### PR DESCRIPTION
### Purpose
This PR makes the necessary changes to the `zk-gadgets` and `zk-circuits` crates to use the new `circuit_type` macro to derive types.

### Testing
- Unit tests pass, though CI may not