### PR TITLE
core, state: Fix debug TUI

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,9 @@ name = "renegade-relayer"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+debug-tui = []
+
 [dependencies]
 # === Runtime + Async === #
 crossbeam = "0.8"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -30,12 +30,15 @@ tokio = { workspace = true }
 libp2p = { workspace = true }
 
 # === Misc === #
-base64 = { version = "0.13" }
+base64 = "0.13"
+crossterm = "0.26"
 indexmap = "1.9"
 itertools = { workspace = true }
 lazy_static = "1.4.0"
 serde = { workspace = true, features = ["serde_derive"] }
 tracing = { workspace = true }
+tui = "0.19"
+tui-logger = "0.8"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/state/src/tui.rs
+++ b/state/src/tui.rs
@@ -1,6 +1,4 @@
 //! Groups definitions of the debug text interface
-#![cfg(feature = "debug-tui")]
-
 use crossterm::{
     event::{self, Event, KeyCode},
     execute,
@@ -9,6 +7,7 @@ use crossterm::{
 
 use futures::executor::block_on;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use std::{
     cell::RefCell,
     thread::JoinHandle,
@@ -31,7 +30,7 @@ use tui_logger::{
 
 use std::io;
 
-use crate::config::RelayerConfig;
+use config::RelayerConfig;
 
 use super::RelayerState;
 
@@ -153,7 +152,6 @@ impl StateTuiApp {
                 if let Event::Key(key) = event::read().unwrap() {
                     match key.code {
                         KeyCode::Char('q') => break,
-                        // TODO: Switch tab
                         KeyCode::Tab => {
                             self.selected_tab = match self.selected_tab {
                                 AppTab::Main => AppTab::Logs,


### PR DESCRIPTION
### Purpose
The debug TUI was broken during the crate refactor because it is gated behind a feature flag that was removed. This PR removes this conditional compilation and simply depends on `cli_args.debug` to switch on/off the TUI mode

### Testing
- Unit and integration tests pass
- Tested the TUI, verified its functionality