### PR TITLE
circuits, circuit-types: Ingest interface changes to `MpcProver`

### DIFF
--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -515,12 +515,12 @@ impl Sub<&AuthenticatedFixedPoint> for &AuthenticatedScalarResult {
 // | Multiprover Constraint System Implementation |
 // ------------------------------------------------
 
-impl<'a, L: MpcLinearCombinationLike> AuthenticatedFixedPointVar<L> {
+impl<L: MpcLinearCombinationLike> AuthenticatedFixedPointVar<L> {
     /// Constrain two authenticated fixed point variables to equal one another
     pub fn constrain_equal<L1, CS>(&self, rhs: &AuthenticatedFixedPointVar<L1>, cs: &mut CS)
     where
         L1: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         cs.constrain(self.repr.clone().into() - rhs.repr.clone().into());
     }
@@ -543,12 +543,12 @@ impl From<AuthenticatedFixedPointVar<MpcVariable>>
     }
 }
 
-impl<'a, L: MpcLinearCombinationLike> AuthenticatedFixedPointVar<L> {
+impl<L: MpcLinearCombinationLike> AuthenticatedFixedPointVar<L> {
     /// Multiply with another fixed point variable
     ///
     /// We cannot implement the `Mul` trait directly, because the variables need access
     /// to their constraint system
-    pub fn mul_fixed_point<CS: MpcRandomizableConstraintSystem<'a>>(
+    pub fn mul_fixed_point<CS: MpcRandomizableConstraintSystem>(
         &self,
         rhs: &Self,
         cs: &mut CS,
@@ -567,7 +567,7 @@ impl<'a, L: MpcLinearCombinationLike> AuthenticatedFixedPointVar<L> {
     ) -> Result<AuthenticatedFixedPointVar<MpcVariable>, MultiproverError>
     where
         L1: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let (_, _, res_repr) = cs.multiply(&self.repr.clone().into(), &rhs.into())?;
         Ok(AuthenticatedFixedPointVar { repr: res_repr })

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -32,7 +32,6 @@ use rand::thread_rng;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 use serde::{de::Error as SerdeErr, Deserialize, Deserializer, Serialize, Serializer};
 use wallet::{Wallet, WalletShare};
-// use wallet::{Wallet, WalletShare};
 
 // -------------
 // | Constants |

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -146,7 +146,7 @@ mod test {
                 let mut rng = OsRng {};
                 let pc_gens = PedersenGens::default();
                 let transcript = Transcript::new(b"test");
-                let mut prover = MpcProver::new_with_fabric(fabric.clone(), transcript, &pc_gens);
+                let mut prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
                 // Allocate the dummy value in the constraint system
                 let dummy_allocated = value.allocate(PARTY0, &fabric);

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -1157,7 +1157,7 @@ pub trait MultiProverCircuit<'a> {
     const BP_GENS_CAPACITY: usize;
 
     /// Apply the constraints of the circuit to a multiprover constraint system
-    fn apply_constraints_multiprover<CS: MpcRandomizableConstraintSystem<'a>>(
+    fn apply_constraints_multiprover<CS: MpcRandomizableConstraintSystem>(
         witness: <Self::Witness as MultiproverCircuitBaseType>::MultiproverVarType<MpcVariable>,
         statement: <Self::Statement as MultiproverCircuitBaseType>::MultiproverVarType<MpcVariable>,
         fabric: MpcFabric,
@@ -1185,7 +1185,7 @@ pub trait MultiProverCircuit<'a> {
         witness: Self::Witness,
         statement: Self::Statement,
         fabric: MpcFabric,
-        mut prover: MpcProver<'a, '_, '_>,
+        mut prover: MpcProver,
     ) -> Result<
         (
             <Self::Witness as MultiproverCircuitBaseType>::MultiproverCommType,

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -144,7 +144,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
         let pc_gens = PedersenGens::default();
         let transcript = Transcript::new(b"test");
         let mut dummy_prover =
-            MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, &pc_gens);
+            MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, pc_gens);
 
         let witness = AuthenticatedValidMatchMpcWitness {
             order1: linkable_order1,
@@ -166,7 +166,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
         )
         .unwrap();
 
-        if dummy_prover.constraints_satisfied().unwrap() {
+        if await_result(dummy_prover.constraints_satisfied()) {
             return Err("Constraints satisfied".to_string());
         }
     }

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -209,7 +209,7 @@ fn constraints_satisfied(
 ) -> Result<bool, String> {
     let pc_gens = PedersenGens::default();
     let transcript = Transcript::new(b"test");
-    let mut prover = MpcProver::new_with_fabric(fabric.clone(), transcript, &pc_gens);
+    let mut prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
     let mut rng = thread_rng();
     let (witness_var, _) = witness
@@ -219,9 +219,7 @@ fn constraints_satisfied(
     ValidMatchMpcCircuit::apply_constraints_multiprover(witness_var, (), fabric, &mut prover)
         .map_err(|err| err.to_string())?;
 
-    prover
-        .constraints_satisfied()
-        .map_err(|err| format!("Error checking constraints: {:?}", err))
+    Ok(await_result(prover.constraints_satisfied()))
 }
 
 // ---------

--- a/circuits/integration/zk_gadgets/arithmetic.rs
+++ b/circuits/integration/zk_gadgets/arithmetic.rs
@@ -32,7 +32,7 @@ fn test_exp_multiprover(test_args: &IntegrationTestArgs) -> Result<(), String> {
     // Prove and verify the exp statement
     let pc_gens = PedersenGens::default();
     let transcript = Transcript::new(b"test");
-    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, &pc_gens);
+    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, pc_gens);
     let (shared_base_var, _) = shared_base.commit_shared(&mut rng, &mut prover).unwrap();
     let res = MultiproverExpGadget::exp(
         shared_base_var,
@@ -45,7 +45,7 @@ fn test_exp_multiprover(test_args: &IntegrationTestArgs) -> Result<(), String> {
         res - MpcLinearCombination::from_scalar(expected_scalar, test_args.mpc_fabric.clone()),
     );
 
-    if prover.constraints_satisfied().unwrap() {
+    if await_result(prover.constraints_satisfied()) {
         Ok(())
     } else {
         Err("Constraints not satisfied".to_string())
@@ -65,7 +65,7 @@ fn test_exp_multiprover_invalid(test_args: &IntegrationTestArgs) -> Result<(), S
 
     let pc_gens = PedersenGens::default();
     let transcript = Transcript::new(b"test");
-    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, &pc_gens);
+    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, pc_gens);
     let (shared_base_var, _) = shared_base.commit_shared(&mut rng, &mut prover).unwrap();
 
     let res = MultiproverExpGadget::exp(
@@ -78,7 +78,7 @@ fn test_exp_multiprover_invalid(test_args: &IntegrationTestArgs) -> Result<(), S
     prover
         .constrain(res - MpcVariable::new_with_type(Variable::One(), test_args.mpc_fabric.clone()));
 
-    if prover.constraints_satisfied().unwrap() {
+    if await_result(prover.constraints_satisfied()) {
         Err("Constraints satisfied".to_string())
     } else {
         Ok(())

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -31,7 +31,7 @@ fn test_to_bits(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     let pc_gens = PedersenGens::default();
     let transcript = Transcript::new(b"test");
-    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, &pc_gens);
+    let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, pc_gens);
     let (shared_scalar_var, _) = shared_scalar.commit_shared(&mut rng, &mut prover).unwrap();
     let res_bits = MultiproverToBitsGadget::<64 /* bits */>::to_bits(
         shared_scalar_var,
@@ -47,7 +47,7 @@ fn test_to_bits(test_args: &IntegrationTestArgs) -> Result<(), String> {
         prover.constrain(bit.clone() - allocated_bit);
     }
 
-    if prover.constraints_satisfied().unwrap() {
+    if await_result(prover.constraints_satisfied()) {
         Ok(())
     } else {
         Err("Constraints not satisfied".to_string())

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -126,7 +126,7 @@ where
 {
     let transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
     let pc_gens = PedersenGens::default();
-    let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, &pc_gens);
+    let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
     // Prove the statement
     C::prove(witness, statement.clone(), fabric, prover)

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -69,7 +69,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         // --- Match Engine Input Validity --- //
         // Check that both orders are for the matched asset pair
@@ -202,7 +202,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
 
     /// Check that a balance covers the advertised amount at a given price, and
     /// that the amount is less than the maximum amount allowed by the order
-    pub fn validate_volume_constraints<CS: MpcRandomizableConstraintSystem<'a>>(
+    pub fn validate_volume_constraints<CS: MpcRandomizableConstraintSystem>(
         match_res: &AuthenticatedMatchResultVar<MpcVariable>,
         balance: &AuthenticatedBalanceVar<MpcVariable>,
         order: &AuthenticatedOrderVar<MpcVariable>,
@@ -243,7 +243,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
     /// Verify the price protection on the orders; i.e. that the executed price is not
     /// worse than some user-defined limit
     #[allow(unused)]
-    pub fn verify_price_protection<CS: MpcRandomizableConstraintSystem<'a>>(
+    pub fn verify_price_protection<CS: MpcRandomizableConstraintSystem>(
         price: &AuthenticatedFixedPointVar<MpcVariable>,
         order: &AuthenticatedOrderVar<MpcVariable>,
         fabric: MpcFabric,
@@ -508,7 +508,7 @@ impl<'a> MultiProverCircuit<'a> for ValidMatchMpcCircuit<'a> {
 
     const BP_GENS_CAPACITY: usize = 512;
 
-    fn apply_constraints_multiprover<CS: MpcRandomizableConstraintSystem<'a>>(
+    fn apply_constraints_multiprover<CS: MpcRandomizableConstraintSystem>(
         witness: <Self::Witness as MultiproverCircuitBaseType>::MultiproverVarType<MpcVariable>,
         _statement: <Self::Statement as MultiproverCircuitBaseType>::MultiproverVarType<
             MpcVariable,
@@ -647,7 +647,7 @@ mod tests {
             let (witness_commitment, proof) = {
                 let pc_gens = PedersenGens::default();
                 let transcript = HashChainTranscript::new(b"test");
-                let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, &pc_gens);
+                let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
                 ValidMatchMpcCircuit::prove(
                     witness,

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -244,7 +244,7 @@ impl<'a> MultiproverExpGadget<'a> {
     ) -> Result<MpcLinearCombination, ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         if alpha == 0 {
             Ok(MpcLinearCombination::from_scalar(Scalar::one(), fabric))

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -73,7 +73,7 @@ impl<'a, const D: usize> MultiproverToBitsGadget<'a, D> {
         cs: &mut CS,
     ) -> Result<Vec<MpcLinearCombination>, ProverError>
     where
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
         L: MpcLinearCombinationLike,
     {
         // Evaluate the linear combination so that we can use a raw MPC to get the bits

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -268,7 +268,7 @@ impl<'a, const D: usize> MultiproverGreaterThanEqZeroGadget<'a, D> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let reconstructed_res = Self::bit_decompose_reconstruct(x.clone(), fabric, cs)?;
         cs.constrain(reconstructed_res - x.into());
@@ -288,7 +288,7 @@ impl<'a, const D: usize> MultiproverGreaterThanEqZeroGadget<'a, D> {
     ) -> Result<MpcLinearCombination, ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         // Evaluate the assignment of the value in the underlying constraint system
         let value_assignment = cs.eval(&x.into());
@@ -375,7 +375,7 @@ impl<'a> MultiproverEqGadget<'a> {
         L2: MpcLinearCombinationLike,
         V1: MultiproverCircuitVariableType<L1>,
         V2: MultiproverCircuitVariableType<L2>,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let a_vars = a.to_mpc_vars();
         let b_vars = b.to_mpc_vars();
@@ -409,7 +409,7 @@ impl<'a, const D: usize> MultiproverGreaterThanEqGadget<'a, D> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         MultiproverGreaterThanEqZeroGadget::<'a, D>::constrain_greater_than_zero(
             a.into() - b.into(),

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -108,7 +108,7 @@ impl<'a> MultiproverFixedPointGadget<'a> {
         cs: &mut CS,
     ) where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         // Shift the integer
         let shifted_rhs = *TWO_TO_M_SCALAR * rhs;
@@ -125,7 +125,7 @@ impl<'a> MultiproverFixedPointGadget<'a> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         // Shift the integer and take the difference
         let shifted_rhs = *TWO_TO_M_SCALAR * rhs;

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -57,7 +57,7 @@ impl<'a> MultiproverOrGate<'a> {
     pub fn or<L, CS>(a: L, b: L, cs: &mut CS) -> Result<MpcLinearCombination, ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let (a, b, a_times_b) = cs
             .multiply(&a.into(), &b.into())

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -311,17 +311,17 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         self.batch_absorb(hash_input, cs)?;
         self.constrained_squeeze(expected_output.clone(), cs)
     }
 
     /// Absorb an input into the hasher state
-    pub fn absorb<'b, L, CS>(&mut self, a: L, cs: &mut CS) -> Result<(), ProverError>
+    pub fn absorb<L, CS>(&mut self, a: L, cs: &mut CS) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         assert!(
             !self.in_squeeze_state,
@@ -344,7 +344,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     pub fn batch_absorb<L, CS>(&mut self, a: &[L], cs: &mut CS) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         a.iter().try_for_each(|val| self.absorb(val.clone(), cs))
     }
@@ -352,7 +352,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     /// Squeeze an output from the hasher and return to the caller
     pub fn squeeze<CS>(&mut self, cs: &mut CS) -> Result<MpcLinearCombination, ProverError>
     where
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         // Once we exit the absorb state, ensure that the digest state is permuted before squeezing
         if !self.in_squeeze_state || self.next_index == self.params.rate {
@@ -373,7 +373,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let squeezed = self.squeeze(cs)?;
         cs.constrain(squeezed - expected.into());
@@ -387,7 +387,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
         cs: &mut CS,
     ) -> Result<Vec<MpcLinearCombination>, ProverError>
     where
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         (0..num_elems)
             .map(|_| self.squeeze(cs))
@@ -403,7 +403,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     ) -> Result<(), ProverError>
     where
         L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         expected
             .iter()
@@ -411,7 +411,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     }
 
     /// Permute the digest by applying the Poseidon round function
-    fn permute<CS: MpcRandomizableConstraintSystem<'a>>(
+    fn permute<CS: MpcRandomizableConstraintSystem>(
         &mut self,
         cs: &mut CS,
     ) -> Result<(), ProverError> {
@@ -464,7 +464,7 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
     ///
     /// This step is applied in the Poseidon permutation after the round constants
     /// are added to the state.
-    fn apply_sbox<CS: MpcRandomizableConstraintSystem<'a>>(
+    fn apply_sbox<CS: MpcRandomizableConstraintSystem>(
         &mut self,
         full_round: bool,
         cs: &mut CS,

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -66,7 +66,7 @@ impl<'a> MultiproverCondSelectGadget<'a> {
     where
         L: MpcLinearCombinationLike,
         V: MultiproverCircuitVariableType<MpcLinearCombination>,
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
     {
         let a_vars = a.to_mpc_vars();
         let b_vars = b.to_mpc_vars();
@@ -143,7 +143,7 @@ impl<'a> MultiproverCondSelectVectorGadget<'a> {
         cs: &mut CS,
     ) -> Result<Vec<V>, ProverError>
     where
-        CS: MpcRandomizableConstraintSystem<'a>,
+        CS: MpcRandomizableConstraintSystem,
         L: MpcLinearCombinationLike,
         V: MultiproverCircuitVariableType<MpcLinearCombination>,
     {


### PR DESCRIPTION
### Purpose
This PR ingests the interface and lifetime parameter changes introduced to `MpcProver` in [this PR](https://github.com/renegade-fi/mpc-bulletproof/pull/8)

These changes are:
- Force the prover to take ownership of all fields
- Remove all lifetime parameters as they are now unnecessary

### Testing
- Unit and integration tests pass