### PR TITLE
task-driver: Setup integration test harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -92,3 +92,5 @@ rand = "0.8"
 serde_json = "1.0"
 test-helpers = { path = "../test-helpers" }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
+
+util = { path = "../util" }

--- a/circuits/integration/main.rs
+++ b/circuits/integration/main.rs
@@ -8,9 +8,7 @@ mod types;
 mod zk_circuits;
 mod zk_gadgets;
 
-use chrono::Local;
 use clap::Parser;
-use env_logger::Builder;
 use mpc_stark::MpcFabric;
 use test_helpers::{integration_test_main, mpc_network::setup_mpc_fabric};
 use tracing::log::LevelFilter;
@@ -55,20 +53,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 }
 
 fn setup_integration_tests(_test_args: &CliArgs) {
-    // Configure logging
-    Builder::new()
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "{} [{}] {} - {}",
-                Local::now().format("%Y-%m-%dT%H:%M:%S"),
-                record.level(),
-                record.module_path().unwrap(),
-                record.args()
-            )
-        })
-        .filter(None, LevelFilter::Info)
-        .init();
+    util::logging::setup_system_logger(LevelFilter::Info);
 }
 
 integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -3,6 +3,11 @@ name = "task-driver"
 version = "0.1.0"
 edition = "2021"
 
+[[test]]
+name = "integration"
+path = "integration/main.rs"
+harness = false
+
 [dependencies]
 # === Async + Runtime === #
 async-trait = "0.1.60"
@@ -17,10 +22,10 @@ num-bigint = { workspace = true }
 circuits = { path = "../circuits" }
 circuit-types = { path = "../circuit-types" }
 common = { path = "../common" }
-renegade-crypto = { path = "../renegade-crypto" }
 external-api = { path = "../external-api" }
 gossip-api = { path = "../gossip-api" }
 job-types = { path = "../workers/job-types" }
+renegade-crypto = { path = "../renegade-crypto" }
 starknet-client = { path = "../starknet-client" }
 state = { path = "../state" }
 system-bus = { path = "../system-bus" }
@@ -31,3 +36,6 @@ serde = { workspace = true }
 starknet = { workspace = true }
 tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
+
+[dev-dependencies]
+test-helpers = { path = "../test-helpers" }

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -38,4 +38,9 @@ tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
+clap = { version = "4.0", features = ["derive"] }
+colored = "2"
+inventory = "0.3"
+
 test-helpers = { path = "../test-helpers" }
+util = { path = "../util" }

--- a/task-driver/Dockerfile
+++ b/task-driver/Dockerfile
@@ -1,0 +1,59 @@
+# Used for running integration tests on a simulated MPC network
+FROM rust:1.63-slim-buster AS builder
+
+# Create a build dir and add local dependencies
+WORKDIR /build
+
+# Build the rust toolchain before adding any dependencies; this is the slowest
+# step and we would like to cache it before anything else
+COPY ./rust-toolchain ./task-driver/rust-toolchain
+RUN cat task-driver/rust-toolchain | xargs rustup toolchain install
+
+# Install pkg-config, openssl
+RUN apt-get update && \
+    apt-get install -y pkg-config && \
+    apt-get install -y libssl-dev 
+
+
+# Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
+# transferring all workspace members to the docker image, and instead only transfer the
+# dependencies of the integration test. Every path dependency of the target crate is automatically
+# added to the workspace
+COPY ./Cargo.toml ./Cargo.toml
+RUN sed -i '/members = \[/,/\]/c\members = [ "task-driver" ]' Cargo.toml
+
+# Copy in dependencies from the same repo and remove the target
+COPY . .
+RUN rm -rf task-driver
+
+# Place a set of dummy sources in the path, build the dummy executable
+# to cache built dependencies, then bulid the full executable
+WORKDIR /build/task-driver
+RUN mkdir src
+RUN touch src/dummy-lib.rs
+
+RUN mkdir integration
+RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
+
+COPY task-driver/Cargo.toml .
+
+# Modify the Cargo.toml to point to our dummy sources
+RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
+RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
+
+# Disable compiler warnings and enable backtraces for panic debugging
+ENV RUSTFLAGS=-Awarnings
+ENV RUST_BACKTRACE=1
+
+RUN cargo build --quiet --test integration
+
+# Edit the Cargo.toml back to the original, build the full executable
+RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
+RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
+
+COPY task-driver/src ./src
+COPY task-driver/integration ./integration
+
+RUN cargo build --quiet --test integration
+
+CMD [ "cargo", "test" ]

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  party0:
+    image: task-driver-integration-test:latest
+    build: .
+    ports:
+      - "8000:8000"
+    command: >
+      cargo test --test integration --
+        --party 0 
+        --port1 8000 
+        --port2 9000 
+        --docker 
+        --verbose
+    tty: true

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -6,9 +6,5 @@ services:
       - "8000:8000"
     command: >
       cargo test --test integration --
-        --party 0 
-        --port1 8000 
-        --port2 9000 
-        --docker 
         --verbose
     tty: true

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -1,0 +1,4 @@
+//! Defines integration tests for
+fn main() {
+    println!("Hello, world!");
+}

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -1,4 +1,50 @@
 //! Defines integration tests for
-fn main() {
-    println!("Hello, world!");
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+
+use clap::Parser;
+use test_helpers::integration_test_main;
+use tracing::log::LevelFilter;
+
+/// The arguments used to run the integration tests
+#[derive(Debug, Clone, Parser)]
+#[command(author, version, about, long_about=None)]
+struct CliArgs {
+    /// The test to run
+    #[arg(short, long, value_parser)]
+    test: Option<String>,
+    /// The verbosity level of the test harness
+    #[arg(long, short)]
+    verbose: bool,
 }
+
+/// The arguments provided to every integration test
+#[derive(Debug, Clone)]
+struct IntegrationTestArgs;
+impl From<CliArgs> for IntegrationTestArgs {
+    fn from(_: CliArgs) -> Self {
+        Self
+    }
+}
+
+/// Setup code for the integration tests
+fn setup_integration_tests(_test_args: &CliArgs) {
+    // Configure logging
+    util::logging::setup_system_logger(LevelFilter::Info);
+}
+
+/// Dummy test
+///
+/// TODO: Remove this test
+fn test_dummy(_test_args: &IntegrationTestArgs) -> Result<(), String> {
+    println!("got here!");
+    Ok(())
+}
+
+inventory::submit!(TestWrapper(IntegrationTest {
+    name: "dummy",
+    test_fn: test_dummy,
+}));
+
+integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/test-helpers/src/macros.rs
+++ b/test-helpers/src/macros.rs
@@ -20,7 +20,6 @@ macro_rules! integration_test_main {
         use std::{borrow::Borrow, cell::RefCell, net::SocketAddr, process::exit, rc::Rc};
 
         use colored::Colorize;
-        use dns_lookup::lookup_host;
         use std::io::{stdout, Write};
         use tokio::runtime::{Builder as RuntimeBuilder, Handle};
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,3 +10,8 @@ libp2p = { workspace = true }
 # === Runtime === #
 futures = "0.3"
 tokio = { workspace = true }
+
+# === Misc === #
+chrono = "0.4"
+env_logger = "0.9"
+tracing = { version = "0.1", features = ["log"] }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,9 +1,13 @@
 //! Defines one-off utility functions used throughout the node
-#![feature(ip)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
 #![allow(incomplete_features)]
+#![feature(ip)]
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub mod logging;
 pub mod networking;
 pub mod runtime;
 

--- a/util/src/logging.rs
+++ b/util/src/logging.rs
@@ -1,0 +1,23 @@
+//! Defines helpers for logging
+
+use chrono::Local;
+use env_logger::Builder;
+use std::io::Write;
+use tracing::log::LevelFilter;
+
+/// Initialize a logger at the given log level
+pub fn setup_system_logger(level: LevelFilter) {
+    Builder::new()
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} [{}] {} - {}",
+                Local::now().format("%Y-%m-%dT%H:%M:%S"),
+                record.level(),
+                record.module_path().unwrap(),
+                record.args()
+            )
+        })
+        .filter(None, level)
+        .init();
+}


### PR DESCRIPTION
### Purpose
This PR sets up the testing harness for the `task-driver` integration tests. This involves:
- Generalizing some of the helpers used for integration test setup in the `circuits` crate (the only other crate with formal integration tests)
- Setting up a docker compose style stack, currently just with a copy of the relayer running the tests
- Adding an integration test harness using the harness defined in the `test-helpers` crate.

### Todo
- Add a devnet sequencer to the `docker-compose`
- Add integration tests to the crate

### Testing
- Ran the integration tests, verified that the dummy test passed