### PR TITLE
core: tasks: settle-match-internal: Fix execution bugs and recursive match

### DIFF
--- a/core/src/tasks/driver.rs
+++ b/core/src/tasks/driver.rs
@@ -35,7 +35,7 @@ const BACKOFF_CEILING_MS: u64 = 30_000; // 30 seconds
 /// The initial backoff time when retrying a task
 const INITIAL_BACKOFF_MS: u64 = 2000; // 2 seconds
 /// The number of threads backing the tokio runtime
-const TASK_DRIVER_N_THREADS: usize = 1;
+const TASK_DRIVER_N_THREADS: usize = 5;
 /// The name of the threads backing the task driver
 const TASK_DRIVER_THREAD_NAME: &str = "renegade-task-driver";
 /// The number of times to retry a step in a task before propagating the error
@@ -164,7 +164,7 @@ impl TaskDriver {
                 }
 
                 tokio::time::sleep(curr_backoff).await;
-                log::info!("retrying task from state: {}", task.state());
+                log::info!("retrying task {task_id:?} from state: {}", task.state());
                 curr_backoff *= BACKOFF_AMPLIFICATION_FACTOR;
                 curr_backoff =
                     Duration::min(curr_backoff, Duration::from_millis(BACKOFF_CEILING_MS));
@@ -172,7 +172,7 @@ impl TaskDriver {
 
             // Update the state in the registry
             let task_state = task.state();
-            log::info!("task {task_name} transitioning to state {task_state}");
+            log::info!("task {task_name}({task_id:?}) transitioning to state {task_state}");
 
             {
                 *self.open_tasks.write().await.get_mut(&task_id).unwrap() = task_state.into()

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -327,6 +327,14 @@ impl SettleMatchTask {
             }
         }
 
+        // If the transaction was successful, cancel all orders on both nullifiers, await new validity proofs
+        self.global_state
+            .nullify_orders(party0_reblind_proof.original_shares_nullifier)
+            .await;
+        self.global_state
+            .nullify_orders(party1_reblind_proof.original_shares_nullifier)
+            .await;
+
         Ok(())
     }
 


### PR DESCRIPTION
### Purpose
This PR fixes a few bugs with the internal matching engine:
- Orders should be nullified during settlement ahead of when their new validity proofs are created. This prevents the internal engine from attempting to double match before new validity proofs are created
- Orders that have zero volume should be ignored by the engine

### Testing
- Unit and integration tests pass
- Tested a recursive internal match in which one buy side order is recursively matched by two separate sell side orders, both of which it fills entirely.