### PR TITLE
task-driver: integration: Setup devnet sequencer for integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 target/
 .git/
+.vscode/
+
+bin/
+**/README.md
+
+**/Cargo.lock
 **/Dockerfile
 **/docker-compose.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 target/
 .git/
+**/Dockerfile
+**/docker-compose.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ mpc-stark = { git = "https://github.com/renegade-fi/mpc-stark" }
 num-bigint = { version = "0.4.3" }
 rand = "0.8"
 
+# === On-Chain === #
 starknet = { git = "https://github.com/renegade-fi/starknet-rs" }
 
-# === On-Chain === #
 # === Networking === #
 libp2p = "0.51"
 libp2p-core = { version = "0.39" }
@@ -55,6 +55,7 @@ libp2p-swarm = { version = "0.42" }
 libp2p-swarm-derive = { version = "0.32" }
 
 # === Misc === #
+eyre = "0.6"
 itertools = "0.10"
 serde = { version = "1.0.139" }
 serde_json = "1.0.64"

--- a/bin/cargo-integrate
+++ b/bin/cargo-integrate
@@ -13,6 +13,9 @@ fi
 # Use BuildKit
 export DOCKER_BUILDKIT=1
 
+# Build the contracts first if not already built
+docker build --tag "renegade-contracts:latest" -f "docker/contracts/Dockerfile" .
+
 # Build the image
 docker build --tag "$2"-integration-test:latest -f "$2"/Dockerfile .
 
@@ -20,6 +23,7 @@ docker build --tag "$2"-integration-test:latest -f "$2"/Dockerfile .
 docker-compose \
   --file "$2"/docker-compose.yml \
   up \
+  --remove-orphans \
   --force-recreate \
   --renew-anon-volumes \
   --abort-on-container-exit \

--- a/docker/contracts/Dockerfile
+++ b/docker/contracts/Dockerfile
@@ -1,0 +1,24 @@
+# This Dockerfile compiles contract sources into .sierra and .casm artifacts so
+# that they me be consumed by other Dockerfiles in the relayer for e.g. integration testing
+FROM ubuntu AS sources
+
+# Install git and curl
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get install -y curl
+
+# Install Scarb
+ARG SCARB_VERSION=0.5.1
+ENV SHELL /bin/bash
+RUN curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | /bin/sh -s -- -v $SCARB_VERSION 
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Clone the contracts source and build the contracts
+WORKDIR /sources
+RUN git clone https://github.com/renegade-fi/renegade-contracts.git
+
+WORKDIR /sources/renegade-contracts
+RUN scarb build
+
+# Move the compiler artifacts to an output direction
+RUN mv target/dev /artifacts

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -1,0 +1,25 @@
+# We modify the base image of the `starknet-devnet` to include the Sierra compiler version
+# used in our contracts. The devnet compiles sources once they are declared from Sierra
+# to casm, so it needs a matching version to those used to generate the sender side artifacts
+FROM shardlabs/starknet-devnet AS base
+
+# Install curl and tar
+RUN apk add --no-cache curl tar
+
+# Install the Cairo compiler version used for our contracts
+ARG CAIRO_COMPILER_VERSION=2.0.1
+WORKDIR /
+RUN curl -L -o /cairo-build.tar.gz https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_COMPILER_VERSION}/release-x86_64-unknown-linux-musl.tar.gz
+
+RUN tar -xzf /cairo-build.tar.gz
+RUN rm /cairo-build.tar.gz
+
+# Modify the entrypoint to run with our custom flags
+ENTRYPOINT starknet-devnet \
+    --sierra-compiler-path /cairo/bin/starknet-sierra-compile \
+    --compiler-args "--add-pythonic-hints --allowed-libfuncs-list-name all" \
+    --fork-network alpha-goerli \
+    --host 0.0.0.0 \
+    --port 5050 \
+    --seed 0 \
+    --verbose \

--- a/starknet-client/src/client.rs
+++ b/starknet-client/src/client.rs
@@ -194,6 +194,7 @@ impl StarknetClient {
                 // Parse the account address and key
                 let account_addr_felt = StarknetFieldElement::from_str(&account_addr).unwrap();
                 let key_felt = StarknetFieldElement::from_str(&key).unwrap();
+
                 // Build the account
                 let signer = LocalWallet::from(SigningKey::from_secret_scalar(key_felt));
                 SingleOwnerAccount::new(

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -40,7 +40,9 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
+eyre = { workspace = true }
 inventory = "0.3"
 
+rand = { workspace = true }
 test-helpers = { path = "../test-helpers" }
 util = { path = "../util" }

--- a/task-driver/Dockerfile
+++ b/task-driver/Dockerfile
@@ -1,8 +1,15 @@
-# Used for running integration tests on a simulated MPC network
-FROM rust:1.63-slim-buster AS builder
+# Build a set of sources that are used to build a dependency cache for the main
+# integration tests. We effectively copy all the sources and then remove the target
+# directory. This means that changes to `task-driver` sources will invalidate the
+# cache for this stage only, as the end state is the same
+FROM alpine AS sources
+COPY . .
+RUN rm -rf task-driver
 
+FROM rust:1.63-slim-buster AS builder
 # Create a build dir and add local dependencies
 WORKDIR /build
+COPY --from=sources . .
 
 # Build the rust toolchain before adding any dependencies; this is the slowest
 # step and we would like to cache it before anything else
@@ -21,10 +28,6 @@ RUN apt-get update && \
 # added to the workspace
 COPY ./Cargo.toml ./Cargo.toml
 RUN sed -i '/members = \[/,/\]/c\members = [ "task-driver" ]' Cargo.toml
-
-# Copy in dependencies from the same repo and remove the target
-COPY . .
-RUN rm -rf task-driver
 
 # Place a set of dummy sources in the path, build the dummy executable
 # to cache built dependencies, then bulid the full executable

--- a/task-driver/Dockerfile
+++ b/task-driver/Dockerfile
@@ -6,21 +6,25 @@ FROM alpine AS sources
 COPY . .
 RUN rm -rf task-driver
 
+# Add a stage for the contract sources, we pull compiled artifacts out of this stage
+FROM renegade-contracts as contract-sources
+
+# Rust build stage
 FROM rust:1.63-slim-buster AS builder
-# Create a build dir and add local dependencies
-WORKDIR /build
-COPY --from=sources . .
 
 # Build the rust toolchain before adding any dependencies; this is the slowest
 # step and we would like to cache it before anything else
 COPY ./rust-toolchain ./task-driver/rust-toolchain
 RUN cat task-driver/rust-toolchain | xargs rustup toolchain install
 
+# Create a build dir and add local dependencies
+WORKDIR /build
+COPY --from=sources . .
+
 # Install pkg-config, openssl
 RUN apt-get update && \
     apt-get install -y pkg-config && \
     apt-get install -y libssl-dev 
-
 
 # Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
 # transferring all workspace members to the docker image, and instead only transfer the
@@ -58,5 +62,8 @@ COPY task-driver/src ./src
 COPY task-driver/integration ./integration
 
 RUN cargo build --quiet --test integration
+
+# Copy the contract artifacts from the contract-sources stage
+COPY --from=contract-sources /artifacts /artifacts
 
 CMD [ "cargo", "test" ]

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -5,7 +5,12 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5050:5050"
-  party0:
+    healthcheck:
+      test: "wget --no-verbose --tries=1 --spider http://localhost:5050/is_alive || exit 1"
+      interval: 5s
+      timeout: 10s
+      retries: 3
+  relayer:
     image: task-driver-integration-test:latest
     build: .
     ports:
@@ -14,3 +19,6 @@ services:
       cargo test --test integration --
         --verbose
     tty: true
+    depends_on:
+      sequencer:
+        condition: service_healthy

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   sequencer:
     build:
-      context: https://github.com/0xSpaceShard/starknet-devnet.git
-      dockerfile: Dockerfile
+      dockerfile: ../docker/devnet/Dockerfile
     ports:
       - "5050:5050"
     healthcheck:
@@ -16,8 +15,9 @@ services:
     ports:
       - "8000:8000"
     command: >
-      cargo test --test integration --
-        --verbose
+      cargo test --test integration -- 
+        --darkpool-addr 0x02179f01358c09410f234f1ece40d235719e05db3babca7bef0babc974333162 
+        --verbose 
     tty: true
     depends_on:
       sequencer:

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  sequencer:
+    build:
+      context: https://github.com/0xSpaceShard/starknet-devnet.git
+      dockerfile: Dockerfile
+    ports:
+      - "5050:5050"
   party0:
     image: task-driver-integration-test:latest
     build: .

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -4,8 +4,17 @@
 #![deny(clippy::missing_docs_in_private_items)]
 
 use clap::Parser;
+use common::types::chain_id::ChainId;
+use starknet_client::client::{StarknetClient, StarknetClientConfig};
 use test_helpers::integration_test_main;
 use tracing::log::LevelFilter;
+use util::runtime::await_result;
+
+/// The hostport that the test expects a local devnet node to be running on
+///
+/// This assumes that the integration tests are running in a docker-compose setup
+/// with a DNS alias `sequencer` pointing to a devnet node running in a sister container
+const DEVNET_HOSTPORT: &str = "http://sequencer:5050/rpc";
 
 /// The arguments used to run the integration tests
 #[derive(Debug, Clone, Parser)]
@@ -20,11 +29,26 @@ struct CliArgs {
 }
 
 /// The arguments provided to every integration test
-#[derive(Debug, Clone)]
-struct IntegrationTestArgs;
+#[derive(Clone)]
+struct IntegrationTestArgs {
+    /// The starknet client that resolves to a locally running devnet node
+    starknet_client: StarknetClient,
+}
+
 impl From<CliArgs> for IntegrationTestArgs {
     fn from(_: CliArgs) -> Self {
-        Self
+        let starknet_client = StarknetClient::new(StarknetClientConfig {
+            chain: ChainId::Devnet,
+            contract_addr: "".to_string(),
+            // Assumes we are running in a docker-compose setup with a DNS alias `sequencer`
+            // pointing to a devnet node running in a sister container
+            starknet_json_rpc_addr: Some(DEVNET_HOSTPORT.to_string()),
+            infura_api_key: None,
+            starknet_account_addresses: vec![],
+            starknet_pkeys: vec![],
+        });
+
+        Self { starknet_client }
     }
 }
 
@@ -37,9 +61,16 @@ fn setup_integration_tests(_test_args: &CliArgs) {
 /// Dummy test
 ///
 /// TODO: Remove this test
-fn test_dummy(_test_args: &IntegrationTestArgs) -> Result<(), String> {
-    println!("got here!");
-    Ok(())
+fn test_dummy(test_args: &IntegrationTestArgs) -> Result<(), String> {
+    let client = &test_args.starknet_client;
+    let block_num = await_result(client.get_block_number())
+        .map_err(|e| format!("error fetching block number: {e}"))?;
+
+    if block_num == 0 {
+        Ok(())
+    } else {
+        Err(format!("expected block number to be 0, got {block_num}"))
+    }
 }
 
 inventory::submit!(TestWrapper(IntegrationTest {

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -5,8 +5,12 @@
 
 use clap::Parser;
 use common::types::chain_id::ChainId;
+use mpc_stark::algebra::scalar::Scalar;
+use rand::thread_rng;
 use starknet_client::client::{StarknetClient, StarknetClientConfig};
-use test_helpers::integration_test_main;
+use test_helpers::{
+    contracts::deploy_darkpool, integration_test_main, mpc_network::await_result_with_error,
+};
 use tracing::log::LevelFilter;
 use util::runtime::await_result;
 
@@ -14,12 +18,42 @@ use util::runtime::await_result;
 ///
 /// This assumes that the integration tests are running in a docker-compose setup
 /// with a DNS alias `sequencer` pointing to a devnet node running in a sister container
-const DEVNET_HOSTPORT: &str = "http://sequencer:5050/rpc";
+const DEVNET_HOSTPORT: &str = "http://sequencer:5050";
 
 /// The arguments used to run the integration tests
 #[derive(Debug, Clone, Parser)]
 #[command(author, version, about, long_about=None)]
 struct CliArgs {
+    /// The private key to use for the Starknet account during testing
+    ///
+    /// Defaults to the first pre-deployed account on `starknet-devnet` when
+    /// run with seed 0
+    #[arg(
+        short = 'p',
+        long,
+        default_value = "0xe3e70682c2094cac629f6fbed82c07cd"
+    )]
+    starknet_pkey: String,
+    /// The address of the account contract to use for testing
+    ///
+    /// Defaults to the first pre-deployed account on `starknet-devnet` when
+    /// run with seed 0
+    #[arg(
+        long,
+        default_value = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a"
+    )]
+    starknet_account_addr: String,
+    /// The address of the darkpool deployed on Starknet at the time the test is started
+    ///
+    /// If not provided, the test will deploy a new darkpool contract
+    #[arg(long)]
+    darkpool_addr: Option<String>,
+    /// The location of the contract compilation artifacts as an absolute path
+    #[arg(long, default_value = "/artifacts")]
+    cairo_artifacts_path: String,
+    /// The url the devnet node api server
+    #[arg(long, default_value = DEVNET_HOSTPORT)]
+    devnet_url: String,
     /// The test to run
     #[arg(short, long, value_parser)]
     test: Option<String>,
@@ -36,16 +70,29 @@ struct IntegrationTestArgs {
 }
 
 impl From<CliArgs> for IntegrationTestArgs {
-    fn from(_: CliArgs) -> Self {
+    fn from(test_args: CliArgs) -> Self {
+        // Deploy a version of the darkpool if one is not given
+        let darkpool_addr = if let Some(addr) = test_args.darkpool_addr {
+            addr
+        } else {
+            await_result_with_error(deploy_darkpool(
+                &test_args.starknet_account_addr,
+                &test_args.starknet_pkey,
+                &test_args.cairo_artifacts_path,
+                &test_args.devnet_url,
+            ))
+            .map(|res| res.to_string())
+            .unwrap()
+        };
+
+        // Build a client that references the darkpool
         let starknet_client = StarknetClient::new(StarknetClientConfig {
             chain: ChainId::Devnet,
-            contract_addr: "".to_string(),
-            // Assumes we are running in a docker-compose setup with a DNS alias `sequencer`
-            // pointing to a devnet node running in a sister container
-            starknet_json_rpc_addr: Some(DEVNET_HOSTPORT.to_string()),
+            contract_addr: darkpool_addr,
+            starknet_json_rpc_addr: Some(format!("{}/rpc", test_args.devnet_url)),
             infura_api_key: None,
-            starknet_account_addresses: vec![],
-            starknet_pkeys: vec![],
+            starknet_account_addresses: vec![test_args.starknet_account_addr],
+            starknet_pkeys: vec![test_args.starknet_pkey],
         });
 
         Self { starknet_client }
@@ -63,13 +110,16 @@ fn setup_integration_tests(_test_args: &CliArgs) {
 /// TODO: Remove this test
 fn test_dummy(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let client = &test_args.starknet_client;
-    let block_num = await_result(client.get_block_number())
-        .map_err(|e| format!("error fetching block number: {e}"))?;
+    let mut rng = thread_rng();
+    let random_nullifier = Scalar::random(&mut rng);
 
-    if block_num == 0 {
+    let res = await_result(client.check_nullifier_unused(random_nullifier))
+        .map_err(|err| format!("error checking nullifier: {}", err))?;
+
+    if res {
         Ok(())
     } else {
-        Err(format!("expected block number to be 0, got {block_num}"))
+        Err("nullifier already used".to_string())
     }
 }
 

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -12,12 +12,22 @@ futures = "0.3"
 tokio = { workspace = true }
 tokio-condvar = "0.1"
 
+# === Node Interaction === #
+starknet = { workspace = true }
+reqwest = "0.11.13"
+
 # === Cryptography + Arithmetic === #
 mpc-stark = { workspace = true }
 num-bigint = { version = "0.4", features = ["rand"] }
 
+# === Workspace Dependencies === # 
+constants = { path = "../constants" }
+
 # === Misc Dependencies === #
 inventory = "0.3"
 itertools = "0.10.5"
+eyre = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }

--- a/test-helpers/src/contracts.rs
+++ b/test-helpers/src/contracts.rs
@@ -1,0 +1,257 @@
+//! Utils related to declaring, deploying, and interacting with smart contracts in
+//! the context of an integration test
+//!
+//! TODO: This should all be productionized and moved to the `starknet-client` crate
+
+use constants::MERKLE_HEIGHT;
+use eyre::{eyre, Result};
+use reqwest::Url as ReqwestUrl;
+use starknet::accounts::{Call, ConnectedAccount};
+use starknet::contract::ContractFactory;
+use starknet::core::chain_id;
+use starknet::core::crypto::compute_hash_on_elements;
+use starknet::core::types::{
+    MaybePendingTransactionReceipt, TransactionReceipt, TransactionStatus,
+};
+use starknet::core::utils::get_selector_from_name;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Provider};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use tracing::log;
+
+use starknet::{
+    accounts::{Account, SingleOwnerAccount},
+    core::types::{
+        contract::{CompiledClass, SierraClass},
+        FieldElement,
+    },
+    signers::{LocalWallet, SigningKey},
+};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The file prefix for Darkpool compilation artifacts
+pub const DARKPOOL_CONTRACT_NAME: &str = "renegade_contracts_Darkpool";
+/// The file prefix for Merkle compilation artifacts
+pub const MERKLE_CONTRACT_NAME: &str = "renegade_contracts_Merkle";
+/// The file prefix for NullifierSet compilation artifacts
+pub const NULLIFIER_SET_CONTRACT_NAME: &str = "renegade_contracts_NullifierSet";
+
+/// The file extension that suffixes Sierra compilation artifacts
+pub const SIERRA_FILE_EXTENSION: &str = "sierra.json";
+/// The file extension that suffixes Cairo assembly (casm) compilation artifacts
+pub const CASM_FILE_EXTENSION: &str = "casm.json";
+
+/// The name of the initialize function
+pub const INITIALIZE_FN_NAME: &str = "initialize";
+
+/// Cairo string for "STARKNET_CONTRACT_ADDRESS"
+const PREFIX_CONTRACT_ADDRESS: FieldElement = FieldElement::from_mont([
+    3829237882463328880,
+    17289941567720117366,
+    8635008616843941496,
+    533439743893157637,
+]);
+
+/// 2 ** 251 - 256
+const ADDR_BOUND: FieldElement = FieldElement::from_mont([
+    18446743986131443745,
+    160989183,
+    18446744073709255680,
+    576459263475590224,
+]);
+
+/// The account type used to deploy contracts
+pub type StarknetTestAcct = SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>;
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Setup the darkpool contract and return its address
+pub async fn deploy_darkpool(
+    account_addr: &str,
+    account_pkey: &str,
+    cairo_artifacts_path: &str,
+    devnet_url: &str,
+) -> Result<FieldElement> {
+    let deployer_account = build_deployer_acct(account_addr, account_pkey, devnet_url);
+
+    // Declare the darkpool implementation
+    log::info!("Declaring darkpool...");
+    let (darkpool_sierra, darkpool_casm) =
+        get_artifacts(cairo_artifacts_path, DARKPOOL_CONTRACT_NAME);
+    let darkpool_hash = declare_class(&darkpool_sierra, &darkpool_casm, &deployer_account).await?;
+
+    // Declare the Merkle implementation
+    log::info!("Declaring merkle tree...");
+    let (merkle_sierra, merkle_casm) = get_artifacts(cairo_artifacts_path, MERKLE_CONTRACT_NAME);
+    let merkle_hash = declare_class(&merkle_sierra, &merkle_casm, &deployer_account).await?;
+
+    // Declare the NullifierSet implementation
+    log::info!("Declaring nullifier set...");
+    let (nullifier_set_sierra, nullifier_set_casm) =
+        get_artifacts(cairo_artifacts_path, NULLIFIER_SET_CONTRACT_NAME);
+    let nullifier_set_hash = declare_class(
+        &nullifier_set_sierra,
+        &nullifier_set_casm,
+        &deployer_account,
+    )
+    .await?;
+
+    // Deploy the darkpool
+    log::info!("Deploying darkpool...");
+    let contract = ContractFactory::new(darkpool_hash, &deployer_account);
+    let calldata = vec![deployer_account.address()];
+    let deploy_tx = contract
+        .deploy(
+            calldata.clone(),
+            FieldElement::ZERO, /* salt */
+            false,              /* unique */
+        )
+        .send()
+        .await?;
+    await_transaction(deploy_tx.transaction_hash, &deployer_account).await?;
+    let addr = calculate_contract_address(darkpool_hash, &calldata);
+
+    // Initialize the contract
+    log::info!("Initializing darkpool contract...");
+    let init_calldata = vec![
+        merkle_hash,
+        nullifier_set_hash,
+        FieldElement::from(MERKLE_HEIGHT),
+    ];
+    let res = deployer_account
+        .execute(vec![Call {
+            to: addr,
+            selector: get_selector_from_name(INITIALIZE_FN_NAME)?,
+            calldata: init_calldata.clone(),
+        }])
+        .send()
+        .await?;
+    await_transaction(res.transaction_hash, &deployer_account).await?;
+
+    log::info!("Darkpool deployed at: {addr}");
+
+    Ok(addr)
+}
+
+/// Build an account to deploy the contracts from
+fn build_deployer_acct(
+    account_addr: &str,
+    account_pkey: &str,
+    devnet_url: &str,
+) -> StarknetTestAcct {
+    // Create the API provider for the JSON-RPC API
+    let rpc_url: ReqwestUrl = format!("{devnet_url}/rpc").parse().unwrap();
+    let provider = JsonRpcClient::new(HttpTransport::new(rpc_url));
+
+    let addr_felt = FieldElement::from_str(account_addr).unwrap();
+    let pkey_felt = FieldElement::from_hex_be(account_pkey).unwrap();
+
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(pkey_felt));
+    SingleOwnerAccount::new(provider, signer, addr_felt, chain_id::TESTNET)
+}
+
+/// Load the compilation artifacts for the given contract
+///
+/// Borrowed from: https://github.com/renegade-fi/renegade-contracts/blob/main/starknet_scripts/src/commands/utils.rs#L85
+fn get_artifacts(artifacts_path: &str, contract_name: &str) -> (PathBuf, PathBuf) {
+    let sierra_path = Path::new(artifacts_path)
+        .join(contract_name)
+        .with_extension(SIERRA_FILE_EXTENSION);
+    let casm_path = Path::new(artifacts_path)
+        .join(contract_name)
+        .with_extension(CASM_FILE_EXTENSION);
+
+    (sierra_path, casm_path)
+}
+
+/// Declare a contract class on the devnet
+///
+/// Borrowed from: https://github.com/renegade-fi/renegade-contracts/blob/main/starknet_scripts/src/commands/utils.rs#L114
+async fn declare_class(
+    sierra_source: &PathBuf,
+    casm_source: &PathBuf,
+    deployer: &StarknetTestAcct,
+) -> Result<FieldElement> {
+    // Read the source files into their runtime objects
+    let sierra_contract: SierraClass = serde_json::from_reader(File::open(sierra_source)?)?;
+    let flattened_class = sierra_contract.flatten()?;
+
+    let casm_contract: CompiledClass = serde_json::from_reader(File::open(casm_source)?)?;
+    let casm_class_hash = casm_contract.class_hash()?;
+
+    let res = deployer
+        .declare(Arc::new(flattened_class), casm_class_hash)
+        .send()
+        .await?;
+    await_transaction(res.transaction_hash, deployer).await?;
+
+    Ok(res.class_hash)
+}
+
+/// Taken from https://github.com/xJonathanLEI/starknet-rs/blob/master/starknet-accounts/src/factory/mod.rs
+fn calculate_contract_address(
+    class_hash: FieldElement,
+    constructor_calldata: &[FieldElement],
+) -> FieldElement {
+    compute_hash_on_elements(&[
+        PREFIX_CONTRACT_ADDRESS,
+        FieldElement::ZERO, /* deployer address */
+        FieldElement::ZERO, /* salt */
+        class_hash,
+        compute_hash_on_elements(constructor_calldata),
+    ]) % ADDR_BOUND
+}
+
+/// Await a transaction to enter the `ACCEPTED ON L2` state
+async fn await_transaction(tx_hash: FieldElement, rpc_client: &StarknetTestAcct) -> Result<()> {
+    log::info!("Awaiting transaction {tx_hash:?}");
+    loop {
+        if let TransactionStatus::AcceptedOnL2 = get_transaction_status(tx_hash, rpc_client).await?
+        {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    Ok(())
+}
+
+/// Get the status of a given transaction
+async fn get_transaction_status(
+    tx_hash: FieldElement,
+    rpc_client: &StarknetTestAcct,
+) -> Result<TransactionStatus> {
+    let tx_receipt = rpc_client
+        .provider()
+        .get_transaction_receipt(tx_hash)
+        .await?;
+    let status = match tx_receipt {
+        MaybePendingTransactionReceipt::PendingReceipt(receipt) => {
+            return Err(eyre!("Transaction is still pending: {:?}", receipt));
+        }
+        MaybePendingTransactionReceipt::Receipt(receipt) => match receipt {
+            TransactionReceipt::Invoke(tx) => tx.status,
+            TransactionReceipt::Declare(tx) => tx.status,
+            TransactionReceipt::Deploy(tx) => tx.status,
+            _ => {
+                return Err(eyre!(
+                    "Transaction receipt is not an invoke, declare, or deploy receipt"
+                ));
+            }
+        },
+    };
+
+    log::info!("transaction has status: {status:?}");
+    Ok(status)
+}

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
 
+pub mod contracts;
 pub mod macros;
 pub mod mpc_network;
 pub mod types;


### PR DESCRIPTION
### Purpose
This PR sets up a devnet sequencer for integration testing the `tasks` crate. Much of this infra is re-usuable and will be used across various crates. The setup is as follows:
1. A docker image the builds our contract sources from `main:HEAD` of `renegade-contracts` so that encapsulating containers may pull pre-built sources in.
2. A docker container that wraps `shardlabs/devnet-sequencer` and installs the `starknet-sierra-compile` binary at the version we use to compile contracts.
3. A docker container that runs the integration tests for the `task-driver` with access to the compiled contract artifacts.

### Testing
- Unit and integration tests pass
- Integration tests against devnet with forked state are passing