### PR TITLE
circuits: benches: `VALID SETTLE`: Add full size benchmarks

### DIFF
--- a/circuits/benches/valid_settle.rs
+++ b/circuits/benches/valid_settle.rs
@@ -2,13 +2,15 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
-use circuits::zk_circuits::valid_settle::{
-    test_helpers::{
-        create_witness_statement, SizedStatement, SizedWitness, MATCH_RES, WALLET1, WALLET2,
-    },
-    ValidSettle,
+use circuit_types::{
+    r#match::MatchResult,
+    traits::{CircuitBaseType, SingleProverCircuit},
+    wallet::Wallet,
 };
+use circuits::zk_circuits::valid_settle::{
+    test_helpers::create_witness_statement, ValidSettle, ValidSettleStatement, ValidSettleWitness,
+};
+use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use merlin::HashChainTranscript;
 use mpc_bulletproof::{
@@ -17,29 +19,62 @@ use mpc_bulletproof::{
 };
 use rand::thread_rng;
 
-/// Create a witness and a statement for the `VALID SETTLE` circuit
-pub fn create_default_witness_statement() -> (SizedWitness, SizedStatement) {
-    let wallet1 = WALLET1.clone();
-    let wallet2 = WALLET2.clone();
-    let match_res = MATCH_RES.clone();
+/// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT)
+const SMALL_PARAM_SET: (usize, usize, usize) = (2, 2, 1);
+/// The parameter set for the large sized circuit
+const LARGE_PARAM_SET: (usize, usize, usize) = (MAX_BALANCES, MAX_ORDERS, MAX_FEES);
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a witness and a statement for the `VALID SETTLE` circuit with the given sizing parameters
+pub fn create_sized_witness_statement<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>() -> (
+    ValidSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+)
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
+    let wallet1 = Wallet::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>::default();
+    let wallet2 = wallet1.clone();
+    let match_res = MatchResult::default();
 
     create_witness_statement(wallet1, wallet2, match_res)
 }
 
 /// Tests the time taken to apply the constraints of `VALID SETTLE` circuit
-pub fn bench_apply_constraints(c: &mut Criterion) {
-    // Build a witness and statement
-    let (witness, statement) = create_default_witness_statement();
-    let mut rng = thread_rng();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
-    let statement_var = statement.commit_public(&mut prover);
-
+pub fn bench_apply_constraints_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_settle");
-    group.bench_function(BenchmarkId::new("constraint-generation", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "constraint-generation",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>();
+        let mut rng = thread_rng();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let mut prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
+        let statement_var = statement.commit_public(&mut prover);
+
         b.iter(|| {
             ValidSettle::apply_constraints(witness_var.clone(), statement_var.clone(), &mut prover)
                 .unwrap();
@@ -48,12 +83,26 @@ pub fn bench_apply_constraints(c: &mut Criterion) {
 }
 
 /// Tests the time taken to prove `VALID SETTLE`
-pub fn bench_prover(c: &mut Criterion) {
-    // Build a witness and statement
-    let (witness, statement) = create_default_witness_statement();
-
+pub fn bench_prover_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_settle");
-    group.bench_function(BenchmarkId::new("prover", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "prover",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>();
+
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let pc_gens = PedersenGens::default();
@@ -65,17 +114,30 @@ pub fn bench_prover(c: &mut Criterion) {
 }
 
 /// Tests the time taken to verify `VALID SETTLE`
-pub fn bench_verifier(c: &mut Criterion) {
-    // First generate a proof that will be verified multiple times
-    let (witness, statement) = create_default_witness_statement();
-    let mut transcript = HashChainTranscript::new(b"test");
-    let pc_gens = PedersenGens::default();
-    let prover = Prover::new(&pc_gens, &mut transcript);
-
-    let (commitments, proof) = ValidSettle::prove(witness, statement.clone(), prover).unwrap();
-
+pub fn bench_verifier_with_sizes<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let mut group = c.benchmark_group("valid_settle");
-    group.bench_function(BenchmarkId::new("verifier", ""), |b| {
+    let benchmark_id = BenchmarkId::new(
+        "verifier",
+        format!("({MAX_BALANCES}, {MAX_ORDERS}, {MAX_FEES})"),
+    );
+
+    group.bench_function(benchmark_id, |b| {
+        // First generate a proof that will be verified multiple times
+        let (witness, statement) =
+            create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>();
+        let mut transcript = HashChainTranscript::new(b"test");
+        let pc_gens = PedersenGens::default();
+        let prover = Prover::new(&pc_gens, &mut transcript);
+
+        let (commitments, proof) = ValidSettle::prove(witness, statement.clone(), prover).unwrap();
         b.iter(|| {
             let mut transcript = HashChainTranscript::new(b"test");
             let verifier = Verifier::new(&pc_gens, &mut transcript);
@@ -91,9 +153,71 @@ pub fn bench_verifier(c: &mut Criterion) {
     });
 }
 
+// --------------
+// | Benchmarks |
+// --------------
+
+/// Benchmark constraint generation latency on a small `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_apply_constraints__small_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { SMALL_PARAM_SET.0 },
+        { SMALL_PARAM_SET.1 },
+        { SMALL_PARAM_SET.2 },
+    >(c)
+}
+
+/// Benchmark prover latency on a small `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_prover__small_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<{ SMALL_PARAM_SET.0 }, { SMALL_PARAM_SET.1 }, { SMALL_PARAM_SET.2 }>(
+        c,
+    )
+}
+
+/// Benchmark verifier latency on a small `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_verifier__small_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<{ SMALL_PARAM_SET.0 }, { SMALL_PARAM_SET.1 }, { SMALL_PARAM_SET.2 }>(
+        c,
+    )
+}
+
+/// Benchmark constraint generation on a large `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_apply_constraints__large_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<
+        { LARGE_PARAM_SET.0 },
+        { LARGE_PARAM_SET.1 },
+        { LARGE_PARAM_SET.2 },
+    >(c)
+}
+
+/// Benchmark prover latency on a large `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_prover__large_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<{ LARGE_PARAM_SET.0 }, { LARGE_PARAM_SET.1 }, { LARGE_PARAM_SET.2 }>(
+        c,
+    )
+}
+
+/// Benchmark verifier latency on a large `VALID SETTLE` circuit
+#[allow(non_snake_case)]
+fn bench_verifier__large_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<{ LARGE_PARAM_SET.0 }, { LARGE_PARAM_SET.1 }, { LARGE_PARAM_SET.2 }>(
+        c,
+    )
+}
+
 criterion_group! {
     name = valid_settle;
     config = Criterion::default().sample_size(10);
-    targets = bench_apply_constraints, bench_prover, bench_verifier
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+        bench_apply_constraints__large_circuit,
+        bench_prover__large_circuit,
+        bench_verifier__large_circuit,
 }
 criterion_main!(valid_settle);

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -300,6 +300,7 @@ pub mod test_helpers {
         order::{Order, OrderSide},
         r#match::MatchResult,
         traits::LinkableBaseType,
+        wallet::Wallet,
     };
     use lazy_static::lazy_static;
     use mpc_stark::algebra::scalar::Scalar;
@@ -367,11 +368,21 @@ pub mod test_helpers {
     pub type SizedStatement = ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     /// Construct a witness and statement for `VALID SETTLE`
-    pub fn create_witness_statement(
-        party0_wallet: SizedWallet,
-        party1_wallet: SizedWallet,
+    pub fn create_witness_statement<
+        const MAX_BALANCES: usize,
+        const MAX_ORDERS: usize,
+        const MAX_FEES: usize,
+    >(
+        party0_wallet: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        party1_wallet: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         match_res: MatchResult,
-    ) -> (SizedWitness, SizedStatement) {
+    ) -> (
+        ValidSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        ValidSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    )
+    where
+        [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+    {
         // Mux between received mints based on the match direction
         let (
             party0_received_mint,
@@ -456,7 +467,17 @@ pub mod test_helpers {
     }
 
     /// Find the index of the balance with the given mint in the given wallet
-    fn find_balance_in_wallet(mint: &BigUint, wallet: &SizedWallet) -> Option<usize> {
+    fn find_balance_in_wallet<
+        const MAX_BALANCES: usize,
+        const MAX_ORDERS: usize,
+        const MAX_FEES: usize,
+    >(
+        mint: &BigUint,
+        wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    ) -> Option<usize>
+    where
+        [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+    {
         wallet
             .balances
             .iter()
@@ -466,11 +487,18 @@ pub mod test_helpers {
     }
 
     /// Find the index of the order within the given wallet that is on the given asset pair's book
-    fn find_order_in_wallet(
+    fn find_order_in_wallet<
+        const MAX_BALANCES: usize,
+        const MAX_ORDERS: usize,
+        const MAX_FEES: usize,
+    >(
         base_mint: &BigUint,
         quote_mint: &BigUint,
-        wallet: &SizedWallet,
-    ) -> Option<usize> {
+        wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    ) -> Option<usize>
+    where
+        [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+    {
         wallet
             .orders
             .iter()


### PR DESCRIPTION
### Purpose
This PR adds full sized benchmarks for the `VALID SETTLE` circuit. Sizing constants are taken from the system wide constants defined in the `constants` crate.

### Testing
- Unit and integration tests pass
- Ran all benchmarks