### PR TITLE
core: stark_client, chain_events: Rebase onto most recent starknet-rs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,7 +67,7 @@ reqwest = "0.11.13"
 ring-channel = "0.11.0"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
-starknet = { git = "https://github.com/joeykraut/starknet-rs" }
+starknet = { git = "https://github.com/renegade-fi/starknet-rs" }
 streaming-stats = "0.1.28"
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.5.9" }

--- a/core/src/gossip/worker.rs
+++ b/core/src/gossip/worker.rs
@@ -31,8 +31,7 @@ pub struct GossipServerConfig {
     pub cluster_id: ClusterId,
     /// The servers to bootstrap into the network with
     pub bootstrap_servers: Vec<(WrappedPeerId, Multiaddr)>,
-    /// The starknet client used to connect to sequencer gateway
-    /// and jsonrpc nodes
+    /// The starknet client used to connect to the JSON-RPC node
     pub starknet_client: StarknetClient,
     /// A reference to the relayer-global state
     pub global_state: RelayerState,

--- a/core/src/price_reporter/exchange/uni_v3.rs
+++ b/core/src/price_reporter/exchange/uni_v3.rs
@@ -373,26 +373,25 @@ impl ExchangeConnection for UniswapV3Connection {
         .await?;
 
         // Start streaming events from the swap_filter.
-        let mapped_stream =
-            base_filter
-                .stream(Duration::new(UNI_V3_POLL_INTERVAL, 0))
-                .filter_map(move |swap| async move {
-                    match swap {
-                        Ok(swap_event) => Some(Ok(Self::midpoint_from_swap_event(
-                            swap_event,
-                            is_flipped,
-                            decimal_adjustment,
-                            &SWAP_EVENT_ABI,
-                        ))),
+        let mapped_stream = base_filter
+            .stream(Duration::new(UNI_V3_POLL_INTERVAL, 0))
+            .filter_map(move |swap| async move {
+                match swap {
+                    Ok(swap_event) => Some(Ok(Self::midpoint_from_swap_event(
+                        swap_event,
+                        is_flipped,
+                        decimal_adjustment,
+                        &SWAP_EVENT_ABI,
+                    ))),
 
-                        Err(e) => {
-                            log::error!("Error parsing Swap event from UniswapV3: {}", e);
-                            Some(Err(ExchangeConnectionError::ConnectionHangup(
-                                e.to_string(),
-                            )))
-                        }
+                    Err(e) => {
+                        log::error!("Error parsing Swap event from UniswapV3: {}", e);
+                        Some(Err(ExchangeConnectionError::ConnectionHangup(
+                            e.to_string(),
+                        )))
                     }
-                });
+                }
+            });
 
         // Build a price stream
         let price_stream = InitializablePriceStream::new_with_initial(

--- a/core/src/tasks/create_new_wallet.rs
+++ b/core/src/tasks/create_new_wallet.rs
@@ -15,7 +15,7 @@ use circuits::{
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::starknet_felt_to_biguint;
 use serde::Serialize;
-use starknet::core::types::TransactionStatus;
+use starknet::providers::sequencer::models::TransactionStatus;
 use tokio::sync::oneshot;
 use tracing::log;
 

--- a/core/src/tasks/settle_match.rs
+++ b/core/src/tasks/settle_match.rs
@@ -13,7 +13,7 @@ use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::{scalar_to_biguint, starknet_felt_to_biguint};
 use mpc_ristretto::mpc_scalar::scalar_to_u64;
 use serde::Serialize;
-use starknet::core::types::{TransactionInfo, TransactionStatus};
+use starknet::providers::sequencer::models::{TransactionInfo, TransactionStatus};
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
 use tracing::log;
 

--- a/core/src/tasks/settle_match_internal.rs
+++ b/core/src/tasks/settle_match_internal.rs
@@ -36,7 +36,7 @@ use crypto::fields::scalar_to_biguint;
 use mpc_ristretto::mpc_scalar::scalar_to_u64;
 use num_bigint::BigUint;
 use serde::Serialize;
-use starknet::core::types::{TransactionFailureReason, TransactionStatus};
+use starknet::providers::sequencer::models::{TransactionFailureReason, TransactionStatus};
 use tokio::{
     sync::{mpsc::UnboundedSender as TokioSender, oneshot},
     task::JoinHandle as TokioJoinHandle,

--- a/core/src/tasks/update_wallet.rs
+++ b/core/src/tasks/update_wallet.rs
@@ -10,7 +10,7 @@ use circuits::{native_helpers::wallet_from_blinded_shares, types::transfers::Ext
 use crossbeam::channel::Sender as CrossbeamSender;
 use crypto::fields::starknet_felt_to_biguint;
 use serde::Serialize;
-use starknet::core::types::TransactionStatus;
+use starknet::providers::sequencer::models::TransactionStatus;
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
 use tracing::log;
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,4 +18,4 @@ rand = { version = "0.8" }
 rand_core = "0.5"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
-starknet = { git = "https://github.com/joeykraut/starknet-rs" }
+starknet = { git = "https://github.com/renegade-fi/starknet-rs" }


### PR DESCRIPTION
### Purpose

Rebase our StarkNet client onto the most recent version of `starknet-rs`, as it has upstream changes that are necessary for new RPC specs.

### Testing

* Rust unit tests pass.
* Integration tests with `renegade-js` pass. This particular branch does not pass, but a rebased `testnet` branch on top of these changes works.

### TODO

We use certain deprecated methods, since even though they're "deprecated", there is no equivalent RPC-compliant version that does not directly contact the sequencer. We will remove this once the RPC is up-to-date.