### PR TITLE
circuits: benches: match: Add `VALID MATCH MPC` benchmarks

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -33,6 +33,11 @@ harness = false
 required-features = ["test_helpers"]
 
 [[bench]]
+name = "match"
+harness = false
+required-features = ["test_helpers"]
+
+[[bench]]
 name = "valid_settle"
 harness = false
 required-features = ["test_helpers"]
@@ -76,7 +81,7 @@ ark-ed25519 = "0.4"
 chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
-criterion = { version = "0.5" }
+criterion = { version = "0.5", features = ["async", "async_tokio"] }
 ctor = "0.1"
 
 dns-lookup = "1.0"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -10,7 +10,6 @@ test_helpers = []
 name = "integration"
 path = "integration/main.rs"
 harness = false
-debug = true
 
 [[bench]]
 name = "valid_wallet_create"

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -1,26 +1,77 @@
 //! Groups integration tests for matching an order and proving `VALID MATCH MPC` collaboratively
+//!
+//! TODO: Benchmark with various simulated latencies
 
-//! Tests the process of proving and verifying a `VALID REBLIND` circuit
-#![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+use std::time::{Duration, Instant};
 
 use circuit_types::{
+    balance::Balance,
     fixed_point::FixedPoint,
     order::Order,
-    traits::{MpcBaseType, MpcType},
+    r#match::LinkableMatchResult,
+    traits::{
+        LinkableBaseType, MpcBaseType, MpcType, MultiProverCircuit, MultiproverCircuitBaseType,
+        SingleProverCircuit,
+    },
 };
-use circuits::mpc_circuits::r#match::compute_match;
+use circuits::{
+    mpc_circuits::r#match::compute_match,
+    zk_circuits::valid_match_mpc::{
+        test_helpers::create_dummy_witness, ValidMatchMpcCircuit, ValidMatchMpcSingleProver,
+        ValidMatchMpcWitness,
+    },
+};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
+use merlin::HashChainTranscript;
+use mpc_bulletproof::{
+    r1cs::{Prover, Verifier},
+    r1cs_mpc::MpcProver,
+    PedersenGens,
+};
 use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use rand::thread_rng;
 use test_helpers::mpc_network::execute_mock_mpc;
 use tokio::runtime::Builder as RuntimeBuilder;
 
+// -----------
+// | Helpers |
+// -----------
+
+/// Get a dummy, single-prover witness for `VALID MATCH MPC`
+pub fn get_dummy_singleprover_witness() -> ValidMatchMpcWitness {
+    // Generate a proof that will be used by the benchmarks to verify
+    ValidMatchMpcWitness {
+        order1: Order::default().to_linkable(),
+        order2: Order::default().to_linkable(),
+        balance1: Balance::default().to_linkable(),
+        balance2: Balance::default().to_linkable(),
+        amount1: Scalar::one(),
+        amount2: Scalar::one(),
+        price1: FixedPoint::from_integer(1),
+        price2: FixedPoint::from_integer(1),
+        match_res: LinkableMatchResult {
+            quote_mint: Scalar::one().to_linkable(),
+            base_mint: Scalar::one().to_linkable(),
+            quote_amount: Scalar::one().to_linkable(),
+            base_amount: Scalar::one().to_linkable(),
+            direction: Scalar::one().to_linkable(),
+            max_minus_min_amount: Scalar::one().to_linkable(),
+            min_amount_order_index: Scalar::one().to_linkable(),
+        },
+    }
+}
+
+// --------------
+// | Benchmarks |
+// --------------
+
 /// Benchmark the time taken to run the raw `match` MPC circuits
-///
-/// TODO: Benchmark with various simulated latencies
 pub fn bench_match_mpc(c: &mut Criterion) {
-    let mut group = c.benchmark_group("match_mpc");
+    let mut group = c.benchmark_group("match-mpc");
 
     group.bench_function(BenchmarkId::new("match", ""), |b| {
         // Build a Tokio runtime and spawn the benchmarks within it
@@ -30,29 +81,167 @@ pub fn bench_match_mpc(c: &mut Criterion) {
             .unwrap();
         let mut async_bencher = b.to_async(runtime);
 
-        async_bencher.iter(|| async {
-            execute_mock_mpc(|fabric| async move {
-                // Allocate the inputs in the fabric
-                let o1 = Order::default().allocate(PARTY0, &fabric);
-                let o2 = Order::default().allocate(PARTY1, &fabric);
-                let amount1 = Scalar::one().allocate(PARTY0, &fabric);
-                let amount2 = Scalar::one().allocate(PARTY1, &fabric);
-                let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
+        async_bencher.iter_custom(|n_iters| async move {
+            let mut total_time = Duration::from_secs(0);
+            for _ in 0..n_iters {
+                let (party0_time, party1_time) = execute_mock_mpc(|fabric| async move {
+                    // Allocate the inputs in the fabric
+                    let start = Instant::now();
+                    let o1 = Order::default().allocate(PARTY0, &fabric);
+                    let o2 = Order::default().allocate(PARTY1, &fabric);
+                    let amount1 = Scalar::one().allocate(PARTY0, &fabric);
+                    let amount2 = Scalar::one().allocate(PARTY1, &fabric);
+                    let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
 
-                // Run the MPC
-                let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, fabric);
+                    // Run the MPC
+                    let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, fabric);
 
-                // Open the result
-                let _open = match_res.open_and_authenticate().await;
-            })
-            .await
+                    // Open the result
+                    let _open = match_res.open_and_authenticate().await;
+                    start.elapsed()
+                })
+                .await;
+
+                total_time += Duration::max(party0_time, party1_time);
+            }
+
+            total_time
         });
+    });
+}
+
+/// Benchmark the constraint generation latency of the `match` MPC circuits
+pub fn bench_apply_constraints(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match-mpc");
+
+    group.bench_function(BenchmarkId::new("constraint-generation", ""), |b| {
+        let runtime = RuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut async_bencher = b.to_async(runtime);
+
+        async_bencher.iter_custom(|n_iters| async move {
+            let mut total_time = Duration::from_secs(0);
+            for _ in 0..n_iters {
+                // Execute an MPC to generate the constraints
+                let (party0_time, party1_time) = execute_mock_mpc(|fabric| async move {
+                    // Create a witness to the proof
+                    let witness = create_dummy_witness(&fabric);
+
+                    // Create a constraint system to allocate the constraints within
+                    let pc_gens = PedersenGens::default();
+                    let transcript = HashChainTranscript::new(b"test");
+                    let mut prover =
+                        MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
+
+                    // Start the measurement after the setup code
+                    let start = Instant::now();
+
+                    // Allocate the inputs in the constraint system
+                    let (witness_var, _) = witness
+                        .commit_shared(&mut thread_rng(), &mut prover)
+                        .unwrap();
+                    ValidMatchMpcCircuit::apply_constraints_multiprover(
+                        witness_var,
+                        (),
+                        fabric,
+                        &mut prover,
+                    )
+                    .unwrap();
+
+                    // There is no great way to await the constraint generation, so we check that the constraints are
+                    // satisfied. This is not an exact way to measure execution time, but it is a decent approximation.
+                    // The benchmarks below measure time taken to generate constraints and prove, so they more directly
+                    // estimate constraint generation latency, but as part of a larger circuit
+                    let _satisfied = prover.constraints_satisfied().await;
+                    start.elapsed()
+                })
+                .await;
+
+                total_time += Duration::max(party0_time, party1_time);
+            }
+
+            total_time
+        });
+    });
+}
+
+/// Benchmarks the time it takes to prove a `VALID MATCH MPC` statement
+pub fn bench_prover_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match-mpc");
+
+    group.bench_function(BenchmarkId::new("prover", ""), |b| {
+        let runtime = RuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut async_bencher = b.to_async(runtime);
+
+        async_bencher.iter_custom(|n_iters| async move {
+            let mut total_time = Duration::from_secs(0);
+            for _ in 0..n_iters {
+                // Execute an MPC to generate the constraints
+                let (party0_time, party1_time) = execute_mock_mpc(|fabric| async move {
+                    // Create a witness to the proof
+                    let witness = create_dummy_witness(&fabric);
+
+                    // Create a constraint system to allocate the constraints within
+                    let pc_gens = PedersenGens::default();
+                    let transcript = HashChainTranscript::new(b"test");
+                    let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
+
+                    // Start the measurement after the setup code
+                    let start = Instant::now();
+
+                    // Allocate the inputs in the constraint system
+                    let (_comm, proof) =
+                        ValidMatchMpcCircuit::prove(witness, (), fabric, prover).unwrap();
+
+                    let _opened_proof = proof.open().await;
+                    start.elapsed()
+                })
+                .await;
+
+                total_time += Duration::max(party0_time, party1_time);
+            }
+
+            total_time
+        });
+    });
+}
+
+/// Benchmarks the verification latency of a `VALID MATCH MPC` statement
+pub fn bench_verifier_latency(c: &mut Criterion) {
+    // Create a dummy proof to verify in the benchmark loop
+    let dummy_witness = get_dummy_singleprover_witness();
+    let pc_gens = PedersenGens::default();
+    let mut transcript = HashChainTranscript::new(b"test");
+    let prover = Prover::new(&pc_gens, &mut transcript);
+
+    let (witness_comm, proof) =
+        ValidMatchMpcSingleProver::prove(dummy_witness, (), prover).unwrap();
+
+    let mut group = c.benchmark_group("match-mpc");
+    group.bench_function(BenchmarkId::new("verifier", ""), |b| {
+        b.iter(|| {
+            let mut transcript = HashChainTranscript::new(b"test");
+            let verifier = Verifier::new(&pc_gens, &mut transcript);
+
+            assert!(ValidMatchMpcSingleProver::verify(
+                witness_comm.clone(),
+                (),
+                proof.clone(),
+                verifier
+            )
+            .is_err());
+        })
     });
 }
 
 criterion_group! {
     name = match_mpc;
     config = Criterion::default().sample_size(10);
-    targets = bench_match_mpc,
+    targets = bench_match_mpc, bench_apply_constraints, bench_prover_latency, bench_verifier_latency
 }
 criterion_main!(match_mpc);

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -1,0 +1,58 @@
+//! Groups integration tests for matching an order and proving `VALID MATCH MPC` collaboratively
+
+//! Tests the process of proving and verifying a `VALID REBLIND` circuit
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use circuit_types::{
+    fixed_point::FixedPoint,
+    order::Order,
+    traits::{MpcBaseType, MpcType},
+};
+use circuits::mpc_circuits::r#match::compute_match;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use test_helpers::mpc_network::execute_mock_mpc;
+use tokio::runtime::Builder as RuntimeBuilder;
+
+/// Benchmark the time taken to run the raw `match` MPC circuits
+///
+/// TODO: Benchmark with various simulated latencies
+pub fn bench_match_mpc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_mpc");
+
+    group.bench_function(BenchmarkId::new("match", ""), |b| {
+        // Build a Tokio runtime and spawn the benchmarks within it
+        let runtime = RuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut async_bencher = b.to_async(runtime);
+
+        async_bencher.iter(|| async {
+            execute_mock_mpc(|fabric| async move {
+                // Allocate the inputs in the fabric
+                let o1 = Order::default().allocate(PARTY0, &fabric);
+                let o2 = Order::default().allocate(PARTY1, &fabric);
+                let amount1 = Scalar::one().allocate(PARTY0, &fabric);
+                let amount2 = Scalar::one().allocate(PARTY1, &fabric);
+                let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
+
+                // Run the MPC
+                let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, fabric);
+
+                // Open the result
+                let _open = match_res.open_and_authenticate().await;
+            })
+            .await
+        });
+    });
+}
+
+criterion_group! {
+    name = match_mpc;
+    config = Criterion::default().sample_size(10);
+    targets = bench_match_mpc,
+}
+criterion_main!(match_mpc);

--- a/circuits/src/zk_circuits/commitment_links.rs
+++ b/circuits/src/zk_circuits/commitment_links.rs
@@ -6,7 +6,7 @@
 //! use the same commitment between proofs
 
 use circuit_types::{traits::CircuitBaseType, wallet::LinkableWalletShare};
-use merlin::Transcript;
+use merlin::HashChainTranscript as Transcript;
 use mpc_bulletproof::{r1cs::Prover, PedersenGens};
 use rand::thread_rng;
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -2,7 +2,7 @@
 //! in proving knowledge of witness for throughout the network
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-// pub mod commitment_links;
+pub mod commitment_links;
 pub mod valid_commitments;
 pub mod valid_match_mpc;
 pub mod valid_reblind;

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -552,29 +552,22 @@ impl SingleProverCircuit for ValidMatchMpcSingleProver {
 // | Tests |
 // ---------
 
-#[cfg(test)]
-mod tests {
+#[cfg(any(test, feature = "test_helpers"))]
+pub mod test_helpers {
     use circuit_types::{
         balance::Balance,
         fixed_point::FixedPoint,
         order::{Order, OrderSide},
         r#match::MatchResult,
-        traits::{
-            LinkableBaseType, MpcBaseType, MultiProverCircuit, MultiproverCircuitCommitmentType,
-        },
+        traits::{LinkableBaseType, MpcBaseType},
     };
-    use merlin::HashChainTranscript;
-    use mpc_bulletproof::{r1cs::Verifier, r1cs_mpc::MpcProver, PedersenGens};
     use mpc_stark::{algebra::scalar::Scalar, MpcFabric, PARTY0, PARTY1};
     use renegade_crypto::fields::scalar_to_u64;
-    use test_helpers::mpc_network::execute_mock_mpc;
 
-    use crate::zk_circuits::valid_match_mpc::{
-        AuthenticatedValidMatchMpcWitness, ValidMatchMpcCircuit,
-    };
+    use crate::zk_circuits::valid_match_mpc::AuthenticatedValidMatchMpcWitness;
 
     /// Create a dummy witness to match on
-    fn create_dummy_witness(fabric: &MpcFabric) -> AuthenticatedValidMatchMpcWitness {
+    pub fn create_dummy_witness(fabric: &MpcFabric) -> AuthenticatedValidMatchMpcWitness {
         let min_amount = 5u64;
         let max_amount = 15u64;
 
@@ -636,6 +629,18 @@ mod tests {
             match_res: match_res.allocate(PARTY0, fabric),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use circuit_types::traits::{MultiProverCircuit, MultiproverCircuitCommitmentType};
+    use merlin::HashChainTranscript;
+    use mpc_bulletproof::{r1cs::Verifier, r1cs_mpc::MpcProver, PedersenGens};
+    use test_helpers::mpc_network::execute_mock_mpc;
+
+    use crate::zk_circuits::valid_match_mpc::{
+        test_helpers::create_dummy_witness, ValidMatchMpcCircuit,
+    };
 
     /// Tests proving a valid match with a valid witness
     #[tokio::test]


### PR DESCRIPTION
### Purpose
This PR makes the following changes:
- Refactors  the `commitment_links` module over the Stark curve -- this only required a one-line change
- Adds benchmarks for the `match` MPC and the `VALID MATCH MPC` collaborative proof (constraint generation, prover latency, and verification latency)

### Testing
- Unit and integration tests pass
- CI will remain red until the refactor is complete