### PR TITLE
circuits: benches: `VALID WALLET UPDATE`: Add full sized benchmark

### DIFF
--- a/circuits/benches/valid_wallet_create.rs
+++ b/circuits/benches/valid_wallet_create.rs
@@ -245,11 +245,11 @@ criterion_group! {
     name = valid_wallet_create;
     config = Criterion::default().sample_size(10);
     targets =
-    bench_apply_constraints__small_circuit,
-    bench_prover__small_circuit,
-    bench_verifier__small_circuit,
-    bench_apply_constraints__large_circuit,
-    bench_prover__large_circuit,
-    bench_verifier__large_circuit
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+        bench_apply_constraints__large_circuit,
+        bench_prover__large_circuit,
+        bench_verifier__large_circuit
 }
 criterion_main!(valid_wallet_create);

--- a/circuits/benches/valid_wallet_update.rs
+++ b/circuits/benches/valid_wallet_update.rs
@@ -7,24 +7,44 @@ use circuit_types::{
     order::Order,
     traits::{CircuitBaseType, SingleProverCircuit},
     transfers::ExternalTransfer,
+    wallet::Wallet,
 };
-use circuits::zk_circuits::{
-    test_helpers::INITIAL_WALLET,
-    valid_wallet_update::{
-        test_helpers::{construct_witness_statement, SizedStatement, SizedWitness},
-        ValidWalletUpdate,
-    },
+use circuits::zk_circuits::valid_wallet_update::{
+    test_helpers::construct_witness_statement, ValidWalletUpdate, ValidWalletUpdateStatement,
+    ValidWalletUpdateWitness,
 };
+use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS, MERKLE_HEIGHT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use merlin::HashChainTranscript;
 use mpc_bulletproof::{r1cs::Prover, PedersenGens};
 use rand::thread_rng;
 
+/// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT)
+const SMALL_PARAM_SET: (usize, usize, usize, usize) = (2, 2, 1, 5);
+/// The parameter set for the large sized circuit
+const LARGE_PARAM_SET: (usize, usize, usize, usize) =
+    (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT);
+
+// -----------
+// | Helpers |
+// -----------
+
 /// Construct a dummy witness and statement for the circuit
-pub fn create_default_witness_statement() -> (SizedWitness, SizedStatement) {
+pub fn create_witness_statement<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>() -> (
+    ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>,
+    ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+)
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     // Take a default wallet and cancel an order
-    let original_wallet = INITIAL_WALLET.clone();
-    let mut modified_wallet = INITIAL_WALLET.clone();
+    let original_wallet = Wallet::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>::default();
+    let mut modified_wallet = original_wallet.clone();
     modified_wallet.orders[0] = Order::default();
 
     construct_witness_statement(
@@ -35,18 +55,37 @@ pub fn create_default_witness_statement() -> (SizedWitness, SizedStatement) {
 }
 
 /// Benchmark constraint generation for the circuit
-pub fn bench_apply_constraints(c: &mut Criterion) {
-    let mut rng = thread_rng();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (witness, statement) = create_default_witness_statement();
-    let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
-    let statement_var = statement.commit_public(&mut prover);
-
+pub fn bench_apply_constraints_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_wallet_update");
-    group.bench_function(BenchmarkId::new("constraint-generation", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "constraint-generation",
+        format!(
+            "({}, {}, {}, {})",
+            MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT
+        ),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement, then allocate them in the proof system
+        let mut rng = thread_rng();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (witness, statement) =
+            create_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
+        let statement_var = statement.commit_public(&mut prover);
+
         b.iter(|| {
             ValidWalletUpdate::apply_constraints(
                 witness_var.clone(),
@@ -59,12 +98,30 @@ pub fn bench_apply_constraints(c: &mut Criterion) {
 }
 
 /// Benchmark proving time for the circuit
-pub fn bench_prover(c: &mut Criterion) {
-    // Build a witness and statement to prove on ahead of time
-    let (witness, statement) = create_default_witness_statement();
-
+pub fn bench_prover_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_wallet_update");
-    group.bench_function(BenchmarkId::new("prover", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "prover",
+        format!(
+            "({}, {}, {}, {})",
+            MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT
+        ),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement to prove on ahead of time
+        let (witness, statement) =
+            create_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let pc_gens = PedersenGens::default();
@@ -76,18 +133,36 @@ pub fn bench_prover(c: &mut Criterion) {
 }
 
 /// Tests the time taken to verify `VALID WALLET UPDATE`
-pub fn bench_verifier(c: &mut Criterion) {
-    // First generate a proof that will be verified multiple times
-    let (witness, statement) = create_default_witness_statement();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (commitments, proof) =
-        ValidWalletUpdate::prove(witness, statement.clone(), prover).unwrap();
-
+pub fn bench_verifier<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_wallet_update");
-    group.bench_function(BenchmarkId::new("verifier", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "verifier",
+        format!(
+            "({}, {}, {}, {})",
+            MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT
+        ),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // First generate a proof that will be verified multiple times
+        let (witness, statement) =
+            create_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (commitments, proof) =
+            ValidWalletUpdate::prove(witness, statement.clone(), prover).unwrap();
+
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let verifier = mpc_bulletproof::r1cs::Verifier::new(&pc_gens, &mut transcript);
@@ -103,10 +178,86 @@ pub fn bench_verifier(c: &mut Criterion) {
     });
 }
 
+// --------------
+// | Benchmarks |
+// --------------
+
+/// Benchmark constraint generation for the small circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__small_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Benchmark prover latency for the small circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__small_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Benchmark verifier latency for the small circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__small_circuit(c: &mut Criterion) {
+    bench_verifier::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Benchmark constraint generation for the large circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__large_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
+/// Benchmark prover latency for the large circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__large_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
+/// Benchmark verifier latency for the large circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__large_circuit(c: &mut Criterion) {
+    bench_verifier::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
 criterion_group!(
     name = valid_wallet_update;
     config = Criterion::default().sample_size(10);
-    targets = bench_apply_constraints, bench_prover, bench_verifier
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+        bench_apply_constraints__large_circuit,
+        bench_prover__large_circuit,
+        bench_verifier__large_circuit
 );
 
 criterion_main!(valid_wallet_update);

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -355,7 +355,6 @@ pub mod test_helpers {
         },
         traits::LinkableBaseType,
     };
-    use rand::thread_rng;
 
     use crate::zk_circuits::test_helpers::{
         create_multi_opening, create_wallet_shares, SizedWallet, MAX_BALANCES, MAX_FEES,
@@ -374,8 +373,6 @@ pub mod test_helpers {
     pub fn construct_witness_statement(
         wallet: &SizedWallet,
     ) -> (SizedWitness, ValidReblindStatement) {
-        let mut rng = thread_rng();
-
         // Build shares of the original wallet, then reblind it
         let (old_wallet_private_shares, old_wallet_public_shares) =
             create_wallet_shares(wallet.clone());
@@ -389,7 +386,7 @@ pub mod test_helpers {
         );
 
         let (merkle_root, mut opening) =
-            create_multi_opening::<_, MERKLE_HEIGHT>(&[original_shares_commitment], &mut rng);
+            create_multi_opening::<MERKLE_HEIGHT>(&[original_shares_commitment]);
         let original_share_opening = opening.pop().unwrap();
 
         // Compute nullifiers for the old shares


### PR DESCRIPTION
### Purpose
This PR adds full sized (i.e. using the sizing constants defined in the `constants` crate) benchmarks for the `VALID WALLET UPDATE` circuit. As well, this PR re-implements a test helper function `create_multi_opening` to work efficiently on larger inputs, avoiding constructing the entire Merkle tree.

### Testing
- Unit and integration tests pass
- Ran all benchmarks