### PR TITLE
core: config: Add `bind_addr` argument for specific interface binding

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     env::{self},
     fs,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
 };
 use toml::{value::Map, Value};
 
@@ -56,6 +56,10 @@ struct Cli {
     /// Allow for discovery of nodes on the localhost IP address
     #[clap(long, value_parser, default_value="false")]
     pub allow_local: bool,
+
+    /// The address to bind to for gossip, defaults to 0.0.0.0 (all interfaces)
+    #[clap(long, value_parser, default_value = "0.0.0.0")]
+    pub bind_addr: IpAddr,
 
     /// The known public IP address of the local peer
     #[clap(long, value_parser)] 
@@ -150,6 +154,8 @@ pub struct RelayerConfig {
     // ----------------------------
     /// Allow for discovery of nodes on the localhost IP address
     pub allow_local: bool,
+    /// The address to bind to for gossip, defaults to 0.0.0.0 (all interfaces)
+    pub bind_addr: IpAddr,
     /// The known public IP address of the local peer
     pub public_ip: Option<SocketAddr>,
 
@@ -215,6 +221,7 @@ impl Clone for RelayerConfig {
             websocket_port: self.websocket_port,
             p2p_key: self.p2p_key.clone(),
             allow_local: self.allow_local,
+            bind_addr: self.bind_addr,
             public_ip: self.public_ip,
             disable_price_reporter: self.disable_price_reporter,
             disable_binance: self.disable_binance,
@@ -302,6 +309,7 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         websocket_port: cli_args.websocket_port,
         allow_local: cli_args.allow_local,
         p2p_key: cli_args.p2p_key,
+        bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         disable_price_reporter: cli_args.disable_price_reporter,
         disable_binance: cli_args.disable_binance,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -219,6 +219,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (network_cancel_sender, network_cancel_receiver) = watch::channel(());
     let network_manager_config = NetworkManagerConfig {
         port: args.p2p_port,
+        bind_addr: args.bind_addr,
         known_public_addr: args.public_ip,
         allow_local: args.allow_local,
         cluster_id: args.cluster_id.clone(),

--- a/core/src/network_manager/worker.rs
+++ b/core/src/network_manager/worker.rs
@@ -38,6 +38,8 @@ const NETWORK_MANAGER_N_THREADS: usize = 3;
 pub struct NetworkManagerConfig {
     /// The port to listen for inbound traffic on
     pub(crate) port: u16,
+    /// The address to bind to for inbound traffic
+    pub(crate) bind_addr: IpAddr,
     /// The cluster ID of the local peer
     pub(crate) cluster_id: ClusterId,
     /// Whether or not to allow discovery of peers on the localhost
@@ -116,7 +118,10 @@ impl Worker for NetworkManager {
 
     fn start(&mut self) -> Result<(), Self::Error> {
         // Build a quic transport
-        let hostport = format!("/ip4/0.0.0.0/udp/{}/quic-v1", self.config.port);
+        let hostport = format!(
+            "/ip4/{}/udp/{}/quic-v1",
+            self.config.bind_addr, self.config.port
+        );
         let addr: Multiaddr = hostport.parse().unwrap();
 
         // Build the quic transport


### PR DESCRIPTION
### Purpose
By default we bind to `0.0.0.0` which listens and sends on all network interfaces. However, we sometimes want to specify a specific network interface to send/receive on. 

One such example is the bootstrap cluster; it is provisioned with a static IP so that it may be reached at a known address, but this IP is attached to a non-default network interface on the node. If the bootstrap node binds to all network interfaces, it may receive traffic on the interface of the static IP and send traffic on a different interface. This will be blocked by symmetric NATs as the response will seem to come from a different hostport. For this reason, we bind the bootstrap nodes to only the network interface on which we provision the static IP.

### Testing
- Tested bootstrapping into the network from my local node, which is behind a symmetric NAT (as per a STUN test)