### PR TITLE
core: price-reporter: uni-v3: Forward connection errors 

### DIFF
--- a/core/src/price_reporter/exchange/uni_v3.rs
+++ b/core/src/price_reporter/exchange/uni_v3.rs
@@ -381,7 +381,9 @@ impl ExchangeConnection for UniswapV3Connection {
 
                         Err(e) => {
                             log::error!("Error parsing Swap event from UniswapV3: {}", e);
-                            None
+                            Some(Err(ExchangeConnectionError::ConnectionHangup(
+                                e.to_string(),
+                            )))
                         }
                     }
                 });


### PR DESCRIPTION
### Purpose
The `web3::WebSocket` occasionally fails and needs to be reset. This is done by forwarding an error to the `ConnectionMuxer` which drops the poisoned connection and restarts it. 

The initial implementation did not properly forward errors up the stack, meaning the connection was never reset.

### Testing
- Unit and integration tests
- Ad hoc tests