### PR TITLE
core: price-reporter: properly disable price reporter with flag

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -90,9 +90,6 @@ struct Cli {
     /// A fresh key is generated at startup if this is not present
     #[clap(long, value_parser)]
     pub p2p_key: Option<String>,
-    /// Flag to disable the API server
-    #[clap(long, value_parser)]
-    pub disable_api_server: bool,
     /// Flag to disable the price reporter
     #[clap(long, value_parser)]
     pub disable_price_reporter: bool,
@@ -175,9 +172,6 @@ pub struct RelayerConfig {
     pub websocket_port: u16,
     /// The local peer's base64 encoded p2p key
     pub p2p_key: Option<String>,
-    /// Whether to disable the API server on the local node if, for example,
-    /// the local node is an MPC-only node
-    pub disable_api_server: bool,
     /// Whether to disable the price reporter if e.g. we are streaming from a dedicated
     /// external API gateway node in the cluster
     pub disable_price_reporter: bool,
@@ -222,7 +216,6 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             allow_local: self.allow_local,
             public_ip: self.public_ip,
-            disable_api_server: self.disable_api_server,
             disable_price_reporter: self.disable_price_reporter,
             disable_binance: self.disable_binance,
             wallets: self.wallets.clone(),
@@ -310,7 +303,6 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         allow_local: cli_args.allow_local,
         p2p_key: cli_args.p2p_key,
         public_ip: cli_args.public_ip,
-        disable_api_server: cli_args.disable_api_server,
         disable_price_reporter: cli_args.disable_price_reporter,
         disable_binance: cli_args.disable_binance,
         wallets: parse_wallet_file(cli_args.wallet_file)?,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -293,6 +293,7 @@ async fn main() -> Result<(), CoordinatorError> {
         coinbase_api_key: args.coinbase_api_key,
         coinbase_api_secret: args.coinbase_api_secret,
         eth_websocket_addr: args.eth_websocket_addr,
+        disabled: args.disable_price_reporter,
         disable_binance: args.disable_binance,
     })
     .expect("failed to build price reporter manager");
@@ -356,18 +357,6 @@ async fn main() -> Result<(), CoordinatorError> {
     let (proof_manager_failure_sender, mut proof_manager_failure_receiver) =
         mpsc::channel(1 /* buffer_size */);
     watch_worker::<ProofManager>(&mut proof_manager, proof_manager_failure_sender);
-
-    // For simplicity, we simply cancel all disabled workers, it is simpler to do this than work with
-    // a dynamic list of futures
-    //
-    // We can refactor this decision if it becomes a performance issue
-    if args.disable_api_server {
-        api_server.cleanup().unwrap();
-    }
-
-    if args.disable_price_reporter {
-        price_reporter_cancel_sender.send(()).unwrap();
-    }
 
     // Await module termination, and send a cancel signal for any modules that
     // have been detected to fault

--- a/core/src/price_reporter/manager.rs
+++ b/core/src/price_reporter/manager.rs
@@ -67,6 +67,11 @@ impl PriceReporterManagerExecutor {
             tokio::select! {
                 // Dequeue the next job from elsewhere in the local node
                 Some(job) = job_receiver.recv() => {
+                    if self.config.disabled {
+                        log::warn!("PriceReporterManager received job while disabled, ignoring...");
+                        continue;
+                    }
+
                     tokio::spawn({
                         let mut self_clone = self.clone();
                         async move {

--- a/core/src/price_reporter/worker.rs
+++ b/core/src/price_reporter/worker.rs
@@ -31,6 +31,8 @@ pub struct PriceReporterManagerConfig {
     pub(crate) coinbase_api_secret: Option<String>,
     /// The ethereum RPC node websocket addresses for on-chain data
     pub(crate) eth_websocket_addr: Option<String>,
+    /// Whether or not the worker is disabled
+    pub(crate) disabled: bool,
     /// Whether or not to disable binance streaming
     ///
     /// Used in locations that Binance has IP blocked

--- a/core/src/state/tui.rs
+++ b/core/src/state/tui.rs
@@ -340,11 +340,6 @@ impl StateTuiApp {
                 .get_addr()
         });
         let full_addr = format!("{local_addr}/p2p/{peer_id}");
-        let api_server_enabled = if self.config.disable_api_server {
-            STR_DISABLED
-        } else {
-            STR_ENABLED
-        };
         let price_reporter_enabled = if self.config.disable_price_reporter {
             STR_DISABLED
         } else {
@@ -382,14 +377,10 @@ impl StateTuiApp {
             Span::styled(self.config.websocket_port.to_string(), *YELLOW_TEXT),
         ]);
         let line7 = Spans::from(vec![
-            Span::styled("API Server: ", *GREEN_TEXT),
-            Span::styled(api_server_enabled, *YELLOW_TEXT),
-        ]);
-        let line8 = Spans::from(vec![
             Span::styled("Price reporter: ", *GREEN_TEXT),
             Span::styled(price_reporter_enabled, *YELLOW_TEXT),
         ]);
-        let line9 = Spans::from(vec![
+        let line8 = Spans::from(vec![
             Span::styled("StarkNet Events Listener: ", *GREEN_TEXT),
             Span::styled(chain_events_enabled, *YELLOW_TEXT),
         ]);
@@ -403,7 +394,6 @@ impl StateTuiApp {
             ListItem::new(line6),
             ListItem::new(line7),
             ListItem::new(line8),
-            ListItem::new(line9),
         ];
 
         List::new(items).block(Self::create_block_with_title("Local Node Metadata"))


### PR DESCRIPTION
### Purpose
This PR changes the way we disable the price reporter to simply ignore jobs, instead of trying to cancel the worker. Long term we can do something more efficient that deallocates the thread, but for now this is sufficient.

### Testing
- Disabled the price reporter, verified that the rest of the relayer worked properly