### PR TITLE
state, config: Mock `RelayerState` object for integration tests

### DIFF
--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -3,6 +3,9 @@ name = "state"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+mocks = []
+
 [dependencies]
 # === Arithmetic + Crypto === #
 num-bigint = { workspace = true }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -6,6 +6,9 @@
 
 //! Groups state object definitions and handles logic for serializing access to shared
 //! global state elements
+
+#[cfg(feature = "mocks")]
+pub mod mock;
 mod orderbook;
 pub mod peers;
 mod priority;

--- a/state/src/mock.rs
+++ b/state/src/mock.rs
@@ -1,0 +1,82 @@
+//! Defines a mock for the state object
+
+use common::types::{gossip::ClusterId, wallet::Wallet};
+use config::RelayerConfig;
+use external_api::bus_message::SystemBusMessage;
+use job_types::handshake_manager::HandshakeExecutionJob;
+use system_bus::SystemBus;
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
+
+use crate::RelayerState;
+
+/// Builds the mock state object for testing
+#[derive(Default)]
+pub struct StateMockBuilder {
+    /// The config to use for the state
+    config: RelayerConfig,
+    /// A reference to the job queue for the handshake manager
+    handshake_job_queue: Option<TokioSender<HandshakeExecutionJob>>,
+    /// A reference to the global system bus
+    bus: Option<SystemBus<SystemBusMessage>>,
+}
+
+impl StateMockBuilder {
+    /// Turn on the debug flag
+    pub fn debug(mut self) -> Self {
+        self.config.debug = true;
+        self
+    }
+
+    /// Turn on the `allow_local` flag
+    pub fn allow_local(mut self) -> Self {
+        self.config.allow_local = true;
+        self
+    }
+
+    /// Turn on the `disable_fee_validation` flag
+    pub fn disable_fee_validation(mut self) -> Self {
+        self.config.disable_fee_validation = true;
+        self
+    }
+
+    /// Set the local keypair
+    pub fn local_keypair(mut self, key: String) -> Self {
+        self.config.p2p_key = Some(key);
+        self
+    }
+
+    /// Set the cluster ID
+    pub fn cluster_id(mut self, cluster_id: ClusterId) -> Self {
+        self.config.cluster_id = cluster_id;
+        self
+    }
+
+    /// Add a wallet to the state
+    pub fn wallet(mut self, wallet: Wallet) -> Self {
+        self.config.wallets.push(wallet);
+        self
+    }
+
+    /// Set the handshake job queue
+    pub fn handshake_job_queue(mut self, queue: TokioSender<HandshakeExecutionJob>) -> Self {
+        self.handshake_job_queue = Some(queue);
+        self
+    }
+
+    /// Set the system bus
+    pub fn bus(mut self, bus: SystemBus<SystemBusMessage>) -> Self {
+        self.bus = Some(bus);
+        self
+    }
+
+    /// Build the mock state
+    pub fn build(self) -> RelayerState {
+        let handshake_queue = self.handshake_job_queue.unwrap_or_else(|| {
+            let (sender, _) = tokio::sync::mpsc::unbounded_channel();
+            sender
+        });
+        let system_bus = self.bus.unwrap_or_else(SystemBus::new);
+
+        RelayerState::initialize_global_state(&self.config, handshake_queue, system_bus)
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a mock for the `RelayerState` object so that it may be injected into integration tests. This also adds a more explicit `Default` behavior to the `RelayerConfig` object.

The mock follows a builder pattern to expose the flags that the `RelayerState` constructor consumes.

### Testing
- Unit and integration tests pass