### PR TITLE
circuits: integration: match: Refactor match MPC tests over the Stark curve

### DIFF
--- a/circuits/integration/main.rs
+++ b/circuits/integration/main.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-// mod mpc_circuits;
+mod mpc_circuits;
 mod mpc_gadgets;
 mod types;
 mod zk_circuits;


### PR DESCRIPTION
### Purpose
This PR refactors the integration tests for the `match` MPC to operate over the Stark curve. This is essentially just making interface changes and simplifications to the tests such that they fit the new `MpcFabric` interface

### Todo
- Benchmarks for the MPC and collaborative proof
- Refactor the `commitment_links` module

### Testing
- Unit and integration tests pass
- CI will remain red until the refactor is complete