### PR TITLE
starknet-client: Remove the use of the sequencer gateway API

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -120,7 +120,6 @@ async fn main() -> Result<(), CoordinatorError> {
         contract_addr: args.contract_address.clone(),
         infura_api_key: None,
         starknet_json_rpc_addr: args.starknet_jsonrpc_node.clone(),
-        sequencer_addr: None, /* use default address */
         starknet_account_addresses: args.starknet_account_addresses,
         starknet_pkeys: args.starknet_private_keys,
     });

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -120,7 +120,6 @@ impl From<CliArgs> for IntegrationTestArgs {
             chain: ChainId::Devnet,
             contract_addr: darkpool_addr,
             starknet_json_rpc_addr: Some(format!("{}/rpc", test_args.devnet_url)),
-            sequencer_addr: Some(test_args.devnet_url),
             infura_api_key: None,
             starknet_account_addresses: vec![test_args.starknet_account_addr],
             starknet_pkeys: vec![test_args.starknet_pkey],

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -20,7 +20,6 @@ use gossip_api::gossip::GossipOutbound;
 use job_types::proof_manager::{ProofJob, ProofManagerJob};
 use renegade_crypto::fields::{scalar_to_biguint, scalar_to_u64, starknet_felt_to_biguint};
 use serde::Serialize;
-use starknet::providers::sequencer::models::{TransactionInfo, TransactionStatus};
 use starknet_client::client::StarknetClient;
 use state::RelayerState;
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, oneshot};
@@ -31,10 +30,8 @@ use super::{
     helpers::{apply_match_to_wallets, find_merkle_path, update_wallet_validity_proofs},
 };
 
-/// Error emitted when a transaction fails
-const ERR_TRANSACTION_FAILED: &str = "transaction rejected";
 /// The error message the contract emits when a nullifier has been used
-const NULLIFIER_USED_ERROR_MSG: &str = "nullifier already used";
+pub(crate) const NULLIFIER_USED_ERROR_MSG: &str = "nullifier already used";
 
 /// The party ID of the first party
 const PARTY0: u64 = 0;
@@ -304,25 +301,15 @@ impl SettleMatchTask {
             && tx_rejection.to_string().contains(NULLIFIER_USED_ERROR_MSG){
                 return Ok(())
             }
+
         let tx_hash =
             tx_submit_res.map_err(|err| SettleMatchTaskError::StarknetClient(err.to_string()))?;
 
         log::info!("tx hash: 0x{:x}", starknet_felt_to_biguint(&tx_hash));
-        let tx_info = self
-            .starknet_client
+        self.starknet_client
             .poll_transaction_completed(tx_hash)
             .await
             .map_err(|err| SettleMatchTaskError::StarknetClient(err.to_string()))?;
-
-        // If the transaction fails because the local party's match nullifier is already spend, then
-        // the counterparty encumbered the local party, in this case, it is safe to move to settlement
-        if let TransactionStatus::Rejected = tx_info.status {
-            if !Self::nullifier_spent_failure(tx_info) {
-                return Err(SettleMatchTaskError::StarknetClient(
-                    ERR_TRANSACTION_FAILED.to_string(),
-                ));
-            }
-        }
 
         // If the transaction was successful, cancel all orders on both nullifiers, await new validity proofs
         self.global_state
@@ -333,17 +320,6 @@ impl SettleMatchTask {
             .await;
 
         Ok(())
-    }
-
-    /// Whether or not a transaction failed because the given nullifier was already spent
-    fn nullifier_spent_failure(tx_info: TransactionInfo) -> bool {
-        if let Some(failure_reason) = tx_info.transaction_failure_reason
-            && let Some(error_message) = failure_reason.error_message
-            {
-                return error_message.contains(NULLIFIER_USED_ERROR_MSG)
-            }
-
-        false
     }
 
     /// Apply the match result to the local wallet, find the wallet's new

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -3,7 +3,10 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use crate::helpers::{apply_match_to_wallets, update_wallet_validity_proofs};
+use crate::{
+    helpers::{apply_match_to_wallets, update_wallet_validity_proofs},
+    settle_match::NULLIFIER_USED_ERROR_MSG,
+};
 
 use super::{
     driver::{StateWrapper, Task},
@@ -33,7 +36,6 @@ use job_types::proof_manager::{ProofJob, ProofManagerJob};
 use num_bigint::BigUint;
 use renegade_crypto::fields::{scalar_to_biguint, scalar_to_u64};
 use serde::Serialize;
-use starknet::providers::sequencer::models::{TransactionFailureReason, TransactionStatus};
 use starknet_client::client::StarknetClient;
 use state::RelayerState;
 use tokio::{
@@ -54,8 +56,6 @@ const ERR_ENQUEUING_JOB: &str = "error enqueuing job with proof generation modul
 const ERR_AWAITING_PROOF: &str = "error awaiting proof";
 /// Error message emitted when a wallet cannot be found
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found in global state";
-/// Error message emitted when a transaction fails with no reason given
-const ERR_UNKNOWN_TX_FAILURE: &str = "transaction failed with no reason given";
 
 // -------------------
 // | Task Definition |
@@ -361,7 +361,7 @@ impl SettleMatchInternalTask {
         let valid_match_proof = self.valid_match_mpc.clone().unwrap();
         let valid_settle_proof = self.valid_settle.clone().unwrap();
 
-        let tx_hash = self
+        let tx_submit_res = self
             .starknet_client
             .submit_match(
                 party0_reblind_proof.original_shares_nullifier,
@@ -375,27 +375,19 @@ impl SettleMatchInternalTask {
                 valid_match_proof,
                 valid_settle_proof,
             )
-            .await
-            .map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
+            .await;
 
-        let tx_info = self
-            .starknet_client
+        if let Err(ref tx_rejection) = tx_submit_res
+            && tx_rejection.to_string().contains(NULLIFIER_USED_ERROR_MSG){
+                return Ok(())
+            }
+        let tx_hash =
+            tx_submit_res.map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
+
+        self.starknet_client
             .poll_transaction_completed(tx_hash)
             .await
             .map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
-
-        // Check transaction status
-        if let TransactionStatus::Rejected = tx_info.status {
-            return Err(SettleMatchInternalTaskError::Starknet(format!(
-                "transaction rejected: {:?}",
-                tx_info
-                    .transaction_failure_reason
-                    .unwrap_or(TransactionFailureReason {
-                        code: "".to_string(),
-                        error_message: Some(ERR_UNKNOWN_TX_FAILURE.to_string())
-                    })
-            )));
-        }
 
         // If the transaction is successful, cancel all orders on the old wallet nullifiers
         // and await new validity proofs


### PR DESCRIPTION
### Purpose
This PR migrates the `StarknetClient` to use only the JSON-RPC api, and not the sequencer gateway. The gateway will be deprecated as Starknet decentralizes, so this change is necessary eventually. As well, this change allows us to test against more recent sequencer versions and implementations, like Katana.

### Testing
- Unit and integration tests pass