### PR TITLE
circuits: benches: `VALID REBLIND`: Add full sized benchmarks

### DIFF
--- a/circuits/benches/valid_reblind.rs
+++ b/circuits/benches/valid_reblind.rs
@@ -2,14 +2,18 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
+use circuit_types::{
+    traits::{CircuitBaseType, SingleProverCircuit},
+    wallet::Wallet,
+};
 use circuits::zk_circuits::{
-    test_helpers::INITIAL_WALLET,
+    test_helpers::PUBLIC_KEYS,
     valid_reblind::{
-        test_helpers::{construct_witness_statement, SizedWitness},
-        ValidReblind, ValidReblindStatement,
+        test_helpers::construct_witness_statement, ValidReblind, ValidReblindStatement,
+        ValidReblindWitness,
     },
 };
+use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS, MERKLE_HEIGHT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use merlin::HashChainTranscript;
 use mpc_bulletproof::{
@@ -18,26 +22,65 @@ use mpc_bulletproof::{
 };
 use rand::thread_rng;
 
-/// Create a witness and a statement for the `VALID REBLIND` circuit
-pub fn create_default_witness_statement() -> (SizedWitness, ValidReblindStatement) {
-    let wallet = INITIAL_WALLET.clone();
-    construct_witness_statement(&wallet)
+/// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT)
+const SMALL_PARAM_SET: (usize, usize, usize, usize) = (2, 2, 1, 5);
+/// The parameter set for the large sized circuit
+const LARGE_PARAM_SET: (usize, usize, usize, usize) =
+    (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT);
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a witness and statement with the given sizing generics
+pub fn create_sized_witness_statement<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>() -> (
+    ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>,
+    ValidReblindStatement,
+)
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    let wallet = Wallet::<MAX_BALANCES, MAX_ORDERS, MAX_FEES> {
+        keys: PUBLIC_KEYS.clone(),
+        ..Default::default()
+    };
+    construct_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>(&wallet)
 }
 
 /// Tests the time taken to apply the constraints of `VALID REBLIND` circuit
-pub fn bench_apply_constraints(c: &mut Criterion) {
-    // Build a witness and statement
-    let (witness, statement) = create_default_witness_statement();
-    let mut rng = thread_rng();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
-    let statement_var = statement.commit_public(&mut prover);
-
+pub fn bench_apply_constraints_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_reblind");
-    group.bench_function(BenchmarkId::new("constraint-generation", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "constraint-generation",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES}, {MERKLE_HEIGHT})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+        let mut rng = thread_rng();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
+        let statement_var = statement.commit_public(&mut prover);
+
         b.iter(|| {
             ValidReblind::apply_constraints(
                 witness_var.clone(),
@@ -50,12 +93,27 @@ pub fn bench_apply_constraints(c: &mut Criterion) {
 }
 
 /// Tests the time taken to prove `VALID REBLIND`
-pub fn bench_prover(c: &mut Criterion) {
-    // Build a witness and statement
-    let (witness, statement) = create_default_witness_statement();
-
+pub fn bench_prover_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_reblind");
-    group.bench_function(BenchmarkId::new("prover", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "prover",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES}, {MERKLE_HEIGHT})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let pc_gens = PedersenGens::default();
@@ -67,17 +125,31 @@ pub fn bench_prover(c: &mut Criterion) {
 }
 
 /// Tests the time taken to verify `VALID REBLIND`
-pub fn bench_verifier(c: &mut Criterion) {
-    // First generate a proof that will be verified multiple times
-    let (witness, statement) = create_default_witness_statement();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (commitments, proof) = ValidReblind::prove(witness, statement.clone(), prover).unwrap();
-
+pub fn bench_verifier_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+    const MERKLE_HEIGHT: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_reblind");
-    group.bench_function(BenchmarkId::new("verifier", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "verifier",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES}, {MERKLE_HEIGHT})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // First generate a proof that will be verified multiple times
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (commitments, proof) = ValidReblind::prove(witness, statement.clone(), prover).unwrap();
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let verifier = Verifier::new(&pc_gens, &mut transcript);
@@ -93,9 +165,85 @@ pub fn bench_verifier(c: &mut Criterion) {
     });
 }
 
+// --------------
+// | Benchmarks |
+// --------------
+
+/// Tests the time taken to apply the constraints of a small `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__small_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Tests the time taken to prove a small `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__small_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Tests the time taken verify a small `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__small_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+        { SMALL_PARAM_SET.3 },
+    >(c);
+}
+
+/// Tests the time taken to apply the constraints of a large `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__large_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
+/// Tests the time taken to prove a large `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__large_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
+/// Tests the time taken verify a large `VALID REBLIND` circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__large_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+        { LARGE_PARAM_SET.3 },
+    >(c);
+}
+
 criterion_group! {
     name = valid_reblind;
     config = Criterion::default().sample_size(10);
-    targets = bench_apply_constraints, bench_prover, bench_verifier
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+        bench_apply_constraints__large_circuit,
+        bench_prover__large_circuit,
+        bench_verifier__large_circuit,
 }
 criterion_main!(valid_reblind);

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -354,11 +354,12 @@ pub mod test_helpers {
             compute_wallet_share_nullifier, reblind_wallet,
         },
         traits::LinkableBaseType,
+        wallet::Wallet,
     };
 
     use crate::zk_circuits::test_helpers::{
-        create_multi_opening, create_wallet_shares, SizedWallet, MAX_BALANCES, MAX_FEES,
-        MAX_ORDERS, PRIVATE_KEYS,
+        create_multi_opening, create_wallet_shares, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
+        PRIVATE_KEYS,
     };
 
     use super::{ValidReblindStatement, ValidReblindWitness};
@@ -370,9 +371,20 @@ pub mod test_helpers {
     pub type SizedWitness = ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>;
 
     /// Construct a witness and statement for `VALID REBLIND` from a given wallet
-    pub fn construct_witness_statement(
-        wallet: &SizedWallet,
-    ) -> (SizedWitness, ValidReblindStatement) {
+    pub fn construct_witness_statement<
+        const MAX_BALANCES: usize,
+        const MAX_ORDERS: usize,
+        const MAX_FEES: usize,
+        const MERKLE_HEIGHT: usize,
+    >(
+        wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    ) -> (
+        ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>,
+        ValidReblindStatement,
+    )
+    where
+        [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+    {
         // Build shares of the original wallet, then reblind it
         let (old_wallet_private_shares, old_wallet_public_shares) =
             create_wallet_shares(wallet.clone());
@@ -397,7 +409,7 @@ pub mod test_helpers {
         let new_private_commitment =
             compute_wallet_private_share_commitment(reblinded_private_shares.clone());
 
-        let witness = SizedWitness {
+        let witness = ValidReblindWitness {
             original_wallet_private_shares: old_wallet_private_shares,
             original_wallet_public_shares: old_wallet_public_shares,
             reblinded_wallet_private_shares: reblinded_private_shares.to_linkable(),


### PR DESCRIPTION
### Purpose
This PR adds full sized benchmarks for the `VALID REBLIND` circuit using the constants defined in the `constants` crate.

### Testing
- Unit and integration tests pass
- Ran benchmarks