### PR TITLE
circuits: benches: Add compile-time flag to enable large benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 .vscode
 *.sw[a-p]
 secrets.env
+**/flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ exclude = ["mpc-stark", "mpc-bulletproof"]
 [profile.bench]
 opt-level = 3 # Full optimizations
 lto = true
+debug = true
 
 [profile.release]
 opt-level = 3 # Full optimizations

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 test_helpers = []
+large_benchmarks = []
 
 [[test]]
 name = "integration"

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -315,6 +315,11 @@ pub fn bench_verifier_latency(c: &mut Criterion) {
     });
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group! {
     name = match_mpc;
     config = Criterion::default().sample_size(10);
@@ -330,4 +335,16 @@ criterion_group! {
         bench_prover_latency__large_delay,
         bench_verifier_latency,
 }
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = match_mpc;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_match_mpc__small_delay,
+        bench_apply_constraints__small_delay,
+        bench_prover_latency__small_delay,
+        bench_verifier_latency,
+}
+
 criterion_main!(match_mpc);

--- a/circuits/benches/valid_commitments.rs
+++ b/circuits/benches/valid_commitments.rs
@@ -221,6 +221,11 @@ fn bench_verifier__large_circuit(c: &mut Criterion) {
     );
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group! {
     name = valid_commitments;
     config = Criterion::default().sample_size(10);
@@ -232,4 +237,15 @@ criterion_group! {
         bench_prover__large_circuit,
         bench_verifier__large_circuit,
 }
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = valid_commitments;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+}
+
 criterion_main!(valid_commitments);

--- a/circuits/benches/valid_reblind.rs
+++ b/circuits/benches/valid_reblind.rs
@@ -235,6 +235,11 @@ pub fn bench_verifier__large_circuit(c: &mut Criterion) {
     >(c);
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group! {
     name = valid_reblind;
     config = Criterion::default().sample_size(10);
@@ -246,4 +251,15 @@ criterion_group! {
         bench_prover__large_circuit,
         bench_verifier__large_circuit,
 }
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = valid_reblind;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+}
+
 criterion_main!(valid_reblind);

--- a/circuits/benches/valid_settle.rs
+++ b/circuits/benches/valid_settle.rs
@@ -209,6 +209,11 @@ fn bench_verifier__large_circuit(c: &mut Criterion) {
     )
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group! {
     name = valid_settle;
     config = Criterion::default().sample_size(10);
@@ -219,5 +224,15 @@ criterion_group! {
         bench_apply_constraints__large_circuit,
         bench_prover__large_circuit,
         bench_verifier__large_circuit,
+}
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = valid_settle;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
 }
 criterion_main!(valid_settle);

--- a/circuits/benches/valid_wallet_create.rs
+++ b/circuits/benches/valid_wallet_create.rs
@@ -241,6 +241,11 @@ pub fn bench_verifier__large_circuit(c: &mut Criterion) {
     );
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group! {
     name = valid_wallet_create;
     config = Criterion::default().sample_size(10);
@@ -252,4 +257,15 @@ criterion_group! {
         bench_prover__large_circuit,
         bench_verifier__large_circuit
 }
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = valid_wallet_create;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+}
+
 criterion_main!(valid_wallet_create);

--- a/circuits/benches/valid_wallet_update.rs
+++ b/circuits/benches/valid_wallet_update.rs
@@ -248,6 +248,11 @@ pub fn bench_verifier__large_circuit(c: &mut Criterion) {
     >(c);
 }
 
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
 criterion_group!(
     name = valid_wallet_update;
     config = Criterion::default().sample_size(10);
@@ -258,6 +263,16 @@ criterion_group!(
         bench_apply_constraints__large_circuit,
         bench_prover__large_circuit,
         bench_verifier__large_circuit
+);
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group!(
+    name = valid_wallet_update;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
 );
 
 criterion_main!(valid_wallet_update);


### PR DESCRIPTION
### Purpose
This PR adds the `large_benchmarks` feature flag to the `circuits` crate to conditionally enable the larger sized benchmarks on the circuits. These benchmarks can be very long running and are not very useful for performance analysis (as compared to their smaller counterparts), so they are disabled by default.

### Testing
- Ran all benchmarks to verify the feature flag works