### PR TITLE
crypto: Refactor implementation over Stark curve

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -3,7 +3,13 @@ name = "crypto"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bench]]
+name = "elgamal"
+harness = false
+
+[[bench]]
+name = "poseidon"
+harness = false
 
 [dependencies]
 # === Cryptography + Arithmetic === #
@@ -22,3 +28,6 @@ rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
 starknet = { workspace = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async", "async_tokio"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -6,14 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# === Cryptography + Arithmetic === #
 ark-ff = "0.4"
 ark-crypto-primitives = { version = "0.4", features = ["sponge"] }
 bigdecimal = "0.3"
-curve25519-dalek = { workspace = true, features = ["serde"] }
+mpc-stark = { workspace = true }
+num-bigint = { version = "0.4", features = ["rand", "serde"] }
+
+# === Misc Dependencies === #
 itertools = "0.10"
 lazy_static = "1.4"
 memoize = "0.4"
-num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = { version = "0.8" }
 rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }

--- a/crypto/benches/elgamal.rs
+++ b/crypto/benches/elgamal.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use crypto::elgamal::{decrypt_scalar, encrypt_scalar};
+use mpc_stark::algebra::scalar::Scalar;
+use rand::thread_rng;
+
+/// Run a benchmark on the ElGamal encryption implementation
+fn bench_encrypt(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    let mut group = c.benchmark_group("ElGamal encryption");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::from_parameter(1), |b| {
+        b.iter_batched(
+            || {
+                (
+                    Scalar::random(&mut rng),
+                    Scalar::random(&mut rng).to_biguint(),
+                )
+            },
+            |(plaintext, public_key)| encrypt_scalar(plaintext, &public_key),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Run a decryption benchmark
+fn bench_decrypt(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    let mut group = c.benchmark_group("ElGamal decryption");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::from_parameter(1), |b| {
+        b.iter_batched(
+            || {
+                let (cipher, _) = encrypt_scalar(
+                    Scalar::random(&mut rng),
+                    &Scalar::random(&mut rng).to_biguint(),
+                );
+                (cipher, Scalar::random(&mut rng).to_biguint())
+            },
+            |(cipher, secret_key)| decrypt_scalar(cipher, &secret_key),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_encrypt, bench_decrypt
+);
+criterion_main!(benches);

--- a/crypto/benches/poseidon.rs
+++ b/crypto/benches/poseidon.rs
@@ -1,0 +1,38 @@
+//! Defines benchmarks for the Poseidon hash function
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use crypto::{
+    constants::{POSEIDON_MDS_MATRIX_T_3, POSEIDON_ROUND_CONSTANTS_T_3},
+    hash::compute_poseidon_hash,
+};
+use mpc_stark::algebra::scalar::Scalar;
+use rand::thread_rng;
+
+/// Run a benchmark on the poseidon hash implementation
+fn bench_hash(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    // The param parsing is memoized, run it once so this does not affect the benchmark
+    {
+        POSEIDON_MDS_MATRIX_T_3();
+        POSEIDON_ROUND_CONSTANTS_T_3();
+    }
+
+    let mut group = c.benchmark_group("Poseidon Hash");
+    for i in [1, 10, 100, 1000] {
+        group.throughput(Throughput::Elements(i));
+        group.bench_function(BenchmarkId::from_parameter(i), |b| {
+            b.iter_batched(
+                || (0..i).map(|_| Scalar::random(&mut rng)).collect::<Vec<_>>(),
+                |input| compute_poseidon_hash(&input),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_hash
+);
+criterion_main!(benches);

--- a/crypto/src/constants.rs
+++ b/crypto/src/constants.rs
@@ -3,9 +3,8 @@
 #![allow(missing_docs)]
 
 use memoize::memoize;
+use mpc_stark::algebra::scalar::Scalar;
 use num_bigint::BigUint;
-
-use crate::fields::DalekRistrettoField;
 
 /// Below are:
 ///     1. The MDS matrix (https://en.wikipedia.org/wiki/MDS_matrix) used in between SBoxes
@@ -21,7 +20,7 @@ use crate::fields::DalekRistrettoField;
 ///     python3 calc_round_numbers.py
 /// from the scripts above and taking the output for t = 3, \alpha = 5
 #[memoize]
-pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<DalekRistrettoField>> {
+pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<Scalar::Field>> {
     vec![
         vec![
             field_element_from_hex_string(
@@ -61,7 +60,7 @@ pub fn POSEIDON_MDS_MATRIX_T_3() -> Vec<Vec<DalekRistrettoField>> {
 
 /// Round constants for t = 3 (2-1 hash)
 #[memoize]
-pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<DalekRistrettoField>> {
+pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<Scalar::Field>> {
     vec![
         vec![
             field_element_from_hex_string(
@@ -773,8 +772,8 @@ pub fn POSEIDON_ROUND_CONSTANTS_T_3() -> Vec<Vec<DalekRistrettoField>> {
 /// Converts a literal hexadecimal string to a field element through BigUint
 /// this function should only ever be called on the constants above, so we panic
 /// if parsing fails
-fn field_element_from_hex_string(byte_string: &[u8]) -> DalekRistrettoField {
-    DalekRistrettoField::from(BigUint::parse_bytes(byte_string, 16 /* radix */).unwrap())
+fn field_element_from_hex_string(byte_string: &[u8]) -> Scalar::Field {
+    Scalar::Field::from(BigUint::parse_bytes(byte_string, 16 /* radix */).unwrap())
 }
 
 #[cfg(test)]

--- a/crypto/src/fields.rs
+++ b/crypto/src/fields.rs
@@ -38,6 +38,7 @@ pub fn scalar_to_bigdecimal(a: &Scalar) -> BigDecimal {
     BigDecimal::from(bigint)
 }
 
+/// Reduces the scalar to a u64, truncating anything above 2^64 - 1
 pub fn scalar_to_u64(a: &Scalar) -> u64 {
     let bytes = a.to_bytes_be();
     let len = bytes.len();

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,5 +1,6 @@
 //! Cryptography helpers and primitives useful throughout the relayer
 #![deny(unsafe_code)]
+#![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 
 pub mod constants;


### PR DESCRIPTION
### Purpose
This PR makes the initial steps to refactor `renegade` over the Stark curve by refactoring the `crypto` crate. This crate defines `crypto` utilities such as:
- Poseidon hashes
- Field conversions
- Elgamal encryptions

### Testing
- Crate tests pass, though CI will be red as the rest of the crates are not refactored