### PR TITLE
core: handshake: Consumer prices from price reporter for handshake

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -96,7 +96,7 @@ struct Cli {
     /// Flag to disable the price reporter
     #[clap(long, value_parser)]
     pub disable_price_reporter: bool,
-    /// Flat to disable streaming price from Binance
+    /// Flag to disable streaming price from Binance
     /// 
     /// This is useful for testing in a region that Binance has IP blocked
     #[clap(long, value_parser)]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -96,6 +96,11 @@ struct Cli {
     /// Flag to disable the price reporter
     #[clap(long, value_parser)]
     pub disable_price_reporter: bool,
+    /// Flat to disable streaming price from Binance
+    /// 
+    /// This is useful for testing in a region that Binance has IP blocked
+    #[clap(long, value_parser)]
+    pub disable_binance: bool,
     /// Whether or not to run the relayer in debug mode
     #[clap(short, long, value_parser)]
     pub debug: bool,
@@ -176,6 +181,8 @@ pub struct RelayerConfig {
     /// Whether to disable the price reporter if e.g. we are streaming from a dedicated
     /// external API gateway node in the cluster
     pub disable_price_reporter: bool,
+    /// Whether to disable price streaming from Binance for location blocks
+    pub disable_binance: bool,
     /// Whether or not the relayer is in debug mode
     pub debug: bool,
 
@@ -217,6 +224,7 @@ impl Clone for RelayerConfig {
             public_ip: self.public_ip,
             disable_api_server: self.disable_api_server,
             disable_price_reporter: self.disable_price_reporter,
+            disable_binance: self.disable_binance,
             wallets: self.wallets.clone(),
             cluster_keypair: Keypair::from_bytes(&self.cluster_keypair.to_bytes()).unwrap(),
             cluster_id: self.cluster_id.clone(),
@@ -304,6 +312,7 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         public_ip: cli_args.public_ip,
         disable_api_server: cli_args.disable_api_server,
         disable_price_reporter: cli_args.disable_price_reporter,
+        disable_binance: cli_args.disable_binance,
         wallets: parse_wallet_file(cli_args.wallet_file)?,
         cluster_keypair: keypair,
         cluster_id,

--- a/core/src/gossip_api/handshake.rs
+++ b/core/src/gossip_api/handshake.rs
@@ -2,10 +2,12 @@
 use portpicker::Port;
 use serde::{Deserialize, Serialize};
 
-use crate::{gossip::types::WrappedPeerId, price_reporter::tokens::Token, state::OrderIdentifier};
+use crate::{
+    gossip::types::WrappedPeerId,
+    price_reporter::{reporter::Price, tokens::Token},
+    state::OrderIdentifier,
+};
 
-/// A type alias for the representation of an ERC20's price
-pub type Price = f64;
 /// A type representing the midpoint price of a given token pair
 pub type MidpointPrice = (Token, Token, Price);
 /// A price vector that a peer proposes to its counterparty during a handshake

--- a/core/src/gossip_api/handshake.rs
+++ b/core/src/gossip_api/handshake.rs
@@ -1,4 +1,6 @@
 //! Groups API definitions for handshake request response
+use std::collections::HashMap;
+
 use portpicker::Port;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +13,27 @@ use crate::{
 /// A type representing the midpoint price of a given token pair
 pub type MidpointPrice = (Token, Token, Price);
 /// A price vector that a peer proposes to its counterparty during a handshake
-pub type PriceVector = Vec<MidpointPrice>;
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PriceVector(pub Vec<MidpointPrice>);
+impl PriceVector {
+    /// Returns the price of a given token pair, if it exists in the price vector
+    pub fn find_pair(&self, base: &Token, quote: &Token) -> Option<MidpointPrice> {
+        self.0
+            .iter()
+            .find(|(b, q, _)| b == base && q == quote)
+            .cloned()
+    }
+}
+
+impl From<PriceVector> for HashMap<(Token, Token), Price> {
+    fn from(price_vector: PriceVector) -> Self {
+        price_vector
+            .0
+            .into_iter()
+            .map(|(base, quote, price)| ((base, quote), price))
+            .collect()
+    }
+}
 
 /// Enumerates the different operations possible via handshake
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/core/src/handshake/error.rs
+++ b/core/src/handshake/error.rs
@@ -5,8 +5,8 @@ use std::fmt::Display;
 /// The core error type for the handshake manager
 #[derive(Clone, Debug)]
 pub enum HandshakeManagerError {
-    /// An error while collaboratively proving a statement
-    Multiprover(String),
+    /// Error resulting from a cancellation signal
+    Cancelled(String),
     /// An invalid request ID was passed in a message; i.e. the request ID is not known
     /// to the local state machine
     InvalidRequest(String),
@@ -14,8 +14,10 @@ pub enum HandshakeManagerError {
     MpcNetwork(String),
     /// An MpcShootdown request has stopped the handshake
     MpcShootdown,
-    /// Error verifying a proof
-    VerificationError(String),
+    /// An error while collaboratively proving a statement
+    Multiprover(String),
+    /// Necessary price data was not available for a token pair
+    NoPriceData(String),
     /// Error sending a message to the network
     SendMessage(String),
     /// Error while setting up the handshake manager
@@ -25,8 +27,8 @@ pub enum HandshakeManagerError {
     /// This may happen if, for example, an order is cancelled during the course
     /// of a match
     StateNotFound(String),
-    /// Error resulting from a cancellation signal
-    Cancelled(String),
+    /// Error verifying a proof
+    VerificationError(String),
 }
 
 impl Display for HandshakeManagerError {

--- a/core/src/handshake/manager.rs
+++ b/core/src/handshake/manager.rs
@@ -1,5 +1,7 @@
 //! The handshake module handles the execution of handshakes from negotiating
 //! a pair of orders to match, all the way through settling any resulting match
+pub mod r#match;
+mod price_agreement;
 
 use circuits::zk_gadgets::fixed_point::FixedPoint;
 use crossbeam::channel::Sender as CrossbeamSender;
@@ -40,11 +42,13 @@ use crate::{
     CancelChannel,
 };
 
+pub use self::r#match::HandshakeResult;
+pub(super) use price_agreement::init_price_streams;
+
 use super::{
     error::HandshakeManagerError,
     handshake_cache::{HandshakeCache, SharedHandshakeCache},
     jobs::HandshakeExecutionJob,
-    r#match::HandshakeResult,
     state::{HandshakeState, HandshakeStateIndex},
     worker::HandshakeManagerConfig,
 };

--- a/core/src/handshake/manager/match.rs
+++ b/core/src/handshake/manager/match.rs
@@ -39,13 +39,14 @@ use tracing::log;
 use uuid::Uuid;
 
 use crate::{
+    handshake::{error::HandshakeManagerError, state::HandshakeState},
     proof_generation::{
         jobs::ValidMatchMpcBundle, OrderValidityProofBundle, OrderValidityWitnessBundle,
     },
     MAX_BALANCES, MAX_FEES, MAX_ORDERS,
 };
 
-use super::{error::HandshakeManagerError, manager::HandshakeExecutor, state::HandshakeState};
+use super::HandshakeExecutor;
 
 /// A type alias for a linkable wallet share with default sizing parameters
 pub type SizedLinkableWalletShare = LinkableWalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;

--- a/core/src/handshake/manager/price_agreement.rs
+++ b/core/src/handshake/manager/price_agreement.rs
@@ -1,0 +1,117 @@
+//! Groups logic for sampling and agreeing upon price vectors during a handshake
+
+use lazy_static::lazy_static;
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
+
+use crate::{
+    handshake::error::HandshakeManagerError,
+    price_reporter::{jobs::PriceReporterManagerJob, tokens::Token},
+};
+
+// ----------------
+// | Quote Tokens |
+// ----------------
+
+/// USDC ticker
+///
+/// For now we only stream prices quoted in USDC
+const USDC_TICKER: &str = "USDC";
+
+// ---------------
+// | Base Tokens |
+// ---------------
+
+/// BTC ticker
+const BTC_TICKER: &str = "WBTC";
+/// ETH ticker
+const ETH_TICKER: &str = "WETH";
+/// BNB ticker
+const BNB_TICKER: &str = "BNB";
+/// MATIC ticker
+const MATIC_TICKER: &str = "MATIC";
+/// LDO ticker
+const LDO_TICKER: &str = "LDO";
+/// CBETH ticker
+const CBETH_TICKER: &str = "CBETH";
+/// LINK ticker
+const LINK_TICKER: &str = "LINK";
+/// UNI ticker
+const UNI_TICKER: &str = "UNI";
+/// CRV ticker
+const CRV_TICKER: &str = "CRV";
+/// DYDX ticker
+const DYDX_TICKER: &str = "DYDX";
+/// AAVE ticker
+const AAVE_TICKER: &str = "AAVE";
+
+lazy_static! {
+    /// The token pairs we want to keep price streams open for persistently
+    static ref DEFAULT_PAIRS: Vec<(Token, Token)> = {
+        // For now we only stream prices quoted in USDC
+        vec![
+            (
+                Token::from_ticker(BTC_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(ETH_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(BNB_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(MATIC_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(LDO_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(CBETH_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(LINK_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(UNI_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(CRV_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(DYDX_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            ),
+            (
+                Token::from_ticker(AAVE_TICKER),
+                Token::from_ticker(USDC_TICKER),
+            )
+        ]
+    };
+}
+
+/// Initializes price streams for the default token pairs in the `price-reporter`
+///
+/// This will cause the price reporter to connect to exchanges and begin streaming, ahead of
+/// when we need prices
+pub fn init_price_streams(
+    price_reporter_job_queue: TokioSender<PriceReporterManagerJob>,
+) -> Result<(), HandshakeManagerError> {
+    for (base, quote) in DEFAULT_PAIRS.iter() {
+        price_reporter_job_queue
+            .send(PriceReporterManagerJob::StartPriceReporter {
+                base_token: base.clone(),
+                quote_token: quote.clone(),
+            })
+            .map_err(|err| HandshakeManagerError::SetupError(err.to_string()))?;
+    }
+
+    Ok(())
+}

--- a/core/src/handshake/mod.rs
+++ b/core/src/handshake/mod.rs
@@ -3,7 +3,6 @@ pub mod error;
 mod handshake_cache;
 pub mod jobs;
 pub mod manager;
-pub mod r#match;
 pub mod state;
 pub mod types;
 pub mod worker;

--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -67,6 +67,7 @@ impl Worker for HandshakeManager {
         let executor = HandshakeExecutor::new(
             config.job_receiver.take().unwrap(),
             config.network_channel.clone(),
+            config.price_reporter_job_queue.clone(),
             config.starknet_client.clone(),
             config.proof_manager_sender.clone(),
             config.global_state.clone(),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -266,6 +266,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
         global_state: global_state.clone(),
         network_channel: network_sender.clone(),
+        price_reporter_job_queue: price_reporter_worker_sender.clone(),
         starknet_client: starknet_client.clone(),
         job_receiver: Some(handshake_worker_receiver),
         job_sender: handshake_worker_sender.clone(),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -292,6 +292,7 @@ async fn main() -> Result<(), CoordinatorError> {
         coinbase_api_key: args.coinbase_api_key,
         coinbase_api_secret: args.coinbase_api_secret,
         eth_websocket_addr: args.eth_websocket_addr,
+        disable_binance: args.disable_binance,
     })
     .expect("failed to build price reporter manager");
     price_reporter_manager

--- a/core/src/price_reporter/errors.rs
+++ b/core/src/price_reporter/errors.rs
@@ -14,8 +14,6 @@ pub enum ExchangeConnectionError {
     HandshakeFailure(String),
     /// Could not parse a remote server message.
     InvalidMessage(String),
-    /// No swap logs found for a given pool
-    NoLogs(String),
     /// The maximum retry count was exceeded while trying to re-establish
     /// an exchange connection
     MaxRetries(Exchange),

--- a/core/src/price_reporter/exchange/uni_v3.rs
+++ b/core/src/price_reporter/exchange/uni_v3.rs
@@ -38,9 +38,6 @@ const FEE_START_BYTE: usize = 32 - 4;
 /// The historical offset to query blocks in for the first swap
 const BLOCK_OFFSET: u64 = 10_000;
 
-/// The error message emitted when swap logs cannot be found for a UniV3 pool
-const ERR_NO_LOGS: &str = "no swap logs found for asset pair";
-
 lazy_static! {
     // The ABI for a UniswapV3 Swap event
     static ref SWAP_EVENT_ABI: ethabi::Event = {
@@ -173,9 +170,8 @@ impl UniswapV3Connection {
             ordering => ordering,
         });
 
-        swap_filter_recent_events
+        Ok(swap_filter_recent_events
             .pop()
-            .ok_or_else(|| ExchangeConnectionError::NoLogs(ERR_NO_LOGS.to_string()))
             .map(|swap| {
                 Self::midpoint_from_swap_event(
                     swap,
@@ -184,6 +180,7 @@ impl UniswapV3Connection {
                     &SWAP_EVENT_ABI,
                 )
             })
+            .unwrap_or_default())
     }
 
     /// Create an event filter for UniV3 swaps

--- a/core/src/price_reporter/reporter.rs
+++ b/core/src/price_reporter/reporter.rs
@@ -397,7 +397,6 @@ impl ConnectionMuxer {
             tokio::select! {
                 // Keepalive timer
                 _ = &mut delay => {
-                    log::info!("Sending keepalive to exchanges");
                     for exchange in stream_map.values_mut() {
                         if let Err(e) = exchange.send_keepalive().await {
                             log::error!("Error sending keepalive to exchange: {e}");

--- a/core/src/price_reporter/reporter.rs
+++ b/core/src/price_reporter/reporter.rs
@@ -267,6 +267,7 @@ impl PriceReporter {
             .intersection(&quote_token_supported_exchanges)
             .copied()
             .filter(|exchange| config.exchange_configured(*exchange))
+            .filter(|exchange| !config.disable_binance || *exchange != Exchange::Binance)
             .collect_vec()
     }
 

--- a/core/src/price_reporter/tokens.rs
+++ b/core/src/price_reporter/tokens.rs
@@ -625,7 +625,7 @@ impl Token {
     }
 
     /// Given an ERC-20 ticker, returns a new Token.
-    pub fn _from_ticker(ticker: &str) -> Self {
+    pub fn from_ticker(ticker: &str) -> Self {
         let addr = ADDR_TICKER_BIMAP
             .get_by_right(&String::from(ticker))
             .expect("Ticker is not supported; specify unnamed token by ERC-20 address using from_addr instead.");

--- a/core/src/price_reporter/worker.rs
+++ b/core/src/price_reporter/worker.rs
@@ -31,6 +31,10 @@ pub struct PriceReporterManagerConfig {
     pub(crate) coinbase_api_secret: Option<String>,
     /// The ethereum RPC node websocket addresses for on-chain data
     pub(crate) eth_websocket_addr: Option<String>,
+    /// Whether or not to disable binance streaming
+    ///
+    /// Used in locations that Binance has IP blocked
+    pub(crate) disable_binance: bool,
     /// The channel on which the coordinator may mandate that the price reporter manager cancel its
     /// execution
     pub(crate) cancel_channel: CancelChannel,

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -10,7 +10,7 @@ use crate::{
     system_bus::SystemBus,
     types::{wallet_topic_name, SystemBusMessage, NETWORK_TOPOLOGY_TOPIC},
 };
-use circuits::types::wallet::Nullifier;
+use circuits::types::{order::Order, wallet::Nullifier};
 use libp2p::{
     identity::{self, Keypair},
     Multiaddr,
@@ -132,6 +132,15 @@ impl RelayerState {
             .get_peer_info(&self.local_peer_id)
             .await
             .unwrap()
+    }
+
+    /// Get the info for a locally managed order
+    pub async fn get_order(&self, order_id: &OrderIdentifier) -> Option<Order> {
+        let locked_wallet_index = self.read_wallet_index().await;
+        let managing_wallet_id = locked_wallet_index.get_wallet_for_order(order_id)?;
+        let wallet = locked_wallet_index.get_wallet(&managing_wallet_id).await?;
+
+        wallet.orders.get(order_id).cloned()
     }
 
     /// Sample an order for handshake

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -20,7 +20,7 @@ use tracing::log;
 
 use crate::{
     gossip_api::gossip::GossipOutbound,
-    handshake::{r#match::HandshakeResult, state::HandshakeState},
+    handshake::{manager::HandshakeResult, state::HandshakeState},
     proof_generation::{
         jobs::{ProofJob, ProofManagerJob, ValidCommitmentsBundle, ValidSettleBundle},
         OrderValidityProofBundle, SizedValidSettleStatement, SizedValidSettleWitness,


### PR DESCRIPTION
### Purpose
This PR integrates the price streams from the `price-reporter` module with the handshake price proposal logic. Specifically, the proposer peeks at the median price for a set of assets, one of which it intends to match on, and proposes these prices to the peer. The peer then peeks their own observed midpoints and validates that the proposed prices are within some tolerance.

Two simplifying assumptions are made in this implementation that will be revisited later:
- We propose a static subset of common asset pairs to mask the desired pair. A better strategy would be to propose a random subset of asset pairs, also including the desired pair, and possibly weighted by trading volume.
- When we validate prices, we only look at max deviation. We'd really like to look at other things as well: for example the deviation on the asset pair we intend to match may need to have a tighter threshold.

### Testing
- Unit and integration tests
- Ad hoc match tests