### PR TITLE
circuits: zk-circuits: `VALID MATCH MPC`: Add price protection constraints

### DIFF
--- a/circuits/src/types/mod.rs
+++ b/circuits/src/types/mod.rs
@@ -5,6 +5,8 @@ use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 use curve25519_dalek::scalar::Scalar;
 use num_bigint::BigUint;
 use serde::{de::Error as SerdeErr, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::zk_gadgets::fixed_point::DEFAULT_PRECISION;
 pub mod balance;
 pub mod fee;
 pub mod keychain;
@@ -19,6 +21,10 @@ pub mod wallet;
 
 /// The number of bits allowed in a balance or transaction "amount"
 pub(crate) const AMOUNT_BITS: usize = 64;
+/// The number of bits allowed in a price
+///
+/// This is the default fixed point precision plus 32 bits for the integer part
+pub(crate) const PRICE_BITS: usize = DEFAULT_PRECISION + 32;
 
 // -----------------------------------------
 // | Serialization Deserialization Helpers |

--- a/circuits/src/types/mod.rs
+++ b/circuits/src/types/mod.rs
@@ -23,7 +23,7 @@ pub mod wallet;
 pub(crate) const AMOUNT_BITS: usize = 64;
 /// The number of bits allowed in a price
 ///
-/// This is the default fixed point precision plus 32 bits for the integer part
+/// This is the default fixed point precision plus 32 bits for the integral part
 pub(crate) const PRICE_BITS: usize = DEFAULT_PRECISION + 32;
 
 // -----------------------------------------

--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -11,6 +11,7 @@ use crate::{
         MultiproverCircuitVariableType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
     types::{biguint_from_hex_string, biguint_to_hex_string},
+    zk_gadgets::fixed_point::FixedPoint,
     LinkableCommitment,
 };
 use circuit_macros::circuit_type;
@@ -54,6 +55,11 @@ pub struct Order {
     pub side: OrderSide,
     /// The amount of base currency to buy or sell
     pub amount: u64,
+    /// The worse case price the user is willing to accept on this order
+    ///
+    /// If the order is a buy, this is the maximum price the user is willing to pay
+    /// If the order is a sell, this is the minimum price the user is willing to accept
+    pub worst_case_price: FixedPoint,
     /// A timestamp indicating when the order was placed, set by the user
     pub timestamp: u64,
 }

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -64,6 +64,8 @@ pub(crate) mod test_helpers {
                 base_mint: 2u8.into(),
                 side: OrderSide::Buy,
                 amount: 1,
+                // No price limit by default
+                worst_case_price: FixedPoint::from_integer(100000),
                 timestamp: TIMESTAMP,
             },
             Order {
@@ -71,6 +73,8 @@ pub(crate) mod test_helpers {
                 base_mint: 3u8.into(),
                 side: OrderSide::Sell,
                 amount: 10,
+                // No price limit by default
+                worst_case_price: FixedPoint::from_integer(0),
                 timestamp: TIMESTAMP,
             }
         ];

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -744,6 +744,9 @@ mod test {
             base_mint: Scalar::zero(),
             side: Scalar::zero(),
             amount: Scalar::zero(),
+            worst_case_price: FixedPointShare {
+                repr: Scalar::zero(),
+            },
             timestamp: Scalar::zero(),
         }
         .to_linkable();

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -326,6 +326,8 @@ mod test {
                     base_mint: 2u8.into(),
                     side: OrderSide::Buy,
                     amount: 1,
+                    // No price limit by default
+                    worst_case_price: 100000u64.into(),
                     timestamp: TIMESTAMP,
                 },
                 Order::default()

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -30,6 +30,7 @@ use crate::{
         comparators::{
             EqGadget, EqVecGadget, EqZeroGadget, GreaterThanEqZeroGadget, NotEqualGadget,
         },
+        fixed_point::FixedPointVar,
         gates::{AndGate, ConstrainBinaryGadget, NotGate, OrGate},
         merkle::{MerkleOpening, MerkleRoot, PoseidonMerkleHashGadget},
         select::CondSelectGadget,
@@ -391,6 +392,9 @@ where
                 base_mint: Variable::Zero().into(),
                 side: Variable::Zero().into(),
                 amount: Variable::Zero().into(),
+                worst_case_price: FixedPointVar {
+                    repr: Variable::Zero().into(),
+                },
                 timestamp: Variable::Zero().into(),
             },
             cs,

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -112,12 +112,7 @@ impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>>
 pub struct CondSelectVectorGadget {}
 impl CondSelectVectorGadget {
     /// Implements the control flow statement if selector { a } else { b }
-    pub fn select<L1, L2, V1, V2, CS>(
-        a: &[V1],
-        b: &[V1],
-        selector: L1,
-        cs: &mut CS,
-    ) -> Vec<LinearCombination>
+    pub fn select<L1, L2, V1, V2, CS>(a: &[V1], b: &[V1], selector: L1, cs: &mut CS) -> Vec<V2>
     where
         L1: LinearCombinationLike,
         L2: LinearCombinationLike,


### PR DESCRIPTION
### Purpose
This PR adds price protection to the `Order` struct and enforces the price protection in `VALID MATCH MPC`.

Price protection is implemented as a `worst_case_price` that represents a maximum price for buy side orders and a minimum price for sell side orders.

### Testing
- Unit tests in `circuits` pass, though CI will fail here because `core` has not consumed the midpoint changes
- Integration tests in `circuits` pass