### PR TITLE
core: tasks: update-wallet: Fix merkle path used in `VALID REBLIND`

### DIFF
--- a/core/src/price_reporter/exchange/kraken.rs
+++ b/core/src/price_reporter/exchange/kraken.rs
@@ -156,7 +156,9 @@ impl ExchangeConnection for KrakenConnection {
                 // Error reading from the websocket
                 Err(e) => {
                     log::error!("Error reading message from Kraken ws: {}", e);
-                    None
+                    Some(Err(ExchangeConnectionError::ConnectionHangup(
+                        e.to_string(),
+                    )))
                 }
             }
         });

--- a/core/src/price_reporter/exchange/okx.rs
+++ b/core/src/price_reporter/exchange/okx.rs
@@ -150,7 +150,9 @@ impl ExchangeConnection for OkxConnection {
                 // Error reading from the websocket
                 Err(e) => {
                     log::error!("Error reading message from Okx ws: {}", e);
-                    None
+                    Some(Err(ExchangeConnectionError::ConnectionHangup(
+                        e.to_string(),
+                    )))
                 }
             }
         });

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -38,7 +38,7 @@ use super::{
 /// Error message when sending a proof response fails
 const ERR_SENDING_RESPONSE: &str = "error sending proof response, channel closed";
 /// The number of threads to allocate towards the proof generation worker pool
-pub(crate) const PROOF_GENERATION_N_THREADS: usize = 3;
+pub(crate) const PROOF_GENERATION_N_THREADS: usize = 10;
 
 // --------------------
 // | Proof Generation |


### PR DESCRIPTION
### Purpose
The `update-wallet` task previously was using the old Merkle authentication path when re-proving `VALID REBLIND` (post update). Instead, the task should find the updated wallet's Merkle path and use this in the proof instead.

As well, this PR fixes a bug in which an invalid order validity proof is broadcast where:
1. A node receives the invalid proof and fails to verify it
2. The node then continues requesting and attempting to verify the invalid proof indefinitely
The fix is to index the order in the `Received` state before the proof is verified and only transition to `Verified` after verification is complete. For invalid proofs, this means the order is stuck in the `Received` state until a managing node pushes a valid proof via `UpdateWalletValidityProof`.

### Testing
- Unit and integration tests pass
- Tested with an invalid proof
- Tested the case in which a validity proof is generated out of an `update-wallet` task