### PR TITLE
core: state: wallet: Track orders/balances with `indexmap` for ordering

### DIFF
--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -25,6 +25,7 @@ use crate::{
         order::OrderVar,
         transfers::{ExternalTransfer, ExternalTransferVar},
         wallet::{Nullifier, WalletShare, WalletShareStateCommitment, WalletVar},
+        AMOUNT_BITS,
     },
     zk_gadgets::{
         comparators::{
@@ -219,7 +220,7 @@ where
 
             // Constrain the updated balance to be non-negative and correctly updated
             cs.constrain(new_balance.amount.clone() - expected_balance);
-            GreaterThanEqZeroGadget::<64 /* bitwidth */>::constrain_greater_than_zero(
+            GreaterThanEqZeroGadget::<AMOUNT_BITS /* bitwidth */>::constrain_greater_than_zero(
                 new_balance.amount.clone(),
                 cs,
             );

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ hex = "0.3.1"
 hmac-sha256 = "1.1.6"
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
 integration-helpers = { path = "../integration-helpers" }
+indexmap = "1.9"
 itertools = "0.10"
 lazy_static = "1.4.0"
 libp2p = { version = "0.51", features = [


### PR DESCRIPTION
### Purpose
When creating a proof of `VALID WALLET UPDATE`, it is important that all orders and balances are input to the proof in the same order as the secret shares committed to in the contract. To enable this, this PR switches the data structure underlying a wallet's orders and balances to `indexmap` which yields an iterator ordered by insertion order.

As well, this PR changes `/wallet/:id/orders/:id/update` to update in-place so that insertion order is again preserved.

### Testing
- Unit and integration tests pass
- Tested the flow of fetching a wallet from on-chain, then calling `VALID WALLET UPDATE`. Verified that the proof was valid.