### PR TITLE
core: handshake: Better handle zero'd orders after complete fill

### DIFF
--- a/circuits/src/types/order.rs
+++ b/circuits/src/types/order.rs
@@ -69,6 +69,14 @@ impl Order {
     pub fn is_default(&self) -> bool {
         self.eq(&Self::default())
     }
+
+    /// Whether or not this order is for zero volume
+    ///
+    /// This is a superset of the class of orders that `is_default` returns
+    /// true for
+    pub fn is_zero(&self) -> bool {
+        self.amount == 0
+    }
 }
 
 /// The side of the market a given order is on

--- a/core/src/api_server/http.rs
+++ b/core/src/api_server/http.rs
@@ -38,10 +38,10 @@ use self::{
         AddFeeHandler, CancelOrderHandler, CreateOrderHandler, CreateWalletHandler,
         DepositBalanceHandler, FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
         GetFeesHandler, GetOrderByIdHandler, GetOrdersHandler, GetWalletHandler, RemoveFeeHandler,
-        WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE,
-        FEES_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE,
-        GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, REMOVE_FEE_ROUTE, WALLET_ORDERS_ROUTE,
-        WITHDRAW_BALANCE_ROUTE,
+        UpdateOrderHandler, WithdrawBalanceHandler, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE,
+        DEPOSIT_BALANCE_ROUTE, FEES_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE,
+        GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE, REMOVE_FEE_ROUTE,
+        UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
     },
 };
 
@@ -318,6 +318,20 @@ impl HttpServer {
             GET_ORDER_BY_ID_ROUTE.to_string(),
             true, /* auth_required */
             GetOrderByIdHandler::new(global_state.clone()),
+        );
+
+        // The "/wallet/:id/orders/:id/update" route
+        router.add_route(
+            Method::POST,
+            UPDATE_ORDER_ROUTE.to_string(),
+            true, /* auth_required */
+            UpdateOrderHandler::new(
+                config.starknet_client.clone(),
+                config.network_sender.clone(),
+                config.global_state.clone(),
+                config.proof_generation_work_queue.clone(),
+                config.task_driver.clone(),
+            ),
         );
 
         // The "/wallet/:id/orders/:id/cancel" route

--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -103,6 +103,24 @@ pub struct CreateOrderResponse {
     pub task_id: TaskIdentifier,
 }
 
+/// The request type to update an order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UpdateOrderRequest {
+    /// The order to be updated
+    pub order: Order,
+    /// A signature of the public variables used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    pub public_var_sig: Vec<u8>,
+}
+
+/// The response type to update an order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UpdateOrderResponse {
+    /// The ID of the task allocated for this request
+    pub task_id: TaskIdentifier,
+}
+
 /// The response type to a request to cancel a given order
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CancelOrderResponse {

--- a/core/src/price_reporter/exchange/uni_v3.rs
+++ b/core/src/price_reporter/exchange/uni_v3.rs
@@ -163,7 +163,10 @@ impl UniswapV3Connection {
         .await?;
 
         // Process the most recent Swap
-        let mut swap_filter_recent_events = swap_filter.logs().await.unwrap();
+        let mut swap_filter_recent_events = swap_filter
+            .logs()
+            .await
+            .map_err(|err| ExchangeConnectionError::ConnectionHangup(err.to_string()))?;
         swap_filter_recent_events.sort_by(|a, b| match a.block_number.cmp(&b.block_number) {
             // Same block resolves by transaction index
             Ordering::Equal => a.transaction_index.cmp(&b.transaction_index),

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -359,7 +359,12 @@ impl RelayerState {
         // Add the wallet's orders to the book
         let mut locked_order_book = self.write_order_book().await;
         let wallet_share_nullifier = wallet.get_wallet_nullifier();
-        for order_id in wallet.orders.keys() {
+        for order_id in wallet
+            .orders
+            .iter()
+            .filter(|(_, order)| !order.is_zero())
+            .map(|(id, _)| id)
+        {
             if !locked_order_book.contains_order(order_id) {
                 locked_order_book
                     .add_order(NetworkOrder::new(

--- a/core/src/tasks/helpers.rs
+++ b/core/src/tasks/helpers.rs
@@ -181,8 +181,8 @@ pub(super) fn construct_wallet_commitment_proof(
     .ok_or_else(|| ERR_BALANCE_NOT_FOUND.to_string())?;
 
     // Find the order in the wallet
-    let order_index = find_order(&order.base_mint, &order.quote_mint, &augmented_wallet)
-        .ok_or_else(|| ERR_ORDER_NOT_FOUND.to_string())?;
+    let order_index =
+        find_order(&order, &augmented_wallet).ok_or_else(|| ERR_ORDER_NOT_FOUND.to_string())?;
 
     // Create new augmented public secret shares
     let reblinded_private_blinder = valid_reblind_witness
@@ -282,13 +282,13 @@ fn find_or_augment_balance(
 }
 
 /// Find an order in the wallet, returns the index at which the order was found
-fn find_order(base_mint: &BigUint, quote_mint: &BigUint, wallet: &SizedWallet) -> Option<usize> {
+fn find_order(order: &Order, wallet: &SizedWallet) -> Option<usize> {
     wallet
         .orders
         .iter()
         .enumerate()
-        .find(|(_ind, order)| order.quote_mint.eq(quote_mint) && order.base_mint.eq(base_mint))
-        .map(|(ind, _order)| ind)
+        .find(|(_ind, o)| (*o).eq(order))
+        .map(|(ind, _o)| ind)
 }
 
 /// Find a wallet on-chain, and update its validity proofs. That is, a proof of `VALID REBLIND`

--- a/core/src/tasks/helpers.rs
+++ b/core/src/tasks/helpers.rs
@@ -301,7 +301,7 @@ pub(super) async fn update_wallet_validity_proofs(
 ) -> Result<(), String> {
     // No validity proofs needed for an empty wallet, they will be re-proven on
     // the next update that adds a non-empty order
-    if wallet.orders.values().all(|o| o.is_default()) {
+    if wallet.orders.values().all(|o| o.is_zero()) {
         return Ok(());
     }
 
@@ -312,7 +312,7 @@ pub(super) async fn update_wallet_validity_proofs(
 
     // For each order, construct a proof of `VALID COMMITMENTS`
     let mut commitments_response_channels = Vec::new();
-    for (order_id, order) in wallet.orders.iter().filter(|(_id, o)| !o.is_default()) {
+    for (order_id, order) in wallet.orders.iter().filter(|(_id, o)| !o.is_zero()) {
         // Start a proof of `VALID COMMITMENTS`
         let (commitments_witness, response_channel) = construct_wallet_commitment_proof(
             wallet.clone(),


### PR DESCRIPTION
### Purpose
After an order is filled, it is not removed from the secret share state (the settling party may not own the wallet and thus cannot zero filled orders). This PR makes two improvements to how these orders are handled:
- Do not create validity proofs for, gossip about, or index zero-amount orders
- Add a `/wallet/:id/orders/:id/update` endpoint so that a now-zero order can be updated directly to a new order without cancelling and re-creating.

### Testing
- Tested the match flow, verified that the zero'd order was not re-indexed in the network order book
- Tested the update order endpoint, verified that it correctly overwrote the zero'd order