### PR TITLE
circuits: mpc-circuits: Refactor MPC circuits to operate over the Stark curve

### DIFF
--- a/circuit-macros/Cargo.toml
+++ b/circuit-macros/Cargo.toml
@@ -10,7 +10,7 @@ proc-macro = true
 bench = []
 
 [dependencies]
-mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
+mpc-bulletproof = { workspace = true }
 
 proc-macro2 = "1.0.50"
 quote = "1.0.23"

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -32,6 +32,7 @@ use num_bigint::BigUint;
 use rand::thread_rng;
 use serde::{de::Error as SerdeErr, Deserialize, Deserializer, Serialize, Serializer};
 use wallet::{Wallet, WalletShare};
+// use wallet::{Wallet, WalletShare};
 
 // -------------
 // | Constants |

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -85,7 +85,9 @@ pub trait BaseType: Clone {
     /// trait
     async fn share_public(&self, owning_party: PartyId, fabric: MpcFabric) -> Self {
         let self_scalars = self.clone().to_scalars_with_linking();
-        let res_scalars = join_all(fabric.batch_share_plaintext(self_scalars, owning_party)).await;
+        let res_scalars = fabric
+            .batch_share_plaintext(self_scalars, owning_party)
+            .await;
 
         Self::from_scalars(&mut res_scalars.into_iter())
     }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -6,26 +6,38 @@ edition = "2021"
 [features]
 bench = []
 
+[[test]]
+name = "integration"
+path = "integration/main.rs"
+harness = false
+features = ["bench"]
+
 [dependencies]
-ark-crypto-primitives = { version = "0.4", features = ["crh", "merkle_tree", "sponge"] }
+# === Crytography + Arithmetic === #
+ark-crypto-primitives = { version = "0.4", features = [
+    "crh",
+    "merkle_tree",
+    "sponge",
+] }
 ark-ff = "0.4"
 bigdecimal = "0.3"
-bitvec = "1.0"
+merlin = { git = "https://github.com/renegade-fi/merlin" }
+mpc-stark = { workspace = true }
+mpc-bulletproof = { workspace = true }
+num-bigint = { version = "0.4", features = ["rand", "serde"] }
+num-integer = "0.1"
+
+# === Workspace Dependencies === #
 circuit-macros = { path = "../circuit-macros" }
 circuit-types = { workspace = true }
 constants = { path = "../constants" }
 crypto = { path = "../crypto" }
-curve25519-dalek = { workspace = true }
-ed25519-dalek = { version = "1.0.1" }
+
+# === Misc Dependencies === #
+bitvec = "1.0"
 itertools = "0.10"
 lazy_static = "1.4"
-merlin = "2.0"
-mpc-ristretto = { workspace = true }
-mpc-bulletproof = { workspace = true }
-num-bigint = { version = "0.4", features = ["rand", "serde"] }
-num-integer = "0.1"
 rand = { version = "0.8" }
-rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_arrays = "0.1"
 serde_json = "1.0"
@@ -38,18 +50,12 @@ chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
 ctor = "0.1"
-criterion = { version = "0.4" } 
+criterion = { version = "0.4" }
 dns-lookup = "1.0"
 env_logger = "0.9"
-integration-helpers = { path = "../integration-helpers" }
+futures = "0.3"
 inventory = "0.3"
-num-primes = "0.3"
 rand = "0.8"
 serde_json = "1.0"
+test-helpers = { path = "../test-helpers" }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
-
-[[test]]
-name = "integration"
-path = "integration/main.rs"
-harness = false
-features = ["bench"]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -29,12 +29,13 @@ num-integer = "0.1"
 
 # === Workspace Dependencies === #
 circuit-macros = { path = "../circuit-macros" }
-circuit-types = { workspace = true }
+circuit-types = { path = "../circuit-types" }
 constants = { path = "../constants" }
-crypto = { path = "../crypto" }
+renegade-crypto = { path = "../renegade-crypto" }
 
 # === Misc Dependencies === #
 bitvec = "1.0"
+futures = "0.3"
 itertools = "0.10"
 lazy_static = "1.4"
 rand = { version = "0.8" }

--- a/circuits/Dockerfile
+++ b/circuits/Dockerfile
@@ -9,14 +9,21 @@ WORKDIR /build
 COPY ./rust-toolchain ./circuits/rust-toolchain
 RUN cat circuits/rust-toolchain | xargs rustup toolchain install
 
-# Copy in dependencies from the same repo
+# Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
+# transferring all workspace members to the docker image, and instead only transfer the
+# dependencies of the integration test. Every path dependency of the target crate is automatically
+# added to the workspace
 COPY ./Cargo.toml ./Cargo.toml
+RUN sed -i '/members = \[/,/\]/c\members = [ "circuits" ]' Cargo.toml
+
+# Copy in dependencies from the same repo
 COPY ./circuit-types ./circuit-types
 COPY ./circuit-macros ./circuit-macros
 COPY ./common ./common
 COPY ./constants ./constants
-COPY ./crypto ./crypto
-COPY ./integration-helpers ./integration-helpers
+COPY ./renegade-crypto ./renegade-crypto
+COPY ./test-helpers ./test-helpers
+COPY ./util ./util
 
 # Place a set of dummy sources in the path, build the dummy executable
 # to cache built dependencies, then bulid the full executable

--- a/circuits/integration/main.rs
+++ b/circuits/integration/main.rs
@@ -5,24 +5,15 @@
 mod mpc_circuits;
 mod mpc_gadgets;
 mod types;
-mod zk_circuits;
-mod zk_gadgets;
-
-use std::cell::Ref;
+// mod zk_circuits;
+// mod zk_gadgets;
 
 use chrono::Local;
-use circuit_types::{MpcFabric, SharedFabric};
 use clap::Parser;
 use env_logger::Builder;
-use integration_helpers::{
-    integration_test_main,
-    mpc_network::{mocks::PartyIDBeaverSource, setup_mpc_fabric},
-};
-use mpc_ristretto::network::QuicTwoPartyNet;
+use mpc_stark::MpcFabric;
+use test_helpers::{integration_test_main, mpc_network::setup_mpc_fabric};
 use tracing::log::LevelFilter;
-
-/// A type alias for a shared mutability wrapper around the MPC fabric
-type SharedMpcFabric = SharedFabric<QuicTwoPartyNet, PartyIDBeaverSource>;
 
 /// The arguments used for running circuits integration tests
 #[derive(Debug, Clone, Parser)]
@@ -52,24 +43,13 @@ struct CliArgs {
 #[derive(Debug, Clone)]
 struct IntegrationTestArgs {
     /// The MPC fabric to use during the course of the integration test
-    pub(crate) mpc_fabric: SharedMpcFabric,
+    pub(crate) mpc_fabric: MpcFabric,
     pub(crate) party_id: u64,
-}
-
-impl IntegrationTestArgs {
-    pub(crate) fn borrow_fabric(&self) -> Ref<MpcFabric<QuicTwoPartyNet, PartyIDBeaverSource>> {
-        self.mpc_fabric.borrow_fabric()
-    }
 }
 
 impl From<CliArgs> for IntegrationTestArgs {
     fn from(args: CliArgs) -> Self {
-        let mpc_fabric = SharedFabric(setup_mpc_fabric(
-            args.party,
-            args.port1,
-            args.port2,
-            args.docker,
-        ));
+        let mpc_fabric = setup_mpc_fabric(args.party, args.port1, args.port2, args.docker);
         let party_id = mpc_fabric.borrow_fabric().party_id();
 
         Self {

--- a/circuits/integration/main.rs
+++ b/circuits/integration/main.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-mod mpc_circuits;
+// mod mpc_circuits;
 mod mpc_gadgets;
 mod types;
 // mod zk_circuits;
@@ -44,18 +44,13 @@ struct CliArgs {
 struct IntegrationTestArgs {
     /// The MPC fabric to use during the course of the integration test
     pub(crate) mpc_fabric: MpcFabric,
-    pub(crate) party_id: u64,
 }
 
 impl From<CliArgs> for IntegrationTestArgs {
     fn from(args: CliArgs) -> Self {
         let mpc_fabric = setup_mpc_fabric(args.party, args.port1, args.port2, args.docker);
-        let party_id = mpc_fabric.borrow_fabric().party_id();
 
-        Self {
-            mpc_fabric,
-            party_id,
-        }
+        Self { mpc_fabric }
     }
 }
 

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -11,11 +11,11 @@ use circuits::{
     mpc_circuits::r#match::compute_match,
     zk_circuits::valid_match_mpc::{AuthenticatedValidMatchMpcWitness, ValidMatchMpcCircuit},
 };
-use integration_helpers::types::IntegrationTest;
 use merlin::Transcript;
 use mpc_bulletproof::{r1cs_mpc::MpcProver, PedersenGens};
 use num_bigint::BigUint;
-use rand_core::OsRng;
+use rand::OsRng;
+use test_helpers::types::IntegrationTest;
 
 use crate::{IntegrationTestArgs, TestWrapper};
 

--- a/circuits/integration/mpc_gadgets/arithmetic.rs
+++ b/circuits/integration/mpc_gadgets/arithmetic.rs
@@ -1,13 +1,13 @@
 //! Groups integration tests for arithmetic gadgets used in the MPC circuits
 
 use circuits::mpc_gadgets::arithmetic::{pow, prefix_mul, product};
-use crypto::fields::{get_scalar_field_modulus, scalar_to_u64};
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     PARTY0, PARTY1,
 };
 use num_bigint::BigUint;
 use rand::{thread_rng, Rng, RngCore};
+use renegade_crypto::fields::{get_scalar_field_modulus, scalar_to_u64};
 use test_helpers::{
     mpc_network::{
         await_result, await_result_batch, await_result_batch_with_error, await_result_with_error,
@@ -43,11 +43,11 @@ fn test_product(test_args: &IntegrationTestArgs) -> Result<(), String> {
     )?;
 
     // Open the shared values and compute the expected result
-    let p1_values_prod = await_result_batch(&AuthenticatedScalarResult::open_batch(&p1_values))
+    let p1_values_prod = await_result_batch(AuthenticatedScalarResult::open_batch(&p1_values))
         .iter()
         .fold(Scalar::one(), |acc, val| acc * val);
 
-    let p2_values_prod = await_result_batch(&AuthenticatedScalarResult::open_batch(&p2_values))
+    let p2_values_prod = await_result_batch(AuthenticatedScalarResult::open_batch(&p2_values))
         .iter()
         .fold(Scalar::one(), |acc, val| acc * val);
     let expected_result = p1_values_prod * p2_values_prod;
@@ -68,7 +68,7 @@ fn test_prefix_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Open the prefixes and verify the result
     let opened_prefix_products = await_result_batch_with_error(
-        &AuthenticatedScalarResult::open_authenticated_batch(&prefixes),
+        AuthenticatedScalarResult::open_authenticated_batch(&prefixes),
     )?;
 
     let mut expected_result = Vec::with_capacity(n);

--- a/circuits/integration/mpc_gadgets/bits.rs
+++ b/circuits/integration/mpc_gadgets/bits.rs
@@ -1,13 +1,13 @@
 //! Groups integration tests for bitwise operating MPC gadgets
 
 use circuits::mpc_gadgets::bits::{bit_add, bit_lt, bit_xor, to_bits_le};
-use crypto::fields::scalar_to_u64;
 use itertools::Itertools;
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     PARTY0, PARTY1,
 };
 use rand::{thread_rng, RngCore};
+use renegade_crypto::fields::scalar_to_u64;
 use test_helpers::{
     mpc_network::{await_result, await_result_batch_with_error, await_result_with_error},
     types::IntegrationTest,
@@ -100,7 +100,7 @@ fn test_bit_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     )
     .0;
     let result = await_result_batch_with_error(
-        &AuthenticatedScalarResult::open_authenticated_batch(&res_bits),
+        AuthenticatedScalarResult::open_authenticated_batch(&res_bits),
     )?;
 
     // Open the original random numbers and bitify the sum
@@ -125,7 +125,7 @@ fn test_bits_le_zero(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     let shared_bits = to_bits_le::<250>(&shared_zero, test_args.mpc_fabric.clone());
     let shared_bits_open = await_result_batch_with_error(
-        &AuthenticatedScalarResult::open_authenticated_batch(&shared_bits),
+        AuthenticatedScalarResult::open_authenticated_batch(&shared_bits),
     )?;
 
     assert_scalar_batch_eq(&shared_bits_open, &vec![Scalar::zero(); shared_bits.len()])
@@ -136,13 +136,12 @@ fn test_to_bits_le(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let fabric = &test_args.mpc_fabric;
     let value = 119;
 
-    // The parties share the value 10 with little endian byte representation 0b0101
     let shared_value = fabric.share_scalar(value, PARTY0);
     let shared_bits = to_bits_le::<8>(&shared_value, test_args.mpc_fabric.clone());
 
     // Open the bits and compare
     let opened_bits = await_result_batch_with_error(
-        &AuthenticatedScalarResult::open_authenticated_batch(&shared_bits),
+        AuthenticatedScalarResult::open_authenticated_batch(&shared_bits),
     )?;
 
     if !opened_bits[..8].eq(&vec![

--- a/circuits/integration/mpc_gadgets/mod.rs
+++ b/circuits/integration/mpc_gadgets/mod.rs
@@ -1,11 +1,4 @@
-use crypto::fields::{
-    prime_field_to_bigint, scalar_to_bigint, scalar_to_prime_field, DalekRistrettoField,
-};
-use curve25519_dalek::scalar::Scalar;
-use mpc_ristretto::{
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource,
-    mpc_scalar::scalar_to_u64, network::MpcNetwork,
-};
+use mpc_stark::algebra::scalar::Scalar;
 
 pub mod arithmetic;
 pub mod bits;
@@ -13,70 +6,31 @@ pub mod comparators;
 pub mod modulo;
 pub mod poseidon;
 
-/**
- * Helpers
- */
+// -----------
+// | Helpers |
+// -----------
 
-/// Converts a nested vector of Dalek scalars to arkworks field elements
-pub(crate) fn convert_scalars_nested_vec(a: &Vec<Vec<Scalar>>) -> Vec<Vec<DalekRistrettoField>> {
-    let mut res = Vec::with_capacity(a.len());
-    for row in a.iter() {
-        let mut row_res = Vec::with_capacity(row.len());
-        for val in row.iter() {
-            row_res.push(scalar_to_prime_field(val))
-        }
-
-        res.push(row_res);
+/// Assert two scalars are equal, returning a `String` error if they are not
+pub fn assert_scalar_eq(a: &Scalar, b: &Scalar) -> Result<(), String> {
+    if a == b {
+        Ok(())
+    } else {
+        Err(format!("Expected {:?} == {:?}", a, b))
     }
-
-    res
 }
 
-/// Compares a Dalek Scalar to an Arkworks field element
-pub(crate) fn compare_scalar_to_felt(scalar: &Scalar, felt: &DalekRistrettoField) -> bool {
-    scalar_to_bigint(scalar).eq(&prime_field_to_bigint(felt))
-}
-
-pub(crate) fn check_equal<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    x: &AuthenticatedScalar<N, S>,
-    expected: u64,
-) -> Result<(), String> {
-    if x.to_scalar().ne(&Scalar::from(expected)) {
+/// Assert two batches of scalars are equal, returning a `String` error if they are not
+pub fn assert_scalar_batch_eq(a: &[Scalar], b: &[Scalar]) -> Result<(), String> {
+    if a.len() != b.len() {
         return Err(format!(
-            "Expected: {:?}, got {:?}",
-            expected,
-            scalar_to_u64(&x.to_scalar())
+            "Expected batch lengths to be equal: {} != {}",
+            a.len(),
+            b.len()
         ));
     }
 
-    Ok(())
-}
-
-pub(crate) fn check_equal_vec<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    x: &[AuthenticatedScalar<N, S>],
-    expected: &[u64],
-) -> Result<(), String> {
-    if x.len() != expected.len() {
-        return Err(format!(
-            "expected result has length different from given result; {:?} vs {:?}",
-            expected.len(),
-            x.len()
-        ));
-    }
-    let x_u64 = x
-        .iter()
-        .map(|val| scalar_to_u64(&val.to_scalar()))
-        .collect::<Vec<_>>();
-
-    for i in 0..x.len() {
-        if x_u64[i].ne(&expected[i]) {
-            return Err(
-                format!(
-                    "Vectors differ in position {:?}: expected element {:?}, got {:?}\nFull Expected Vec: {:?}\nFull Result Vec: {:?}",
-                    i, expected[i], x_u64[i], expected, x_u64
-                )
-            );
-        }
+    for (a, b) in a.iter().zip(b.iter()) {
+        assert_scalar_eq(a, b)?;
     }
 
     Ok(())

--- a/circuits/integration/mpc_gadgets/mod.rs
+++ b/circuits/integration/mpc_gadgets/mod.rs
@@ -15,7 +15,7 @@ pub fn assert_scalar_eq(a: &Scalar, b: &Scalar) -> Result<(), String> {
     if a == b {
         Ok(())
     } else {
-        Err(format!("Expected {:?} == {:?}", a, b))
+        Err(format!("Expected {a} == {b}"))
     }
 }
 

--- a/circuits/integration/mpc_gadgets/modulo.rs
+++ b/circuits/integration/mpc_gadgets/modulo.rs
@@ -1,9 +1,13 @@
 //! Groups integration tests for modulo MPC gadgets
 use circuits::mpc_gadgets::modulo::{mod_2m, shift_right, truncate};
-use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
-use num_bigint::{BigInt, RandomBits};
+use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use num_bigint::{BigUint, RandomBits};
 use rand::{thread_rng, Rng, RngCore};
-use test_helpers::types::IntegrationTest;
+use renegade_crypto::fields::scalar_to_biguint;
+use test_helpers::{
+    mpc_network::{await_result, await_result_with_error},
+    types::IntegrationTest,
+};
 
 use crate::{IntegrationTestArgs, TestWrapper};
 
@@ -11,98 +15,69 @@ use super::assert_scalar_eq;
 
 /// Test the mod_2m method
 fn test_mod_2m(test_args: &IntegrationTestArgs) -> Result<(), String> {
-    let m = 5;
+    const M: usize = 5;
 
     // Clean multiple of 2^m
-    let value: u64 = (1 << m) * thread_rng().next_u32() as u64;
-    let shared_value = test_args
-        .borrow_fabric()
-        .allocate_private_u64(0 /* owning_party */, value)
-        .map_err(|err| format!("Error sharing value: {:?}", err))?;
-    let value_mod_2m = mod_2m::<5_usize, _, _>(&shared_value, test_args.mpc_fabric.clone())
-        .map_err(|err| format!("Error computing mod_2m: {:?}", err))?
-        .open_and_authenticate()
-        .map_err(|err| format!("Error opening the result of mod_2m: {:?}", err))?;
+    let fabric = &test_args.mpc_fabric;
+    let value: u64 = (1 << M) * thread_rng().next_u32() as u64;
+    let shared_value = fabric.share_scalar(value, PARTY0);
+    let value_mod_2m = await_result_with_error(
+        mod_2m::<M>(&shared_value, test_args.mpc_fabric.clone()).open_authenticated(),
+    )?;
 
-    assert_scalar_eq(&value_mod_2m, 0)?;
+    assert_scalar_eq(&value_mod_2m, &Scalar::zero())?;
 
     // Random value
-    let random_value: BigInt = thread_rng().sample(RandomBits::new(250));
-    let shared_random_value = test_args
-        .borrow_fabric()
-        .allocate_private_scalar(1 /* owning_party */, bigint_to_scalar(&random_value))
-        .map_err(|err| format!("Error sharing value: {:?}", err))?;
-    let random_value_mod_2m = mod_2m::<5, _, _>(&shared_random_value, test_args.mpc_fabric.clone())
-        .map_err(|err| format!("Error computing mod_2m: {:?}", err))?
-        .open_and_authenticate()
-        .map_err(|err| format!("Error opening the result of mod_2m: {:?}", err))?;
+    let random_value: BigUint = thread_rng().sample(RandomBits::new(250));
+    let shared_random_value = fabric.share_scalar(random_value, PARTY1);
+    let random_value_mod_2m = await_result_with_error(
+        mod_2m::<M>(&shared_random_value, test_args.mpc_fabric.clone()).open_authenticated(),
+    )?;
 
-    let expected_result: BigInt = scalar_to_bigint(
-        &shared_random_value
-            .open_and_authenticate()
-            .map_err(|err| format!("Error opening value: {:?}", err))?
-            .to_scalar(),
-    ) % (1 << m);
-    let expected_result_u64: u64 = expected_result.try_into().unwrap();
-    assert_scalar_eq(&random_value_mod_2m, expected_result_u64)?;
+    let value_opened = await_result_with_error(shared_random_value.open_authenticated())?;
+    let expected_result: BigUint = scalar_to_biguint(&value_opened) % (1u64 << M);
 
-    Ok(())
+    assert_scalar_eq(&random_value_mod_2m, &expected_result.into())
 }
 
 /// Tests truncation circuit
 fn test_truncate(test_args: &IntegrationTestArgs) -> Result<(), String> {
+    const M: usize = 190;
+    let fabric = &test_args.mpc_fabric;
+
     let mut rng = thread_rng();
-    let random_value: BigInt = rng.sample(RandomBits::new(250));
-    let m = 190;
+    let random_value: BigUint = rng.sample(RandomBits::new(250));
 
     // Party 0 chooses truncated value, party 1 chooses truncation amount
-    let shared_random_value = test_args
-        .borrow_fabric()
-        .allocate_private_scalar(0 /* owning_party */, bigint_to_scalar(&random_value))
-        .map_err(|err| format!("Error sharing random value: {:?}", err))?;
-
-    let res = truncate::<190, _, _>(&shared_random_value, test_args.mpc_fabric.clone())
-        .map_err(|err| format!("Error truncating value: {:?}", err))?
-        .open_and_authenticate()
-        .map_err(|err| format!("Error opening truncate result: {:?}", err))?;
+    let shared_random_value = fabric.share_scalar(random_value, PARTY0);
+    let res = await_result_with_error(
+        truncate::<M>(&shared_random_value, test_args.mpc_fabric.clone()).open_authenticated(),
+    )?;
 
     // Open the original value and compute the expected result
-    let random_value = shared_random_value
-        .open_and_authenticate()
-        .map_err(|err| format!("Error opening shared random value: {:?}", err))?
-        .to_scalar();
+    let random_value = await_result_with_error(shared_random_value.open_authenticated())?;
+    let expected_result = scalar_to_biguint(&random_value) >> M;
 
-    let expected_result = scalar_to_bigint(&random_value) >> m;
-    if bigint_to_scalar(&expected_result).ne(&res.to_scalar()) {
-        return Err(format!(
-            "Expected {:?}, got {:?}",
-            expected_result,
-            scalar_to_bigint(&res.to_scalar()),
-        ));
-    }
-
-    Ok(())
+    assert_scalar_eq(&res, &expected_result.into())
 }
 
 /// Tests the shift right gadget
 fn test_shift_right(test_args: &IntegrationTestArgs) -> Result<(), String> {
     // Sample a random value and shift it right
-    let shift_amount = 3;
+    const SHIFT_AMOUNT: usize = 3;
+    let fabric = &test_args.mpc_fabric;
     let mut rng = thread_rng();
-    let random_value = test_args
-        .borrow_fabric()
-        .allocate_private_u64(0 /* owning_party */, rng.next_u32() as u64)
-        .map_err(|err| format!("Error sharing private random value: {:?}", err))?;
+    let random_value = fabric.share_scalar(rng.next_u32(), PARTY0);
 
-    let res = shift_right::<3, _, _>(&random_value, test_args.mpc_fabric.clone())
-        .map_err(|err| format!("Error computing the right shifted result: {:?}", err))?
-        .open_and_authenticate()
-        .map_err(|err| format!("Error opening and authenticating the result: {:?}", err))?;
+    let res = await_result_with_error(
+        shift_right::<SHIFT_AMOUNT>(&random_value, test_args.mpc_fabric.clone())
+            .open_authenticated(),
+    )?;
 
     // Open the random value and compute the expected result
-    let random_value_open = &random_value.open_and_authenticate();
-
-    assert_scalar_eq(&res, random_value_open >> shift_amount)
+    let random_value_open = await_result(random_value.open());
+    let expected_res = scalar_to_biguint(&random_value_open) >> SHIFT_AMOUNT;
+    assert_scalar_eq(&res, &expected_res.into())
 }
 
 inventory::submit!(TestWrapper(IntegrationTest {

--- a/circuits/integration/mpc_gadgets/modulo.rs
+++ b/circuits/integration/mpc_gadgets/modulo.rs
@@ -1,14 +1,13 @@
 //! Groups integration tests for modulo MPC gadgets
 use circuits::mpc_gadgets::modulo::{mod_2m, shift_right, truncate};
 use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
-use integration_helpers::types::IntegrationTest;
-use mpc_ristretto::mpc_scalar::scalar_to_u64;
 use num_bigint::{BigInt, RandomBits};
 use rand::{thread_rng, Rng, RngCore};
+use test_helpers::types::IntegrationTest;
 
 use crate::{IntegrationTestArgs, TestWrapper};
 
-use super::check_equal;
+use super::assert_scalar_eq;
 
 /// Test the mod_2m method
 fn test_mod_2m(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -25,7 +24,7 @@ fn test_mod_2m(test_args: &IntegrationTestArgs) -> Result<(), String> {
         .open_and_authenticate()
         .map_err(|err| format!("Error opening the result of mod_2m: {:?}", err))?;
 
-    check_equal(&value_mod_2m, 0)?;
+    assert_scalar_eq(&value_mod_2m, 0)?;
 
     // Random value
     let random_value: BigInt = thread_rng().sample(RandomBits::new(250));
@@ -45,7 +44,7 @@ fn test_mod_2m(test_args: &IntegrationTestArgs) -> Result<(), String> {
             .to_scalar(),
     ) % (1 << m);
     let expected_result_u64: u64 = expected_result.try_into().unwrap();
-    check_equal(&random_value_mod_2m, expected_result_u64)?;
+    assert_scalar_eq(&random_value_mod_2m, expected_result_u64)?;
 
     Ok(())
 }
@@ -101,14 +100,9 @@ fn test_shift_right(test_args: &IntegrationTestArgs) -> Result<(), String> {
         .map_err(|err| format!("Error opening and authenticating the result: {:?}", err))?;
 
     // Open the random value and compute the expected result
-    let random_value_open = scalar_to_u64(
-        &random_value
-            .open_and_authenticate()
-            .map_err(|err| format!("Error opening expected result: {:?}", err))?
-            .to_scalar(),
-    );
+    let random_value_open = &random_value.open_and_authenticate();
 
-    check_equal(&res, random_value_open >> shift_amount)
+    assert_scalar_eq(&res, random_value_open >> shift_amount)
 }
 
 inventory::submit!(TestWrapper(IntegrationTest {

--- a/circuits/integration/mpc_gadgets/poseidon.rs
+++ b/circuits/integration/mpc_gadgets/poseidon.rs
@@ -2,13 +2,13 @@
 
 use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
 use circuits::mpc_gadgets::poseidon::AuthenticatedPoseidonHasher;
-use crypto::hash::{default_poseidon_params, PoseidonParams};
 use itertools::Itertools;
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     PARTY0, PARTY1,
 };
 use rand::{thread_rng, RngCore};
+use renegade_crypto::hash::{default_poseidon_params, PoseidonParams};
 use test_helpers::{
     mpc_network::{await_result, await_result_batch},
     types::IntegrationTest,
@@ -29,7 +29,7 @@ fn check_against_arkworks_hash(
     hasher_params: &PoseidonParams,
 ) -> Result<(), String> {
     // Open the input sequence and cast it to field elements
-    let arkworks_input = await_result_batch(&AuthenticatedScalarResult::open_batch(input_sequence))
+    let arkworks_input = await_result_batch(AuthenticatedScalarResult::open_batch(input_sequence))
         .into_iter()
         .map(|s| s.inner())
         .collect_vec();

--- a/circuits/integration/types/mod.rs
+++ b/circuits/integration/types/mod.rs
@@ -6,8 +6,8 @@ use circuit_types::{
     native_helpers::create_wallet_shares_with_randomness,
     wallet::{Wallet, WalletShare},
 };
-use curve25519_dalek::scalar::Scalar;
-use rand_core::OsRng;
+use mpc_stark::algebra::scalar::Scalar;
+use rand::rngs::OsRng;
 
 pub mod sharing;
 

--- a/circuits/integration/types/sharing.rs
+++ b/circuits/integration/types/sharing.rs
@@ -5,7 +5,7 @@ use circuit_types::{
     wallet::Wallet,
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
-use integration_helpers::types::IntegrationTest;
+use test_helpers::types::IntegrationTest;
 
 use crate::{IntegrationTestArgs, TestWrapper};
 
@@ -55,7 +55,7 @@ fn test_open_linkable_match_res(test_args: &IntegrationTestArgs) -> Result<(), S
 
     let linkable_match_res = match_res.link_commitments(fabric.clone());
     let opened = linkable_match_res
-        .open_and_authenticate(fabric)
+        .open_and_authenticate()
         .map_err(|err| format!("Error opening match result: {:?}", err))?;
 
     if opened.to_base_type() != MatchResult::default() {

--- a/circuits/integration/zk_gadgets/arithmetic.rs
+++ b/circuits/integration/zk_gadgets/arithmetic.rs
@@ -1,7 +1,6 @@
 //! Groups gadgets around arithmetic integration tests
 use circuit_types::traits::MultiproverCircuitBaseType;
 use circuits::zk_gadgets::arithmetic::MultiproverExpGadget;
-use crypto::fields::{bigint_to_scalar, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{
     mpc_network::field::get_ristretto_group_modulus, types::IntegrationTest,
@@ -13,6 +12,7 @@ use mpc_bulletproof::{
     PedersenGens,
 };
 use rand_core::{OsRng, RngCore};
+use renegade_cryptofields::{bigint_to_scalar, scalar_to_bigint};
 
 use crate::{IntegrationTestArgs, TestWrapper};
 

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -3,7 +3,6 @@
 
 use circuit_types::traits::MultiproverCircuitBaseType;
 use circuits::zk_gadgets::bits::MultiproverToBitsGadget;
-use crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::{mpc_network::batch_share_plaintext_scalar, types::IntegrationTest};
 use merlin::Transcript;
@@ -12,6 +11,7 @@ use mpc_bulletproof::{
     PedersenGens,
 };
 use rand_core::{OsRng, RngCore};
+use renegade_cryptofields::{bigint_to_scalar_bits, scalar_to_bigint};
 
 use crate::{IntegrationTestArgs, TestWrapper};
 
@@ -19,7 +19,7 @@ use crate::{IntegrationTestArgs, TestWrapper};
 #[allow(unused)]
 macro_rules! print_multiprover_wire {
     ($x:expr, $cs:ident, $party_id:expr) => {{
-        use crypto::fields::scalar_to_biguint;
+        use renegade_cryptofields::scalar_to_biguint;
         let x_eval = $cs.eval(&$x.into()).unwrap().open().unwrap().to_scalar();
         if $party_id == 0 {
             println!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));

--- a/circuits/integration/zk_gadgets/poseidon.rs
+++ b/circuits/integration/zk_gadgets/poseidon.rs
@@ -7,7 +7,6 @@ use circuits::{
     zk_gadgets::poseidon::MultiproverPoseidonHashGadget,
 };
 
-use crypto::fields::{prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField};
 use curve25519_dalek::scalar::Scalar;
 use integration_helpers::types::IntegrationTest;
 use itertools::Itertools;
@@ -18,6 +17,7 @@ use mpc_bulletproof::{
 };
 use mpc_ristretto::authenticated_scalar::AuthenticatedScalar;
 use rand_core::{OsRng, RngCore};
+use renegade_cryptofields::{prime_field_to_scalar, scalar_to_prime_field, DalekRistrettoField};
 
 use crate::{mpc_gadgets::poseidon::convert_params, IntegrationTestArgs, TestWrapper};
 

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -26,8 +26,6 @@ mod tracing;
 // pub mod zk_circuits;
 // pub mod zk_gadgets;
 
-/// The highest possible set bit for a positive scalar
-pub(crate) const POSITIVE_SCALAR_MAX_BITS: usize = 251;
 /// The highest possible set bit in the Dalek scalar field
 pub(crate) const SCALAR_MAX_BITS: usize = 253;
 /// The seed for a fiat-shamir transcript
@@ -228,9 +226,9 @@ pub(crate) mod test_helpers {
 
 #[cfg(test)]
 mod circuits_test {
-    use crypto::fields::bigint_to_scalar;
     use num_bigint::BigInt;
     use rand::{thread_rng, Rng};
+    use renegade_crypto::fields::bigint_to_scalar;
 
     use crate::scalar_2_to_m;
 

--- a/circuits/src/mpc_circuits/match.rs
+++ b/circuits/src/mpc_circuits/match.rs
@@ -1,7 +1,7 @@
 //! Groups logic related to the match computation circuit
 
 use circuit_types::{
-    errors::MpcError, fixed_point::AuthenticatedFixedPoint, order::AuthenticatedOrder,
+    fixed_point::AuthenticatedFixedPoint, order::AuthenticatedOrder,
     r#match::AuthenticatedMatchResult, AMOUNT_BITS,
 };
 use mpc_stark::{

--- a/circuits/src/mpc_gadgets/arithmetic.rs
+++ b/circuits/src/mpc_gadgets/arithmetic.rs
@@ -1,18 +1,11 @@
 //! Groups MPC gadgets centered around arithmetic operations
 
-use circuit_types::{errors::MpcError, SharedFabric};
-use curve25519_dalek::scalar::Scalar;
-use mpc_ristretto::{
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
-};
+use mpc_stark::{algebra::authenticated_scalar::AuthenticatedScalarResult, MpcFabric};
 
 /// Computes the product of all elements in constant number of rounds
 ///     Result = a_0 * ... * a_n
-pub fn product<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &[AuthenticatedScalar<N, S>],
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    Ok(prefix_product_impl(a, fabric, &[a.len() - 1])?[0].clone())
+pub fn product(a: &[AuthenticatedScalarResult], fabric: MpcFabric) -> AuthenticatedScalarResult {
+    prefix_product_impl(a, fabric, &[a.len() - 1])[0].clone()
 }
 
 /// Computes the prefix products of the given list of elements: i.e.
@@ -20,10 +13,10 @@ pub fn product<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 ///
 /// This implementation is done in a constant number of rounds according to:
 /// https://iacr.org/archive/tcc2006/38760286/38760286.pdf
-pub fn prefix_mul<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &[AuthenticatedScalar<N, S>],
-    fabric: SharedFabric<N, S>,
-) -> Result<Vec<AuthenticatedScalar<N, S>>, MpcError> {
+pub fn prefix_mul(
+    a: &[AuthenticatedScalarResult],
+    fabric: MpcFabric,
+) -> Vec<AuthenticatedScalarResult> {
     prefix_product_impl(
         a,
         fabric,
@@ -38,11 +31,11 @@ pub fn prefix_mul<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 /// method returns \prod_{i=0}^l a_i in the lth element of the return vector
 ///
 /// Note that each additional prefix incurs more bandwidth (although constant round)
-fn prefix_product_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &[AuthenticatedScalar<N, S>],
-    fabric: SharedFabric<N, S>,
+fn prefix_product_impl(
+    a: &[AuthenticatedScalarResult],
+    fabric: MpcFabric,
     pre: &[usize],
-) -> Result<Vec<AuthenticatedScalar<N, S>>, MpcError> {
+) -> Vec<AuthenticatedScalarResult> {
     let n = a.len();
     assert!(
         pre.iter().all(|x| x < &n),
@@ -50,30 +43,22 @@ fn prefix_product_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     );
 
     // Fetch one inverse pair per element from the pre-processing source
-    let (b_values, b_inv_values) = fabric
-        .borrow_fabric()
-        .allocate_random_inverse_pair_batch(n + 1 /* num_inverses */)
-        .into_iter()
-        .unzip::<_, _, Vec<_>, Vec<_>>();
+    let (b_values, b_inv_values) = fabric.random_inverse_pairs(n + 1 /* num_inverses */);
 
     // Using the inverse pairs (b_i, b_i^-1), compute d_i = b_{i-1} * a_i * b_i^-1
     // We will open these values and use them to form telescoping partial products wherein the only non-cancelled terms
     // are a b_{k-1} * b_k^-1
-    let d_partial = AuthenticatedScalar::batch_mul(&b_values[..n], a)
-        .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
-
-    let d_values = AuthenticatedScalar::batch_mul(&d_partial, &b_inv_values[1..])
-        .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
+    let d_partial = AuthenticatedScalarResult::batch_mul(&b_values[..n], a);
+    let d_values = AuthenticatedScalarResult::batch_mul(&d_partial, &b_inv_values[1..]);
 
     // TODO: Can we just call `batch_open` here and simply authenticate at the end?
-    let d_values_open = AuthenticatedScalar::batch_open(&d_values)
-        .map_err(|_| MpcError::OpeningError("error opening d_values in prefix_mul".to_string()))?;
+    let d_values_open = AuthenticatedScalarResult::open_batch(&d_values);
 
     // The partial products are formed by creating a series of telescoping products and then cancelling them out with the correct b_i values
     let mut partial_products = Vec::with_capacity(n);
-    let mut accumulator = fabric.borrow_fabric().allocate_public_u64(1);
+    let mut accumulator = fabric.one_authenticated();
     for d_value in d_values_open.iter() {
-        accumulator *= d_value;
+        accumulator = accumulator * d_value;
         partial_products.push(accumulator.clone());
     }
 
@@ -82,13 +67,12 @@ fn prefix_product_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     // So it must be multiplied by b_{i-1}^-1 * b_i to create a secret sharing
     // of a_0 * ... * a_i.
     // To do so, we first batch multiply b_0^-1 * b_i for i > 0
-    let cancellation_factors = AuthenticatedScalar::batch_mul(
+    let cancellation_factors = AuthenticatedScalarResult::batch_mul(
         &vec![b_inv_values[0].clone(); pre.len()], // Each prefix product starts at 0
         &pre.iter()
             .map(|index| b_values[*index].clone())
             .collect::<Vec<_>>(),
-    )
-    .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
+    );
 
     let selected_partial_products = pre
         .iter()
@@ -98,17 +82,13 @@ fn prefix_product_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
     // No communication is required here, the partial_products are public and the
     // cancellation_factors are shared, so computation can be done locally.
     // Unwrap is therefore safe
-    Ok(AuthenticatedScalar::batch_mul(&selected_partial_products, &cancellation_factors).unwrap())
+    AuthenticatedScalarResult::batch_mul(&selected_partial_products, &cancellation_factors)
 }
 
 /// Computes a^n using a recursive squaring approach for a public parameter exponent
-pub fn pow<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    n: u64,
-    fabric: SharedFabric<N, S>,
-) -> AuthenticatedScalar<N, S> {
+pub fn pow(a: &AuthenticatedScalarResult, n: u64, fabric: MpcFabric) -> AuthenticatedScalarResult {
     if n == 0 {
-        fabric.borrow_fabric().allocate_zero()
+        fabric.one_authenticated()
     } else if n == 1 {
         a.clone()
     } else if n % 2 == 0 {

--- a/circuits/src/mpc_gadgets/comparators.rs
+++ b/circuits/src/mpc_gadgets/comparators.rs
@@ -2,7 +2,6 @@
 
 use std::iter;
 
-use circuit_types::errors::MpcError;
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     MpcFabric,
@@ -143,7 +142,7 @@ pub fn kary_or<const D: usize>(
     let unblinded_shared_bits = blinded_sum_bits
         .into_iter()
         .zip(blinding_bits.iter())
-        .map(|(blinded_bit, blinder_bit)| bit_xor_public(blinder_bit, &blinded_bit))
+        .map(|(blinded_bit, blinder_bit)| bit_xor_public(&blinded_bit, blinder_bit))
         .collect::<Vec<_>>();
 
     constant_round_or_impl(&unblinded_shared_bits, fabric)

--- a/circuits/src/mpc_gadgets/comparators.rs
+++ b/circuits/src/mpc_gadgets/comparators.rs
@@ -2,113 +2,109 @@
 
 use std::iter;
 
-use circuit_types::{errors::MpcError, SharedFabric};
-use curve25519_dalek::scalar::Scalar;
-use mpc_ristretto::{
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
+use circuit_types::errors::MpcError;
+use mpc_stark::{
+    algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
+    MpcFabric,
 };
 
 use super::{
     arithmetic::product,
-    bits::{bit_xor, scalar_from_bits_le, scalar_to_bits_le, to_bits_le},
+    bits::{bit_xor_public, scalar_from_bits_le, scalar_to_bits_le, to_bits_le},
     modulo::truncate,
 };
 
 /// Implements the comparator a < 0
 ///
 /// D represents is the bitlength of the input
-pub fn less_than_zero<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
+pub fn less_than_zero<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
     // Truncate the first 250 bits of the input
-    let truncated = truncate::<250, _, _>(a, fabric.clone())?;
+    let truncated = truncate::<250>(a, fabric.clone());
 
     // Because the Ristretto scalar field is a prime field of order slightly greater than 2^252
     // values are negative if either their 251st bit or 252nd bit are set. Therefore, we truncate
     // all bits below this and compare the value to zero.
-    ne::<2, N, S>(
-        &truncated,
-        &fabric.borrow_fabric().allocate_zero(),
-        fabric.clone(),
-    )
+    ne::<2 /* bit_length */>(&truncated, &fabric.zero_authenticated(), fabric)
 }
 
 /// Implements the comparator a == 0
 ///
 /// D represents the bitlength of the input
-pub fn eq_zero<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    let bits = to_bits_le::<D, N, S>(a, fabric.clone())?;
-    Ok(Scalar::one() - kary_or(&bits, fabric)?)
+pub fn eq_zero<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    let bits = to_bits_le::<D>(a, fabric.clone());
+    Scalar::one() - kary_or::<D>(&bits.try_into().unwrap(), fabric)
 }
 
 /// Implements the comparator a == b
 ///
 /// D represents the bitlength of the inputs
-pub fn eq<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    eq_zero::<D, N, S>(&(a - b), fabric)
+pub fn eq<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    eq_zero::<D>(&(a - b), fabric)
 }
 
 /// Implements the comparator a != b
 ///
 /// D represents the bitlength of the inputs
-pub fn ne<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    Ok(Scalar::one() - eq::<D, N, S>(a, b, fabric)?)
+pub fn ne<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    Scalar::one() - eq::<D>(a, b, fabric)
 }
 
 /// Implements the comparator a < b
 ///
 /// D represents the bitlength of a and b
-pub fn less_than<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    less_than_zero::<D, _, _>(&(a - b), fabric)
+pub fn less_than<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    less_than_zero::<D>(&(a - b), fabric)
 }
 
 /// Implements the comparator a <= b
 ///
 /// D represents the bitlength of a and b
-pub fn less_than_equal<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    Ok(Scalar::one() - greater_than::<D, _, _>(a, b, fabric)?)
+pub fn less_than_equal<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    Scalar::one() - greater_than::<D>(a, b, fabric)
 }
 
 /// Implements the comparator a > b
 ///
 /// D represents the bitlength of a and b
-pub fn greater_than<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    less_than_zero::<D, _, _>(&(b - a), fabric)
+pub fn greater_than<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    less_than_zero::<D>(&(b - a), fabric)
 }
 
 /// Implements the comparator a >= b
 ///
 /// D represents the bitlength of a and b
-pub fn greater_than_equal<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    Ok(Scalar::one() - less_than::<D, _, _>(a, b, fabric)?)
+pub fn greater_than_equal<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
+    Scalar::one() - less_than::<D>(a, b, fabric)
 }
 
 /// Implements a k-ary Or comparator; i.e. a_1 || a_2 || ... || a_n
@@ -118,39 +114,36 @@ pub fn greater_than_equal<const D: usize, N: MpcNetwork + Send, S: SharedValueSo
 ///     2. Blind this sum, open the blinded value, and decompose to bits
 ///     3. xor the bits with their blinding bits to recover shared bits
 ///     4. Compute an "or" over the recovered bits
-pub fn kary_or<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &[AuthenticatedScalar<N, S>],
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
+///
+/// `D` is the number of variables present in the OR expression
+pub fn kary_or<const D: usize>(
+    a: &[AuthenticatedScalarResult; D],
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
     // Sample random blinding bits from the pre-processing functionality
     // We only need to be able to hold the maximum possible count, log_2(# of booleans)
     let max_bits = ((a.len() + 1) as f32).log2().ceil() as usize;
-    let blinding_bits = fabric
-        .borrow_fabric()
-        .allocate_random_shared_bit_batch(max_bits);
+    let blinding_bits = fabric.random_shared_bits(max_bits);
     let blinding_value = scalar_from_bits_le(&blinding_bits);
     let blinding_value_upper_bits = Scalar::from((1 << max_bits) as u64)
-        * fabric.borrow_fabric().allocate_random_shared_scalar();
+        * &fabric.random_shared_scalars_authenticated(1 /* n */)[0];
 
     // Blind the sum of all booleans and open the result
-    let sum_a: AuthenticatedScalar<N, S> = a.iter().sum();
-    let blinded_sum: AuthenticatedScalar<N, S> =
+    let sum_a: AuthenticatedScalarResult = a.iter().cloned().sum();
+    let blinded_sum: AuthenticatedScalarResult =
         &sum_a + &blinding_value + &blinding_value_upper_bits;
 
-    let blinded_sum_open = blinded_sum
-        .open_and_authenticate()
-        .map_err(|err| MpcError::OpeningError(err.to_string()))?;
+    let blinded_sum_open = blinded_sum.open_authenticated();
 
     // Decompose the blinded sum into bits
-    let blinded_sum_bits = scalar_to_bits_le(&blinded_sum_open.to_scalar())
-        .into_iter()
-        .map(|val| fabric.borrow_fabric().allocate_public_scalar(val));
+    let blinded_sum_bits = scalar_to_bits_le::<D>(&blinded_sum_open.value);
 
     // XOR the blinded sum bits with the blinding bits that are still shared to obtain a sharing of the
     // sum bits (unblinded)
     let unblinded_shared_bits = blinded_sum_bits
+        .into_iter()
         .zip(blinding_bits.iter())
-        .map(|(blinded_bit, blinder_bit)| bit_xor(&blinded_bit, blinder_bit))
+        .map(|(blinded_bit, blinder_bit)| bit_xor_public(blinder_bit, &blinded_bit))
         .collect::<Vec<_>>();
 
     constant_round_or_impl(&unblinded_shared_bits, fabric)
@@ -164,25 +157,23 @@ pub fn kary_or<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 /// which is zero at 1..n and 1 at 0. Then we take 1 - f(x) to flip the result
 ///
 /// This effectively maps any non-zero count to 1 and zero to 0
-fn constant_round_or_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &[AuthenticatedScalar<N, S>],
-    fabric: SharedFabric<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
+fn constant_round_or_impl(
+    a: &[AuthenticatedScalarResult],
+    fabric: MpcFabric,
+) -> AuthenticatedScalarResult {
     // Sum up the booleans
     let n = a.len();
-    let sum_a: AuthenticatedScalar<N, S> = a.iter().sum();
+    let sum_a: AuthenticatedScalarResult = a.iter().cloned().sum();
 
     // Compute (1 - sum) * (2 - sum) * ... * (n - sum) / n!
     // We wrap the n! in implicitly here to avoid overflow computing n! directly for large n
     let sum_monomials = (1..n + 1)
-        .map(|x| (Scalar::from(x as u64) - &sum_a) * Scalar::from(x as u64).invert())
+        .map(|x| (Scalar::from(x as u64) - &sum_a) * Scalar::from(x as u64).inverse())
         .collect::<Vec<_>>();
-
-    let monomial_product = product(&sum_monomials, fabric)
-        .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
+    let monomial_product = product(&sum_monomials, fabric);
 
     // Flip the result
-    Ok(Scalar::one() - monomial_product)
+    Scalar::one() - monomial_product
 }
 
 /// TODO: Optimize this method
@@ -193,43 +184,45 @@ fn constant_round_or_impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
 ///
 /// D represents the bitlength of a and b
 #[allow(clippy::type_complexity)]
-pub fn min<const D: usize, N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-    fabric: SharedFabric<N, S>,
-) -> Result<(AuthenticatedScalar<N, S>, AuthenticatedScalar<N, S>), MpcError> {
-    let a_lt_b = less_than::<D, _, _>(a, b, fabric)?;
-    Ok((
+pub fn min<const D: usize>(
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+    fabric: MpcFabric,
+) -> (AuthenticatedScalarResult, AuthenticatedScalarResult) {
+    let a_lt_b = less_than::<D>(a, b, fabric);
+    (
         Scalar::from(1u64) - a_lt_b.clone(),
         &a_lt_b * a + (Scalar::one() - a_lt_b) * b,
-    ))
+    )
 }
 
 /// Computes res = a if s else b
-pub fn cond_select<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    s: &AuthenticatedScalar<N, S>,
-    a: &AuthenticatedScalar<N, S>,
-    b: &AuthenticatedScalar<N, S>,
-) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-    let selectors =
-        AuthenticatedScalar::batch_mul(&[a.clone(), b.clone()], &[s.clone(), Scalar::one() - s])
-            .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
-    Ok(&selectors[0] + &selectors[1])
+pub fn cond_select(
+    s: &AuthenticatedScalarResult,
+    a: &AuthenticatedScalarResult,
+    b: &AuthenticatedScalarResult,
+) -> AuthenticatedScalarResult {
+    let selectors = AuthenticatedScalarResult::batch_mul(
+        &[a.clone(), b.clone()],
+        &[s.clone(), Scalar::one() - s],
+    );
+
+    &selectors[0] + &selectors[1]
 }
 
 /// Computes res = [a] if s else [b] where a and b are slices
-pub fn cond_select_vec<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    s: &AuthenticatedScalar<N, S>,
-    a: &[AuthenticatedScalar<N, S>],
-    b: &[AuthenticatedScalar<N, S>],
-) -> Result<Vec<AuthenticatedScalar<N, S>>, MpcError> {
+pub fn cond_select_vec(
+    s: &AuthenticatedScalarResult,
+    a: &[AuthenticatedScalarResult],
+    b: &[AuthenticatedScalarResult],
+) -> Vec<AuthenticatedScalarResult> {
     assert_eq!(
         a.len(),
         b.len(),
         "cond_select_vec requires equal length vectors"
     );
     // Batch mul each a value with `s` and each `b` value with 1 - s
-    let selectors = AuthenticatedScalar::batch_mul(
+    let selectors = AuthenticatedScalarResult::batch_mul(
         &a.iter()
             .cloned()
             .chain(b.iter().cloned())
@@ -238,8 +231,7 @@ pub fn cond_select_vec<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
             .take(a.len())
             .chain(iter::repeat(Scalar::one() - s).take(b.len()))
             .collect::<Vec<_>>(),
-    )
-    .map_err(|err| MpcError::ArithmeticError(err.to_string()))?;
+    );
 
     // Destruct the vector by zipping its first half with its second half
     let mut result = Vec::with_capacity(a.len());
@@ -251,5 +243,5 @@ pub fn cond_select_vec<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
         result.push(a_selected + b_selected)
     }
 
-    Ok(result)
+    result
 }

--- a/circuits/src/mpc_gadgets/fixed_point.rs
+++ b/circuits/src/mpc_gadgets/fixed_point.rs
@@ -1,30 +1,19 @@
 //! Defines MPC gadgets for operating on fixed-point values
 
-use std::marker::PhantomData;
-
-use circuit_types::{
-    errors::MpcError,
-    fixed_point::{AuthenticatedFixedPoint, DEFAULT_FP_PRECISION},
-    SharedFabric,
-};
-use curve25519_dalek::scalar::Scalar;
-use mpc_ristretto::{
-    authenticated_scalar::AuthenticatedScalar, beaver::SharedValueSource, network::MpcNetwork,
-};
+use circuit_types::fixed_point::{AuthenticatedFixedPoint, DEFAULT_FP_PRECISION};
+use mpc_stark::{algebra::authenticated_scalar::AuthenticatedScalarResult, MpcFabric};
 
 use super::modulo::shift_right;
 
 /// Implements gadgets on top of the existing shared fixed point type
-pub struct FixedPointMpcGadget<N: MpcNetwork + Send, S: SharedValueSource<Scalar>>(
-    PhantomData<(N, S)>,
-);
-impl<N: MpcNetwork + Send, S: SharedValueSource<Scalar>> FixedPointMpcGadget<N, S> {
+pub struct FixedPointMpcGadget;
+impl FixedPointMpcGadget {
     /// Shift the given fixed point value to the right by the given number of bits
     /// and return the result as an integer
     pub fn as_integer(
-        val: AuthenticatedFixedPoint<N, S>,
-        fabric: SharedFabric<N, S>,
-    ) -> Result<AuthenticatedScalar<N, S>, MpcError> {
-        shift_right::<DEFAULT_FP_PRECISION, N, S>(&val.repr, fabric)
+        val: AuthenticatedFixedPoint,
+        fabric: MpcFabric,
+    ) -> AuthenticatedScalarResult {
+        shift_right::<DEFAULT_FP_PRECISION>(&val.repr, fabric)
     }
 }

--- a/circuits/src/mpc_gadgets/poseidon.rs
+++ b/circuits/src/mpc_gadgets/poseidon.rs
@@ -10,11 +10,11 @@
 //! Their poseidon implementation can be found here:
 //!     https://github.com/arkworks-rs/sponge/blob/master/src/poseidon/mod.rs
 
-use crypto::hash::PoseidonParams;
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     MpcFabric,
 };
+use renegade_crypto::hash::PoseidonParams;
 
 // -----------
 // | Helpers |
@@ -156,7 +156,6 @@ impl AuthenticatedPoseidonHasher {
 
     /// Add the next round constants to the state
     fn add_round_constants(&mut self, round_index: usize) {
-        // .zip(self.params.ark(round_index))
         for (elem, round_constant) in self
             .state
             .iter_mut()
@@ -202,10 +201,10 @@ impl AuthenticatedPoseidonHasher {
 #[cfg(test)]
 mod poseidon_tests {
     use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
-    use crypto::hash::default_poseidon_params;
     use itertools::Itertools;
     use mpc_stark::{algebra::scalar::Scalar, PARTY0};
     use rand::{thread_rng, Rng, RngCore};
+    use renegade_crypto::hash::default_poseidon_params;
     use test_helpers::mpc_network::execute_mock_mpc;
 
     use super::AuthenticatedPoseidonHasher;
@@ -235,7 +234,7 @@ mod poseidon_tests {
             arkworks_poseidon.squeeze_field_elements(1 /* num_elements */)[0];
 
         // Hash and squeeze in an MPC circuit
-        let (party0_res, _) = execute_mock_mpc(|fabric| {
+        let (party0_res, _) = execute_mock_mpc(move |fabric| {
             let params = params.clone();
             let random_vec = random_vec.clone();
 

--- a/circuits/src/tracing.rs
+++ b/circuits/src/tracing.rs
@@ -109,14 +109,14 @@ lazy_static! {
 #[cfg(test)]
 pub mod test {
     use circuit_macros::circuit_trace;
-    use curve25519_dalek::scalar::Scalar;
     use lazy_static::lazy_static;
-    use merlin::Transcript;
+    use merlin::HashChainTranscript as Transcript;
     use mpc_bulletproof::{
         r1cs::{ConstraintSystem, Prover, Variable},
         PedersenGens,
     };
-    use rand_core::OsRng;
+    use mpc_stark::algebra::scalar::Scalar;
+    use rand::thread_rng;
     use std::{
         collections::{hash_map::Entry, HashMap},
         sync::Mutex,
@@ -141,7 +141,7 @@ pub mod test {
         #[circuit_trace(n_constraints, n_multipliers, latency)]
         pub fn apply_constraints(cs: &mut Prover) {
             // Apply dummy constraints
-            let mut rng = OsRng {};
+            let mut rng = thread_rng();
             let (_, var) = cs.commit(Scalar::one(), Scalar::random(&mut rng));
             let (_, _, mul_out) = cs.multiply(var.into(), Variable::Zero().into());
             cs.constrain(mul_out.into());
@@ -156,7 +156,7 @@ pub mod test {
     #[circuit_trace(non_associated, n_constraints, n_multipliers, latency)]
     fn non_associated_gadget(cs: &mut Prover) {
         // Apply dummy constraints
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let (_, var) = cs.commit(Scalar::one(), Scalar::random(&mut rng));
         let (_, _, mul_out) = cs.multiply(var.into(), Variable::Zero().into());
         cs.constrain(mul_out.into());

--- a/circuits/src/zk_circuits/commitment_links.rs
+++ b/circuits/src/zk_circuits/commitment_links.rs
@@ -8,7 +8,7 @@
 use circuit_types::{traits::CircuitBaseType, wallet::LinkableWalletShare};
 use merlin::Transcript;
 use mpc_bulletproof::{r1cs::Prover, PedersenGens};
-use rand_core::OsRng;
+use rand::thread_rng;
 
 use super::{
     valid_commitments::ValidCommitmentsWitnessCommitment,
@@ -96,7 +96,7 @@ where
 
     // Commit to the linked augmented shares and verify that the commitments are the same
     // as the commitments in the validity proofs
-    let mut rng = OsRng {};
+    let mut rng = thread_rng();
     let (_, party0_shares_comm) = party0_augmented_shares.commit_witness(&mut rng, &mut prover);
     let (_, party1_shares_comm) = party1_augmented_shares.commit_witness(&mut rng, &mut prover);
 

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -28,10 +28,9 @@ use circuit_types::{
     wallet::{LinkableWalletShare, WalletVar},
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
-use curve25519_dalek::ristretto::CompressedRistretto;
-use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::r1cs::{LinearCombination, R1CSError, RandomizableConstraintSystem, Variable};
-use rand_core::{CryptoRng, RngCore};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 // ----------------------
@@ -380,13 +379,12 @@ mod test {
         order::{OrderShare, OrderSide},
         traits::{CircuitBaseType, LinkableBaseType},
     };
-    use curve25519_dalek::scalar::Scalar;
     use lazy_static::lazy_static;
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+    use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
-    use rand_core::OsRng;
 
     use crate::zk_circuits::test_helpers::{
         create_wallet_shares, SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
@@ -528,7 +526,7 @@ mod test {
 
     /// Returns true if the given witness and statement satisfy the relation defined by `VALID COMMITMENTS`
     fn constraints_satisfied(witness: SizedWitness, statement: ValidCommitmentsStatement) -> bool {
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
 
         // Create a constrain system
         let pc_gens = PedersenGens::default();

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -10,10 +10,9 @@ use circuit_types::{
     wallet::{LinkableWalletShare, WalletShare, WalletShareVar},
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
-use curve25519_dalek::ristretto::CompressedRistretto;
-use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::r1cs::{LinearCombination, R1CSError, RandomizableConstraintSystem, Variable};
-use rand_core::{CryptoRng, RngCore};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -302,12 +301,12 @@ mod test {
         r#match::MatchResult,
         traits::{CircuitBaseType, LinkableBaseType},
     };
-    use curve25519_dalek::scalar::Scalar;
     use lazy_static::lazy_static;
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+    use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
-    use rand_core::OsRng;
+    use rand::thread_rng;
 
     use crate::zk_circuits::test_helpers::{
         create_wallet_shares, SizedWallet, INITIAL_BALANCES, INITIAL_FEES, MAX_BALANCES, MAX_FEES,
@@ -498,7 +497,7 @@ mod test {
         let mut prover = Prover::new(&pc_gens, &mut transcript);
 
         // Allocate the witness and statement in the constraint system
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
         let statement_var = statement.commit_public(&mut prover);
 

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -16,12 +16,12 @@ use circuit_types::{
     wallet::{WalletShare, WalletVar},
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::R1CSError,
 };
-use rand_core::{CryptoRng, RngCore};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{zk_gadgets::wallet_operations::WalletShareCommitGadget, SingleProverCircuit};
@@ -168,10 +168,10 @@ mod test {
         balance::Balance, native_helpers::compute_wallet_private_share_commitment, order::Order,
         traits::CircuitBaseType,
     };
-    use curve25519_dalek::scalar::Scalar;
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
-    use rand_core::OsRng;
+    use mpc_stark::algebra::scalar::Scalar;
+    use rand::thread_rng;
 
     use crate::{
         test_helpers::bulletproof_prove_and_verify,
@@ -244,7 +244,7 @@ mod test {
         let mut prover = Prover::new(&pc_gens, &mut transcript);
 
         // Allocate the witness and statement in the constraint system
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
         let statement_var = statement.commit_public(&mut prover);
 

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -21,12 +21,12 @@ use circuit_types::{
     AMOUNT_BITS,
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS, MERKLE_HEIGHT};
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::R1CSError,
 };
-use rand_core::{CryptoRng, RngCore};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -527,7 +527,7 @@ mod test {
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
     use num_bigint::BigUint;
-    use rand_core::{OsRng, RngCore};
+    use rand::{thread_rng, RngCore};
 
     use crate::zk_circuits::test_helpers::{
         create_multi_opening, create_wallet_shares, SizedWallet, INITIAL_WALLET, MAX_BALANCES,
@@ -566,7 +566,7 @@ mod test {
         new_wallet: SizedWallet,
         external_transfer: ExternalTransfer,
     ) -> (SizedWitness, SizedStatement) {
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
 
         // Construct secret shares of the wallets
         let (old_wallet_private_shares, old_wallet_public_shares) =
@@ -619,7 +619,7 @@ mod test {
         let mut prover = Prover::new(&pc_gens, &mut transcript);
 
         // Allocate the witness and statement in the constraint system
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let statement_var = statement.commit_public(&mut prover);
         let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
 
@@ -852,7 +852,7 @@ mod test {
         let new_wallet = INITIAL_WALLET.clone();
 
         // Withdraw a random balance
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let withdrawn_mint = BigUint::from(rng.next_u32());
         let withdrawn_amount = 1u8;
 

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -5,13 +5,14 @@ use circuit_macros::circuit_type;
 use circuit_types::traits::{
     BaseType, CircuitBaseType, CircuitCommitmentType, CircuitVarType, LinearCombinationLike,
 };
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 use lazy_static::lazy_static;
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::R1CSError,
 };
-use rand_core::{CryptoRng, RngCore};
+use mpc_stark::algebra::scalar::Scalar;
+use mpc_stark::algebra::stark_curve::StarkPoint;
+use rand::{CryptoRng, RngCore};
 
 use super::arithmetic::PrivateExpGadget;
 
@@ -75,13 +76,12 @@ pub struct ElGamalCiphertext {
 #[cfg(test)]
 mod elgamal_tests {
     use circuit_types::traits::CircuitBaseType;
-    use crypto::fields::{biguint_to_scalar, scalar_to_biguint};
-    use curve25519_dalek::scalar::Scalar;
-    use integration_helpers::mpc_network::field::get_ristretto_group_modulus;
+    use crypto::fields::{biguint_to_scalar, get_scalar_field_modulus, scalar_to_biguint};
     use merlin::Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
+    use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
-    use rand_core::{OsRng, RngCore};
+    use rand::{thread_rng, RngCore};
 
     use crate::zk_gadgets::comparators::EqGadget;
 
@@ -91,7 +91,7 @@ mod elgamal_tests {
     #[test]
     fn test_encrypt() {
         // Create a random cipher
-        let mut rng = OsRng {};
+        let mut rng = thread_rng();
         let randomness_bitlength = 16;
         let mut randomness_bytes = vec![0u8; randomness_bitlength / 8];
         rng.fill_bytes(&mut randomness_bytes);
@@ -103,7 +103,7 @@ mod elgamal_tests {
         let generator = Scalar::from(3u64);
 
         // Generate the expected encryption
-        let field_mod = get_ristretto_group_modulus();
+        let field_mod = get_scalar_field_modulus();
         let generator_bigint = scalar_to_biguint(&generator);
         let pubkey_bigint = scalar_to_biguint(&pubkey);
         let randomness_bigint = scalar_to_biguint(&randomness);

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -6,12 +6,11 @@ use circuit_types::{
     errors::ProverError,
     traits::{LinearCombinationLike, MpcLinearCombinationLike},
 };
-use curve25519_dalek::scalar::Scalar;
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
     r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem},
 };
-use mpc_ristretto::{beaver::SharedValueSource, network::MpcNetwork};
+use mpc_stark::algebra::scalar::Scalar;
 
 use crate::zk_gadgets::comparators::EqGadget;
 
@@ -48,20 +47,17 @@ impl OrGate {
 }
 
 /// Represents an OR gate in a multi-prover constraint system
-pub struct MultiproverOrGate<'a, N: MpcNetwork + Send, S: SharedValueSource<Scalar>> {
-    /// Phantom
-    _phantom: &'a PhantomData<(N, S)>,
-}
+pub struct MultiproverOrGate<'a>(&'a PhantomData<()>);
 
-impl<'a, N: 'a + MpcNetwork + Send, S: 'a + SharedValueSource<Scalar>> MultiproverOrGate<'a, N, S> {
+impl<'a> MultiproverOrGate<'a> {
     /// Return the logical OR of the two arguments
     ///
     /// The arguments are assumed to be binary (0 or 1), but this assumption should be
     /// constrained elsewhere in the calling circuit
-    pub fn or<L, CS>(a: L, b: L, cs: &mut CS) -> Result<MpcLinearCombination<N, S>, ProverError>
+    pub fn or<L, CS>(a: L, b: L, cs: &mut CS) -> Result<MpcLinearCombination, ProverError>
     where
-        L: MpcLinearCombinationLike<N, S>,
-        CS: MpcRandomizableConstraintSystem<'a, N, S>,
+        L: MpcLinearCombinationLike,
+        CS: MpcRandomizableConstraintSystem<'a>,
     {
         let (a, b, a_times_b) = cs
             .multiply(&a.into(), &b.into())

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -4,13 +4,12 @@ use circuit_types::{
     traits::{CircuitVarType, LinearCombinationLike},
     wallet::WalletShareVar,
 };
+use crypto::hash::default_poseidon_params;
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem},
     r1cs_mpc::R1CSError,
 };
-
-use crate::mpc_gadgets::poseidon::PoseidonSpongeParameters;
 
 use super::poseidon::PoseidonHashGadget;
 
@@ -39,7 +38,7 @@ where
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
         // Create a new hash gadget
-        let hash_params = PoseidonSpongeParameters::default();
+        let hash_params = default_poseidon_params();
         let mut hasher = PoseidonHashGadget::new(hash_params);
 
         // Serialize the wallet and hash it into the hasher's state
@@ -60,7 +59,7 @@ where
         cs: &mut CS,
     ) -> Result<LinearCombination, R1CSError> {
         // Create a new hash gadget
-        let hash_params = PoseidonSpongeParameters::default();
+        let hash_params = default_poseidon_params();
         let mut hasher = PoseidonHashGadget::new(hash_params);
 
         // The public shares are added directly to a sponge H(private_commit || public shares)
@@ -107,7 +106,7 @@ impl NullifierGadget {
         CS: RandomizableConstraintSystem,
     {
         // The nullifier is computed as H(C(w)||r)
-        let hash_params = PoseidonSpongeParameters::default();
+        let hash_params = default_poseidon_params();
         let mut hasher = PoseidonHashGadget::new(hash_params);
 
         hasher.batch_absorb(&[share_commitment, wallet_blinder], cs)?;

--- a/test-helpers/src/mpc_network/mocks.rs
+++ b/test-helpers/src/mpc_network/mocks.rs
@@ -1,7 +1,5 @@
 //! Mocks of various types used throughout the implementation of the MPC Network
 
-use std::mem::size_of;
-
 use async_trait::async_trait;
 
 use mpc_stark::{
@@ -11,10 +9,7 @@ use mpc_stark::{
     network::{MpcNetwork, NetworkOutbound, PartyId},
     PARTY0,
 };
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt, DuplexStream},
-    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 /// The maximum message length in the mock network, used for debugging
 pub const MAX_MESSAGE_LEN: u64 = 1_000_000;
@@ -101,10 +96,6 @@ impl UnboundedDuplexStream {
 pub struct MockNetwork {
     /// The ID of the local party
     party_id: PartyId,
-    /// The sent message number in the sequence
-    send_sequence_number: usize,
-    /// The receive message number in the sequence
-    recv_sequence_number: usize,
     /// The underlying mock network connection
     mock_conn: UnboundedDuplexStream,
 }
@@ -114,8 +105,6 @@ impl MockNetwork {
     pub fn new(party_id: PartyId, stream: UnboundedDuplexStream) -> Self {
         Self {
             party_id,
-            send_sequence_number: 0,
-            recv_sequence_number: 0,
             mock_conn: stream,
         }
     }
@@ -141,7 +130,6 @@ impl MpcNetwork for MockNetwork {
         &mut self,
         message: NetworkOutbound,
     ) -> Result<NetworkOutbound, MpcNetworkError> {
-        panic!("exchange called");
         if self.party_id() == PARTY0 {
             self.send_message(message).await?;
             self.receive_message().await


### PR DESCRIPTION
### Purpose
This PR refactors the implementation of the MPC circuits to work over the Stark curve. This is mostly changing interfaces to accommodate the new `async` flow of the MPC execution

### Testing
- Unit and integration tests pass, though CI will remain red throughout the refactor