### PR TITLE
core: price-reporter: Stabilize price reporter

### DIFF
--- a/core/src/price_reporter/exchange/coinbase.rs
+++ b/core/src/price_reporter/exchange/coinbase.rs
@@ -180,6 +180,11 @@ impl CoinbaseConnection {
             .map(|key| key.parse::<f64>().unwrap())
             .fold(f64::INFINITY, f64::min);
 
+        // Do not let the best offer be infinite as this gives an infinite midpoint
+        if best_offer == f64::INFINITY {
+            return Ok(Some(0.));
+        }
+
         Ok(Some((best_bid + best_offer) / 2.))
     }
 }

--- a/core/src/price_reporter/reporter.rs
+++ b/core/src/price_reporter/reporter.rs
@@ -35,7 +35,7 @@ pub type Price = f64;
 /// milliseconds), we pause matches until we receive a more recent price. Note that this threshold
 /// cannot be too aggressive, as certain long-tail asset pairs legitimately do not update that
 /// often.
-const MAX_REPORT_AGE_MS: u64 = 5_000; // 5 seconds
+const MAX_REPORT_AGE_MS: u64 = 20_000; // 20 seconds
 /// If we do not have at least MIN_CONNECTIONS reports, we pause matches until we have enough
 /// reports. This only applies to Named tokens, as Unnamed tokens simply use UniswapV3.
 const MIN_CONNECTIONS: usize = 1;

--- a/core/src/price_reporter/reporter.rs
+++ b/core/src/price_reporter/reporter.rs
@@ -421,6 +421,11 @@ impl ConnectionMuxer {
                     if let Some((exchange, res)) = stream_elem {
                         match res {
                             Ok(price) => {
+                                // Do not update if the price is default, simply let the price age
+                                if price == Price::default() {
+                                    continue;
+                                }
+
                                 let ts = get_current_time();
                                 self.exchange_state
                                     .new_price(exchange, price, ts);


### PR DESCRIPTION
### Purpose
This PR makes two updates to the price reporter that stabilize prices:
1. Allow a longer interval on stale prices; from 5s to 20s. It is common that some exchanges won't report updates when no price action is detected, so we lengthen the interval. Long term we may want different intervals for different base assets.
2. Ignore infinite and default prices when updating the atomic state. So instead of updating a non-zero, non-infinite price to 0 of `inf`, we let the price go stale and error that way instead. This is a common issue when e.g. Coinbase's book has no orders on it.

### Testing
- Unit and integration tests
- Tested the price reporter over an extended period of time, verified that the number of invalid price reports dropped significantly