### PR TITLE
starknet-client: integration: Add integration test skeleton

### DIFF
--- a/starknet-client/Cargo.toml
+++ b/starknet-client/Cargo.toml
@@ -3,7 +3,10 @@ name = "starknet-client"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[test]]
+name = "integration"
+path = "integration/main.rs"
+harness = false
 
 [dependencies]
 # === Cryptographic + arithmetic dependencies === #
@@ -31,3 +34,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
+
+[dev-dependencies]
+clap = { version = "4.0", features = ["derive"] }
+colored = "2"
+eyre = { workspace = true }
+inventory = "0.3"
+
+rand = { workspace = true }
+
+test-helpers = { path = "../test-helpers" }
+util = { path = "../util" }

--- a/starknet-client/Dockerfile
+++ b/starknet-client/Dockerfile
@@ -1,10 +1,10 @@
 # Build a set of sources that are used to build a dependency cache for the main
 # integration tests. We effectively copy all the sources and then remove the target
-# directory. This means that changes to `task-driver` sources will invalidate the
+# directory. This means that changes to `starknet-client` sources will invalidate the
 # cache for this stage only, as the end state is the same
 FROM alpine AS sources
 COPY . .
-RUN rm -rf task-driver
+RUN rm -rf starknet-client
 
 # Rust build stage
 FROM rust:1.63-slim-buster AS builder
@@ -16,8 +16,8 @@ RUN apt-get update && \
 
 # Build the rust toolchain before adding any dependencies; this is the slowest
 # step and we would like to cache it before anything else
-COPY ./rust-toolchain ./task-driver/rust-toolchain
-RUN cat task-driver/rust-toolchain | xargs rustup toolchain install
+COPY ./rust-toolchain ./starknet-client/rust-toolchain
+RUN cat starknet-client/rust-toolchain | xargs rustup toolchain install
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -28,18 +28,18 @@ COPY --from=sources . .
 # dependencies of the integration test. Every path dependency of the target crate is automatically
 # added to the workspace
 COPY ./Cargo.toml ./Cargo.toml
-RUN sed -i '/members = \[/,/\]/c\members = [ "task-driver" ]' Cargo.toml
+RUN sed -i '/members = \[/,/\]/c\members = [ "starknet-client" ]' Cargo.toml
 
 # Place a set of dummy sources in the path, build the dummy executable
 # to cache built dependencies, then bulid the full executable
-WORKDIR /build/task-driver
+WORKDIR /build/starknet-client
 RUN mkdir src
 RUN touch src/dummy-lib.rs
 
 RUN mkdir integration
 RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
 
-COPY task-driver/Cargo.toml .
+COPY starknet-client/Cargo.toml .
 
 # Modify the Cargo.toml to point to our dummy sources
 RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
@@ -49,15 +49,13 @@ RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
-RUN cargo build --quiet --test integration --features "integration"
+RUN cargo build --quiet --test integration 
 
 # Edit the Cargo.toml back to the original, build the full executable
 RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
 RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
 
-COPY task-driver/src ./src
-COPY task-driver/integration ./integration
+COPY starknet-client/src ./src
+COPY starknet-client/integration ./integration
 
-RUN cargo build --quiet --test integration --features "integration"
-
-CMD [ "cargo", "test" ]
+RUN cargo build --quiet --test integration 

--- a/starknet-client/docker-compose.yml
+++ b/starknet-client/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  contracts:
+    build:
+      context: ../docker/contracts
+    image: renegade-contracts:latest
+    entrypoint: sleep infinity
+  sequencer:
+    build:
+      context: ../docker/devnet
+    volumes:
+      - deployments:/deployments
+    ports:
+      - "5050:5050"
+    healthcheck:
+      test: "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"starknet_chainId\",\"params\":[],\"id\":1}' http://localhost:5050/rpc || exit 1"
+      interval: 5s
+      timeout: 10s
+      retries: 3
+    depends_on:
+      - contracts
+  relayer:
+    image: starknet-client-integration-test:latest
+    build:
+      context: ..
+      dockerfile: starknet-client/Dockerfile
+    volumes:
+      - deployments:/deployments
+    command: >
+      cargo test --test integration -- 
+        --deployments-path /deployments/deployments.json
+        --verbose 
+    tty: true
+    depends_on:
+      sequencer:
+        condition: service_healthy
+volumes:
+  deployments:

--- a/starknet-client/integration/main.rs
+++ b/starknet-client/integration/main.rs
@@ -1,0 +1,127 @@
+//! Defines integration tests for
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use clap::{ArgGroup, Parser};
+use common::types::chain_id::ChainId;
+use eyre::Result;
+use mpc_stark::algebra::scalar::Scalar;
+use rand::thread_rng;
+use starknet_client::client::{StarknetClient, StarknetClientConfig};
+use test_helpers::{
+    assert_true, contracts::parse_addr_from_deployments_file, integration_test_async,
+    integration_test_main,
+};
+use tracing::log::LevelFilter;
+
+/// The hostport that the test expects a local devnet node to be running on
+///
+/// This assumes that the integration tests are running in a docker-compose setup
+/// with a DNS alias `sequencer` pointing to a devnet node running in a sister container
+const DEVNET_HOSTPORT: &str = "http://sequencer:5050";
+
+/// The arguments used to run the integration tests
+#[derive(Debug, Clone, Parser)]
+#[command(author, version, about, long_about=None)]
+#[clap(group = ArgGroup::new("deploy_config").required(true).multiple(false))]
+struct CliArgs {
+    /// The private key to use for the Starknet account during testing
+    ///
+    /// Defaults to the first pre-deployed account on `starknet-devnet` when
+    /// run with seed 0
+    #[arg(
+        short = 'p',
+        long,
+        default_value = "0x300001800000000300000180000000000030000000000003006001800006600"
+    )]
+    starknet_pkey: String,
+    /// The address of the account contract to use for testing
+    ///
+    /// Defaults to the first pre-deployed account on `starknet-devnet` when
+    /// run with seed 0
+    #[arg(
+        long,
+        default_value = "0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0"
+    )]
+    starknet_account_addr: String,
+    /// The address of the darkpool deployed on Starknet at the time the test is started
+    #[clap(long, group = "deploy_config")]
+    darkpool_addr: Option<String>,
+    /// The location of a `deployments.json` file that contains the addresses of the
+    /// deployed contracts
+    #[arg(long, group = "deploy_config")]
+    deployments_path: Option<String>,
+    /// The location of the contract compilation artifacts as an absolute path
+    #[arg(long, default_value = "/artifacts")]
+    cairo_artifacts_path: String,
+    /// The url the devnet node api server
+    #[arg(long, default_value = DEVNET_HOSTPORT)]
+    devnet_url: String,
+    /// The test to run
+    #[arg(short, long, value_parser)]
+    test: Option<String>,
+    /// The verbosity level of the test harness
+    #[arg(long, short)]
+    verbose: bool,
+}
+
+/// The arguments provided to every integration test
+#[derive(Clone)]
+struct IntegrationTestArgs {
+    /// The starknet client that resolves to a locally running devnet node
+    starknet_client: StarknetClient,
+}
+
+impl From<CliArgs> for IntegrationTestArgs {
+    fn from(test_args: CliArgs) -> Self {
+        // Pull the contract address either from the CLI or a shared volume at the CLI specified path
+        assert!(
+            test_args.darkpool_addr.is_some() || test_args.deployments_path.is_some(),
+            "one of `darkpool_addr` or `deployments_path` must be provided"
+        );
+        let darkpool_addr = if let Some(addr) = test_args.darkpool_addr {
+            addr
+        } else {
+            parse_addr_from_deployments_file(test_args.deployments_path.unwrap()).unwrap()
+        };
+
+        // Build a client that references the darkpool
+        let starknet_client = StarknetClient::new(StarknetClientConfig {
+            chain: ChainId::Katana,
+            contract_addr: darkpool_addr,
+            starknet_json_rpc_addr: format!("{}/rpc", test_args.devnet_url),
+            infura_api_key: None,
+            starknet_account_addresses: vec![test_args.starknet_account_addr],
+            starknet_pkeys: vec![test_args.starknet_pkey],
+        });
+
+        Self { starknet_client }
+    }
+}
+
+/// Setup code for the integration tests
+fn setup_integration_tests(_test_args: &CliArgs) {
+    // Configure logging
+    util::logging::setup_system_logger(LevelFilter::Info);
+}
+
+/// A dummy test that always passes
+///
+/// TODO: Delete this
+async fn test_dummy(args: IntegrationTestArgs) -> Result<()> {
+    // Test that a random nullifier is not marked as used by the contract
+    let client = &args.starknet_client;
+
+    let mut rng = thread_rng();
+    let random_nullifier = Scalar::random(&mut rng);
+
+    let unused = client.check_nullifier_unused(random_nullifier).await?;
+    assert_true!(unused)
+}
+
+integration_test_async!(test_dummy);
+
+integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/test-helpers/src/assertions.rs
+++ b/test-helpers/src/assertions.rs
@@ -1,0 +1,34 @@
+//! Defines assertion helpers that match the signature of the `renegade` integration tests
+
+/// Assert that a boolean value is true, return an error otherwise
+#[macro_export]
+macro_rules! assert_true {
+    ($x:expr) => {
+        if $x {
+            Ok(())
+        } else {
+            Err(eyre::eyre!(
+                "Expected `{} == true`, got `false`",
+                stringify!($x)
+            ))
+        }
+    };
+}
+
+/// Assert that two values are equal, return an error otherwise
+#[macro_export]
+macro_rules! assert_eq {
+    ($x:expr, $y:expr) => {
+        if $x == $y {
+            Ok(())
+        } else {
+            Err(eyre::eyre!(
+                "Expected `{} == {}`, got `{:?} == {:?}`",
+                stringify!($x),
+                stringify!($y),
+                $x,
+                $y
+            ))
+        }
+    };
+}

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
 
+pub mod assertions;
 pub mod contracts;
 pub mod macros;
 pub mod mpc_network;


### PR DESCRIPTION
### Purpose
This PR adds the skeleton for the `starknet-client` integration tests. This includes a docker compose setup for compiling the contracts, deploying them to a devnet, and then running the integration tests in a node targeting this devnet. Included is a sample PR for checking a dummy nullifier is not used immediately after the contract is initialized.

### Testing
- Unit and integration tests pass, including the nullifier test added with this PR