### PR TITLE
starknet-client: Update client to match Cairo 1.0 contract interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ num-bigint = { version = "0.4.3" }
 rand = "0.8"
 
 # === On-Chain === #
-starknet = { git = "https://github.com/renegade-fi/starknet-rs" }
+starknet = "0.5"
 
 # === Networking === #
 libp2p = "0.51"

--- a/common/src/types/chain_id.rs
+++ b/common/src/types/chain_id.rs
@@ -3,7 +3,9 @@
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use starknet::core::types::FieldElement as StarknetFieldElement;
+use starknet::core::{
+    types::FieldElement as StarknetFieldElement, utils::cairo_short_string_to_felt,
+};
 
 /// Starknet mainnet chain-id
 /// TODO: use `starknet-rs` implementation once we upgrade versions
@@ -34,9 +36,12 @@ pub enum ChainId {
     /// Starknet mainnet
     #[serde(rename = "mainnet")]
     Mainnet,
-    /// Devnet at localhost:5050
+    /// A locally hosted devnet node
     #[serde(rename = "devnet")]
     Devnet,
+    /// A Katana devnet node at `localhost:5050`
+    #[serde(rename = "katana")]
+    Katana,
 }
 
 impl From<ChainId> for StarknetFieldElement {
@@ -45,6 +50,7 @@ impl From<ChainId> for StarknetFieldElement {
             ChainId::AlphaGoerli => STARKNET_TESTNET_ID,
             ChainId::Mainnet => STARKNET_MAINNET_ID,
             ChainId::Devnet => STARKNET_DEVNET_ID,
+            ChainId::Katana => cairo_short_string_to_felt("KATANA").unwrap(),
         }
     }
 }
@@ -59,6 +65,8 @@ impl FromStr for ChainId {
             Ok(Self::Mainnet)
         } else if s == "devnet" {
             Ok(Self::Devnet)
+        } else if s == "katana" {
+            Ok(Self::Katana)
         } else {
             Err(format!("unknown chain ID {s}"))
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -48,7 +48,7 @@ struct Cli {
     #[clap(long, default_value="goerli")]
     pub chain_id: ChainId,
     /// The address of the darkpool contract, defaults to the Goerli deployment
-    #[clap(long, value_parser, default_value = "0x02179f01358c09410f234f1ece40d235719e05db3babca7bef0babc974333162")]
+    #[clap(long, value_parser, default_value = "0x06aadd0758f809d4dc5c5686bcde6dc3e51d211aaf7eca8e902dc76e1217c7ab")]
     pub contract_address: String,
 
     // ----------------------------

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -119,8 +119,7 @@ async fn main() -> Result<(), CoordinatorError> {
         chain: args.chain_id,
         contract_addr: args.contract_address.clone(),
         infura_api_key: None,
-        starknet_json_rpc_addr: args.starknet_jsonrpc_node.clone(),
-        sequencer_addr: None, /* use default address */
+        starknet_json_rpc_addr: args.starknet_jsonrpc_node.clone().unwrap(),
         starknet_account_addresses: args.starknet_account_addresses,
         starknet_pkeys: args.starknet_private_keys,
     });

--- a/starknet-client/Cargo.toml
+++ b/starknet-client/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 # === Cryptographic + arithmetic dependencies === #
+ark-ff = "0.4"
+mpc-bulletproof = { workspace = true }
 mpc-stark = { workspace = true }
 num-bigint = { version = "0.4.3" }
 
@@ -21,7 +23,6 @@ common = { path = "../common" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 state = { path = "../state" }
-
 
 # === Misc dependencies === #
 itertools = "0.10.0"

--- a/starknet-client/src/client.rs
+++ b/starknet-client/src/client.rs
@@ -1,62 +1,26 @@
 //! A wrapper around the starknet client made available by:
 //! https://docs.rs/starknet-core/latest/starknet_core/
 
+mod chain_state;
+mod contract_interaction;
+
 use std::{
-    collections::{HashMap, HashSet},
     str::FromStr,
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
-use circuit_types::{
-    merkle::MerkleRoot,
-    native_helpers::compute_wallet_commitment_from_private,
-    wallet::{Nullifier, WalletShareStateCommitment},
-    SizedWalletShare,
-};
-use common::types::{
-    chain_id::ChainId,
-    merkle::{MerkleAuthenticationPath, MerkleTreeCoords},
-    proof_bundles::{
-        OrderValidityProofBundle, ValidMatchMpcBundle, ValidSettleBundle, ValidWalletCreateBundle,
-        ValidWalletUpdateBundle,
-    },
-};
+use common::types::chain_id::ChainId;
 use constants::{
     DEVNET_CONTRACT_DEPLOYMENT_BLOCK, GOERLI_CONTRACT_DEPLOYMENT_BLOCK,
     MAINNET_CONTRACT_DEPLOYMENT_BLOCK,
 };
-use mpc_stark::algebra::scalar::Scalar;
-use num_bigint::BigUint;
-use renegade_crypto::fields::{
-    scalar_to_starknet_felt, starknet_felt_to_biguint, starknet_felt_to_scalar,
-    starknet_felt_to_u64,
-};
+
 use reqwest::Url as ReqwestUrl;
 use starknet::{
-    accounts::{Account, Call, SingleOwnerAccount},
-    core::types::{
-        BlockId as CoreBlockId, BlockTag, EmittedEvent, EventFilter,
-        FieldElement as StarknetFieldElement, FunctionCall, InvokeTransaction,
-        MaybePendingTransactionReceipt, Transaction, TransactionReceipt,
-    },
-    providers::{
-        jsonrpc::{HttpTransport, JsonRpcClient},
-        Provider,
-    },
+    accounts::SingleOwnerAccount,
+    core::types::FieldElement as StarknetFieldElement,
+    providers::jsonrpc::{HttpTransport, JsonRpcClient},
     signers::{LocalWallet, SigningKey},
-};
-use tracing::log;
-
-use crate::{
-    helpers::parse_shares_from_calldata, INTERNAL_NODE_CHANGED_EVENT_SELECTOR, MATCH_SELECTOR,
-    MERKLE_HEIGHT, MERKLE_ROOT_IN_HISTORY_SELECTOR, NEW_WALLET_SELECTOR, UPDATE_WALLET_SELECTOR,
-    VALUE_INSERTED_EVENT_SELECTOR,
-};
-
-use super::{
-    error::StarknetClientError, helpers::pack_bytes_into_felts, types::ExternalTransfer,
-    DEFAULT_AUTHENTICATION_PATH, GET_PUBLIC_BLINDER_TRANSACTION, NULLIFIER_USED_SELECTOR,
 };
 
 /// A type alias for a felt that represents a transaction hash
@@ -72,7 +36,7 @@ pub type StarknetAcct = SingleOwnerAccount<RpcProvider, LocalWallet>;
 /// `BLOCK_PAGINATION_WINDOW` blocks. Meaning we first fetch the most recent
 /// `BLOCK_PAGINATION_WINDOW` blocks; scan them, then search the next
 /// `BLOCK_PAGINATION_WINDOW` blocks
-const BLOCK_PAGINATION_WINDOW: u64 = 1000;
+const BLOCK_PAGINATION_WINDOW: usize = 1000;
 /// The page size to request when querying events
 const EVENTS_PAGE_SIZE: u64 = 50;
 /// The interval at which to poll the gateway for transaction status
@@ -83,19 +47,6 @@ const MAX_FEE_MULTIPLIER: f32 = 3.0;
 /// Error message emitted when an unexpected transaction type is found
 const ERR_UNEXPECTED_TX_TYPE: &str = "unexpected transaction type found";
 
-/// Macro helper to pack a serializable value into a vector of felts
-///
-/// Prepends a length felt for run length encoding
-macro_rules! pack_serializable {
-    ($val:ident) => {{
-        let bytes = serde_json::to_vec(&($val))
-            .map_err(|err| StarknetClientError::Serde(err.to_string()))?;
-        let mut felts = pack_bytes_into_felts(&bytes);
-        felts.insert(0, (felts.len() as u64).into());
-
-        felts
-    }};
-}
 /// The config type for the client, consists of secrets needed to connect to
 /// the gateway and API server, as well as keys for sending transactions
 #[derive(Clone)]
@@ -134,6 +85,15 @@ impl StarknetClientConfig {
             ReqwestUrl::parse(&self.starknet_json_rpc_addr).expect("invalid JSON-RPC URL"),
         );
         JsonRpcClient::new(transport)
+    }
+
+    /// Get the earliest block at which the contract may have been deployed
+    pub fn earliest_block(&self) -> u64 {
+        match self.chain {
+            ChainId::AlphaGoerli => GOERLI_CONTRACT_DEPLOYMENT_BLOCK,
+            ChainId::Mainnet => MAINNET_CONTRACT_DEPLOYMENT_BLOCK,
+            ChainId::Devnet | ChainId::Katana => DEVNET_CONTRACT_DEPLOYMENT_BLOCK,
+        }
     }
 }
 
@@ -220,517 +180,5 @@ impl StarknetClient {
         let current_account_index = *account_index;
         *account_index = (*account_index + 1) % self.accounts.as_ref().len();
         current_account_index
-    }
-
-    /// Helper to make a view call to the contract
-    async fn call_contract(
-        &self,
-        call: FunctionCall,
-    ) -> Result<Vec<StarknetFieldElement>, StarknetClientError> {
-        self.get_jsonrpc_client()
-            .call(call, CoreBlockId::Tag(BlockTag::Pending))
-            .await
-            .map_err(|err| StarknetClientError::Gateway(err.to_string()))
-    }
-
-    /// Helper to setup a contract call with the correct max fee and account nonce
-    async fn execute_transaction(
-        &self,
-        call: Call,
-    ) -> Result<TransactionHash, StarknetClientError> {
-        // Estimate the fee and add a buffer to avoid rejected transaction
-        let account_index = self.next_account_index();
-        let acct_nonce = self.pending_block_nonce(account_index).await?;
-        let execution = self
-            .get_account(account_index)
-            .execute(vec![call])
-            .nonce(acct_nonce);
-
-        let fee_estimate = execution
-            .estimate_fee()
-            .await
-            .map_err(|err| StarknetClientError::ExecuteTransaction(err.to_string()))?;
-        let max_fee = (fee_estimate.overall_fee as f32) * MAX_FEE_MULTIPLIER;
-        let max_fee = StarknetFieldElement::from(max_fee as u64);
-
-        // Send the transaction and await receipt
-        execution
-            .max_fee(max_fee)
-            .send()
-            .await
-            .map(|res| res.transaction_hash)
-            .map_err(|err| StarknetClientError::ExecuteTransaction(err.to_string()))
-    }
-
-    // ---------------
-    // | Chain State |
-    // ---------------
-
-    /// Get the current StarkNet block number
-    pub async fn get_block_number(&self) -> Result<u64, StarknetClientError> {
-        self.get_jsonrpc_client()
-            .block_number()
-            .await
-            .map_err(|err| StarknetClientError::Rpc(err.to_string()))
-    }
-
-    /// Get the nonce of the account at the provided index in the pending block
-    pub async fn pending_block_nonce(
-        &self,
-        account_index: usize,
-    ) -> Result<StarknetFieldElement, StarknetClientError> {
-        self.jsonrpc_client
-            .get_nonce(
-                CoreBlockId::Tag(BlockTag::Pending),
-                self.get_account(account_index).address(),
-            )
-            .await
-            .map_err(|err| StarknetClientError::Rpc(err.to_string()))
-    }
-
-    /// Poll a transaction until it is finalized into the accepted on L2 state
-    #[allow(deprecated)]
-    pub async fn poll_transaction_completed(
-        &self,
-        tx_hash: StarknetFieldElement,
-    ) -> Result<TransactionReceipt, StarknetClientError> {
-        let sleep_duration = Duration::from_millis(TX_STATUS_POLL_INTERVAL_MS);
-        loop {
-            let res = self
-                .jsonrpc_client
-                .get_transaction_receipt(tx_hash)
-                .await
-                .map_err(|err| StarknetClientError::Gateway(err.to_string()))?;
-
-            // Break if the transaction has made it out of the received state
-            match res {
-                MaybePendingTransactionReceipt::PendingReceipt(_) => {
-                    log::info!("transaction 0x{tx_hash:x} pending...");
-                }
-                MaybePendingTransactionReceipt::Receipt(receipt) => {
-                    log::info!(
-                        "transaction 0x{tx_hash:x} finalized with status: {:?}",
-                        receipt.finality_status()
-                    );
-
-                    return Ok(receipt);
-                }
-            }
-
-            // Sleep and poll again
-            tokio::time::sleep(sleep_duration).await;
-        }
-    }
-
-    /// Searches on-chain state for the insertion of the given wallet, then finds the most
-    /// recent updates of the path's siblings and creates a Merkle authentication path
-    pub async fn find_merkle_authentication_path(
-        &self,
-        commitment: Scalar,
-    ) -> Result<MerkleAuthenticationPath, StarknetClientError> {
-        // Find the index of the wallet in the commitment tree
-        let leaf_index = self.find_commitment_in_state(commitment).await?;
-
-        // Construct a set that holds pairs of (depth, index) values in the authentication path; i.e. the
-        // tree coordinates of the sibling nodes in the authentication path
-        let mut authentication_path_coords: HashSet<MerkleTreeCoords> =
-            MerkleAuthenticationPath::construct_path_coords(leaf_index.clone(), MERKLE_HEIGHT)
-                .into_iter()
-                .collect();
-
-        // Search for these on-chain
-        let mut found_coords: HashMap<MerkleTreeCoords, StarknetFieldElement> = HashMap::new();
-        let coords_ref = &mut found_coords;
-        self.paginate_events(
-            move |event| {
-                let height: usize = starknet_felt_to_u64(&event.data[0]) as usize;
-                let index = starknet_felt_to_biguint(&event.data[1]);
-                let new_value = event.data[2];
-
-                let coords = MerkleTreeCoords::new(height, index);
-                if authentication_path_coords.remove(&coords) {
-                    coords_ref.insert(coords, new_value);
-                }
-
-                if authentication_path_coords.is_empty() {
-                    Ok(Some(()))
-                } else {
-                    Ok(None)
-                }
-            },
-            vec![*INTERNAL_NODE_CHANGED_EVENT_SELECTOR],
-            true, /* pending */
-        )
-        .await?;
-
-        // Gather the coordinates found on-chain into a Merkle authentication path
-        let mut path = *DEFAULT_AUTHENTICATION_PATH;
-        for (coordinate, value) in found_coords.into_iter() {
-            let path_index = MERKLE_HEIGHT - coordinate.height;
-            path[path_index] = starknet_felt_to_scalar(&value);
-        }
-
-        Ok(MerkleAuthenticationPath::new(path, leaf_index, commitment))
-    }
-
-    /// A helper to find a commitment in the Merkle tree
-    pub async fn find_commitment_in_state(
-        &self,
-        commitment: Scalar,
-    ) -> Result<BigUint, StarknetClientError> {
-        let commitment_starknet_felt = scalar_to_starknet_felt(&commitment);
-
-        log::info!(
-            "searching for commitment: 0x{:x}",
-            starknet_felt_to_biguint(&commitment_starknet_felt)
-        );
-
-        // Paginate through events in the contract, searching for the Merkle tree insertion event that
-        // corresponds to the given commitment
-        //
-        // Return the Merkle leaf index at which the commitment was inserted
-        self.paginate_events(
-            |event| {
-                let index = event.data[0];
-                let value = event.data[1];
-
-                if value == commitment_starknet_felt {
-                    return Ok(Some(starknet_felt_to_biguint(&index)));
-                }
-
-                Ok(None)
-            },
-            vec![*VALUE_INSERTED_EVENT_SELECTOR],
-            true, /* pending */
-        )
-        .await?
-        .ok_or_else(|| {
-            StarknetClientError::NotFound("commitment not found in Merkle tree".to_string())
-        })
-    }
-
-    /// A helper for paginating backwards in block history over contract events
-    ///
-    /// Calls the handler on each event, which indicates whether the pagination should
-    /// stop, and gives a response value
-    async fn paginate_events<T>(
-        &self,
-        mut handler: impl FnMut(EmittedEvent) -> Result<Option<T>, StarknetClientError>,
-        event_keys: Vec<StarknetFieldElement>,
-        pending: bool,
-    ) -> Result<Option<T>, StarknetClientError> {
-        // Paginate backwards in block history
-        let current_block = self.get_block_number().await?;
-        let mut start_block = current_block.saturating_sub(BLOCK_PAGINATION_WINDOW);
-        let mut end_block = if pending {
-            CoreBlockId::Tag(BlockTag::Pending)
-        } else {
-            CoreBlockId::Number(current_block)
-        };
-
-        // Build the event filter template
-        let mut filter = EventFilter {
-            from_block: Some(CoreBlockId::Number(start_block)),
-            to_block: Some(end_block),
-            address: Some(self.contract_address),
-            keys: if event_keys.is_empty() {
-                None
-            } else {
-                Some(vec![event_keys])
-            },
-        };
-
-        println!("got block range: [{start_block}, {end_block:?}]");
-
-        let earliest_block = match self.config.chain {
-            ChainId::AlphaGoerli => GOERLI_CONTRACT_DEPLOYMENT_BLOCK,
-            ChainId::Mainnet => MAINNET_CONTRACT_DEPLOYMENT_BLOCK,
-            ChainId::Devnet | ChainId::Katana => DEVNET_CONTRACT_DEPLOYMENT_BLOCK,
-        };
-        while start_block >= earliest_block.saturating_sub(BLOCK_PAGINATION_WINDOW) {
-            // Exhaust events from the start block to the end block
-            let mut pagination_token = Some(String::from("0"));
-            filter.from_block = Some(CoreBlockId::Number(start_block));
-            filter.to_block = Some(end_block);
-
-            while pagination_token.is_some() {
-                // Fetch the next page of events
-                let res = self
-                    .get_jsonrpc_client()
-                    .get_events(filter.clone(), pagination_token.clone(), EVENTS_PAGE_SIZE)
-                    .await
-                    .map_err(|err| StarknetClientError::Rpc(err.to_string()))?;
-
-                // Process each event with the handler
-                for event in res.events.into_iter() {
-                    if let Some(ret_val) = handler(event)? {
-                        return Ok(Some(ret_val));
-                    }
-                }
-
-                pagination_token = res.continuation_token;
-            }
-
-            // If we are already at the genesis block, break
-            if start_block == 0 {
-                break;
-            }
-
-            // If no return value is found decrement the start and end block
-            end_block = CoreBlockId::Number(start_block.saturating_sub(BLOCK_PAGINATION_WINDOW));
-            start_block = start_block.saturating_sub(BLOCK_PAGINATION_WINDOW);
-        }
-
-        Ok(None)
-    }
-
-    /// Fetch and parse the public secret shares from the calldata of the given transactions
-    ///
-    /// In the case that the referenced transaction is a `match`, we disambiguate between the
-    /// two parties by adding the public blinder of the party's shares the caller intends to fetch
-    #[allow(deprecated)]
-    pub async fn fetch_public_shares_from_tx(
-        &self,
-        public_blinder_share: Scalar,
-        tx_hash: TransactionHash,
-    ) -> Result<SizedWalletShare, StarknetClientError> {
-        // Parse the selector and calldata from the transaction info
-        let tx_info = self
-            .get_jsonrpc_client()
-            .get_transaction_by_hash(tx_hash)
-            .await
-            .map_err(|err| StarknetClientError::Gateway(err.to_string()))?;
-
-        let (selector, calldata) = if let Transaction::Invoke(info) = tx_info {
-            match info {
-                InvokeTransaction::V0(tx_info) => (tx_info.entry_point_selector, tx_info.calldata),
-                InvokeTransaction::V1(tx_info) => {
-                    // In an invoke v1 transaction, the calldata is of the form:
-                    //      `[contract_addr, entrypoint_selector, ..calldata]`
-                    // We need to strip the first two elements to get the actual calldata
-                    let selector = tx_info.calldata[1];
-                    let calldata = tx_info.calldata[2..].to_vec();
-                    (selector, calldata)
-                }
-            }
-        } else {
-            return Err(StarknetClientError::NotFound(
-                ERR_UNEXPECTED_TX_TYPE.to_string(),
-            ));
-        };
-
-        // Parse the secret shares from the calldata
-        parse_shares_from_calldata(
-            selector,
-            &calldata,
-            scalar_to_starknet_felt(&public_blinder_share),
-        )
-    }
-
-    // ------------------------
-    // | Contract Interaction |
-    // ------------------------
-
-    // --- Getters ---
-
-    /// Check whether the given Merkle root is valid
-    pub async fn check_merkle_root_valid(
-        &self,
-        root: MerkleRoot,
-    ) -> Result<bool, StarknetClientError> {
-        // TODO: Implement BigUint on the contract
-        let reduced_root = scalar_to_starknet_felt(&root);
-        let call = FunctionCall {
-            contract_address: self.contract_address,
-            entry_point_selector: *MERKLE_ROOT_IN_HISTORY_SELECTOR,
-            calldata: vec![reduced_root],
-        };
-
-        let res = self.call_contract(call).await?;
-        Ok(res[0].eq(&StarknetFieldElement::from(1u8)))
-    }
-
-    /// Check whether the given nullifier is used
-    pub async fn check_nullifier_unused(
-        &self,
-        nullifier: Nullifier,
-    ) -> Result<bool, StarknetClientError> {
-        let reduced_nullifier = scalar_to_starknet_felt(&nullifier);
-        let call = FunctionCall {
-            contract_address: self.contract_address,
-            entry_point_selector: *NULLIFIER_USED_SELECTOR,
-            calldata: vec![reduced_nullifier],
-        };
-
-        let res = self.call_contract(call).await?;
-        Ok(res[0].eq(&StarknetFieldElement::from(0u8)))
-    }
-
-    /// Return the hash of the transaction that last indexed secret shares for
-    /// the given public blinder share
-    ///
-    /// Returns `None` if the public blinder share has not been used
-    pub async fn get_public_blinder_tx(
-        &self,
-        public_blinder_share: Scalar,
-    ) -> Result<Option<TransactionHash>, StarknetClientError> {
-        let reduced_blinder_share = scalar_to_starknet_felt(&public_blinder_share);
-        let call = FunctionCall {
-            contract_address: self.contract_address,
-            entry_point_selector: *GET_PUBLIC_BLINDER_TRANSACTION,
-            calldata: vec![reduced_blinder_share],
-        };
-
-        self.call_contract(call)
-            .await
-            .map(|call_res| call_res[0])
-            .map(|ret_val| {
-                if ret_val.eq(&StarknetFieldElement::from(0u8)) {
-                    None
-                } else {
-                    Some(ret_val)
-                }
-            })
-    }
-
-    // --- Setters ---
-
-    /// Call the `new_wallet` contract method with the given source data
-    ///
-    /// Returns the transaction hash corresponding to the `new_wallet` invocation
-    pub async fn new_wallet(
-        &self,
-        private_share_commitment: WalletShareStateCommitment,
-        public_shares: SizedWalletShare,
-        valid_wallet_create: ValidWalletCreateBundle,
-    ) -> Result<TransactionHash, StarknetClientError> {
-        assert!(
-            self.config.account_enabled(),
-            "no private key given to sign transactions with"
-        );
-
-        // Compute a commitment to the public shares
-        let wallet_share_commitment =
-            compute_wallet_commitment_from_private(public_shares.clone(), private_share_commitment);
-        let mut calldata = vec![
-            scalar_to_starknet_felt(&public_shares.blinder),
-            scalar_to_starknet_felt(&wallet_share_commitment),
-            scalar_to_starknet_felt(&private_share_commitment),
-        ];
-
-        // Pack the wallet's public shares into a list of felts
-        calldata.append(&mut pack_serializable!(public_shares));
-
-        // Pack the proof into a list of felts
-        calldata.append(&mut pack_serializable!(valid_wallet_create));
-
-        // Call the `new_wallet` contract function
-        self.execute_transaction(Call {
-            to: self.contract_address,
-            selector: *NEW_WALLET_SELECTOR,
-            calldata,
-        })
-        .await
-    }
-
-    /// Call the `update_wallet` function in the contract, passing it all the information
-    /// needed to nullify the old wallet, transition the wallet to a newly committed one,
-    /// and handle internal/external transfers
-    ///
-    /// Returns the transaction hash of the `update_wallet` call
-    #[allow(clippy::too_many_arguments)]
-    pub async fn update_wallet(
-        &self,
-        new_private_shares_commitment: WalletShareStateCommitment,
-        old_shares_nullifier: Nullifier,
-        external_transfer: Option<ExternalTransfer>,
-        new_public_shares: SizedWalletShare,
-        valid_wallet_update: ValidWalletUpdateBundle,
-    ) -> Result<TransactionHash, StarknetClientError> {
-        let new_wallet_share_commitment = compute_wallet_commitment_from_private(
-            new_public_shares.clone(),
-            new_private_shares_commitment,
-        );
-        let mut calldata = vec![
-            scalar_to_starknet_felt(&old_shares_nullifier),
-            scalar_to_starknet_felt(&new_public_shares.blinder),
-            scalar_to_starknet_felt(&new_wallet_share_commitment),
-            scalar_to_starknet_felt(&new_private_shares_commitment),
-        ];
-
-        // Add the external transfer tuple to the calldata
-        if let Some(transfer) = external_transfer {
-            calldata.push(1u8.into() /* external_transfers_len */);
-            calldata.append(&mut transfer.into());
-        } else {
-            calldata.push(0u8.into() /* external_transfers_len */);
-        }
-
-        // Append the packed wallet shares and proof of `VALID WALLET UPDATE`
-        calldata.append(&mut pack_serializable!(new_public_shares));
-        calldata.append(&mut pack_serializable!(valid_wallet_update));
-
-        // Call the `update_wallet` function in the contract
-        self.execute_transaction(Call {
-            to: self.contract_address,
-            selector: *UPDATE_WALLET_SELECTOR,
-            calldata,
-        })
-        .await
-    }
-
-    /// Submit a `match` transaction to the contract
-    ///
-    /// Returns the transaction hash of the call
-    #[allow(clippy::too_many_arguments)]
-    pub async fn submit_match(
-        &self,
-        party0_old_shares_nullifier: Nullifier,
-        party1_old_shares_nullifier: Nullifier,
-        party0_private_share_commitment: WalletShareStateCommitment,
-        party1_private_share_commitment: WalletShareStateCommitment,
-        party0_public_shares: SizedWalletShare,
-        party1_public_shares: SizedWalletShare,
-        party0_validity_proofs: OrderValidityProofBundle,
-        party1_validity_proofs: OrderValidityProofBundle,
-        valid_match_proof: ValidMatchMpcBundle,
-        valid_settle_proof: ValidSettleBundle,
-    ) -> Result<TransactionHash, StarknetClientError> {
-        // Compute commitments to both party's public shares
-        let party0_wallet_share_commitment = compute_wallet_commitment_from_private(
-            party0_public_shares.clone(),
-            party0_private_share_commitment,
-        );
-        let party1_wallet_share_commitment = compute_wallet_commitment_from_private(
-            party1_public_shares.clone(),
-            party1_private_share_commitment,
-        );
-
-        // Build the calldata
-        let mut calldata = vec![
-            scalar_to_starknet_felt(&party0_old_shares_nullifier),
-            scalar_to_starknet_felt(&party1_old_shares_nullifier),
-            scalar_to_starknet_felt(&party0_public_shares.blinder),
-            scalar_to_starknet_felt(&party1_public_shares.blinder),
-            scalar_to_starknet_felt(&party0_wallet_share_commitment),
-            scalar_to_starknet_felt(&party0_private_share_commitment),
-            scalar_to_starknet_felt(&party1_wallet_share_commitment),
-            scalar_to_starknet_felt(&party1_private_share_commitment),
-        ];
-
-        calldata.append(&mut pack_serializable!(party0_public_shares));
-        calldata.append(&mut pack_serializable!(party1_public_shares));
-        calldata.append(&mut pack_serializable!(party0_validity_proofs));
-        calldata.append(&mut pack_serializable!(party1_validity_proofs));
-        calldata.append(&mut pack_serializable!(valid_match_proof));
-        calldata.append(&mut pack_serializable!(valid_settle_proof));
-
-        // Call the contract
-        self.execute_transaction(Call {
-            to: self.contract_address,
-            selector: *MATCH_SELECTOR,
-            calldata,
-        })
-        .await
     }
 }

--- a/starknet-client/src/client/chain_state.rs
+++ b/starknet-client/src/client/chain_state.rs
@@ -1,0 +1,324 @@
+//! Defines `StarknetClient` implementations related to querying and updating the chain state
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
+
+use circuit_types::SizedWalletShare;
+use common::types::merkle::{MerkleAuthenticationPath, MerkleTreeCoords};
+use constants::MERKLE_HEIGHT;
+use mpc_stark::algebra::scalar::Scalar;
+use num_bigint::BigUint;
+use renegade_crypto::fields::{
+    scalar_to_starknet_felt, starknet_felt_to_biguint, starknet_felt_to_scalar,
+    starknet_felt_to_u64,
+};
+use starknet::{
+    accounts::{Account, Call},
+    core::types::{
+        BlockId, BlockTag, EmittedEvent, EventFilter, FieldElement as StarknetFieldElement,
+        FunctionCall, InvokeTransaction, MaybePendingTransactionReceipt, Transaction,
+        TransactionReceipt,
+    },
+    providers::Provider,
+};
+use tracing::log;
+
+use crate::{
+    client::EVENTS_PAGE_SIZE, error::StarknetClientError, helpers::parse_shares_from_calldata,
+    DEFAULT_AUTHENTICATION_PATH, INTERNAL_NODE_CHANGED_EVENT_SELECTOR,
+    VALUE_INSERTED_EVENT_SELECTOR,
+};
+
+use super::{
+    StarknetClient, TransactionHash, BLOCK_PAGINATION_WINDOW, ERR_UNEXPECTED_TX_TYPE,
+    MAX_FEE_MULTIPLIER, TX_STATUS_POLL_INTERVAL_MS,
+};
+impl StarknetClient {
+    /// Helper to make a view call to the contract
+    pub(crate) async fn call_contract(
+        &self,
+        call: FunctionCall,
+    ) -> Result<Vec<StarknetFieldElement>, StarknetClientError> {
+        self.get_jsonrpc_client()
+            .call(call, BlockId::Tag(BlockTag::Pending))
+            .await
+            .map_err(|err| StarknetClientError::Rpc(err.to_string()))
+    }
+
+    /// Helper to setup a contract call with the correct max fee and account nonce
+    pub(crate) async fn execute_transaction(
+        &self,
+        call: Call,
+    ) -> Result<TransactionHash, StarknetClientError> {
+        // Estimate the fee and add a buffer to avoid rejected transaction
+        let account_index = self.next_account_index();
+        let acct_nonce = self.pending_block_nonce(account_index).await?;
+        let execution = self
+            .get_account(account_index)
+            .execute(vec![call])
+            .nonce(acct_nonce);
+
+        let fee_estimate = execution
+            .estimate_fee()
+            .await
+            .map_err(|err| StarknetClientError::ExecuteTransaction(err.to_string()))?;
+        let max_fee = (fee_estimate.overall_fee as f32) * MAX_FEE_MULTIPLIER;
+        let max_fee = StarknetFieldElement::from(max_fee as u64);
+
+        // Send the transaction and await receipt
+        execution
+            .max_fee(max_fee)
+            .send()
+            .await
+            .map(|res| res.transaction_hash)
+            .map_err(|err| StarknetClientError::ExecuteTransaction(err.to_string()))
+    }
+
+    /// Get the current StarkNet block number
+    pub async fn get_block_number(&self) -> Result<u64, StarknetClientError> {
+        self.get_jsonrpc_client()
+            .block_number()
+            .await
+            .map_err(|err| StarknetClientError::Rpc(err.to_string()))
+    }
+
+    /// Get the nonce of the account at the provided index in the pending block
+    pub async fn pending_block_nonce(
+        &self,
+        account_index: usize,
+    ) -> Result<StarknetFieldElement, StarknetClientError> {
+        self.jsonrpc_client
+            .get_nonce(
+                BlockId::Tag(BlockTag::Pending),
+                self.get_account(account_index).address(),
+            )
+            .await
+            .map_err(|err| StarknetClientError::Rpc(err.to_string()))
+    }
+
+    /// Poll a transaction until it is finalized into the accepted on L2 state
+    #[allow(deprecated)]
+    pub async fn poll_transaction_completed(
+        &self,
+        tx_hash: StarknetFieldElement,
+    ) -> Result<TransactionReceipt, StarknetClientError> {
+        let sleep_duration = Duration::from_millis(TX_STATUS_POLL_INTERVAL_MS);
+        loop {
+            let res = self
+                .jsonrpc_client
+                .get_transaction_receipt(tx_hash)
+                .await
+                .map_err(|err| StarknetClientError::Rpc(err.to_string()))?;
+
+            // Break if the transaction has made it out of the received state
+            match res {
+                MaybePendingTransactionReceipt::PendingReceipt(_) => {
+                    log::info!("transaction 0x{tx_hash:x} pending...");
+                }
+                MaybePendingTransactionReceipt::Receipt(receipt) => {
+                    log::info!("transaction 0x{tx_hash:x} finalized",);
+
+                    return Ok(receipt);
+                }
+            }
+
+            // Sleep and poll again
+            tokio::time::sleep(sleep_duration).await;
+        }
+    }
+
+    /// Searches on-chain state for the insertion of the given wallet, then finds the most
+    /// recent updates of the path's siblings and creates a Merkle authentication path
+    pub async fn find_merkle_authentication_path(
+        &self,
+        commitment: Scalar,
+    ) -> Result<MerkleAuthenticationPath, StarknetClientError> {
+        // Find the index of the wallet in the commitment tree
+        let leaf_index = self.find_commitment_in_state(commitment).await?;
+
+        // Construct a set that holds pairs of (depth, index) values in the authentication path; i.e. the
+        // tree coordinates of the sibling nodes in the authentication path
+        let mut authentication_path_coords: HashSet<MerkleTreeCoords> =
+            MerkleAuthenticationPath::construct_path_coords(leaf_index.clone(), MERKLE_HEIGHT)
+                .into_iter()
+                .collect();
+
+        // Search for these on-chain
+        let mut found_coords: HashMap<MerkleTreeCoords, StarknetFieldElement> = HashMap::new();
+        let coords_ref = &mut found_coords;
+        self.paginate_events(
+            move |event| {
+                let height: usize = starknet_felt_to_u64(&event.data[0]) as usize;
+                let index = starknet_felt_to_biguint(&event.data[1]);
+                let new_value = event.data[2];
+
+                let coords = MerkleTreeCoords::new(height, index);
+                if authentication_path_coords.remove(&coords) {
+                    coords_ref.insert(coords, new_value);
+                }
+
+                if authentication_path_coords.is_empty() {
+                    Ok(Some(()))
+                } else {
+                    Ok(None)
+                }
+            },
+            vec![*INTERNAL_NODE_CHANGED_EVENT_SELECTOR],
+        )
+        .await?;
+
+        // Gather the coordinates found on-chain into a Merkle authentication path
+        let mut path = *DEFAULT_AUTHENTICATION_PATH;
+        for (coordinate, value) in found_coords.into_iter() {
+            let path_index = MERKLE_HEIGHT - coordinate.height;
+            path[path_index] = starknet_felt_to_scalar(&value);
+        }
+
+        Ok(MerkleAuthenticationPath::new(path, leaf_index, commitment))
+    }
+
+    /// A helper to find a commitment in the Merkle tree
+    pub async fn find_commitment_in_state(
+        &self,
+        commitment: Scalar,
+    ) -> Result<BigUint, StarknetClientError> {
+        let commitment_starknet_felt = scalar_to_starknet_felt(&commitment);
+
+        log::info!(
+            "searching for commitment: 0x{:x}",
+            starknet_felt_to_biguint(&commitment_starknet_felt)
+        );
+
+        // Paginate through events in the contract, searching for the Merkle tree insertion event that
+        // corresponds to the given commitment
+        //
+        // Return the Merkle leaf index at which the commitment was inserted
+        self.paginate_events(
+            |event| {
+                let index = event.data[0];
+                let value = event.data[1];
+
+                if value == commitment_starknet_felt {
+                    return Ok(Some(starknet_felt_to_biguint(&index)));
+                }
+
+                Ok(None)
+            },
+            vec![*VALUE_INSERTED_EVENT_SELECTOR],
+        )
+        .await?
+        .ok_or_else(|| {
+            StarknetClientError::NotFound("commitment not found in Merkle tree".to_string())
+        })
+    }
+
+    /// A helper for paginating backwards in block history over contract events
+    ///
+    /// Calls the handler on each event, which indicates whether the pagination should
+    /// stop, and gives a response value
+    async fn paginate_events<T>(
+        &self,
+        mut handler: impl FnMut(EmittedEvent) -> Result<Option<T>, StarknetClientError>,
+        event_keys: Vec<StarknetFieldElement>,
+    ) -> Result<Option<T>, StarknetClientError> {
+        // Build the event filter template
+        let current_block = self.get_block_number().await?;
+        let mut filter = EventFilter {
+            from_block: None,
+            to_block: None,
+            address: Some(self.contract_address),
+            keys: if event_keys.is_empty() {
+                None
+            } else {
+                Some(vec![event_keys])
+            },
+        };
+
+        // Paginate backwards in block history
+        let earliest_block = self.config.earliest_block();
+        'outer: for end_block in (earliest_block..current_block)
+            .rev()
+            .step_by(BLOCK_PAGINATION_WINDOW)
+        {
+            // Exhaust events from the start block to the end block
+            let start_block = end_block.saturating_sub(BLOCK_PAGINATION_WINDOW as u64);
+            filter.from_block = Some(BlockId::Number(start_block));
+            filter.to_block = Some(BlockId::Number(end_block));
+
+            // Keep paging until the response includes no token
+            let mut pagination_token = None;
+            'inner: loop {
+                // Fetch the next page of events
+                let res = self
+                    .get_jsonrpc_client()
+                    .get_events(filter.clone(), pagination_token.clone(), EVENTS_PAGE_SIZE)
+                    .await
+                    .map_err(|err| StarknetClientError::Rpc(err.to_string()))?;
+
+                // Process each event with the handler
+                for event in res.events.into_iter() {
+                    if let Some(ret_val) = handler(event)? {
+                        return Ok(Some(ret_val));
+                    }
+                }
+
+                if res.continuation_token.is_none() {
+                    break 'inner;
+                }
+                pagination_token = res.continuation_token;
+            }
+
+            // If we are already at the genesis block, stop searching
+            if start_block == 0 {
+                break 'outer;
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Fetch and parse the public secret shares from the calldata of the given transactions
+    ///
+    /// In the case that the referenced transaction is a `match`, we disambiguate between the
+    /// two parties by adding the public blinder of the party's shares the caller intends to fetch
+    #[allow(deprecated)]
+    pub async fn fetch_public_shares_from_tx(
+        &self,
+        public_blinder_share: Scalar,
+        tx_hash: TransactionHash,
+    ) -> Result<SizedWalletShare, StarknetClientError> {
+        // Parse the selector and calldata from the transaction info
+        let tx_info = self
+            .get_jsonrpc_client()
+            .get_transaction_by_hash(tx_hash)
+            .await
+            .map_err(|err| StarknetClientError::Rpc(err.to_string()))?;
+
+        let (selector, calldata) = if let Transaction::Invoke(info) = tx_info {
+            match info {
+                InvokeTransaction::V0(tx_info) => (tx_info.entry_point_selector, tx_info.calldata),
+                InvokeTransaction::V1(tx_info) => {
+                    // In an invoke v1 transaction, the calldata is of the form:
+                    //      `[contract_addr, entrypoint_selector, ..calldata]`
+                    // We need to strip the first two elements to get the actual calldata
+                    let selector = tx_info.calldata[1];
+                    let calldata = tx_info.calldata[2..].to_vec();
+                    (selector, calldata)
+                }
+            }
+        } else {
+            return Err(StarknetClientError::NotFound(
+                ERR_UNEXPECTED_TX_TYPE.to_string(),
+            ));
+        };
+
+        // Parse the secret shares from the calldata
+        parse_shares_from_calldata(
+            selector,
+            &calldata,
+            scalar_to_starknet_felt(&public_blinder_share),
+        )
+    }
+}

--- a/starknet-client/src/client/contract_interaction.rs
+++ b/starknet-client/src/client/contract_interaction.rs
@@ -1,0 +1,265 @@
+//! Defines `StarknetClient` helpers that allow for interacting with the `darkpool` contract
+
+use circuit_types::merkle::MerkleRoot;
+use circuit_types::native_helpers::compute_wallet_commitment_from_private;
+use circuit_types::traits::BaseType;
+use circuit_types::traits::CircuitCommitmentType;
+use circuit_types::wallet::Nullifier;
+use circuit_types::wallet::WalletShareStateCommitment;
+use circuit_types::SizedWalletShare;
+use common::types::proof_bundles::OrderValidityProofBundle;
+use common::types::proof_bundles::ValidMatchMpcBundle;
+use common::types::proof_bundles::ValidSettleBundle;
+use common::types::proof_bundles::ValidWalletCreateBundle;
+use common::types::proof_bundles::ValidWalletUpdateBundle;
+use mpc_stark::algebra::scalar::Scalar;
+use renegade_crypto::fields::scalar_to_starknet_felt;
+use starknet::accounts::Call;
+use starknet::core::types::FieldElement as StarknetFieldElement;
+use starknet::core::types::FunctionCall;
+
+use crate::types::CalldataSerializable;
+use crate::types::ExternalTransfer;
+use crate::types::MatchPayload;
+use crate::GET_PUBLIC_BLINDER_TRANSACTION;
+use crate::MATCH_SELECTOR;
+use crate::NEW_WALLET_SELECTOR;
+use crate::NULLIFIER_USED_SELECTOR;
+use crate::UPDATE_WALLET_SELECTOR;
+use crate::{error::StarknetClientError, MERKLE_ROOT_IN_HISTORY_SELECTOR};
+
+use super::StarknetClient;
+use super::TransactionHash;
+
+impl StarknetClient {
+    // --- Getters ---
+
+    /// Check whether the given Merkle root is valid
+    pub async fn check_merkle_root_valid(
+        &self,
+        root: MerkleRoot,
+    ) -> Result<bool, StarknetClientError> {
+        let root = scalar_to_starknet_felt(&root);
+        let call = FunctionCall {
+            contract_address: self.contract_address,
+            entry_point_selector: *MERKLE_ROOT_IN_HISTORY_SELECTOR,
+            calldata: vec![root],
+        };
+
+        let res = self.call_contract(call).await?;
+        Ok(res[0].eq(&StarknetFieldElement::from(1u8)))
+    }
+
+    /// Check whether the given nullifier is used
+    pub async fn check_nullifier_unused(
+        &self,
+        nullifier: Nullifier,
+    ) -> Result<bool, StarknetClientError> {
+        let reduced_nullifier = scalar_to_starknet_felt(&nullifier);
+        let call = FunctionCall {
+            contract_address: self.contract_address,
+            entry_point_selector: *NULLIFIER_USED_SELECTOR,
+            calldata: vec![reduced_nullifier],
+        };
+
+        let res = self.call_contract(call).await?;
+        Ok(res[0].eq(&StarknetFieldElement::from(0u8)))
+    }
+
+    /// Return the hash of the transaction that last indexed secret shares for
+    /// the given public blinder share
+    ///
+    /// Returns `None` if the public blinder share has not been used
+    pub async fn get_public_blinder_tx(
+        &self,
+        public_blinder_share: Scalar,
+    ) -> Result<Option<TransactionHash>, StarknetClientError> {
+        let reduced_blinder_share = scalar_to_starknet_felt(&public_blinder_share);
+        let call = FunctionCall {
+            contract_address: self.contract_address,
+            entry_point_selector: *GET_PUBLIC_BLINDER_TRANSACTION,
+            calldata: vec![reduced_blinder_share],
+        };
+
+        self.call_contract(call)
+            .await
+            .map(|call_res| call_res[0])
+            .map(|ret_val| {
+                if ret_val.eq(&StarknetFieldElement::from(0u8)) {
+                    None
+                } else {
+                    Some(ret_val)
+                }
+            })
+    }
+
+    // --- Setters --- //
+
+    /// Call the `new_wallet` contract method with the given source data
+    ///
+    /// Returns the transaction hash corresponding to the `new_wallet` invocation
+    pub async fn new_wallet(
+        &self,
+        private_share_commitment: WalletShareStateCommitment,
+        public_shares: SizedWalletShare,
+        valid_wallet_create: ValidWalletCreateBundle,
+    ) -> Result<TransactionHash, StarknetClientError> {
+        assert!(
+            self.config.account_enabled(),
+            "no private key given to sign transactions with"
+        );
+
+        // Compute a commitment to the public shares
+        let wallet_share_commitment =
+            compute_wallet_commitment_from_private(public_shares.clone(), private_share_commitment);
+
+        // Build the calldata
+        let mut calldata = public_shares.blinder.to_calldata();
+        calldata.extend(wallet_share_commitment.to_calldata());
+        calldata.extend(public_shares.to_scalars().to_calldata());
+        calldata.extend(valid_wallet_create.proof.to_calldata());
+        calldata.extend(
+            valid_wallet_create
+                .commitment
+                .to_commitments()
+                .to_calldata(),
+        );
+
+        // Call the `new_wallet` contract function
+        self.execute_transaction(Call {
+            to: self.contract_address,
+            selector: *NEW_WALLET_SELECTOR,
+            calldata,
+        })
+        .await
+    }
+
+    /// Call the `update_wallet` function in the contract, passing it all the information
+    /// needed to nullify the old wallet, transition the wallet to a newly committed one,
+    /// and handle internal/external transfers
+    ///
+    /// Returns the transaction hash of the `update_wallet` call
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_wallet(
+        &self,
+        new_private_shares_commitment: WalletShareStateCommitment,
+        old_shares_nullifier: Nullifier,
+        external_transfer: Option<ExternalTransfer>,
+        new_public_shares: SizedWalletShare,
+        valid_wallet_update: ValidWalletUpdateBundle,
+    ) -> Result<TransactionHash, StarknetClientError> {
+        let new_wallet_share_commitment = compute_wallet_commitment_from_private(
+            new_public_shares.clone(),
+            new_private_shares_commitment,
+        );
+
+        // Build the calldata
+        let mut calldata = new_public_shares.blinder.to_calldata();
+        calldata.extend(new_wallet_share_commitment.to_calldata());
+        calldata.extend(old_shares_nullifier.to_calldata());
+        calldata.extend(new_public_shares.to_scalars().to_calldata());
+
+        // Add the external transfer tuple to the calldata
+        if let Some(transfer) = external_transfer {
+            calldata.push(1u8.into() /* external_transfers_len */);
+            calldata.extend(transfer.to_calldata());
+        } else {
+            calldata.push(0u8.into() /* external_transfers_len */);
+        }
+
+        calldata.extend(valid_wallet_update.proof.to_calldata());
+        calldata.extend(
+            valid_wallet_update
+                .commitment
+                .to_commitments()
+                .to_calldata(),
+        );
+
+        // Call the `update_wallet` function in the contract
+        self.execute_transaction(Call {
+            to: self.contract_address,
+            selector: *UPDATE_WALLET_SELECTOR,
+            calldata,
+        })
+        .await
+    }
+
+    /// Submit a `match` transaction to the contract
+    ///
+    /// Returns the transaction hash of the call
+    #[allow(clippy::too_many_arguments)]
+    pub async fn submit_match(
+        &self,
+        party0_old_shares_nullifier: Nullifier,
+        party1_old_shares_nullifier: Nullifier,
+        party0_private_share_commitment: WalletShareStateCommitment,
+        party1_private_share_commitment: WalletShareStateCommitment,
+        party0_public_shares: SizedWalletShare,
+        party1_public_shares: SizedWalletShare,
+        party0_validity_proofs: OrderValidityProofBundle,
+        party1_validity_proofs: OrderValidityProofBundle,
+        valid_match_proof: ValidMatchMpcBundle,
+        valid_settle_proof: ValidSettleBundle,
+    ) -> Result<TransactionHash, StarknetClientError> {
+        // Compute commitments to both party's public shares
+        let party0_wallet_share_commitment = compute_wallet_commitment_from_private(
+            party0_public_shares.clone(),
+            party0_private_share_commitment,
+        );
+        let party1_wallet_share_commitment = compute_wallet_commitment_from_private(
+            party1_public_shares.clone(),
+            party1_private_share_commitment,
+        );
+
+        // Construct the match payloads for each party
+        let party0_match_payload = MatchPayload {
+            wallet_blinder_share: party0_public_shares.blinder,
+            old_shares_nullifier: party0_old_shares_nullifier,
+            wallet_share_commitment: party0_wallet_share_commitment,
+            public_wallet_shares: party0_public_shares.to_scalars(),
+            valid_commitments_proof: party0_validity_proofs.commitment_proof.proof.clone(),
+            valid_commitments_witness_commitments: party0_validity_proofs
+                .commitment_proof
+                .commitment
+                .to_commitments(),
+            valid_reblind_proof: party0_validity_proofs.reblind_proof.proof.clone(),
+            valid_reblind_witness_commitments: party0_validity_proofs
+                .reblind_proof
+                .commitment
+                .to_commitments(),
+        };
+
+        let party1_match_payload = MatchPayload {
+            wallet_blinder_share: party1_public_shares.blinder,
+            old_shares_nullifier: party1_old_shares_nullifier,
+            wallet_share_commitment: party1_wallet_share_commitment,
+            public_wallet_shares: party1_public_shares.to_scalars(),
+            valid_commitments_proof: party1_validity_proofs.commitment_proof.proof.clone(),
+            valid_commitments_witness_commitments: party1_validity_proofs
+                .commitment_proof
+                .commitment
+                .to_commitments(),
+            valid_reblind_proof: party1_validity_proofs.reblind_proof.proof.clone(),
+            valid_reblind_witness_commitments: party1_validity_proofs
+                .reblind_proof
+                .commitment
+                .to_commitments(),
+        };
+
+        // Build the calldata
+        let mut calldata = party0_match_payload.to_calldata();
+        calldata.extend(party1_match_payload.to_calldata());
+        calldata.extend(valid_match_proof.proof.to_calldata());
+        calldata.extend(valid_match_proof.commitment.to_commitments().to_calldata());
+        calldata.extend(valid_settle_proof.proof.to_calldata());
+        calldata.extend(valid_settle_proof.commitment.to_commitments().to_calldata());
+
+        // Call the contract
+        self.execute_transaction(Call {
+            to: self.contract_address,
+            selector: *MATCH_SELECTOR,
+            calldata,
+        })
+        .await
+    }
+}

--- a/starknet-client/src/error.rs
+++ b/starknet-client/src/error.rs
@@ -8,8 +8,6 @@ use std::fmt::Display;
 pub enum StarknetClientError {
     /// An error executing a transaction
     ExecuteTransaction(String),
-    /// An error performing a request against the sequencer gateway
-    Gateway(String),
     /// No value was found when scanning contract state
     NotFound(String),
     /// An error performing a JSON-RPC request

--- a/starknet-client/src/helpers.rs
+++ b/starknet-client/src/helpers.rs
@@ -1,9 +1,8 @@
 //! Various helpers for Starknet client execution
 
-use std::{convert::TryInto, iter};
+use std::convert::TryInto;
 
 use circuit_types::SizedWalletShare;
-use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use starknet::core::types::FieldElement as StarknetFieldElement;
 
@@ -119,33 +118,6 @@ fn parse_shares_from_match(
     };
 
     Ok(calldata[start_idx..end_idx].to_vec())
-}
-
-/// Pack bytes into Starknet field elements
-pub(super) fn pack_bytes_into_felts(bytes: &[u8]) -> Vec<StarknetFieldElement> {
-    // Run-length encoded
-    let mut res = vec![StarknetFieldElement::from(bytes.len() as u64)];
-    for i in (0..bytes.len()).step_by(BYTES_PER_FELT) {
-        // Construct a felt from bytes [i..i+BYTES_PER_FELT], padding
-        // to 32 in length
-        let range_end = usize::min(i + BYTES_PER_FELT, bytes.len());
-        let mut bytes_padded: Vec<u8> = bytes[i..range_end]
-            .iter()
-            .cloned()
-            .chain(iter::repeat(0u8))
-            .take(32)
-            .collect_vec();
-
-        // We pack into the felt in little endian format so that the felt does
-        // not overflow the field size
-        bytes_padded.reverse();
-
-        // Cast to array
-        let bytes_padded: [u8; 32] = bytes_padded.try_into().unwrap();
-        res.push(StarknetFieldElement::from_bytes_be(&bytes_padded).unwrap());
-    }
-
-    res
 }
 
 /// Unpack bytes that were previously packed into felts

--- a/starknet-client/src/lib.rs
+++ b/starknet-client/src/lib.rs
@@ -36,7 +36,7 @@ lazy_static! {
     static ref NULLIFIER_USED_SELECTOR: StarknetFieldElement = get_selector_from_name("is_nullifier_used")
         .unwrap();
     /// Contract view function selector to fetch the hash of the transaction that indexed a given public blinder share
-    static ref GET_PUBLIC_BLINDER_TRANSACTION: StarknetFieldElement = get_selector_from_name("get_public_blinder_transaction")
+    static ref GET_PUBLIC_BLINDER_TRANSACTION: StarknetFieldElement = get_selector_from_name("get_wallet_blinder_transaction")
         .unwrap();
 
     // -- Setters --
@@ -48,18 +48,15 @@ lazy_static! {
     static ref UPDATE_WALLET_SELECTOR: StarknetFieldElement = get_selector_from_name("update_wallet")
         .unwrap();
     /// Contract function selector to submit a match, encumbering two wallets
-    static ref MATCH_SELECTOR: StarknetFieldElement = get_selector_from_name("match")
-        .unwrap();
-    /// Contract function selector to settle a note into a wallet
-    static ref SETTLE_SELECTOR: StarknetFieldElement = get_selector_from_name("settle")
+    static ref MATCH_SELECTOR: StarknetFieldElement = get_selector_from_name("process_match")
         .unwrap();
 
     /// The event selector for internal node changes
     pub static ref INTERNAL_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement =
-        get_selector_from_name("Merkle_internal_node_changed").unwrap();
+        get_selector_from_name("MerkleInternalNodeChanged").unwrap();
     /// The event selector for Merkle value insertion
     pub static ref VALUE_INSERTED_EVENT_SELECTOR: StarknetFieldElement =
-        get_selector_from_name("Merkle_value_inserted").unwrap();
+        get_selector_from_name("MerkleValueInserted").unwrap();
 
     // ------------------------
     // | Merkle Tree Metadata |

--- a/starknet-client/src/types.rs
+++ b/starknet-client/src/types.rs
@@ -3,14 +3,20 @@
 use std::{
     convert::TryInto,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
+    iter,
 };
 
+use ark_ff::{BigInteger, PrimeField};
 use circuit_types::transfers::{
     ExternalTransfer as CircuitExternalTransfer, ExternalTransferDirection,
 };
 use lazy_static::lazy_static;
+use mpc_bulletproof::r1cs::R1CSProof;
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
 use num_bigint::BigUint;
-use renegade_crypto::fields::{biguint_to_starknet_felt, u128_to_starknet_felt};
+use renegade_crypto::fields::{
+    biguint_to_starknet_felt, scalar_to_starknet_felt, u128_to_starknet_felt,
+};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement as StarknetFieldElement;
 
@@ -78,6 +84,28 @@ impl From<ExternalTransfer> for Vec<StarknetFieldElement> {
     }
 }
 
+/// A single party's state validity proof bundle used as input to the matching engine
+/// and forwarded to the contract for verification
+#[derive(Clone)]
+pub struct MatchPayload {
+    /// The public share of the new wallet's blinder
+    pub wallet_blinder_share: Scalar,
+    /// The nullifier of the old shares before reblinding
+    pub old_shares_nullifier: Scalar,
+    /// The commitment to the new wallet's private shares
+    pub wallet_share_commitment: Scalar,
+    /// The public shares of the new, reblinded wallet
+    pub public_wallet_shares: Vec<Scalar>,
+    /// The proof of `VALID COMMITMENTS` for the new wallet
+    pub valid_commitments_proof: R1CSProof,
+    /// The commitments to the witness data for the `VALID COMMITMENTS` proof
+    pub valid_commitments_witness_commitments: Vec<StarkPoint>,
+    /// The proof of `VALID REBLIND` for the new wallet
+    pub valid_reblind_proof: R1CSProof,
+    /// The commitments to the witness data for the `VALID REBLIND` proof
+    pub valid_reblind_witness_commitments: Vec<StarkPoint>,
+}
+
 /// Represents the U256 type in Starknet
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct StarknetU256 {
@@ -125,5 +153,159 @@ impl From<StarknetU256> for Vec<StarknetFieldElement> {
         let high_felt = u128_to_starknet_felt(val.high);
 
         vec![low_felt, high_felt]
+    }
+}
+
+// --------------------------
+// | Calldata Serialization |
+// --------------------------
+
+/// Implementing types may be serialized into `Starknet` calldata, i.e. a vector of `FieldElement`s
+///
+/// Borrowed from https://github.com/renegade-fi/renegade-contracts/blob/main/tests/src/utils.rs#L357
+pub trait CalldataSerializable {
+    /// Serializes the type into a vector of `FieldElement`s
+    fn to_calldata(&self) -> Vec<StarknetFieldElement>;
+}
+
+impl CalldataSerializable for Scalar {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        vec![scalar_to_starknet_felt(self)]
+    }
+}
+
+impl CalldataSerializable for Vec<Scalar> {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        // Prepend the length to the result
+        let mut calldata = vec![StarknetFieldElement::from(self.len())];
+        calldata.extend(self.iter().flat_map(|s| s.to_calldata()));
+
+        calldata
+    }
+}
+
+impl CalldataSerializable for BigUint {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        vec![biguint_to_starknet_felt(self)]
+    }
+}
+
+impl CalldataSerializable for StarkPoint {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        if self.is_identity() {
+            vec![StarknetFieldElement::ZERO, StarknetFieldElement::ZERO]
+        } else {
+            let aff = self.to_affine();
+            let x_bytes = aff.x.into_bigint().to_bytes_be();
+            let y_bytes = aff.y.into_bigint().to_bytes_be();
+            vec![
+                StarknetFieldElement::from_byte_slice_be(&x_bytes).unwrap(),
+                StarknetFieldElement::from_byte_slice_be(&y_bytes).unwrap(),
+            ]
+        }
+    }
+}
+
+impl CalldataSerializable for Vec<StarkPoint> {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        // Prepend the length
+        let mut calldata = vec![StarknetFieldElement::from(self.len())];
+        calldata.extend(self.iter().flat_map(|p| p.to_calldata()));
+
+        calldata
+    }
+}
+
+impl CalldataSerializable for StarknetU256 {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        vec![
+            StarknetFieldElement::from(self.low),
+            StarknetFieldElement::from(self.high),
+        ]
+    }
+}
+
+impl CalldataSerializable for R1CSProof {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        [
+            self.A_I1, self.A_O1, self.S1, self.T_1, self.T_3, self.T_4, self.T_5, self.T_6,
+        ]
+        .iter()
+        .flat_map(|p| p.to_calldata())
+        .chain(
+            [self.t_x, self.t_x_blinding, self.e_blinding]
+                .iter()
+                .map(scalar_to_starknet_felt),
+        )
+        .chain(iter::once(StarknetFieldElement::from(
+            self.ipp_proof.L_vec.len(),
+        )))
+        .chain(self.ipp_proof.L_vec.iter().flat_map(|p| p.to_calldata()))
+        .chain(iter::once(StarknetFieldElement::from(
+            self.ipp_proof.R_vec.len(),
+        )))
+        .chain(self.ipp_proof.R_vec.iter().flat_map(|p| p.to_calldata()))
+        .chain(
+            [self.ipp_proof.a, self.ipp_proof.b]
+                .iter()
+                .map(scalar_to_starknet_felt),
+        )
+        .collect()
+    }
+}
+
+impl CalldataSerializable for ExternalTransferDirection {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        vec![StarknetFieldElement::from(*self as u8)]
+    }
+}
+
+impl CalldataSerializable for ExternalTransfer {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        let mut calldata = self.sender_address.to_calldata();
+        calldata.extend(self.mint.to_calldata());
+        calldata.extend(self.amount.to_calldata());
+        calldata.extend(self.direction.to_calldata());
+
+        calldata
+    }
+}
+
+impl CalldataSerializable for MatchPayload {
+    fn to_calldata(&self) -> Vec<StarknetFieldElement> {
+        [
+            self.wallet_blinder_share,
+            self.old_shares_nullifier,
+            self.wallet_share_commitment,
+        ]
+        .iter()
+        .map(scalar_to_starknet_felt)
+        .chain(iter::once(StarknetFieldElement::from(
+            self.public_wallet_shares.len(),
+        )))
+        .chain(
+            self.public_wallet_shares
+                .iter()
+                .map(scalar_to_starknet_felt),
+        )
+        .chain(self.valid_commitments_proof.to_calldata().into_iter())
+        .chain(iter::once(StarknetFieldElement::from(
+            self.valid_commitments_witness_commitments.len(),
+        )))
+        .chain(
+            self.valid_commitments_witness_commitments
+                .iter()
+                .flat_map(|p| p.to_calldata()),
+        )
+        .chain(self.valid_reblind_proof.to_calldata().into_iter())
+        .chain(iter::once(StarknetFieldElement::from(
+            self.valid_reblind_witness_commitments.len(),
+        )))
+        .chain(
+            self.valid_reblind_witness_commitments
+                .iter()
+                .flat_map(|p| p.to_calldata()),
+        )
+        .collect()
     }
 }

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -117,10 +117,9 @@ impl From<CliArgs> for IntegrationTestArgs {
 
         // Build a client that references the darkpool
         let starknet_client = StarknetClient::new(StarknetClientConfig {
-            chain: ChainId::Devnet,
+            chain: ChainId::Katana,
             contract_addr: darkpool_addr,
-            starknet_json_rpc_addr: Some(format!("{}/rpc", test_args.devnet_url)),
-            sequencer_addr: Some(test_args.devnet_url),
+            starknet_json_rpc_addr: format!("{}/rpc", test_args.devnet_url),
             infura_api_key: None,
             starknet_account_addresses: vec![test_args.starknet_account_addr],
             starknet_pkeys: vec![test_args.starknet_pkey],

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -3,7 +3,10 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use crate::{helpers::{apply_match_to_wallets, update_wallet_validity_proofs}, settle_match::NULLIFIER_USED_ERROR_MSG};
+use crate::{
+    helpers::{apply_match_to_wallets, update_wallet_validity_proofs},
+    settle_match::NULLIFIER_USED_ERROR_MSG,
+};
 
 use super::{
     driver::{StateWrapper, Task},
@@ -374,15 +377,15 @@ impl SettleMatchInternalTask {
             )
             .await;
 
-        if let Err(ref tx_rejection) = tx_submit_res 
+        if let Err(ref tx_rejection) = tx_submit_res
             && tx_rejection.to_string().contains(NULLIFIER_USED_ERROR_MSG)
         {
             return Ok(());
         }
-        let tx_hash = tx_submit_res.map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
+        let tx_hash =
+            tx_submit_res.map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
 
-         self
-            .starknet_client
+        self.starknet_client
             .poll_transaction_completed(tx_hash)
             .await
             .map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;

--- a/test-helpers/src/contracts.rs
+++ b/test-helpers/src/contracts.rs
@@ -11,7 +11,7 @@ use starknet::contract::ContractFactory;
 use starknet::core::chain_id;
 use starknet::core::crypto::compute_hash_on_elements;
 use starknet::core::types::{
-    MaybePendingTransactionReceipt, TransactionReceipt, TransactionStatus,
+    MaybePendingTransactionReceipt, TransactionFinalityStatus, TransactionReceipt,
 };
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
@@ -235,7 +235,8 @@ fn calculate_contract_address(
 async fn await_transaction(tx_hash: FieldElement, rpc_client: &StarknetTestAcct) -> Result<()> {
     log::info!("Awaiting transaction {tx_hash:?}");
     loop {
-        if let TransactionStatus::AcceptedOnL2 = get_transaction_status(tx_hash, rpc_client).await?
+        if let TransactionFinalityStatus::AcceptedOnL2 =
+            get_transaction_status(tx_hash, rpc_client).await?
         {
             break;
         }
@@ -249,7 +250,7 @@ async fn await_transaction(tx_hash: FieldElement, rpc_client: &StarknetTestAcct)
 async fn get_transaction_status(
     tx_hash: FieldElement,
     rpc_client: &StarknetTestAcct,
-) -> Result<TransactionStatus> {
+) -> Result<TransactionFinalityStatus> {
     let tx_receipt = rpc_client
         .provider()
         .get_transaction_receipt(tx_hash)
@@ -259,9 +260,9 @@ async fn get_transaction_status(
             return Err(eyre!("Transaction is still pending: {:?}", receipt));
         }
         MaybePendingTransactionReceipt::Receipt(receipt) => match receipt {
-            TransactionReceipt::Invoke(tx) => tx.status,
-            TransactionReceipt::Declare(tx) => tx.status,
-            TransactionReceipt::Deploy(tx) => tx.status,
+            TransactionReceipt::Invoke(tx) => tx.finality_status,
+            TransactionReceipt::Declare(tx) => tx.finality_status,
+            TransactionReceipt::Deploy(tx) => tx.finality_status,
             _ => {
                 return Err(eyre!(
                     "Transaction receipt is not an invoke, declare, or deploy receipt"

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -260,16 +260,15 @@ impl OnChainEventListenerExecutor {
 
             // Skip this event if all Merkle events for this block have been consumed
             let last_consistent_block = self.merkle_last_consistent_block.load(Ordering::Relaxed);
-            let event_block = event.block_number.unwrap_or(last_consistent_block);
-            if event_block <= last_consistent_block {
+            if event.block_number <= last_consistent_block {
                 return Ok(());
             }
 
-            self.handle_root_changed(event_block).await?;
+            self.handle_root_changed(event.block_number).await?;
 
             // Update the last consistent block
             self.merkle_last_consistent_block
-                .store(event_block, Ordering::Relaxed);
+                .store(event.block_number, Ordering::Relaxed);
         } else if key == *NULLIFIER_SPENT_EVENT_SELECTOR {
             // Parse the nullifier from the felt
             log::info!("Handling nullifier spent event");

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -87,14 +87,6 @@ pub struct OnChainEventListenerConfig {
     pub cancel_channel: CancelChannel,
 }
 
-impl OnChainEventListenerConfig {
-    /// Determines whether the parameters needed to enable the on-chain event
-    /// listener are present. If not the worker should not startup
-    pub fn enabled(&self) -> bool {
-        self.starknet_client.jsonrpc_enabled()
-    }
-}
-
 /// The worker responsible for listening for on-chain events, translating them to jobs for
 /// other workers, and forwarding these jobs to the relevant workers
 pub struct OnChainEventListener {


### PR DESCRIPTION
### Purpose
This PR updates the `starknet-client` to match the Cairo 1 contracts that are now deployed. This involves:
- Updating the `starknet` dependency to target `0.5` and inheriting all the library changes that come along with that. Notably the removal of the pending block from most interfaces.
- Updating selectors for changed names in the new contracts
- Refactoring the `starknet-client` to aid discoverability now that the code size has grown

### Testing
- Existing tests pass
- I will add integration tests for the client in a follow up