### PR TITLE
core: handshake: Refactor handshake process to use midpoint prices

### DIFF
--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -89,7 +89,12 @@ impl FixedPoint {
 
     /// Create a new fixed point representation, rounding down to the nearest representable float
     pub fn from_f32_round_down(val: f32) -> Self {
-        let shifted_val = val * (2u64.pow(DEFAULT_PRECISION as u32) as f32);
+        Self::from_f64_round_down(val as f64)
+    }
+
+    /// Create a new fixed point representation, rounding up to the nearest representable float
+    pub fn from_f64_round_down(val: f64) -> Self {
+        let shifted_val = val * (2u64.pow(DEFAULT_PRECISION as u32) as f64);
         Self {
             repr: Scalar::from(shifted_val.floor() as u64),
         }

--- a/core/src/external_api/types.rs
+++ b/core/src/external_api/types.rs
@@ -181,7 +181,7 @@ pub struct Order {
     pub worst_case_price: FixedPoint,
     /// The order size
     pub amount: BigUint,
-    /// The timestamp this ord placed at
+    /// The timestamp this order was placed at
     pub timestamp: u64,
 }
 

--- a/core/src/external_api/types.rs
+++ b/core/src/external_api/types.rs
@@ -174,11 +174,14 @@ pub struct Order {
     /// The type of order
     #[serde(rename = "type")]
     pub type_: OrderType,
-    /// The limit price in the case that this is a limit order
-    pub price: FixedPoint,
+    /// The worse case price that the order may be executed at
+    ///
+    /// For buy side orders this is a maximum price, for sell side orders
+    /// this is a minimum price
+    pub worst_case_price: FixedPoint,
     /// The order size
     pub amount: BigUint,
-    /// The timestamp this order was placed at
+    /// The timestamp this ord placed at
     pub timestamp: u64,
 }
 
@@ -190,7 +193,7 @@ impl From<(OrderIdentifier, IndexedOrder)> for Order {
             base_mint: order.base_mint,
             side: order.side,
             type_: OrderType::Limit,
-            price: order.price,
+            worst_case_price: order.worst_case_price,
             amount: BigUint::from(order.amount),
             timestamp: order.timestamp,
         }
@@ -203,7 +206,7 @@ impl From<Order> for IndexedOrder {
             quote_mint: order.quote_mint,
             base_mint: order.base_mint,
             side: order.side,
-            price: order.price,
+            worst_case_price: order.worst_case_price,
             amount: order.amount.try_into().unwrap(),
             timestamp: order.timestamp,
         }

--- a/core/src/gossip_api/handshake.rs
+++ b/core/src/gossip_api/handshake.rs
@@ -2,7 +2,14 @@
 use portpicker::Port;
 use serde::{Deserialize, Serialize};
 
-use crate::{gossip::types::WrappedPeerId, state::OrderIdentifier};
+use crate::{gossip::types::WrappedPeerId, price_reporter::tokens::Token, state::OrderIdentifier};
+
+/// A type alias for the representation of an ERC20's price
+pub type Price = f64;
+/// A type representing the midpoint price of a given token pair
+pub type MidpointPrice = (Token, Token, Price);
+/// A price vector that a peer proposes to its counterparty during a handshake
+pub type PriceVector = Vec<MidpointPrice>;
 
 /// Enumerates the different operations possible via handshake
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +30,8 @@ pub enum HandshakeMessage {
         /// Set to `None` by the sender if all locally held orders are cached
         /// as already matched with the `peer_order`
         sender_order: OrderIdentifier,
+        /// The vector of prices that the sender is proposing to the receiver
+        price_vector: PriceVector,
     },
     /// Reject a proposed match candidate, this can happen for a number of reasons;
     /// e.g. the local peer has already cached the proposed order pair as matched,
@@ -70,4 +79,6 @@ pub enum MatchRejectionReason {
     LocalOrderNotReady,
     /// The rejecting peer has not yet verified the proposer's proof of `VALID COMMITMENTS`
     NoValidityProof,
+    /// The prices proposed by the peer are not accepted by the rejecting peer
+    NoPriceAgreement,
 }

--- a/core/src/handshake/state.rs
+++ b/core/src/handshake/state.rs
@@ -9,6 +9,7 @@ use crate::{
 use std::collections::{HashMap, HashSet};
 
 use super::error::HandshakeManagerError;
+use circuits::zk_gadgets::fixed_point::FixedPoint;
 use crossbeam::channel::Sender;
 use curve25519_dalek::scalar::Scalar;
 use uuid::Uuid;
@@ -52,6 +53,7 @@ impl HandshakeStateIndex {
         role: ConnectionRole,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
+        execution_price: FixedPoint,
     ) -> Result<(), HandshakeManagerError> {
         // Lookup the public share nullifiers for the order
         let locked_order_book = self.global_state.read_order_book().await;
@@ -80,6 +82,7 @@ impl HandshakeStateIndex {
                     local_order_id,
                     peer_nullifier,
                     local_nullifier,
+                    execution_price,
                 ),
             );
         } // locked_state released
@@ -212,6 +215,8 @@ pub struct HandshakeState {
     pub peer_share_nullifier: Scalar,
     /// The public secret share nullifier of the local peer's order
     pub local_share_nullifier: Scalar,
+    /// The agreed upon price of the asset the local party intends to match on
+    pub execution_price: FixedPoint,
     /// The current state information of the
     pub state: State,
     /// The cancel channel that the coordinator may use to cancel MPC execution
@@ -247,6 +252,7 @@ impl HandshakeState {
         local_order_id: OrderIdentifier,
         peer_share_nullifier: Scalar,
         local_share_nullifier: Scalar,
+        execution_price: FixedPoint,
     ) -> Self {
         Self {
             request_id,
@@ -255,6 +261,7 @@ impl HandshakeState {
             local_order_id,
             peer_share_nullifier,
             local_share_nullifier,
+            execution_price,
             state: State::OrderNegotiation,
             cancel_channel: None,
         }

--- a/core/src/price_reporter/tokens.rs
+++ b/core/src/price_reporter/tokens.rs
@@ -11,6 +11,7 @@
 //! In general, Named Tokens use all exchanges where they are listed, whereas Unnamed Tokens only
 //! use Uniswap V3 for the price feed.
 use bimap::BiMap;
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -599,7 +600,7 @@ lazy_static! {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Token {
     /// The ERC-20 address of the Token.
-    addr: String,
+    pub addr: String,
 }
 
 impl Display for Token {
@@ -613,6 +614,13 @@ impl Token {
     pub fn from_addr(addr: &str) -> Self {
         Self {
             addr: String::from(addr).to_lowercase(),
+        }
+    }
+
+    /// Given an ERC-20 contract address represented as a `BigUint`, returns a Token
+    pub fn from_addr_biguint(addr: &BigUint) -> Self {
+        Self {
+            addr: format!("0x{}", addr.to_str_radix(16 /* radix */)),
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR makes the initial changes to the `handshake::manager` logic to support midpoint prices. Specifically, this PR changes the communication structure such that the proposer proposes a price vector and each party selects the midpoint price of their asset pair. The execution is then done at the midpoint as specified by these vectors.

This PR also makes the smaller, necessary API and state management changes to bring `core` into consistency with the `circuits` changes for midpoints.

### Todo
- Incorporate price feeds from the `price_reporter`

### Testing 
- Unit and integration tests pass
- Ad hoc tested with the current dummy prices from the handshake manager