### PR TITLE
core: tasks: settle-match: Fix bugs preventing chained matches

### DIFF
--- a/core/src/external_api/http/wallet.rs
+++ b/core/src/external_api/http/wallet.rs
@@ -119,6 +119,14 @@ pub struct UpdateOrderRequest {
 pub struct UpdateOrderResponse {
     /// The ID of the task allocated for this request
     pub task_id: TaskIdentifier,
+    /// The new ID assigned to the updated order
+    ///
+    /// We cannot use the previously assigned ID because the order
+    /// may be cached as "already matched" elsewhere in the network
+    ///
+    /// The effectual state update is as if the caller had cancelled
+    /// the target order and created a new order
+    pub new_order_id: Uuid,
 }
 
 /// The response type to a request to cancel a given order


### PR DESCRIPTION
### Purpose
This PR fixes a couple bugs that prevent chained matches:
1. In the `settle-match` task, we previously were not properly re-blinding the wallet and recomputing its Merkle inclusion proof. This PR fixes that
2. The `/wallet/:id/orders/:id/update` endpoint needs to re-assign `OrderIdentifier`s to updated orders. This is because stale identifiers are used as match engine cache keys, so if an updated order maintains its identifier, it may never be matched by counterparties that believe they have already matched it.

### Testing
- Unit and integration tests pass
- Tested the end-to-end flow of matching an order, topping off the order on the filled counterparty's side, and then re-matching to fill more of the unfilled counterparty's side.