### PR TITLE
circuits: Pre-allocate `BulletproofGens` for circuits

### DIFF
--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -1082,6 +1082,7 @@ pub trait SingleProverCircuit {
     fn prove(
         witness: Self::Witness,
         statement: Self::Statement,
+        bp_gens: &BulletproofGens,
         mut prover: Prover,
     ) -> Result<
         (
@@ -1100,8 +1101,7 @@ pub trait SingleProverCircuit {
             .map_err(ProverError::R1CS)?;
 
         // Generate the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::R1CS)?;
+        let proof = prover.prove(bp_gens).map_err(ProverError::R1CS)?;
 
         Ok((witness_comm, proof))
     }
@@ -1114,6 +1114,7 @@ pub trait SingleProverCircuit {
         witness_commitment: <Self::Witness as CircuitBaseType>::CommitmentType,
         statement: Self::Statement,
         proof: R1CSProof,
+        bp_gens: &BulletproofGens,
         mut verifier: Verifier,
     ) -> Result<(), VerifierError> {
         // Commit to the witness and statement
@@ -1125,9 +1126,8 @@ pub trait SingleProverCircuit {
             .map_err(VerifierError::R1CS)?;
 
         // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         verifier
-            .verify(&proof, &bp_gens)
+            .verify(&proof, bp_gens)
             .map_err(VerifierError::R1CS)
     }
 }
@@ -1184,6 +1184,7 @@ pub trait MultiProverCircuit {
     fn prove(
         witness: Self::Witness,
         statement: Self::Statement,
+        bp_gens: &BulletproofGens,
         fabric: MpcFabric,
         mut prover: MpcProver,
     ) -> Result<
@@ -1206,8 +1207,7 @@ pub trait MultiProverCircuit {
         Self::apply_constraints_multiprover(witness_var, statement_var, fabric, &mut prover)?;
 
         // Generate the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
-        let proof = prover.prove(&bp_gens).map_err(ProverError::Collaborative)?;
+        let proof = prover.prove(bp_gens).map_err(ProverError::Collaborative)?;
 
         Ok((witness_comm, proof))
     }
@@ -1227,6 +1227,7 @@ pub trait MultiProverCircuit {
                 as MultiproverCircuitCommitmentType>::BaseCommitType,
         statement: <Self::Statement as MultiproverCircuitBaseType>::BaseType,
         proof: R1CSProof,
+        bp_gens: &BulletproofGens,
         mut verifier: Verifier,
     ) -> Result<(), VerifierError>
 where {
@@ -1239,9 +1240,8 @@ where {
             .map_err(VerifierError::R1CS)?;
 
         // Verify the proof
-        let bp_gens = BulletproofGens::new(Self::BP_GENS_CAPACITY, 1 /* party_capacity */);
         verifier
-            .verify(&proof, &bp_gens)
+            .verify(&proof, bp_gens)
             .map_err(VerifierError::R1CS)
     }
 }

--- a/circuits/benches/valid_commitments.rs
+++ b/circuits/benches/valid_commitments.rs
@@ -6,20 +6,20 @@ use circuit_types::{
     traits::{CircuitBaseType, SingleProverCircuit},
     wallet::Wallet,
 };
-use circuits::zk_circuits::{
-    test_helpers::PUBLIC_KEYS,
-    valid_commitments::{
-        test_helpers::create_witness_and_statement, ValidCommitments, ValidCommitmentsStatement,
-        ValidCommitmentsWitness,
+use circuits::{
+    singleprover_prove, verify_singleprover_proof,
+    zk_circuits::{
+        test_helpers::PUBLIC_KEYS,
+        valid_commitments::{
+            test_helpers::create_witness_and_statement, ValidCommitments,
+            ValidCommitmentsStatement, ValidCommitmentsWitness,
+        },
     },
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use merlin::HashChainTranscript;
-use mpc_bulletproof::{
-    r1cs::{Prover, Verifier},
-    PedersenGens,
-};
+use mpc_bulletproof::{r1cs::Prover, PedersenGens};
 use rand::thread_rng;
 
 /// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT)
@@ -110,11 +110,11 @@ pub fn bench_prover_with_sizes<
         let (witness, statement) =
             create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>();
         b.iter(|| {
-            let mut transcript = HashChainTranscript::new(b"test");
-            let pc_gens = PedersenGens::default();
-            let prover = Prover::new(&pc_gens, &mut transcript);
-
-            ValidCommitments::prove(witness.clone(), statement.clone(), prover).unwrap();
+            singleprover_prove::<ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>>(
+                witness.clone(),
+                statement.clone(),
+            )
+            .unwrap();
         });
     });
 }
@@ -139,23 +139,16 @@ pub fn bench_verifier_with_sizes<
         // First generate a proof that will be verified multiple times
         let (witness, statement) =
             create_sized_witness_statement::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>();
-        let mut transcript = HashChainTranscript::new(b"test");
-        let pc_gens = PedersenGens::default();
-        let prover = Prover::new(&pc_gens, &mut transcript);
 
-        let (commitments, proof) =
-            ValidCommitments::prove(witness, statement.clone(), prover).unwrap();
+        let (commitments, proof) = singleprover_prove::<
+            ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        >(witness, statement.clone())
+        .unwrap();
 
         b.iter(|| {
-            let mut transcript = HashChainTranscript::new(b"test");
-            let verifier = Verifier::new(&pc_gens, &mut transcript);
-
-            let res = ValidCommitments::verify(
-                commitments.clone(),
-                statement.clone(),
-                proof.clone(),
-                verifier,
-            );
+            let res = verify_singleprover_proof::<
+                ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+            >(statement.clone(), commitments.clone(), proof.clone());
 
             #[allow(unused_must_use)]
             {

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -630,7 +630,7 @@ pub mod test_helpers {
 mod tests {
     use circuit_types::traits::{MultiProverCircuit, MultiproverCircuitCommitmentType};
     use merlin::HashChainTranscript;
-    use mpc_bulletproof::{r1cs::Verifier, r1cs_mpc::MpcProver, PedersenGens};
+    use mpc_bulletproof::{r1cs::Verifier, r1cs_mpc::MpcProver, BulletproofGens, PedersenGens};
     use test_helpers::mpc_network::execute_mock_mpc;
 
     use crate::zk_circuits::valid_match_mpc::{
@@ -649,9 +649,15 @@ mod tests {
                 let transcript = HashChainTranscript::new(b"test");
                 let prover = MpcProver::new_with_fabric(fabric.clone(), transcript, pc_gens);
 
+                let bp_gens = BulletproofGens::new(
+                    ValidMatchMpcCircuit::BP_GENS_CAPACITY,
+                    1, /* party_capacity */
+                );
+
                 ValidMatchMpcCircuit::prove(
                     witness,
                     (), /* statement */
+                    &bp_gens,
                     fabric.clone(),
                     prover,
                 )
@@ -670,7 +676,18 @@ mod tests {
         let mut transcript = HashChainTranscript::new(b"test");
         let verifier = Verifier::new(&pc_gens, &mut transcript);
 
-        ValidMatchMpcCircuit::verify(witness_commitment, () /* statement */, proof, verifier)
-            .unwrap();
+        let bp_gens = BulletproofGens::new(
+            ValidMatchMpcCircuit::BP_GENS_CAPACITY,
+            1, /* party_capacity */
+        );
+
+        ValidMatchMpcCircuit::verify(
+            witness_commitment,
+            (), /* statement */
+            proof,
+            &bp_gens,
+            verifier,
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the `BulletproofGens` used by the prover and verifiers in the `circuits` crate to be statically allocated via `lazy_static`. This removes the need to allocate them in the prove/verify critical path, which proves time consuming for large circuits.

### Testing
- All unit and integration tests pass