### PR TITLE
core: config, api-server: Add `disable_fee_validation` flag, and serialize an empty request/response as `null`

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -102,6 +102,9 @@ struct Cli {
     /// This is useful for testing in a region that Binance has IP blocked
     #[clap(long, value_parser)]
     pub disable_binance: bool,
+    /// Flag to disable fee validation
+    #[clap(long, value_parser)]
+    pub disable_fee_validation: bool,
     /// Whether or not to run the relayer in debug mode
     #[clap(short, long, value_parser)]
     pub debug: bool,
@@ -183,6 +186,8 @@ pub struct RelayerConfig {
     pub disable_price_reporter: bool,
     /// Whether to disable price streaming from Binance for location blocks
     pub disable_binance: bool,
+    /// Whether to disable fee validation, allowing for zero fees
+    pub disable_fee_validation: bool,
     /// Whether or not the relayer is in debug mode
     pub debug: bool,
 
@@ -225,6 +230,7 @@ impl Clone for RelayerConfig {
             public_ip: self.public_ip,
             disable_price_reporter: self.disable_price_reporter,
             disable_binance: self.disable_binance,
+            disable_fee_validation: self.disable_fee_validation,
             wallets: self.wallets.clone(),
             cluster_keypair: Keypair::from_bytes(&self.cluster_keypair.to_bytes()).unwrap(),
             cluster_id: self.cluster_id.clone(),
@@ -313,6 +319,7 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, CoordinatorError> {
         public_ip: cli_args.public_ip,
         disable_price_reporter: cli_args.disable_price_reporter,
         disable_binance: cli_args.disable_binance,
+        disable_fee_validation: cli_args.disable_fee_validation,
         wallets: parse_wallet_file(cli_args.wallet_file)?,
         cluster_keypair: keypair,
         cluster_id,

--- a/core/src/external_api/mod.rs
+++ b/core/src/external_api/mod.rs
@@ -10,8 +10,45 @@ pub mod types;
 pub mod websocket;
 
 /// An empty request/response type
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmptyRequestResponse {}
+
+/// Serialize an empty request/response
+impl Serialize for EmptyRequestResponse {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_none()
+    }
+}
+
+/// Deserialize an empty request/response
+impl<'de> Deserialize<'de> for EmptyRequestResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_unit(EmptyRequestResponseVisitor)
+    }
+}
+
+/// Visitor for deserializing an empty request/response
+struct EmptyRequestResponseVisitor;
+impl<'de> serde::de::Visitor<'de> for EmptyRequestResponseVisitor {
+    type Value = EmptyRequestResponse;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("null")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(EmptyRequestResponse {})
+    }
+}
 
 /// A helper to serialize a BigUint to a hex string
 pub fn biguint_to_hex_string<S>(val: &BigUint, s: S) -> Result<S::Ok, S::Error>
@@ -40,14 +77,14 @@ mod test {
     use super::EmptyRequestResponse;
 
     /// Tests empty request/response serialization, expected behavior is that it serializes to and from
-    /// an empty json struct
+    /// the string "null"
     #[test]
     fn test_serde_empty() {
         let req = EmptyRequestResponse {};
         let serialized_str = serde_json::to_string(&req).unwrap();
-        assert_eq!(serialized_str, "{}");
+        assert_eq!(serialized_str, "null");
 
         // Test deserialization from empty json struct encoded as a string
-        let _req: EmptyRequestResponse = serde_json::from_str("{}").unwrap();
+        let _req: EmptyRequestResponse = serde_json::from_str("null").unwrap();
     }
 }

--- a/core/src/state/state.rs
+++ b/core/src/state/state.rs
@@ -63,6 +63,8 @@ pub struct RelayerState {
     pub local_keypair: Keypair,
     /// The cluster id of the local relayer
     pub local_cluster_id: ClusterId,
+    /// Whether to disable fee validation
+    pub disable_fee_validation: bool,
     /// The list of wallets managed by the sending relayer
     wallet_index: AsyncShared<WalletIndex>,
     /// The set of peers known to the sending relayer
@@ -113,6 +115,7 @@ impl RelayerState {
             local_peer_id,
             local_keypair,
             local_cluster_id: args.cluster_id.clone(),
+            disable_fee_validation: args.disable_fee_validation,
             wallet_index: new_async_shared(wallet_index),
             matched_order_pairs: new_async_shared(vec![]),
             peer_index: new_async_shared(peer_index),

--- a/core/src/tasks/initialize_state.rs
+++ b/core/src/tasks/initialize_state.rs
@@ -247,6 +247,7 @@ impl InitializeStateTask {
                     order.clone(),
                     &wallet_reblind_witness,
                     self.proof_manager_work_queue.clone(),
+                    self.global_state.disable_fee_validation,
                 )
                 .map_err(InitializeStateTaskError::ProveValidCommitments)?;
 


### PR DESCRIPTION
### Purpose

Adds the `disable_fee_validation` flag, which disables the check that a wallet's fee is nonzero. This is useful for either a testnet or for a private cluster.

### Testing

Tested with both 1) the full testing suite of `renegade-js` version `3.0.1`, and 2) an order placement in the browser.