### PR TITLE
circuits, starknet-client: expose test helper types

### DIFF
--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -175,9 +175,9 @@ pub mod test_helpers {
     use super::{ValidWalletCreateStatement, ValidWalletCreateWitness};
 
     /// Witness with default size parameters
-    pub(super) type SizedWitness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    pub type SizedWitness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     /// Statement with default size parameters
-    pub(super) type SizedStatement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
+    pub type SizedStatement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     // -----------
     // | Helpers |

--- a/starknet-client/src/types.rs
+++ b/starknet-client/src/types.rs
@@ -82,9 +82,9 @@ impl From<ExternalTransfer> for Vec<StarknetFieldElement> {
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct StarknetU256 {
     /// The low 128 bits of the represented integer
-    low: u128,
+    pub low: u128,
     /// The high 128 bits of the represented integer
-    high: u128,
+    pub high: u128,
 }
 
 impl From<BigUint> for StarknetU256 {


### PR DESCRIPTION
This PR exposes the `SizedWitness` / `SizedStatement` types from the `VALID WALLET CREATE` test helpers, and makes the fields of the `StarknetU256` public, so that they may be better reused in e2e tests in the `renegade-contracts` repo