### PR TITLE
docker: devnet: Run Katana node with pre-deployed contracts for tests

### DIFF
--- a/bin/cargo-integrate
+++ b/bin/cargo-integrate
@@ -13,17 +13,12 @@ fi
 # Use BuildKit
 export DOCKER_BUILDKIT=1
 
-# Build the contracts first if not already built
-docker build --tag "renegade-contracts:latest" -f "docker/contracts/Dockerfile" .
-
-# Build the image
-docker build --tag "$2"-integration-test:latest -f "$2"/Dockerfile .
-
 # Bring up the compose file for the target package
 docker-compose \
   --file "$2"/docker-compose.yml \
   up \
   --remove-orphans \
+  --build \
   --force-recreate \
   --renew-anon-volumes \
   --abort-on-container-exit \

--- a/circuits/docker-compose.yml
+++ b/circuits/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   party0:
     image: circuits-integration-test:latest
-    build: .
+    build:
+      context: ..
+      dockerfile: circuits/Dockerfile
     ports:
       - "8000:8000"
     command: >
@@ -14,7 +16,9 @@ services:
     tty: true
   party1:
     image: circuits-integration-test:latest
-    build: .
+    build:
+      context: ..
+      dockerfile: circuits/Dockerfile
     ports:
       - "9000:9000"
     command: >

--- a/docker/contracts/Dockerfile
+++ b/docker/contracts/Dockerfile
@@ -8,14 +8,16 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Install Scarb
-ARG SCARB_VERSION=0.5.1
+ARG SCARB_VERSION=0.6.2
 ENV SHELL /bin/bash
 RUN curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | /bin/sh -s -- -v $SCARB_VERSION 
 ENV PATH="/root/.local/bin:${PATH}"
 
 # Clone the contracts source and build the contracts
 WORKDIR /sources
-RUN git clone https://github.com/renegade-fi/renegade-contracts.git
+RUN git clone \
+    -b cairo2-no-poseidon-or-verifier \
+    https://github.com/renegade-fi/renegade-contracts.git
 
 WORKDIR /sources/renegade-contracts
 RUN scarb build

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -1,28 +1,50 @@
-# We modify the base image of the `starknet-devnet` to include the Sierra compiler version
-# used in our contracts. The devnet compiles sources once they are declared from Sierra
-# to casm, so it needs a matching version to those used to generate the sender side artifacts
-FROM shardlabs/starknet-devnet AS base
+# Pull the compiled contract sources from the locally avialable image
+# This assumes that you have already built the contract sources, which happens
+# automatically when run via `cargo-integrate`
+FROM renegade-contracts:latest AS sources
 
-# Install curl and tar
-RUN apk add --no-cache curl tar
+# We use the katana RPC node as a devnet sequencer for testing
+# https://book.dojoengine.org/toolchain/katana/overview.html
+FROM ubuntu AS devnet
 
-# Install the Cairo compiler version used for our contracts
-ARG CAIRO_COMPILER_VERSION=2.0.1
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y git \
+    curl \
+    jq \
+    gcc
+
+# Install Cargo
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Katana directly from source
+ARG DOJO_REVISION=b0d24a3
+RUN git clone https://github.com/dojoengine/dojo
+WORKDIR /dojo
+RUN git checkout $DOJO_REVISION
+RUN cargo install --path ./crates/katana --locked --force
+
+# Install the CLI for deploying contracts
 WORKDIR /
-RUN curl -L -o /cairo-build.tar.gz https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_COMPILER_VERSION}/release-x86_64-unknown-linux-musl.tar.gz
+RUN git clone -b cairo2-no-poseidon-or-verifier \
+    https://github.com/renegade-fi/renegade-contracts.git
+WORKDIR /renegade-contracts/starknet_scripts
+RUN cargo build
 
-RUN tar -xzf /cairo-build.tar.gz
-RUN rm /cairo-build.tar.gz
+# Copy the compiled contract sources from the sources image
+WORKDIR /
+COPY --from=sources /artifacts /artifacts
+COPY ./setup-sequencer.sh /setup-sequencer.sh
+RUN /setup-sequencer.sh || exit -1
 
-# Modify the entrypoint to run with our custom flags
-ENTRYPOINT starknet-devnet \
-    --sierra-compiler-path /cairo/bin/starknet-sierra-compile \
-    --compiler-args "--add-pythonic-hints --allowed-libfuncs-list-name all" \
-    --fork-network alpha-goerli \
-    --fork-retries 3 \
-    --timeout 1000 \
-    --host 0.0.0.0 \
-    --port 5050 \
+# Copy the deployment log to a configurable location
+ARG DEPLOYMENT_CONFIG_VOLUME=/deployments
+RUN mkdir $DEPLOYMENT_CONFIG_VOLUME
+RUN cp /renegade-contracts/starknet_scripts/deployments.json $DEPLOYMENT_CONFIG_VOLUME
+
+ENTRYPOINT katana \
     --seed 0 \
-    --lite-mode \
-    --verbose
+    --load-state /katana-state.out \
+    --disable-fee \
+    --chain-id KATANA

--- a/docker/devnet/setup-sequencer.sh
+++ b/docker/devnet/setup-sequencer.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+cd renegade-contracts/starknet_scripts
+export RUST_BACKTRACE=1
+
+# Run a sequencer with state dump enabled
+katana \
+    --seed 0 \
+    --dump-state /katana-state.out \
+    --disable-fee \
+    --chain-id KATANA &
+katana_pid=$!
+sleep 5
+
+# Deploy and initialize the contracts, uses the first predeployed account and private key of the
+# sequencer when run with `--seed 0`
+cargo run -- \
+    deploy \
+    --initialize \
+    --dump-deployments \
+    --artifacts-path /artifacts \
+    -c darkpool \
+    --network localhost \
+    --address 0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0 \
+    --private-key 0x300001800000000300000180000000000030000000000003006001800006600
+
+# Kill the sequencer with SIGINT to force a state dump
+kill -INT $katana_pid
+sleep 3

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -1,26 +1,41 @@
 services:
+  contracts:
+    build:
+      context: ../docker/contracts
+    image: renegade-contracts:latest
+    entrypoint: sleep infinity
   sequencer:
     build:
-      dockerfile: ../docker/devnet/Dockerfile
+      context: ../docker/devnet
+    volumes:
+      - deployments:/deployments
     ports:
       - "5050:5050"
     environment:
       - STARKNET_DEVNET_CAIRO_VM=rust
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:5050/is_alive || exit 1"
+      test: "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"starknet_chainId\",\"params\":[],\"id\":1}' http://localhost:5050/rpc || exit 1"
       interval: 5s
       timeout: 10s
       retries: 3
+    depends_on:
+      - contracts
   relayer:
     image: task-driver-integration-test:latest
-    build: .
+    build:
+      context: ..
+      dockerfile: task-driver/Dockerfile
+    volumes:
+      - deployments:/deployments
     ports:
       - "8000:8000"
     command: >
       cargo test --test integration --features "integration" -- 
-        --darkpool-addr 0x02179f01358c09410f234f1ece40d235719e05db3babca7bef0babc974333162 
+        --deployments-path /deployments/deployments.json
         --verbose 
     tty: true
     depends_on:
       sequencer:
         condition: service_healthy
+volumes:
+  deployments:

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -28,6 +28,7 @@ renegade-crypto = { path = "../renegade-crypto" }
 inventory = "0.3"
 itertools = "0.10.5"
 eyre = { workspace = true }
+json = "0.12"
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/test-helpers/src/contracts.rs
+++ b/test-helpers/src/contracts.rs
@@ -16,6 +16,7 @@ use starknet::core::types::{
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
+use std::io::Read;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{
@@ -53,6 +54,11 @@ pub const CASM_FILE_EXTENSION: &str = "casm.json";
 /// The name of the initialize function
 pub const INITIALIZE_FN_NAME: &str = "initialize";
 
+/// The deployments key in the `deployments.json` file
+pub const DEPLOYMENTS_KEY: &str = "deployments";
+/// The darkpool key in the `deployments.json` file
+pub const DARKPOOL_KEY: &str = "darkpool";
+
 /// Cairo string for "STARKNET_CONTRACT_ADDRESS"
 const PREFIX_CONTRACT_ADDRESS: FieldElement = FieldElement::from_mont([
     3829237882463328880,
@@ -75,6 +81,18 @@ pub type StarknetTestAcct = SingleOwnerAccount<JsonRpcClient<HttpTransport>, Loc
 // -----------
 // | Helpers |
 // -----------
+
+/// Parse a `deployments.json` file to get the address of the darkpool contract
+pub fn parse_addr_from_deployments_file(file_path: String) -> Result<String> {
+    let mut file_contents = String::new();
+    File::open(file_path)?.read_to_string(&mut file_contents)?;
+
+    let parsed_json = json::parse(&file_contents)?;
+    parsed_json[DEPLOYMENTS_KEY][DARKPOOL_KEY]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| eyre!("Could not parse darkpool address from deployments file"))
+}
 
 /// Setup the darkpool contract and return its address
 pub async fn deploy_darkpool(


### PR DESCRIPTION
### Purpose
This PR sets up a [katana](https://book.dojoengine.org/toolchain/katana/overview.html) node in CI for integration tests to run against. This setup depends on a locally available image with the contract sources compiled within them. The katana sequencer copies the contract sources from this image, deploys them to the sequencer, then dumps the state of the sequencer so that it may be started back up with pre-deployed contracts.

### Testing
- Tested a nullifier check integration test in the `task-driver` integration tests against the sequencer stack