### PR TITLE
integration-helpers: Refactor over Stark curve

### DIFF
--- a/integration-helpers/Cargo.toml
+++ b/integration-helpers/Cargo.toml
@@ -11,11 +11,15 @@ name = "integration_helpers"
 path = "src/lib.rs"
 
 [dependencies]
+# === Runtime + Networking === #
 async-trait = "0.1"
-curve25519-dalek = "2"
 dns-lookup = "1.0"
 futures = "0.3"
+
+# === Cryptography + Arithmetic === #
+mpc-stark =  { workspace = true }
+num-bigint = { version = "0.4", features = ["rand"] }
+
+# === Misc Dependencies === #
 inventory = "0.3"
 itertools = "0.10.5"
-mpc-ristretto = { workspace = true }
-num-bigint = { version = "0.4", features = ["rand"] }

--- a/integration-helpers/src/mpc_network/mocks.rs
+++ b/integration-helpers/src/mpc_network/mocks.rs
@@ -1,8 +1,13 @@
 //! Mocks of various types used throughout the implementation of the MPC Network
 
 use async_trait::async_trait;
-use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
-use mpc_ristretto::{beaver::SharedValueSource, error::MpcNetworkError, network::MpcNetwork};
+use mpc_stark::{
+    algebra::scalar::Scalar,
+    beaver::SharedValueSource,
+    error::MpcNetworkError,
+    network::{MpcNetwork, NetworkOutbound, NetworkPayload, PartyId},
+    PARTY0,
+};
 
 /// An implementation of a beaver value source that returns
 /// beaver triples (0, 0, 0) for party 0 and (1, 1, 1) for party 1
@@ -21,7 +26,7 @@ impl PartyIDBeaverSource {
 
 /// The PartyIDBeaverSource returns beaver triplets split statically between the
 /// parties. We assume a = 2, b = 3 ==> c = 6. [a] = (1, 1); [b] = (3, 0) [c] = (2, 4)
-impl SharedValueSource<Scalar> for PartyIDBeaverSource {
+impl SharedValueSource for PartyIDBeaverSource {
     fn next_shared_bit(&mut self) -> Scalar {
         // Simply output partyID, assume partyID \in {0, 1}
         assert!(self.party_id == 0 || self.party_id == 1);
@@ -45,95 +50,35 @@ impl SharedValueSource<Scalar> for PartyIDBeaverSource {
     }
 }
 
-/// Mocks out an MPC network and allows creation of mock values from the peer
-#[derive(Clone, Debug, Default)]
-pub struct MockMpcNet {
-    /// A list of scalars to be drained when the interface expects to
-    /// receive a scalar
-    mock_scalars: Vec<Scalar>,
-    /// A list of Ristretto points to be drained when the interface expects to
-    /// receive a point
-    mock_points: Vec<RistrettoPoint>,
-}
-
-impl MockMpcNet {
-    /// Constructor
-    pub fn new() -> Self {
-        Self {
-            mock_scalars: vec![],
-            mock_points: vec![],
-        }
-    }
-
-    /// Add scalars to the mock response buffer
-    ///
-    /// Subsequent calls to the MpcNetwork interface that expect a non-empty
-    /// Scalar response will drain from this buffer.
-    pub fn add_mock_scalars(&mut self, scalars: Vec<Scalar>) {
-        self.mock_scalars.extend_from_slice(&scalars);
-    }
-
-    /// Add Ristretto points to the mock response buffer
-    ///
-    /// Subsequent calls to the MpcNetwork interface that expect a non-empty
-    /// RistrettoPoint response will drain from this buffer
-    pub fn add_mock_points(&mut self, points: Vec<RistrettoPoint>) {
-        self.mock_points.extend_from_slice(&points);
-    }
-}
+/// A dummy network implementation used for unit testing
+#[derive(Default)]
+pub struct MockNetwork;
 
 #[async_trait]
-impl MpcNetwork for MockMpcNet {
-    fn party_id(&self) -> u64 {
-        0
+impl MpcNetwork for MockNetwork {
+    fn party_id(&self) -> PartyId {
+        PARTY0
     }
 
-    async fn send_bytes(&mut self, _bytes: &[u8]) -> Result<(), MpcNetworkError> {
+    async fn send_message(&mut self, _message: NetworkOutbound) -> Result<(), MpcNetworkError> {
         Ok(())
     }
 
-    async fn receive_bytes(&mut self) -> Result<Vec<u8>, MpcNetworkError> {
-        Err(MpcNetworkError::RecvError)
+    async fn receive_message(&mut self) -> Result<NetworkOutbound, MpcNetworkError> {
+        Ok(NetworkOutbound {
+            op_id: 0,
+            payload: NetworkPayload::Scalar(Scalar::one()),
+        })
     }
 
-    async fn send_scalars(&mut self, _: &[Scalar]) -> Result<(), MpcNetworkError> {
-        Ok(())
-    }
-
-    async fn receive_scalars(
+    async fn exchange_messages(
         &mut self,
-        num_scalars: usize,
-    ) -> Result<Vec<Scalar>, MpcNetworkError> {
-        Ok(self.mock_scalars.drain(0..num_scalars).as_slice().to_vec())
-    }
-
-    async fn broadcast_points(
-        &mut self,
-        points: &[RistrettoPoint],
-    ) -> Result<Vec<RistrettoPoint>, MpcNetworkError> {
-        Ok(self.mock_points.drain(0..points.len()).as_slice().to_vec())
-    }
-
-    async fn send_points(&mut self, _: &[RistrettoPoint]) -> Result<(), MpcNetworkError> {
-        Ok(())
-    }
-
-    async fn receive_points(
-        &mut self,
-        num_points: usize,
-    ) -> Result<Vec<RistrettoPoint>, MpcNetworkError> {
-        Ok(self.mock_points.drain(0..num_points).as_slice().to_vec())
-    }
-
-    async fn broadcast_scalars(
-        &mut self,
-        scalars: &[Scalar],
-    ) -> Result<Vec<Scalar>, MpcNetworkError> {
-        Ok(self
-            .mock_scalars
-            .drain(0..scalars.len())
-            .as_slice()
-            .to_vec())
+        _message: NetworkOutbound,
+    ) -> Result<NetworkOutbound, MpcNetworkError> {
+        Ok(NetworkOutbound {
+            op_id: 0,
+            payload: NetworkPayload::Scalar(Scalar::one()),
+        })
     }
 
     async fn close(&mut self) -> Result<(), MpcNetworkError> {


### PR DESCRIPTION
### Purpose
This PR refactors the `integration-helpers` crate to work over the new `mpc-stark` library, i.e. over the Stark curve. This largely involves deleting helper code that has been replaced by functionality in the `MpcFabric`.

### Testing
- CI will fail until other crates are refactored