### PR TITLE
core: handshake: price-agreement: Convert token addrs to ETH mainnet

### DIFF
--- a/core/src/handshake/worker.rs
+++ b/core/src/handshake/worker.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     price_reporter::jobs::PriceReporterManagerJob,
     proof_generation::jobs::ProofManagerJob,
-    starknet_client::client::StarknetClient,
+    starknet_client::{client::StarknetClient, ChainId},
     state::RelayerState,
     system_bus::SystemBus,
     tasks::driver::TaskDriver,
@@ -29,6 +29,8 @@ use super::{error::HandshakeManagerError, jobs::HandshakeExecutionJob, manager::
 
 /// The config type for the handshake manager
 pub struct HandshakeManagerConfig {
+    /// The chain that the local node targets
+    pub chain_id: ChainId,
     /// The relayer-global state
     pub global_state: RelayerState,
     /// The channel on which to send outbound network requests
@@ -65,6 +67,7 @@ impl Worker for HandshakeManager {
             config.cancel_channel.clone(),
         );
         let executor = HandshakeExecutor::new(
+            config.chain_id,
             config.job_receiver.take().unwrap(),
             config.network_channel.clone(),
             config.price_reporter_job_queue.clone(),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -264,6 +264,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the handshake manager
     let (handshake_cancel_sender, handshake_cancel_receiver) = watch::channel(());
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
+        chain_id: args.chain_id,
         global_state: global_state.clone(),
         network_channel: network_sender.clone(),
         price_reporter_job_queue: price_reporter_worker_sender.clone(),

--- a/core/src/price_reporter/exchange/kraken.rs
+++ b/core/src/price_reporter/exchange/kraken.rs
@@ -156,7 +156,9 @@ impl ExchangeConnection for KrakenConnection {
                 // Error reading from the websocket
                 Err(e) => {
                     log::error!("Error reading message from Kraken ws: {}", e);
-                    None
+                    Some(Err(ExchangeConnectionError::ConnectionHangup(
+                        e.to_string(),
+                    )))
                 }
             }
         });

--- a/core/src/price_reporter/exchange/okx.rs
+++ b/core/src/price_reporter/exchange/okx.rs
@@ -150,7 +150,9 @@ impl ExchangeConnection for OkxConnection {
                 // Error reading from the websocket
                 Err(e) => {
                     log::error!("Error reading message from Okx ws: {}", e);
-                    None
+                    Some(Err(ExchangeConnectionError::ConnectionHangup(
+                        e.to_string(),
+                    )))
                 }
             }
         });

--- a/core/src/proof_generation/proof_manager.rs
+++ b/core/src/proof_generation/proof_manager.rs
@@ -38,7 +38,7 @@ use super::{
 /// Error message when sending a proof response fails
 const ERR_SENDING_RESPONSE: &str = "error sending proof response, channel closed";
 /// The number of threads to allocate towards the proof generation worker pool
-pub(crate) const PROOF_GENERATION_N_THREADS: usize = 3;
+pub(crate) const PROOF_GENERATION_N_THREADS: usize = 10;
 
 // --------------------
 // | Proof Generation |


### PR DESCRIPTION
### Purpose
For now, we specify order asset pairs in terms of their Starknet addresses, but measure prices in terms of Eth mainnet addresses. This may change when we implement a custom bridging scheme, but for now we must translate addresses.

### Testing
- Unit and integration tests
- Ad hoc match tests