### PR TITLE
circuits: zk-circuits: Add midpoint orders to `VALID MATCH MPC`

### DIFF
--- a/circuit-macros/src/circuit_type/multiprover_circuit_types.rs
+++ b/circuit-macros/src/circuit_type/multiprover_circuit_types.rs
@@ -33,6 +33,8 @@ const BASE_COMM_TYPE_ASSOCIATED_NAME: &str = "BaseCommitType";
 
 /// The `from_mpc_vars` method on the `MultiproverCircuitVariableType` trait
 const FROM_MPC_VARS_METHOD: &str = "from_mpc_vars";
+/// The `to_mpc_vars` method on the `MultiproverCircuitVariableType` trait
+const TO_MPC_VARS_METHOD: &str = "to_mpc_vars";
 /// The `from_mpc_commitments` method on the `MultiproverCircuitCommitmentType` trait
 const FROM_MPC_COMMS_METHOD: &str = "from_mpc_commitments";
 /// The `to_mpc_commitments` method on the `MultiproverCircuitCommitmentType` trait
@@ -175,6 +177,12 @@ fn build_multiprover_var_type_impl(var_type: &ItemStruct) -> TokenStream2 {
     let var_type_name = ident_with_generics(var_type.ident.clone(), impl_generics.clone());
 
     let mpc_variable_type: Path = parse_quote!(L);
+    let to_mpc_vars_method = build_serialize_method(
+        new_ident(TO_MPC_VARS_METHOD),
+        mpc_variable_type.clone(),
+        var_type,
+    );
+
     let from_mpc_vars_method = build_deserialize_method(
         new_ident(FROM_MPC_VARS_METHOD),
         mpc_variable_type,
@@ -186,6 +194,7 @@ fn build_multiprover_var_type_impl(var_type: &ItemStruct) -> TokenStream2 {
         impl #impl_generics #trait_name for #var_type_name
             #where_clause
         {
+            #to_mpc_vars_method
             #from_mpc_vars_method
         }
     };

--- a/circuits/src/mpc_circuits/match.rs
+++ b/circuits/src/mpc_circuits/match.rs
@@ -1,13 +1,15 @@
 //! Groups logic related to the match computation circuit
 
 use curve25519_dalek::scalar::Scalar;
-use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
+use mpc_ristretto::{
+    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
+};
 
 use crate::{
     errors::MpcError,
     mpc::SharedFabric,
     mpc_gadgets::comparators::min,
-    types::{order::AuthenticatedOrder, r#match::AuthenticatedMatchResult},
+    types::{order::AuthenticatedOrder, r#match::AuthenticatedMatchResult, AMOUNT_BITS},
     zk_gadgets::fixed_point::AuthenticatedFixedPoint,
 };
 
@@ -23,23 +25,21 @@ use crate::{
 pub fn compute_match<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     order1: &AuthenticatedOrder<N, S>,
     order2: &AuthenticatedOrder<N, S>,
+    amount1: &AuthenticatedScalar<N, S>,
+    amount2: &AuthenticatedScalar<N, S>,
+    price: &AuthenticatedFixedPoint<N, S>,
     fabric: SharedFabric<N, S>,
 ) -> Result<AuthenticatedMatchResult<N, S>, MpcError> {
     // Compute the amount and execution price that will be swapped if the orders match
-    let (min_index, min_base_amount) =
-        min::<32, _, _>(&order1.amount, &order2.amount, fabric.clone())?;
+    let (min_index, min_base_amount) = min::<AMOUNT_BITS, _, _>(amount1, amount2, fabric.clone())?;
 
     // The maximum of the two amounts minus the minimum of the two amounts
     let max_minus_min_amount =
         &order1.amount + &order2.amount - Scalar::from(2u64) * &min_base_amount;
 
-    // Compute execution price = (price1 + price2) / 2
-    let one_half = AuthenticatedFixedPoint::from_public_f32(0.5, fabric.clone());
-    let execution_price = &(&order1.price + &order2.price) * &one_half;
-
     // The amount of quote token exchanged
     // Round down to the nearest integer value
-    let quote_exchanged_fp = min_base_amount.clone() * &execution_price;
+    let quote_exchanged_fp = min_base_amount.clone() * price;
     let quote_exchanged = quote_exchanged_fp.as_integer(fabric)?;
 
     // Zero out the orders if any of the initial checks failed
@@ -49,7 +49,6 @@ pub fn compute_match<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
         quote_amount: quote_exchanged,
         base_amount: min_base_amount,
         direction: order1.side.clone(),
-        execution_price,
         max_minus_min_amount,
         min_amount_order_index: min_index,
     })

--- a/circuits/src/mpc_gadgets/comparators.rs
+++ b/circuits/src/mpc_gadgets/comparators.rs
@@ -21,10 +21,7 @@ use super::{
 pub fn less_than_zero<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     a: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<AuthenticatedScalar<N, S>, MpcError> {
     // Truncate the first 250 bits of the input
     let truncated = truncate::<250, _, _>(a, fabric.clone())?;
 
@@ -78,10 +75,7 @@ pub fn less_than<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scal
     a: &AuthenticatedScalar<N, S>,
     b: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<AuthenticatedScalar<N, S>, MpcError> {
     less_than_zero::<D, _, _>(&(a - b), fabric)
 }
 
@@ -92,10 +86,7 @@ pub fn less_than_equal<const D: usize, N: MpcNetwork + Send, S: SharedValueSourc
     a: &AuthenticatedScalar<N, S>,
     b: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<AuthenticatedScalar<N, S>, MpcError> {
     Ok(Scalar::one() - greater_than::<D, _, _>(a, b, fabric)?)
 }
 
@@ -106,10 +97,7 @@ pub fn greater_than<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<S
     a: &AuthenticatedScalar<N, S>,
     b: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<AuthenticatedScalar<N, S>, MpcError> {
     less_than_zero::<D, _, _>(&(b - a), fabric)
 }
 
@@ -120,10 +108,7 @@ pub fn greater_than_equal<const D: usize, N: MpcNetwork + Send, S: SharedValueSo
     a: &AuthenticatedScalar<N, S>,
     b: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<AuthenticatedScalar<N, S>, MpcError> {
     Ok(Scalar::one() - less_than::<D, _, _>(a, b, fabric)?)
 }
 
@@ -213,10 +198,7 @@ pub fn min<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     a: &AuthenticatedScalar<N, S>,
     b: &AuthenticatedScalar<N, S>,
     fabric: SharedFabric<N, S>,
-) -> Result<(AuthenticatedScalar<N, S>, AuthenticatedScalar<N, S>), MpcError>
-where
-    [(); D - 1]: Sized,
-{
+) -> Result<(AuthenticatedScalar<N, S>, AuthenticatedScalar<N, S>), MpcError> {
     let a_lt_b = less_than::<D, _, _>(a, b, fabric)?;
     Ok((
         Scalar::from(1u64) - a_lt_b.clone(),

--- a/circuits/src/types/match.rs
+++ b/circuits/src/types/match.rs
@@ -9,7 +9,6 @@ use crate::{
         MultiproverCircuitBaseType, MultiproverCircuitCommitmentType,
         MultiproverCircuitVariableType,
     },
-    zk_gadgets::fixed_point::FixedPoint,
     AuthenticatedLinkableCommitment,
 };
 
@@ -54,8 +53,6 @@ pub struct MatchResult {
     /// shrinking the size of the zero knowledge circuit. As well, they are computed during
     /// the course of the MPC, so it incurs no extra cost to include them in the witness
 
-    /// The execution price; the midpoint between two limit prices if they cross
-    pub execution_price: FixedPoint,
     /// The minimum amount of the two orders minus the maximum amount of the two orders.
     /// We include it here to tame some of the non-linearity of the zk circuit, i.e. we
     /// can shortcut some of the computation and implicitly constrain the match result

--- a/circuits/src/types/mod.rs
+++ b/circuits/src/types/mod.rs
@@ -13,6 +13,13 @@ pub mod order;
 pub mod transfers;
 pub mod wallet;
 
+// -------------
+// | Constants |
+// -------------
+
+/// The number of bits allowed in a balance or transaction "amount"
+pub(crate) const AMOUNT_BITS: usize = 64;
+
 // -----------------------------------------
 // | Serialization Deserialization Helpers |
 // -----------------------------------------

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -68,12 +68,13 @@ where
         let augmented_wallet = witness.private_secret_shares.clone() + unblinded_augmented_shares;
 
         // The mint that the wallet will receive if the order is matched
-        let mut receive_send_mint = CondSelectVectorGadget::select(
-            &[witness.order.quote_mint, witness.order.base_mint],
-            &[witness.order.base_mint, witness.order.quote_mint],
-            witness.order.side,
-            cs,
-        );
+        let mut receive_send_mint =
+            CondSelectVectorGadget::select::<_, _, Variable, LinearCombination, _>(
+                &[witness.order.quote_mint, witness.order.base_mint],
+                &[witness.order.base_mint, witness.order.quote_mint],
+                witness.order.side,
+                cs,
+            );
         let receive_mint = receive_send_mint.remove(0);
         let send_mint = receive_send_mint.remove(0);
 

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -38,18 +38,19 @@ where
         cs: &mut CS,
     ) {
         // Select the balances received by each party
-        let mut party0_party1_received = CondSelectVectorGadget::select(
-            &[
-                witness.match_res.quote_amount,
-                witness.match_res.base_amount,
-            ],
-            &[
-                witness.match_res.base_amount,
-                witness.match_res.quote_amount,
-            ],
-            witness.match_res.direction,
-            cs,
-        );
+        let mut party0_party1_received =
+            CondSelectVectorGadget::select::<_, _, Variable, LinearCombination, _>(
+                &[
+                    witness.match_res.quote_amount,
+                    witness.match_res.base_amount,
+                ],
+                &[
+                    witness.match_res.base_amount,
+                    witness.match_res.quote_amount,
+                ],
+                witness.match_res.direction,
+                cs,
+            );
 
         let party0_received_amount = party0_party1_received.remove(0);
         let party1_received_amount = party0_party1_received.remove(0);
@@ -356,7 +357,6 @@ mod test {
             quote_amount: 5,
             base_amount: 1,
             direction: 0, /* party0 buys base */
-            execution_price: FixedPoint::from(5.),
             max_minus_min_amount: 0,
             min_amount_order_index: 0,
         };

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -182,7 +182,7 @@ where
             cs.multiply(external_transfer.amount.into(), external_transfer_not_zero);
 
         // The term added to the balance matching the external transfer mint
-        let external_transfer_term = CondSelectGadget::select::<LinearCombination, _, _>(
+        let external_transfer_term: LinearCombination = CondSelectGadget::select(
             -transfer_amount,
             transfer_amount.into(),
             external_transfer.direction,

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -158,7 +158,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         let recursive_plus_one = x * recursive_doubled;
 
         // Mux between the two results depending on whether the current exponent is odd or even
-        let odd_bit_selection =
+        let odd_bit_selection: LinearCombination =
             CondSelectGadget::select(recursive_plus_one, recursive_doubled.into(), is_odd, cs);
 
         // Mask the value of the output if alpha is already zero
@@ -196,7 +196,7 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
         let (_, _, recursive_plus_one) = cs.multiply(x_lc, recursive_doubled.into());
 
         // Mux between the two results depending on whether the current exponent is odd or even
-        let odd_bit_selection =
+        let odd_bit_selection: LinearCombination =
             CondSelectGadget::select(recursive_plus_one, recursive_doubled, is_odd, cs);
 
         // Mask the value of the output if alpha is already zero

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -25,7 +25,7 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    errors::MpcError,
+    errors::{MpcError, ProverError},
     mpc::SharedFabric,
     mpc_gadgets::modulo::shift_right,
     traits::{
@@ -37,7 +37,10 @@ use crate::{
     LinkableCommitment,
 };
 
-use super::{arithmetic::DivRemGadget, comparators::EqGadget};
+use super::{
+    arithmetic::DivRemGadget,
+    comparators::{EqGadget, MultiproverGreaterThanEqGadget},
+};
 
 /// The default fixed point decimal precision in bits
 /// i.e. the number of bits allocated to a fixed point's decimal
@@ -303,7 +306,7 @@ impl<L: LinearCombinationLike> FixedPointVar<L> {
     }
 
     /// Constrain a fixed point variable to equal an integer
-    pub fn constraint_equal_integer<CS: RandomizableConstraintSystem>(
+    pub fn constrain_equal_integer<CS: RandomizableConstraintSystem>(
         &self,
         rhs: Variable,
         cs: &mut CS,
@@ -619,6 +622,19 @@ impl<
         L: MpcLinearCombinationLike<N, S>,
     > AuthenticatedFixedPointVar<N, S, L>
 {
+    /// Create a new authenticated fixed point variable from an integer representation
+    pub fn from_integer<L1, CS>(
+        val: L1,
+    ) -> AuthenticatedFixedPointVar<N, S, MpcLinearCombination<N, S>>
+    where
+        L1: MpcLinearCombinationLike<N, S>,
+        CS: MpcRandomizableConstraintSystem<'a, N, S>,
+    {
+        // Shift the scalar before allocating
+        let val_shifted = val.into() * *TWO_TO_M_SCALAR;
+        AuthenticatedFixedPointVar { repr: val_shifted }
+    }
+
     /// Constrain two authenticated fixed point variables to equal one another
     pub fn constrain_equal<L1, CS>(&self, rhs: &AuthenticatedFixedPointVar<N, S, L1>, cs: &mut CS)
     where
@@ -637,6 +653,27 @@ impl<
         // Shift the integer
         let shifted_rhs = *TWO_TO_M_SCALAR * rhs;
         cs.constrain(self.repr.clone().into() - shifted_rhs);
+    }
+
+    /// Constrain a fixed point variable to be less than or equal to a given integer value
+    pub fn constrain_less_than_eq_integer<const D: usize, L1, CS>(
+        &self,
+        rhs: L1,
+        fabric: SharedFabric<N, S>,
+        cs: &mut CS,
+    ) -> Result<(), ProverError>
+    where
+        L1: MpcLinearCombinationLike<N, S>,
+        CS: MpcRandomizableConstraintSystem<'a, N, S>,
+    {
+        // Shift the integer
+        let shifted_rhs = *TWO_TO_M_SCALAR * Into::<MpcLinearCombination<N, S>>::into(rhs);
+        MultiproverGreaterThanEqGadget::<'_, D, N, S>::constrain_greater_than_eq(
+            shifted_rhs,
+            self.repr.clone().into(),
+            fabric,
+            cs,
+        )
     }
 
     /// Convert the underlying type to an `MpcLinearCombination`


### PR DESCRIPTION
### Purpose
This PR adds the initial changes to the `match` MPC and ZK-MPC circuits for midpoint orders. Specifically, the changes are:
- Remove `execution_price` from the `MatchResult` type and take in a price as part of the witness from each party. The parties should agree upon these prices outside of the circuit.
- Remove the computation of the midpoint price in the circuit, the execution price is the agreed upon price.
- Add in checks that the balance covers the matched amount at the executed price.
- Add in checks that the matched amount is less than those specified in the order

### Todo
The following are left for another PR:
- Price protection; i.e. buy side can specify a maximum price, sell side can specify a minimum price
- Integration and unit tests

### Testing
- None; will follow up in another PR for testing specifically
- `circuits` unit tests pass, though CI here will fail to build