### PR TITLE
circuits: mpc-circuits: match: Take commitment linked orders directly

### DIFF
--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -186,7 +186,7 @@ pub struct AuthenticatedLinkableCommitment {
     /// The underlying shared scalar
     pub(crate) val: AuthenticatedScalarResult,
     /// The randomness used to blind the commitment
-    pub(crate) randomness: AuthenticatedScalarResult,
+    randomness: AuthenticatedScalarResult,
 }
 
 impl AuthenticatedLinkableCommitment {
@@ -194,6 +194,11 @@ impl AuthenticatedLinkableCommitment {
     /// blinder
     pub fn new(val: AuthenticatedScalarResult, randomness: AuthenticatedScalarResult) -> Self {
         Self { val, randomness }
+    }
+
+    /// Get the underlying value of the commitment
+    pub fn value(&self) -> &AuthenticatedScalarResult {
+        &self.val
     }
 }
 

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -87,8 +87,8 @@ pub fn bench_match_mpc_with_delay(c: &mut Criterion, delay: Duration) {
                     |fabric| async move {
                         // Allocate the inputs in the fabric
                         let start = Instant::now();
-                        let o1 = Order::default().allocate(PARTY0, &fabric);
-                        let o2 = Order::default().allocate(PARTY1, &fabric);
+                        let o1 = Order::default().to_linkable().allocate(PARTY0, &fabric);
+                        let o2 = Order::default().to_linkable().allocate(PARTY1, &fabric);
                         let amount1 = Scalar::one().allocate(PARTY0, &fabric);
                         let amount2 = Scalar::one().allocate(PARTY1, &fabric);
                         let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);

--- a/circuits/src/mpc_circuits/match.rs
+++ b/circuits/src/mpc_circuits/match.rs
@@ -1,7 +1,7 @@
 //! Groups logic related to the match computation circuit
 
 use circuit_types::{
-    fixed_point::AuthenticatedFixedPoint, order::AuthenticatedOrder,
+    fixed_point::AuthenticatedFixedPoint, order::AuthenticatedLinkableOrder,
     r#match::AuthenticatedMatchResult, AMOUNT_BITS,
 };
 use mpc_stark::{
@@ -21,8 +21,8 @@ use crate::mpc_gadgets::{comparators::min, fixed_point::FixedPointMpcGadget};
 /// never be opened, and the information never leaked. Therefore, we do not need to zero
 /// out any values in the circuit.
 pub fn compute_match(
-    order1: &AuthenticatedOrder,
-    order2: &AuthenticatedOrder,
+    order1: &AuthenticatedLinkableOrder,
+    order2: &AuthenticatedLinkableOrder,
     amount1: &AuthenticatedScalarResult,
     amount2: &AuthenticatedScalarResult,
     price: &AuthenticatedFixedPoint,
@@ -33,7 +33,7 @@ pub fn compute_match(
 
     // The maximum of the two amounts minus the minimum of the two amounts
     let max_minus_min_amount =
-        &order1.amount + &order2.amount - Scalar::from(2u64) * &min_base_amount;
+        order1.amount.value() + order2.amount.value() - Scalar::from(2u64) * &min_base_amount;
 
     // The amount of quote token exchanged
     // Round down to the nearest integer value
@@ -42,11 +42,11 @@ pub fn compute_match(
 
     // Zero out the orders if any of the initial checks failed
     AuthenticatedMatchResult {
-        quote_mint: order1.quote_mint.clone(),
-        base_mint: order1.base_mint.clone(),
+        quote_mint: order1.quote_mint.value().clone(),
+        base_mint: order1.base_mint.value().clone(),
         quote_amount: quote_exchanged,
         base_amount: min_base_amount,
-        direction: order1.side.clone(),
+        direction: order1.side.value().clone(),
         max_minus_min_amount,
         min_amount_order_index: min_index,
     }


### PR DESCRIPTION
### Purpose
This PR restructures the `match` MPC circuit to take `AuthenticatedLinkableOrder` types directly instead of the un-linked `AuthenticatedOrder` types. this allows us to avoid re-allocation at MPC time (once for the linkable type and once for the un-linked type) and instead use the same, pre-allocated types across both the `match` MPC and the collaborative proof of `VALID MATCH MPC`.

### Testing
- Unit and integration tests pass