### PR TITLE
circuits: Cleanup crate after Stark curve refactor

### DIFF
--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -1141,7 +1141,7 @@ pub trait SingleProverCircuit {
 /// The witness type represents the secret witness that the prover has access to but
 /// that the verifier does not. The statement is the set of public inputs and any
 /// other circuit meta-parameters that both prover and verifier have access to.
-pub trait MultiProverCircuit<'a> {
+pub trait MultiProverCircuit {
     /// The witness type, given only to the prover, which generates a blinding commitment
     /// that can be given to the verifier
     type Witness: MultiproverCircuitBaseType;

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -94,7 +94,7 @@ pub fn bench_match_mpc(c: &mut Criterion) {
                     let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
 
                     // Run the MPC
-                    let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, fabric);
+                    let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, &fabric);
 
                     // Open the result
                     let _open = match_res.open_and_authenticate().await;

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -137,7 +137,7 @@ fn test_match_no_match(test_args: &IntegrationTestArgs) -> Result<(), String> {
             &order1.amount,
             &order2.amount,
             &price1, // Use the first party's price
-            test_args.mpc_fabric.clone(),
+            fabric,
         );
 
         // Assert that match verification fails
@@ -258,7 +258,7 @@ fn test_match_valid_match(test_args: &IntegrationTestArgs) -> Result<(), String>
                 &order1.amount,
                 &order2.amount,
                 &price1,
-                test_args.mpc_fabric.clone(),
+                fabric,
             )
             .open_and_authenticate(),
         )

--- a/circuits/integration/mpc_gadgets/arithmetic.rs
+++ b/circuits/integration/mpc_gadgets/arithmetic.rs
@@ -38,9 +38,7 @@ fn test_product(test_args: &IntegrationTestArgs) -> Result<(), String> {
     all_values.append(&mut p2_values.clone());
 
     // Compute the product
-    let res = await_result_with_error(
-        product(&all_values, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let res = await_result_with_error(product(&all_values, fabric).open_authenticated())?;
 
     // Open the shared values and compute the expected result
     let p1_values_prod = await_result_batch(AuthenticatedScalarResult::open_batch(&p1_values))
@@ -64,7 +62,7 @@ fn test_prefix_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let shared_values = fabric.batch_share_scalar(vec![value; n], PARTY0);
 
     // Run the prefix_mul gadget
-    let prefixes = prefix_mul(&shared_values, test_args.mpc_fabric.clone());
+    let prefixes = prefix_mul(&shared_values, fabric);
 
     // Open the prefixes and verify the result
     let opened_prefix_products = await_result_batch_with_error(
@@ -91,12 +89,7 @@ fn test_pow(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let random_exp = await_result(fabric.share_plaintext(Scalar::from(rng.next_u32()), PARTY1));
 
     let res = await_result_with_error(
-        pow(
-            &random_base,
-            scalar_to_u64(&random_exp),
-            test_args.mpc_fabric.clone(),
-        )
-        .open_authenticated(),
+        pow(&random_base, scalar_to_u64(&random_exp), fabric).open_authenticated(),
     )?;
 
     // Open the random input and compute the expected result

--- a/circuits/integration/mpc_gadgets/bits.rs
+++ b/circuits/integration/mpc_gadgets/bits.rs
@@ -96,7 +96,7 @@ fn test_bit_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let res_bits = bit_add(
         shared_bits_a.as_slice()[..64].try_into().unwrap(),
         shared_bits_b.as_slice()[..64].try_into().unwrap(),
-        test_args.mpc_fabric.clone(),
+        fabric,
     )
     .0;
     let result = await_result_batch_with_error(
@@ -123,7 +123,7 @@ fn test_bits_le_zero(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let fabric = &test_args.mpc_fabric;
     let shared_zero = fabric.zero_authenticated();
 
-    let shared_bits = to_bits_le::<250>(&shared_zero, test_args.mpc_fabric.clone());
+    let shared_bits = to_bits_le::<250>(&shared_zero, fabric);
     let shared_bits_open = await_result_batch_with_error(
         AuthenticatedScalarResult::open_authenticated_batch(&shared_bits),
     )?;
@@ -137,7 +137,7 @@ fn test_to_bits_le(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let value = 119;
 
     let shared_value = fabric.share_scalar(value, PARTY0);
-    let shared_bits = to_bits_le::<8>(&shared_value, test_args.mpc_fabric.clone());
+    let shared_bits = to_bits_le::<8>(&shared_value, fabric);
 
     // Open the bits and compare
     let opened_bits = await_result_batch_with_error(
@@ -176,9 +176,9 @@ fn test_bit_lt(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let equal_value2 = fabric.share_scalar(value, PARTY1);
 
     let res = bit_lt(
-        &to_bits_le::<250>(&equal_value1, test_args.mpc_fabric.clone()),
-        &to_bits_le::<250>(&equal_value2, test_args.mpc_fabric.clone()),
-        test_args.mpc_fabric.clone(),
+        &to_bits_le::<250>(&equal_value1, fabric),
+        &to_bits_le::<250>(&equal_value2, fabric),
+        fabric,
     )
     .open_authenticated();
     let res_open = await_result_with_error(res)?;
@@ -193,9 +193,9 @@ fn test_bit_lt(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let shared_value2 = fabric.share_scalar(my_value, PARTY1);
 
     let res = bit_lt(
-        &to_bits_le::<250>(&shared_value1, test_args.mpc_fabric.clone()),
-        &to_bits_le::<250>(&shared_value2, test_args.mpc_fabric.clone()),
-        test_args.mpc_fabric.clone(),
+        &to_bits_le::<250>(&shared_value1, fabric),
+        &to_bits_le::<250>(&shared_value2, fabric),
+        fabric,
     )
     .open_authenticated();
     let res_open = await_result_with_error(res)?;

--- a/circuits/integration/mpc_gadgets/comparators.rs
+++ b/circuits/integration/mpc_gadgets/comparators.rs
@@ -33,7 +33,7 @@ fn test_inequalities(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Test <
     let lt_result = await_result_with_error(
-        less_than::<250>(&shared_a, &shared_b, test_args.mpc_fabric.clone()).open_authenticated(),
+        less_than::<250>(&shared_a, &shared_b, fabric).open_authenticated(),
     )?;
     let mut expected_result = opened_a < opened_b;
 
@@ -41,31 +41,27 @@ fn test_inequalities(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Test <= with equal values
     let mut lte_result = await_result_with_error(
-        less_than_equal::<250>(&shared_a, &shared_a, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        less_than_equal::<250>(&shared_a, &shared_a, fabric).open_authenticated(),
     )?;
     assert_scalar_eq(&lte_result, &Scalar::one())?;
 
     // Test <= with random values
     lte_result = await_result_with_error(
-        less_than_equal::<250>(&shared_a, &shared_b, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        less_than_equal::<250>(&shared_a, &shared_b, fabric).open_authenticated(),
     )?;
     expected_result = opened_a <= opened_b;
     assert_scalar_eq(&lte_result, &expected_result.into())?;
 
     // Test >
     let gt_result = await_result_with_error(
-        greater_than::<250>(&shared_a, &shared_b, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        greater_than::<250>(&shared_a, &shared_b, fabric).open_authenticated(),
     )?;
     expected_result = opened_a > opened_b;
     assert_scalar_eq(&gt_result, &expected_result.into())?;
 
     // Test >= with random values
     let gte_result = await_result_with_error(
-        greater_than_equal::<250>(&shared_a, &shared_b, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        greater_than_equal::<250>(&shared_a, &shared_b, fabric).open_authenticated(),
     )?;
     expected_result = opened_a >= opened_b;
     assert_scalar_eq(&gte_result, &expected_result.into())?;
@@ -78,26 +74,22 @@ fn test_equalities(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let fabric = &test_args.mpc_fabric;
     // 0 == 0
     let shared_zero = fabric.zero_authenticated();
-    let mut res = await_result_with_error(
-        eq_zero::<250>(&shared_zero, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let mut res =
+        await_result_with_error(eq_zero::<250>(&shared_zero, fabric).open_authenticated())?;
 
     assert_scalar_eq(&res, &Scalar::one())?;
 
     // random == 0
     let mut rng = thread_rng();
     let shared_random = fabric.share_scalar(rng.next_u32() as u64, PARTY0);
-    res = await_result_with_error(
-        eq_zero::<250>(&shared_random, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    res = await_result_with_error(eq_zero::<250>(&shared_random, fabric).open_authenticated())?;
 
     assert_scalar_eq(&res, &Scalar::zero())?;
 
     // random_1 == random_1
     let shared_random = fabric.share_scalar(rng.next_u32(), PARTY0);
     res = await_result_with_error(
-        eq::<250>(&shared_random, &shared_random, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        eq::<250>(&shared_random, &shared_random, fabric).open_authenticated(),
     )?;
 
     assert_scalar_eq(&res, &Scalar::one())?;
@@ -107,12 +99,7 @@ fn test_equalities(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let shared_random2 = fabric.share_scalar(rng.next_u32(), PARTY1);
 
     res = await_result_with_error(
-        eq::<250>(
-            &shared_random1,
-            &shared_random2,
-            test_args.mpc_fabric.clone(),
-        )
-        .open_authenticated(),
+        eq::<250>(&shared_random1, &shared_random2, fabric).open_authenticated(),
     )?;
 
     assert_scalar_eq(&res, &Scalar::zero())
@@ -125,9 +112,7 @@ fn test_kary_or(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // All zeros
     let zeros: [AuthenticatedScalarResult; N] = fabric.zeros_authenticated(N).try_into().unwrap();
-    let res = await_result_with_error(
-        kary_or::<N>(&zeros, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let res = await_result_with_error(kary_or::<N>(&zeros, fabric).open_authenticated())?;
 
     assert_scalar_eq(&res, &Scalar::zero())?;
 
@@ -147,9 +132,7 @@ fn test_kary_or(test_args: &IntegrationTestArgs) -> Result<(), String> {
         .try_into()
         .unwrap();
 
-    let res = await_result_with_error(
-        kary_or(&shared_bits, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let res = await_result_with_error(kary_or(&shared_bits, fabric).open_authenticated())?;
     assert_scalar_eq(&res, &Scalar::one())
 }
 

--- a/circuits/integration/mpc_gadgets/modulo.rs
+++ b/circuits/integration/mpc_gadgets/modulo.rs
@@ -21,18 +21,16 @@ fn test_mod_2m(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let fabric = &test_args.mpc_fabric;
     let value: u64 = (1 << M) * thread_rng().next_u32() as u64;
     let shared_value = fabric.share_scalar(value, PARTY0);
-    let value_mod_2m = await_result_with_error(
-        mod_2m::<M>(&shared_value, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let value_mod_2m =
+        await_result_with_error(mod_2m::<M>(&shared_value, fabric).open_authenticated())?;
 
     assert_scalar_eq(&value_mod_2m, &Scalar::zero())?;
 
     // Random value
     let random_value: BigUint = thread_rng().sample(RandomBits::new(250));
     let shared_random_value = fabric.share_scalar(random_value, PARTY1);
-    let random_value_mod_2m = await_result_with_error(
-        mod_2m::<M>(&shared_random_value, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let random_value_mod_2m =
+        await_result_with_error(mod_2m::<M>(&shared_random_value, fabric).open_authenticated())?;
 
     let value_opened = await_result_with_error(shared_random_value.open_authenticated())?;
     let expected_result: BigUint = scalar_to_biguint(&value_opened) % (1u64 << M);
@@ -50,9 +48,8 @@ fn test_truncate(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Party 0 chooses truncated value, party 1 chooses truncation amount
     let shared_random_value = fabric.share_scalar(random_value, PARTY0);
-    let res = await_result_with_error(
-        truncate::<M>(&shared_random_value, test_args.mpc_fabric.clone()).open_authenticated(),
-    )?;
+    let res =
+        await_result_with_error(truncate::<M>(&shared_random_value, fabric).open_authenticated())?;
 
     // Open the original value and compute the expected result
     let random_value = await_result_with_error(shared_random_value.open_authenticated())?;
@@ -70,8 +67,7 @@ fn test_shift_right(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let random_value = fabric.share_scalar(rng.next_u32(), PARTY0);
 
     let res = await_result_with_error(
-        shift_right::<SHIFT_AMOUNT>(&random_value, test_args.mpc_fabric.clone())
-            .open_authenticated(),
+        shift_right::<SHIFT_AMOUNT>(&random_value, fabric).open_authenticated(),
     )?;
 
     // Open the random value and compute the expected result

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -186,9 +186,8 @@ fn prove_and_verify_match(
     fabric: MpcFabric,
 ) -> Result<bool, String> {
     // Prove
-    let (witness_comm, proof) =
-        multiprover_prove::<'_, ValidMatchMpcCircuit<'_>>(witness, (), fabric)
-            .map_err(|err| format!("Error proving: {:?}", err))?;
+    let (witness_comm, proof) = multiprover_prove::<ValidMatchMpcCircuit>(witness, (), fabric)
+        .map_err(|err| format!("Error proving: {:?}", err))?;
 
     // Open
     let opened_proof = await_result_with_error(proof.open())?;
@@ -196,10 +195,7 @@ fn prove_and_verify_match(
         .map_err(|err| format!("Error opening witness commitment: {:?}", err))?;
 
     // Verify
-    Ok(
-        verify_collaborative_proof::<'_, ValidMatchMpcCircuit<'_>>((), opened_comm, opened_proof)
-            .is_ok(),
-    )
+    Ok(verify_collaborative_proof::<ValidMatchMpcCircuit>((), opened_comm, opened_proof).is_ok())
 }
 
 /// Return whether the `VALID MATCH MPC` constraints are satisfied on the given witness

--- a/circuits/integration/zk_gadgets/arithmetic.rs
+++ b/circuits/integration/zk_gadgets/arithmetic.rs
@@ -37,7 +37,7 @@ fn test_exp_multiprover(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let res = MultiproverExpGadget::exp(
         shared_base_var,
         exp_open.try_into().unwrap(),
-        test_args.mpc_fabric.clone(),
+        fabric,
         &mut prover,
     )
     .map_err(|err| format!("Error computing exp circuit: {:?}", err))?;
@@ -71,7 +71,7 @@ fn test_exp_multiprover_invalid(test_args: &IntegrationTestArgs) -> Result<(), S
     let res = MultiproverExpGadget::exp(
         shared_base_var,
         exp_open.try_into().unwrap(),
-        test_args.mpc_fabric.clone(),
+        fabric,
         &mut prover,
     )
     .map_err(|err| format!("Error computing exp circuit: {:?}", err))?;

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -33,12 +33,9 @@ fn test_to_bits(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let transcript = Transcript::new(b"test");
     let mut prover = MpcProver::new_with_fabric(test_args.mpc_fabric.clone(), transcript, pc_gens);
     let (shared_scalar_var, _) = shared_scalar.commit_shared(&mut rng, &mut prover).unwrap();
-    let res_bits = MultiproverToBitsGadget::<64 /* bits */>::to_bits(
-        shared_scalar_var,
-        test_args.mpc_fabric.clone(),
-        &mut prover,
-    )
-    .map_err(|err| format!("Error computing to_bits circuit: {:?}", err))?;
+    let res_bits =
+        MultiproverToBitsGadget::<64 /* bits */>::to_bits(shared_scalar_var, fabric, &mut prover)
+            .map_err(|err| format!("Error computing to_bits circuit: {:?}", err))?;
 
     for (expected_bit, bit) in expected_bits.iter().zip(res_bits.iter()) {
         let allocated_bit =

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -110,7 +110,7 @@ pub fn singleprover_prove<C: SingleProverCircuit>(
 
 /// Abstracts over the flow of collaboratively proving a generic circuit
 #[allow(clippy::type_complexity)]
-pub fn multiprover_prove<'a, C>(
+pub fn multiprover_prove<C>(
     witness: C::Witness,
     statement: C::Statement,
     fabric: MpcFabric,
@@ -122,14 +122,14 @@ pub fn multiprover_prove<'a, C>(
     ProverError,
 >
 where
-    C: MultiProverCircuit<'a>,
+    C: MultiProverCircuit,
 {
     let transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());
     let pc_gens = PedersenGens::default();
     let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
     // Prove the statement
-    C::prove(witness, statement.clone(), fabric, prover)
+    C::prove(witness, statement, fabric, prover)
 }
 
 /// Abstracts over the flow of verifying a proof for a single-prover proved circuit
@@ -147,7 +147,7 @@ pub fn verify_singleprover_proof<C: SingleProverCircuit>(
 }
 
 /// Abstracts over the flow of verifying a proof for a collaboratively proved circuit
-pub fn verify_collaborative_proof<'a, C>(
+pub fn verify_collaborative_proof<C>(
     statement: <C::Statement as MultiproverCircuitBaseType>::BaseType,
     witness_commitment: <
         <C::Witness as MultiproverCircuitBaseType>::MultiproverCommType as MultiproverCircuitCommitmentType
@@ -155,7 +155,7 @@ pub fn verify_collaborative_proof<'a, C>(
     proof: R1CSProof,
 ) -> Result<(), VerifierError>
 where
-    C: MultiProverCircuit<'a>,
+    C: MultiProverCircuit,
 {
     // Verify the statement with a fresh transcript
     let mut verifier_transcript = Transcript::new(TRANSCRIPT_SEED.as_bytes());

--- a/circuits/src/mpc_circuits/match.rs
+++ b/circuits/src/mpc_circuits/match.rs
@@ -26,10 +26,10 @@ pub fn compute_match(
     amount1: &AuthenticatedScalarResult,
     amount2: &AuthenticatedScalarResult,
     price: &AuthenticatedFixedPoint,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedMatchResult {
     // Compute the amount and execution price that will be swapped if the orders match
-    let (min_index, min_base_amount) = min::<AMOUNT_BITS>(amount1, amount2, fabric.clone());
+    let (min_index, min_base_amount) = min::<AMOUNT_BITS>(amount1, amount2, fabric);
 
     // The maximum of the two amounts minus the minimum of the two amounts
     let max_minus_min_amount =

--- a/circuits/src/mpc_gadgets/arithmetic.rs
+++ b/circuits/src/mpc_gadgets/arithmetic.rs
@@ -4,8 +4,8 @@ use mpc_stark::{algebra::authenticated_scalar::AuthenticatedScalarResult, MpcFab
 
 /// Computes the product of all elements in constant number of rounds
 ///     Result = a_0 * ... * a_n
-pub fn product(a: &[AuthenticatedScalarResult], fabric: MpcFabric) -> AuthenticatedScalarResult {
-    prefix_product_impl(a, fabric, &[a.len() - 1])[0].clone()
+pub fn product(a: &[AuthenticatedScalarResult], fabric: &MpcFabric) -> AuthenticatedScalarResult {
+    prefix_product_impl(a, &[a.len() - 1], fabric)[0].clone()
 }
 
 /// Computes the prefix products of the given list of elements: i.e.
@@ -15,12 +15,12 @@ pub fn product(a: &[AuthenticatedScalarResult], fabric: MpcFabric) -> Authentica
 /// https://iacr.org/archive/tcc2006/38760286/38760286.pdf
 pub fn prefix_mul(
     a: &[AuthenticatedScalarResult],
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> Vec<AuthenticatedScalarResult> {
     prefix_product_impl(
         a,
-        fabric,
         &(0usize..a.len()).collect::<Vec<_>>(), // Select all prefix products
+        fabric,
     )
 }
 
@@ -33,8 +33,8 @@ pub fn prefix_mul(
 /// Note that each additional prefix incurs more bandwidth (although constant round)
 fn prefix_product_impl(
     a: &[AuthenticatedScalarResult],
-    fabric: MpcFabric,
     pre: &[usize],
+    fabric: &MpcFabric,
 ) -> Vec<AuthenticatedScalarResult> {
     let n = a.len();
     assert!(
@@ -86,7 +86,7 @@ fn prefix_product_impl(
 }
 
 /// Computes a^n using a recursive squaring approach for a public parameter exponent
-pub fn pow(a: &AuthenticatedScalarResult, n: u64, fabric: MpcFabric) -> AuthenticatedScalarResult {
+pub fn pow(a: &AuthenticatedScalarResult, n: u64, fabric: &MpcFabric) -> AuthenticatedScalarResult {
     if n == 0 {
         fabric.one_authenticated()
     } else if n == 1 {

--- a/circuits/src/mpc_gadgets/comparators.rs
+++ b/circuits/src/mpc_gadgets/comparators.rs
@@ -18,10 +18,10 @@ use super::{
 /// D represents is the bitlength of the input
 pub fn less_than_zero<const D: usize>(
     a: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     // Truncate the first 250 bits of the input
-    let truncated = truncate::<250>(a, fabric.clone());
+    let truncated = truncate::<250>(a, fabric);
 
     // Because the Ristretto scalar field is a prime field of order slightly greater than 2^252
     // values are negative if either their 251st bit or 252nd bit are set. Therefore, we truncate
@@ -34,9 +34,9 @@ pub fn less_than_zero<const D: usize>(
 /// D represents the bitlength of the input
 pub fn eq_zero<const D: usize>(
     a: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
-    let bits = to_bits_le::<D>(a, fabric.clone());
+    let bits = to_bits_le::<D>(a, fabric);
     Scalar::one() - kary_or::<D>(&bits.try_into().unwrap(), fabric)
 }
 
@@ -46,7 +46,7 @@ pub fn eq_zero<const D: usize>(
 pub fn eq<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     eq_zero::<D>(&(a - b), fabric)
 }
@@ -57,7 +57,7 @@ pub fn eq<const D: usize>(
 pub fn ne<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     Scalar::one() - eq::<D>(a, b, fabric)
 }
@@ -68,7 +68,7 @@ pub fn ne<const D: usize>(
 pub fn less_than<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     less_than_zero::<D>(&(a - b), fabric)
 }
@@ -79,7 +79,7 @@ pub fn less_than<const D: usize>(
 pub fn less_than_equal<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     Scalar::one() - greater_than::<D>(a, b, fabric)
 }
@@ -90,7 +90,7 @@ pub fn less_than_equal<const D: usize>(
 pub fn greater_than<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     less_than_zero::<D>(&(b - a), fabric)
 }
@@ -101,7 +101,7 @@ pub fn greater_than<const D: usize>(
 pub fn greater_than_equal<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     Scalar::one() - less_than::<D>(a, b, fabric)
 }
@@ -117,7 +117,7 @@ pub fn greater_than_equal<const D: usize>(
 /// `D` is the number of variables present in the OR expression
 pub fn kary_or<const D: usize>(
     a: &[AuthenticatedScalarResult; D],
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     // Sample random blinding bits from the pre-processing functionality
     // We only need to be able to hold the maximum possible count, log_2(# of booleans)
@@ -158,7 +158,7 @@ pub fn kary_or<const D: usize>(
 /// This effectively maps any non-zero count to 1 and zero to 0
 fn constant_round_or_impl(
     a: &[AuthenticatedScalarResult],
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     // Sum up the booleans
     let n = a.len();
@@ -186,7 +186,7 @@ fn constant_round_or_impl(
 pub fn min<const D: usize>(
     a: &AuthenticatedScalarResult,
     b: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> (AuthenticatedScalarResult, AuthenticatedScalarResult) {
     let a_lt_b = less_than::<D>(a, b, fabric);
     (

--- a/circuits/src/mpc_gadgets/fixed_point.rs
+++ b/circuits/src/mpc_gadgets/fixed_point.rs
@@ -12,7 +12,7 @@ impl FixedPointMpcGadget {
     /// and return the result as an integer
     pub fn as_integer(
         val: AuthenticatedFixedPoint,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
     ) -> AuthenticatedScalarResult {
         shift_right::<DEFAULT_FP_PRECISION>(&val.repr, fabric)
     }

--- a/circuits/src/mpc_gadgets/modulo.rs
+++ b/circuits/src/mpc_gadgets/modulo.rs
@@ -41,7 +41,7 @@ fn scalar_mod_2m(val: &ScalarResult, m: usize) -> ScalarResult {
 /// factor, we have to shift the value up by one addition of the modulus.
 pub fn mod_2m<const M: usize>(
     a: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     // The input has 256 bits, so any modulus larger can be ignored
     if M >= 256 {
@@ -81,7 +81,7 @@ pub fn mod_2m<const M: usize>(
 /// Computes the input with the `m` least significant bits truncated
 pub fn truncate<const M: usize>(
     x: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     // Apply mod2m and then subtract the result to make the value divisible by a public 2^-m
     if M >= SCALAR_MAX_BITS {
@@ -97,7 +97,7 @@ pub fn truncate<const M: usize>(
 /// Effectively just calls out to truncate, but is placed here for abstraction purposes
 pub fn shift_right<const M: usize>(
     a: &AuthenticatedScalarResult,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     if M >= 256 {
         return fabric.zero_authenticated();
@@ -124,7 +124,7 @@ mod tests {
 
         let (res, _): (Result<bool, MpcError>, _) = execute_mock_mpc(move |fabric| async move {
             let shared_value = fabric.share_scalar(value, PARTY0);
-            let res = mod_2m::<M>(&shared_value, fabric.clone())
+            let res = mod_2m::<M>(&shared_value, &fabric)
                 .open_authenticated()
                 .await
                 .unwrap();
@@ -145,7 +145,7 @@ mod tests {
 
         let (res, _): (Result<bool, MpcError>, _) = execute_mock_mpc(move |fabric| async move {
             let shared_value = fabric.share_scalar(value, PARTY0);
-            let res = shift_right::<SHIFT_AMOUNT>(&shared_value, fabric.clone())
+            let res = shift_right::<SHIFT_AMOUNT>(&shared_value, &fabric)
                 .open_authenticated()
                 .await
                 .unwrap();

--- a/circuits/src/mpc_gadgets/poseidon.rs
+++ b/circuits/src/mpc_gadgets/poseidon.rs
@@ -24,7 +24,7 @@ use renegade_crypto::hash::PoseidonParams;
 fn scalar_exp(
     x: &AuthenticatedScalarResult,
     a: u64,
-    fabric: MpcFabric,
+    fabric: &MpcFabric,
 ) -> AuthenticatedScalarResult {
     if a == 0 {
         fabric.one_authenticated()
@@ -171,10 +171,10 @@ impl AuthenticatedPoseidonHasher {
         // If this is a full round, apply the sbox to each elem
         if full_round {
             for elem in self.state.iter_mut() {
-                *elem = scalar_exp(elem, self.params.alpha, self.fabric.clone());
+                *elem = scalar_exp(elem, self.params.alpha, &self.fabric);
             }
         } else {
-            self.state[0] = scalar_exp(&self.state[0], self.params.alpha, self.fabric.clone())
+            self.state[0] = scalar_exp(&self.state[0], self.params.alpha, &self.fabric)
         }
     }
 

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -90,7 +90,7 @@ impl ValidMatchMpcCircuit {
                     witness.match_res.base_mint.clone().into(),
                 ],
                 witness.match_res.direction.clone(),
-                fabric.clone(),
+                &fabric,
                 cs,
             )?;
 
@@ -150,7 +150,7 @@ impl ValidMatchMpcCircuit {
                 max_minus_min1,
                 max_minus_min2,
                 witness.match_res.min_amount_order_index,
-                fabric.clone(),
+                &fabric,
                 cs,
             )?;
         cs.constrain(&max_minus_min_expected - &witness.match_res.max_minus_min_amount);
@@ -162,7 +162,7 @@ impl ValidMatchMpcCircuit {
         // Constraining the value to be positive forces it to be equal to max(amounts) - min(amounts)
         MultiproverGreaterThanEqZeroGadget::<AMOUNT_BITS>::constrain_greater_than_zero(
             witness.match_res.max_minus_min_amount.clone(),
-            fabric.clone(),
+            &fabric,
             cs,
         )?;
 
@@ -184,7 +184,7 @@ impl ValidMatchMpcCircuit {
         MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
             &expected_quote_amount,
             &witness.match_res.quote_amount,
-            fabric.clone(),
+            &fabric,
             cs,
         )?;
 
@@ -211,7 +211,7 @@ impl ValidMatchMpcCircuit {
         MultiproverGreaterThanEqGadget::<AMOUNT_BITS /* bitlength */>::constrain_greater_than_eq(
             order.amount.clone(),
             match_res.base_amount.clone(),
-            fabric.clone(),
+            &fabric,
             cs,
         )?;
 
@@ -224,13 +224,13 @@ impl ValidMatchMpcCircuit {
             match_res.base_amount.clone().into(),
             match_res.quote_amount.clone().into(),
             order.side.clone(),
-            fabric.clone(),
+            &fabric,
             cs,
         )?;
         MultiproverGreaterThanEqGadget::<AMOUNT_BITS>::constrain_greater_than_eq(
             balance.amount.clone().into(),
             amount_sold,
-            fabric,
+            &fabric,
             cs,
         )
     }
@@ -257,14 +257,14 @@ impl ValidMatchMpcCircuit {
                 price.clone().to_lc(),
             ],
             order.side.clone(),
-            fabric.clone(),
+            &fabric,
             cs,
         )?;
 
         MultiproverGreaterThanEqGadget::<PRICE_BITS>::constrain_greater_than_eq(
             gte_terms.remove(0).repr,
             gte_terms.remove(0).repr,
-            fabric,
+            &fabric,
             cs,
         );
 

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -26,7 +26,6 @@ use mpc_stark::{
     },
     MpcFabric,
 };
-use std::marker::PhantomData;
 
 use crate::zk_gadgets::{
     comparators::{
@@ -55,12 +54,8 @@ use rand::{CryptoRng, RngCore};
 /// This statement is only proven within the context of an MPC, so it only
 /// implements the Multiprover circuit trait
 #[derive(Clone, Debug)]
-pub struct ValidMatchMpcCircuit<'a> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a> ValidMatchMpcCircuit<'a> {
+pub struct ValidMatchMpcCircuit;
+impl ValidMatchMpcCircuit {
     /// The order crossing check, verifies that the matches result is valid given the orders
     /// and balances of the two parties
     pub fn matching_engine_check<CS>(
@@ -165,7 +160,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
         // I.e. the above constraint forces `max_minus_min_amount` to be either max(amounts) - min(amounts)
         // or min(amounts) - max(amounts).
         // Constraining the value to be positive forces it to be equal to max(amounts) - min(amounts)
-        MultiproverGreaterThanEqZeroGadget::<'_, AMOUNT_BITS>::constrain_greater_than_zero(
+        MultiproverGreaterThanEqZeroGadget::<AMOUNT_BITS>::constrain_greater_than_zero(
             witness.match_res.max_minus_min_amount.clone(),
             fabric.clone(),
             cs,
@@ -213,7 +208,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
         [(); AMOUNT_BITS + DEFAULT_FP_PRECISION]: Sized,
     {
         // Validate that the amount is less than the maximum amount given in the order
-        MultiproverGreaterThanEqGadget::<'_, AMOUNT_BITS /* bitlength */>::constrain_greater_than_eq(
+        MultiproverGreaterThanEqGadget::<AMOUNT_BITS /* bitlength */>::constrain_greater_than_eq(
             order.amount.clone(),
             match_res.base_amount.clone(),
             fabric.clone(),
@@ -232,7 +227,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
             fabric.clone(),
             cs,
         )?;
-        MultiproverGreaterThanEqGadget::<'_, AMOUNT_BITS>::constrain_greater_than_eq(
+        MultiproverGreaterThanEqGadget::<AMOUNT_BITS>::constrain_greater_than_eq(
             balance.amount.clone().into(),
             amount_sold,
             fabric,
@@ -266,7 +261,7 @@ impl<'a> ValidMatchMpcCircuit<'a> {
             cs,
         )?;
 
-        MultiproverGreaterThanEqGadget::<'_, PRICE_BITS>::constrain_greater_than_eq(
+        MultiproverGreaterThanEqGadget::<PRICE_BITS>::constrain_greater_than_eq(
             gte_terms.remove(0).repr,
             gte_terms.remove(0).repr,
             fabric,
@@ -502,7 +497,7 @@ pub struct ValidMatchMpcWitness {
 // ---------------------
 
 /// Prover implementation of the Valid Match circuit
-impl<'a> MultiProverCircuit<'a> for ValidMatchMpcCircuit<'a> {
+impl MultiProverCircuit for ValidMatchMpcCircuit {
     type Statement = ();
     type Witness = AuthenticatedValidMatchMpcWitness;
 

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -233,7 +233,7 @@ impl MultiproverExpGadget {
     pub fn exp<L, CS>(
         x: L,
         alpha: u64,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<MpcLinearCombination, ProverError>
     where
@@ -241,7 +241,10 @@ impl MultiproverExpGadget {
         CS: MpcRandomizableConstraintSystem,
     {
         if alpha == 0 {
-            Ok(MpcLinearCombination::from_scalar(Scalar::one(), fabric))
+            Ok(MpcLinearCombination::from_scalar(
+                Scalar::one(),
+                fabric.clone(),
+            ))
         } else if alpha == 1 {
             Ok(x.into())
         } else if alpha % 2 == 0 {

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -1,7 +1,5 @@
 //! Groups ZK gadgets used as arithmetic primitives in more complicated computations
 
-use std::marker::PhantomData;
-
 use ark_ff::Zero;
 use circuit_types::errors::ProverError;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
@@ -229,12 +227,8 @@ impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
 // -----------------------
 
 /// A multiprover implementation of the exp gadget
-pub struct MultiproverExpGadget<'a> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a> MultiproverExpGadget<'a> {
+pub struct MultiproverExpGadget;
+impl MultiproverExpGadget {
     /// Apply the gadget to the input
     pub fn exp<L, CS>(
         x: L,

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -65,7 +65,7 @@ impl<const D: usize> MultiproverToBitsGadget<D> {
     /// Converts a value into its bitwise representation
     pub fn to_bits<L, CS>(
         a: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<Vec<MpcLinearCombination>, ProverError>
     where

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -1,5 +1,5 @@
 //! Groups gadgets for going from scalar -> bits and from bits -> scalar
-use std::{iter, marker::PhantomData};
+use std::iter;
 
 use bitvec::{order::Lsb0, slice::BitSlice};
 use circuit_types::{
@@ -60,12 +60,8 @@ impl<const D: usize> ToBitsGadget<D> {
 /// Takes a scalar and returns its bit representation, constrained to be correct
 ///
 /// D is the bitlength of the input vector to bitify
-pub struct MultiproverToBitsGadget<'a, const D: usize> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a, const D: usize> MultiproverToBitsGadget<'a, D> {
+pub struct MultiproverToBitsGadget<const D: usize>;
+impl<const D: usize> MultiproverToBitsGadget<D> {
     /// Converts a value into its bitwise representation
     pub fn to_bits<L, CS>(
         a: L,

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -1,7 +1,5 @@
 //! Groups gadgets for binary comparison operators
 
-use std::marker::PhantomData;
-
 use circuit_types::{
     errors::ProverError,
     traits::{
@@ -253,12 +251,8 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
 }
 
 /// A multiprover version of the greater than or equal to zero gadget
-pub struct MultiproverGreaterThanEqZeroGadget<'a, const D: usize> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a, const D: usize> MultiproverGreaterThanEqZeroGadget<'a, D> {
+pub struct MultiproverGreaterThanEqZeroGadget<const D: usize>;
+impl<const D: usize> MultiproverGreaterThanEqZeroGadget<D> {
     /// Constrains the input value to be greater than or equal to zero implicitly
     /// by bit-decomposing the value and re-composing it thereafter
     pub fn constrain_greater_than_zero<L, CS>(
@@ -362,12 +356,8 @@ impl<const D: usize> LessThanGadget<D> {
 }
 
 /// A multiprover variant of the EqGadget
-pub struct MultiproverEqGadget<'a> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a> MultiproverEqGadget<'a> {
+pub struct MultiproverEqGadget;
+impl MultiproverEqGadget {
     /// Constraint two values to be equal
     pub fn constrain_eq<L1, L2, V1, V2, CS>(a: V1, b: V2, cs: &mut CS)
     where
@@ -394,12 +384,8 @@ impl<'a> MultiproverEqGadget<'a> {
 /// A multiprover variant of the GreaterThanEqGadget
 ///
 /// `D` is the bitlength of the input values
-pub struct MultiproverGreaterThanEqGadget<'a, const D: usize> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a, const D: usize> MultiproverGreaterThanEqGadget<'a, D> {
+pub struct MultiproverGreaterThanEqGadget<const D: usize>;
+impl<const D: usize> MultiproverGreaterThanEqGadget<D> {
     /// Constrain the relation a >= b
     pub fn constrain_greater_than_eq<L, CS>(
         a: L,
@@ -411,7 +397,7 @@ impl<'a, const D: usize> MultiproverGreaterThanEqGadget<'a, D> {
         L: MpcLinearCombinationLike,
         CS: MpcRandomizableConstraintSystem,
     {
-        MultiproverGreaterThanEqZeroGadget::<'a, D>::constrain_greater_than_zero(
+        MultiproverGreaterThanEqZeroGadget::<D>::constrain_greater_than_zero(
             a.into() - b.into(),
             fabric,
             cs,

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -257,7 +257,7 @@ impl<const D: usize> MultiproverGreaterThanEqZeroGadget<D> {
     /// by bit-decomposing the value and re-composing it thereafter
     pub fn constrain_greater_than_zero<L, CS>(
         x: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where
@@ -277,7 +277,7 @@ impl<const D: usize> MultiproverGreaterThanEqZeroGadget<D> {
     /// value is non-negative
     fn bit_decompose_reconstruct<L, CS>(
         x: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<MpcLinearCombination, ProverError>
     where
@@ -390,7 +390,7 @@ impl<const D: usize> MultiproverGreaterThanEqGadget<D> {
     pub fn constrain_greater_than_eq<L, CS>(
         a: L,
         b: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -97,8 +97,8 @@ impl<CS: RandomizableConstraintSystem> FixedPointGadget<CS> {
 }
 
 /// Performs fixed point operations on a multiprover circuit
-pub struct MultiproverFixedPointGadget<'a>(&'a PhantomData<()>);
-impl<'a> MultiproverFixedPointGadget<'a> {
+pub struct MultiproverFixedPointGadget;
+impl MultiproverFixedPointGadget {
     // === Equality === //
 
     /// Constrain a fixed point variable to equal a native field element
@@ -136,7 +136,7 @@ impl<'a> MultiproverFixedPointGadget<'a> {
         // component of zero
         let shifted_precision =
             MpcLinearCombination::from_scalar(*TWO_TO_M_SCALAR - Scalar::one(), fabric.clone());
-        MultiproverGreaterThanEqGadget::<'_, DEFAULT_FP_PRECISION>::constrain_greater_than_eq(
+        MultiproverGreaterThanEqGadget::<DEFAULT_FP_PRECISION>::constrain_greater_than_eq(
             shifted_precision,
             diff,
             fabric,

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -120,7 +120,7 @@ impl MultiproverFixedPointGadget {
     pub fn constrain_equal_integer_ignore_fraction<L, CS>(
         lhs: &AuthenticatedFixedPointVar<L>,
         rhs: &MpcVariable,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<(), ProverError>
     where

--- a/circuits/src/zk_gadgets/gates.rs
+++ b/circuits/src/zk_gadgets/gates.rs
@@ -1,7 +1,5 @@
 //! Groups logical gate gadgets used in ZK circuits
 
-use std::marker::PhantomData;
-
 use circuit_types::{
     errors::ProverError,
     traits::{LinearCombinationLike, MpcLinearCombinationLike},
@@ -47,9 +45,8 @@ impl OrGate {
 }
 
 /// Represents an OR gate in a multi-prover constraint system
-pub struct MultiproverOrGate<'a>(&'a PhantomData<()>);
-
-impl<'a> MultiproverOrGate<'a> {
+pub struct MultiproverOrGate;
+impl MultiproverOrGate {
     /// Return the logical OR of the two arguments
     ///
     /// The arguments are assumed to be binary (0 or 1), but this assumption should be

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -1,8 +1,6 @@
 //! Groups logic for adding Poseidon hash function constraints to a Bulletproof
 //! constraint system
 
-use std::marker::PhantomData;
-
 use circuit_types::{
     errors::ProverError,
     traits::{LinearCombinationLike, MpcLinearCombinationLike},
@@ -268,7 +266,7 @@ impl PoseidonHashGadget {
 ///
 /// This version of the gadget is used for the multi-prover case, i.e in an MPC execution
 #[derive(Debug)]
-pub struct MultiproverPoseidonHashGadget<'a> {
+pub struct MultiproverPoseidonHashGadget {
     /// The parameterization of the hash function
     params: PoseidonParams,
     /// The hash state
@@ -280,11 +278,9 @@ pub struct MultiproverPoseidonHashGadget<'a> {
     in_squeeze_state: bool,
     /// A reference to the shared MPC fabric that the computation variables are allocated in
     fabric: MpcFabric,
-    /// Phantom for the lifetime parameter
-    _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> MultiproverPoseidonHashGadget<'a> {
+impl MultiproverPoseidonHashGadget {
     /// Construct a new hash gadget with the given parameterization
     pub fn new(params: PoseidonParams, fabric: MpcFabric) -> Self {
         // Initialize the state as all zeros
@@ -297,7 +293,6 @@ impl<'a> MultiproverPoseidonHashGadget<'a> {
             next_index: 0,
             in_squeeze_state: false, // Start in absorb state
             fabric,
-            _phantom: PhantomData,
         }
     }
 

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -470,19 +470,14 @@ impl MultiproverPoseidonHashGadget {
                 .state
                 .iter()
                 .map(|val| {
-                    MultiproverExpGadget::exp(
-                        val.clone(),
-                        self.params.alpha,
-                        self.fabric.clone(),
-                        cs,
-                    )
+                    MultiproverExpGadget::exp(val.clone(), self.params.alpha, &self.fabric, cs)
                 })
                 .collect::<Result<Vec<_>, ProverError>>()?;
         } else {
             self.state[0] = MultiproverExpGadget::exp(
                 self.state[0].clone(),
                 self.params.alpha,
-                self.fabric.clone(),
+                &self.fabric,
                 cs,
             )?
         }

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -1,7 +1,5 @@
 //! Groups gadgets for conditional selection
 
-use std::marker::PhantomData;
-
 use circuit_types::{
     errors::ProverError,
     traits::{
@@ -49,12 +47,8 @@ impl CondSelectGadget {
 }
 
 /// A multiprover version of the conditional select gadget
-pub struct MultiproverCondSelectGadget<'a> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a> MultiproverCondSelectGadget<'a> {
+pub struct MultiproverCondSelectGadget;
+impl MultiproverCondSelectGadget {
     /// Computes the control flow statement if selector { a } else { b }
     pub fn select<L, V, CS>(
         a: V,
@@ -127,12 +121,8 @@ impl CondSelectVectorGadget {
 }
 
 /// A multiprover variant of the CondSelectVectorGadget
-pub struct MultiproverCondSelectVectorGadget<'a> {
-    /// Phantom
-    _phantom: &'a PhantomData<()>,
-}
-
-impl<'a> MultiproverCondSelectVectorGadget<'a> {
+pub struct MultiproverCondSelectVectorGadget;
+impl MultiproverCondSelectVectorGadget {
     /// Implements the control flow block if selector { a } else { b }
     /// where `a` and `b` are vectors
     pub fn select<L, V, CS>(

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -54,7 +54,7 @@ impl MultiproverCondSelectGadget {
         a: V,
         b: V,
         selector: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<V, ProverError>
     where
@@ -129,7 +129,7 @@ impl MultiproverCondSelectVectorGadget {
         a: &[V],
         b: &[V],
         selector: L,
-        fabric: MpcFabric,
+        fabric: &MpcFabric,
         cs: &mut CS,
     ) -> Result<Vec<V>, ProverError>
     where
@@ -145,7 +145,7 @@ impl MultiproverCondSelectVectorGadget {
                 a_val.clone(),
                 b_val.clone(),
                 selector.clone(),
-                fabric.clone(),
+                fabric,
                 cs,
             )?)
         }


### PR DESCRIPTION
### Purpose
This PR cleans up the MPC and ZK circuits and gadgets implementation after the Stark curve refactor of the `circuits` crate completed. This largely revolves around two big changes:
- Remove unused lifetimes from gadget and circuit interfaces now that `MpcProver` has removed its lifetimes
- Pass `MpcFabric` by reference when possible. The `MpcFabric` type already has a fairly efficient `Clone` impl, but this simplifies interfaces and avoids some of the cloning overhead for very large circuits that clone frequently

### Testing
- Unit and integration tests pass