### PR TITLE
circuits: zk-gadgets: Update gadgets after Stark curve refactor

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -24,12 +24,14 @@ pub mod mpc_circuits;
 pub mod mpc_gadgets;
 mod tracing;
 // pub mod zk_circuits;
-// pub mod zk_gadgets;
+pub mod zk_gadgets;
 
 /// The highest possible set bit in the Dalek scalar field
 pub(crate) const SCALAR_MAX_BITS: usize = 253;
 /// The seed for a fiat-shamir transcript
 pub(crate) const TRANSCRIPT_SEED: &str = "merlin seed";
+/// The maximum bit index that may be set in a positive `Scalar`
+pub(crate) const POSITIVE_SCALAR_MAX_BITS: usize = 250;
 
 // ----------
 // | Macros |

--- a/circuits/src/mpc_gadgets/bits.rs
+++ b/circuits/src/mpc_gadgets/bits.rs
@@ -356,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scalar_from_bits() {
-        let n = 252;
+        let n = 251;
 
         let (party0_res, party1_res) = execute_mock_mpc(move |fabric| async move {
             let bits = {

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -67,7 +67,7 @@ impl<const SCALAR_BITS: usize> ElGamalGadget<SCALAR_BITS> {
 #[circuit_type(singleprover_circuit)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ElGamalCiphertext {
-    /// The parital shared secret; the generator raised to the randomness
+    /// The partial shared secret; the generator raised to the randomness
     pub partial_shared_secret: Scalar,
     /// The encrypted value; the pubkey raised to the randomness, multiplied with the message
     pub encrypted_message: Scalar,
@@ -76,12 +76,12 @@ pub struct ElGamalCiphertext {
 #[cfg(test)]
 mod elgamal_tests {
     use circuit_types::traits::CircuitBaseType;
-    use crypto::fields::{biguint_to_scalar, get_scalar_field_modulus, scalar_to_biguint};
-    use merlin::Transcript;
+    use merlin::HashChainTranscript as Transcript;
     use mpc_bulletproof::{r1cs::Prover, PedersenGens};
     use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
     use rand::{thread_rng, RngCore};
+    use renegade_crypto::fields::{biguint_to_scalar, get_scalar_field_modulus, scalar_to_biguint};
 
     use crate::zk_gadgets::comparators::EqGadget;
 

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -135,8 +135,8 @@ impl<'a> MultiproverFixedPointGadget<'a> {
         // This is effectively the same as constraining the difference to have an integral
         // component of zero
         let shifted_precision =
-            MpcLinearCombination::from_scalar(*TWO_TO_M_SCALAR - Scalar::one(), fabric.clone().0);
-        MultiproverGreaterThanEqGadget::<'_, DEFAULT_FP_PRECISION, _, _>::constrain_greater_than_eq(
+            MpcLinearCombination::from_scalar(*TWO_TO_M_SCALAR - Scalar::one(), fabric.clone());
+        MultiproverGreaterThanEqGadget::<'_, DEFAULT_FP_PRECISION>::constrain_greater_than_eq(
             shifted_precision,
             diff,
             fabric,

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -85,7 +85,7 @@ impl<'a> MultiproverCondSelectGadget<'a> {
             let (_, _, mul2_out) = cs
                 .multiply(
                     &b_var,
-                    &(MpcLinearCombination::from_scalar(Scalar::one(), fabric.0.clone())
+                    &(MpcLinearCombination::from_scalar(Scalar::one(), fabric.clone())
                         - selector.clone().into()),
                 )
                 .map_err(ProverError::Collaborative)?;
@@ -168,7 +168,7 @@ impl<'a> MultiproverCondSelectVectorGadget<'a> {
 mod cond_select_test {
     use circuit_types::traits::CircuitBaseType;
     use itertools::Itertools;
-    use merlin::Transcript;
+    use merlin::HashChainTranscript as Transcript;
     use mpc_bulletproof::{
         r1cs::{ConstraintSystem, LinearCombination, Prover, Variable},
         PedersenGens,

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -4,12 +4,12 @@ use circuit_types::{
     traits::{CircuitVarType, LinearCombinationLike},
     wallet::WalletShareVar,
 };
-use crypto::hash::default_poseidon_params;
 use itertools::Itertools;
 use mpc_bulletproof::{
     r1cs::{LinearCombination, RandomizableConstraintSystem},
     r1cs_mpc::R1CSError,
 };
+use renegade_crypto::hash::default_poseidon_params;
 
 use super::poseidon::PoseidonHashGadget;
 


### PR DESCRIPTION
### Purpose
This PR updates the `zk-gadgets` module to operate over the Stark curve. This largely involves changing interfaces where they differ between the old `mpc-ristretto` and the new `mpc-stark`.

### Testing
- Unit and integration tests pass
- CI will fail locally until refactor is complete