### PR TITLE
starknet-client: Add chain state integration tests

### DIFF
--- a/circuit-types/src/merkle.rs
+++ b/circuit-types/src/merkle.rs
@@ -20,7 +20,7 @@ pub type MerkleRoot = Scalar;
 
 /// A fully specified merkle opening from hashed leaf to root
 #[circuit_type(serde, singleprover_circuit)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MerkleOpening<const HEIGHT: usize> {
     /// The opening from the leaf node to the root, i.e. the set of sister nodes
     /// that hash together with the input from the leaf to the root

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -17,7 +17,7 @@ use mpc_bulletproof::{r1cs_mpc::MpcProver, PedersenGens};
 use mpc_stark::{PARTY0, PARTY1};
 use num_bigint::BigUint;
 use rand::thread_rng;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/mpc_gadgets/arithmetic.rs
+++ b/circuits/integration/mpc_gadgets/arithmetic.rs
@@ -10,7 +10,7 @@ use mpc_stark::{
 use num_bigint::BigUint;
 use rand::{thread_rng, Rng, RngCore};
 use renegade_crypto::fields::{get_scalar_field_modulus, scalar_to_u64};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/mpc_gadgets/bits.rs
+++ b/circuits/integration/mpc_gadgets/bits.rs
@@ -10,7 +10,7 @@ use mpc_stark::{
 };
 use rand::{thread_rng, RngCore};
 use renegade_crypto::fields::scalar_to_u64;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/mpc_gadgets/comparators.rs
+++ b/circuits/integration/mpc_gadgets/comparators.rs
@@ -12,7 +12,7 @@ use mpc_stark::{
 };
 use rand::{seq::SliceRandom, thread_rng, Rng, RngCore};
 use renegade_crypto::fields::scalar_to_u64;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/mpc_gadgets/modulo.rs
+++ b/circuits/integration/mpc_gadgets/modulo.rs
@@ -5,7 +5,7 @@ use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
 use num_bigint::{BigUint, RandomBits};
 use rand::{thread_rng, Rng, RngCore};
 use renegade_crypto::fields::scalar_to_biguint;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/mpc_gadgets/poseidon.rs
+++ b/circuits/integration/mpc_gadgets/poseidon.rs
@@ -11,7 +11,7 @@ use mpc_stark::{
 };
 use rand::{thread_rng, RngCore};
 use renegade_crypto::hash::{default_poseidon_params, PoseidonParams};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/types/sharing.rs
+++ b/circuits/integration/types/sharing.rs
@@ -6,7 +6,7 @@ use circuit_types::{
 };
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use eyre::{eyre, Result};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -23,7 +23,7 @@ use mpc_stark::{algebra::scalar::Scalar, MpcFabric, PARTY0, PARTY1};
 use rand::{thread_rng, Rng};
 use renegade_crypto::fields::scalar_to_u64;
 use std::{cmp, time::SystemTime};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/zk_gadgets/arithmetic.rs
+++ b/circuits/integration/zk_gadgets/arithmetic.rs
@@ -11,7 +11,7 @@ use mpc_bulletproof::{
 use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
 use rand::{thread_rng, RngCore};
 use renegade_crypto::fields::get_scalar_field_modulus;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/zk_gadgets/bits.rs
+++ b/circuits/integration/zk_gadgets/bits.rs
@@ -12,7 +12,7 @@ use mpc_bulletproof::{
 use mpc_stark::{algebra::scalar::Scalar, PARTY0};
 use rand::{thread_rng, RngCore};
 use renegade_crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/integration/zk_gadgets/poseidon.rs
+++ b/circuits/integration/zk_gadgets/poseidon.rs
@@ -17,7 +17,7 @@ use mpc_stark::{
 };
 use rand::{thread_rng, RngCore};
 use renegade_crypto::hash::{compute_poseidon_hash, default_poseidon_params};
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::IntegrationTestArgs;
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -143,6 +143,14 @@ pub mod test_helpers {
     pub fn create_multi_opening<const HEIGHT: usize>(
         items: &[Scalar],
     ) -> (Scalar, Vec<MerkleOpening<HEIGHT>>) {
+        create_multi_opening_with_default_leaf(items, Scalar::zero() /* default_value */)
+    }
+
+    /// Create a multi opening with a non-zero default (empty) leaf value
+    pub fn create_multi_opening_with_default_leaf<const HEIGHT: usize>(
+        items: &[Scalar],
+        default_leaf: Scalar,
+    ) -> (Scalar, Vec<MerkleOpening<HEIGHT>>) {
         let tree_capacity = 2usize.pow(HEIGHT as u32);
         assert!(
             items.len() <= tree_capacity,
@@ -153,9 +161,8 @@ pub mod test_helpers {
             "cannot create a multi-opening for an empty tree"
         );
 
-        let zero_value = Scalar::zero();
         let (root, mut opening_paths) =
-            create_multi_opening_helper(items.to_vec(), zero_value, HEIGHT);
+            create_multi_opening_helper(items.to_vec(), default_leaf, HEIGHT);
         opening_paths.truncate(items.len());
 
         // Create Merkle opening paths from each of the results

--- a/renegade-crypto/src/fields.rs
+++ b/renegade-crypto/src/fields.rs
@@ -48,6 +48,11 @@ pub fn scalar_to_u64(a: &Scalar) -> u64 {
     u64::from_be_bytes(bytes)
 }
 
+/// Reduces the scalar to a usize, truncating anything above usize::MAX
+pub fn scalar_to_usize(a: &Scalar) -> usize {
+    scalar_to_u64(a) as usize
+}
+
 /// Converts a dalek scalar to a StarkNet field element
 pub fn scalar_to_starknet_felt(a: &Scalar) -> StarknetFieldElement {
     StarknetFieldElement::from_byte_slice_be(&a.to_bytes_be())
@@ -116,6 +121,11 @@ pub fn starknet_felt_to_biguint(element: &StarknetFieldElement) -> BigUint {
 pub fn starknet_felt_to_u64(element: &StarknetFieldElement) -> u64 {
     let bytes: [u8; 8] = element.to_bytes_be()[24..].try_into().unwrap();
     u64::from_be_bytes(bytes)
+}
+
+/// Convert from a Starknet felt to a usize
+pub fn starknet_felt_to_usize(element: &StarknetFieldElement) -> usize {
+    starknet_felt_to_u64(element) as usize
 }
 
 /// Convert a u128 to a Starknet felt

--- a/starknet-client/Cargo.toml
+++ b/starknet-client/Cargo.toml
@@ -3,10 +3,14 @@ name = "starknet-client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+integration = ["circuits/test_helpers"]
+
 [[test]]
 name = "integration"
 path = "integration/main.rs"
 harness = false
+required-features = ["integration"]
 
 [dependencies]
 # === Cryptographic + arithmetic dependencies === #
@@ -42,6 +46,8 @@ eyre = { workspace = true }
 inventory = "0.3"
 
 rand = { workspace = true }
+
+tokio = { workspace = true }
 
 test-helpers = { path = "../test-helpers" }
 util = { path = "../util" }

--- a/starknet-client/Dockerfile
+++ b/starknet-client/Dockerfile
@@ -49,7 +49,7 @@ RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
-RUN cargo build --quiet --test integration 
+RUN cargo build --quiet --test integration --features "integration"
 
 # Edit the Cargo.toml back to the original, build the full executable
 RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
@@ -58,4 +58,4 @@ RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
 COPY starknet-client/src ./src
 COPY starknet-client/integration ./integration
 
-RUN cargo build --quiet --test integration 
+RUN cargo build --quiet --test integration --features "integration"

--- a/starknet-client/docker-compose.yml
+++ b/starknet-client/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - deployments:/deployments
     command: >
-      cargo test --test integration -- 
+      cargo test --test integration --features "integration" -- 
         --deployments-path /deployments/deployments.json
         --verbose 
     tty: true

--- a/starknet-client/integration/chain_state.rs
+++ b/starknet-client/integration/chain_state.rs
@@ -1,0 +1,25 @@
+//! Integration tests for client functionality that searches contract state
+
+use eyre::Result;
+use num_bigint::BigUint;
+use test_helpers::{assert_eq_result, integration_test_async};
+
+use crate::IntegrationTestArgs;
+
+/// Find a pre-allocated commitment in the Merkle state
+async fn test_find_commitment(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+
+    // Test the zeroth index commitment
+    let commitment_index = client
+        .find_commitment_in_state(test_args.pre_allocated_state.index0_commitment)
+        .await?;
+    assert_eq_result!(commitment_index, BigUint::from(0u8))?;
+
+    // Test the first index commitment
+    let commitment_index = client
+        .find_commitment_in_state(test_args.pre_allocated_state.index1_commitment)
+        .await?;
+    assert_eq_result!(commitment_index, BigUint::from(1u8))
+}
+integration_test_async!(test_find_commitment);

--- a/starknet-client/integration/chain_state.rs
+++ b/starknet-client/integration/chain_state.rs
@@ -1,25 +1,108 @@
 //! Integration tests for client functionality that searches contract state
 
+use circuit_types::merkle::MerkleOpening;
+use circuits::zk_circuits::test_helpers::create_multi_opening_with_default_leaf;
+use constants::MERKLE_HEIGHT;
 use eyre::Result;
 use num_bigint::BigUint;
+use starknet_client::EMPTY_LEAF_VALUE;
 use test_helpers::{assert_eq_result, integration_test_async};
+use tracing::log;
 
 use crate::IntegrationTestArgs;
 
-/// Find a pre-allocated commitment in the Merkle state
+/// Tests finding a pre-allocated commitment in the Merkle state
 async fn test_find_commitment(test_args: IntegrationTestArgs) -> Result<()> {
     let client = &test_args.starknet_client;
 
-    // Test the zeroth index commitment
-    let commitment_index = client
-        .find_commitment_in_state(test_args.pre_allocated_state.index0_commitment)
-        .await?;
-    assert_eq_result!(commitment_index, BigUint::from(0u8))?;
+    for (index, commitment) in [
+        test_args.pre_allocated_state.index0_commitment,
+        test_args.pre_allocated_state.index1_commitment,
+        test_args.pre_allocated_state.index2_commitment,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        // Test the commitment
+        let commitment_index = client.find_commitment_in_state(commitment).await?;
+        assert_eq_result!(commitment_index, BigUint::from(index as u8))?;
+    }
 
-    // Test the first index commitment
-    let commitment_index = client
-        .find_commitment_in_state(test_args.pre_allocated_state.index1_commitment)
-        .await?;
-    assert_eq_result!(commitment_index, BigUint::from(1u8))
+    Ok(())
 }
 integration_test_async!(test_find_commitment);
+
+/// Tests finding a Merkle authentication path for a pre-allocated commitment
+///
+/// For now, the test only checks that the indices are correct, but not that the path is valid
+/// because the contract is using Pedersen for efficiency
+///
+/// TODO: Check the validity of the Merkle path
+async fn test_find_merkle_path(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+
+    // Create Merkle openings to test against
+    let (_root, expected_paths) = create_multi_opening_with_default_leaf::<MERKLE_HEIGHT>(
+        &[
+            test_args.pre_allocated_state.index0_commitment,
+            test_args.pre_allocated_state.index1_commitment,
+            test_args.pre_allocated_state.index2_commitment,
+        ],
+        *EMPTY_LEAF_VALUE,
+    );
+
+    // Find Merkle openings via the `StarknetClient` and compare them to the expected openings
+    for (index, commitment) in [
+        test_args.pre_allocated_state.index0_commitment,
+        test_args.pre_allocated_state.index1_commitment,
+        test_args.pre_allocated_state.index2_commitment,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let merkle_path: MerkleOpening<MERKLE_HEIGHT> = client
+            .find_merkle_authentication_path(commitment)
+            .await?
+            .into(); // Convert to circuit type for easy comparison
+
+        assert_eq_result!(merkle_path.indices, expected_paths[index].indices)?;
+        log::warn!("Merkle path validity not checked, implement this test after contract migrates to Poseidon");
+    }
+
+    Ok(())
+}
+integration_test_async!(test_find_merkle_path);
+
+/// Tests looking up a wallet by its public blinder share and parsing the
+/// public shares from the calldata
+async fn test_parse_public_shares_from_calldata(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+
+    for expected_public_share in [
+        test_args.pre_allocated_state.index0_public_wallet_shares,
+        test_args.pre_allocated_state.index1_public_wallet_shares,
+        test_args.pre_allocated_state.index2_public_wallet_shares,
+    ]
+    .into_iter()
+    {
+        // The public share of the wallet blinder
+        let blinder_share = expected_public_share.blinder;
+
+        // Fetch the transaction hash that indexed the public blinder share
+        let transaction_hash = client
+            .get_public_blinder_tx(blinder_share)
+            .await?
+            .ok_or_else(|| eyre::eyre!("public blinder share not found in contract state"))?;
+
+        // Parse the public shares from the calldata
+        let public_shares = client
+            .fetch_public_shares_from_tx(blinder_share, transaction_hash)
+            .await?;
+
+        // Check that the public shares match the expected public shares
+        assert_eq_result!(public_shares, expected_public_share)?;
+    }
+
+    Ok(())
+}
+integration_test_async!(test_parse_public_shares_from_calldata);

--- a/starknet-client/integration/helpers.rs
+++ b/starknet-client/integration/helpers.rs
@@ -1,0 +1,81 @@
+//! Helpers for `starknet-client` integration tests
+
+use std::iter;
+
+use circuit_types::{
+    native_helpers::compute_wallet_commitment_from_private,
+    traits::{BaseType, CircuitCommitmentType},
+    wallet::WalletShareStateCommitment,
+    SizedWalletShare,
+};
+use circuits::zk_circuits::valid_wallet_create::{
+    ValidWalletCreateStatement, ValidWalletCreateWitnessCommitment,
+};
+use common::types::proof_bundles::ValidWalletCreateBundle;
+use eyre::Result;
+use mpc_bulletproof::{r1cs::R1CSProof, InnerProductProof};
+use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+use rand::thread_rng;
+use starknet_client::client::StarknetClient;
+
+/// Deploy a new wallet and return the commitment inserted into the state tree
+pub async fn deploy_new_wallet(client: &StarknetClient) -> Result<WalletShareStateCommitment> {
+    let mut rng = thread_rng();
+    let private_shares_commitment = Scalar::random(&mut rng);
+    let public_shares = SizedWalletShare::from_scalars(&mut iter::repeat(Scalar::random(&mut rng)));
+
+    let tx_hash = client
+        .new_wallet(
+            private_shares_commitment,
+            public_shares.clone(),
+            ValidWalletCreateBundle {
+                statement: ValidWalletCreateStatement {
+                    private_shares_commitment,
+                    public_wallet_shares: public_shares.clone(),
+                },
+                commitment: ValidWalletCreateWitnessCommitment::from_commitments(
+                    &mut iter::repeat(StarkPoint::identity()),
+                ),
+                proof: dummy_r1cs_proof(),
+            },
+        )
+        .await?;
+    client.poll_transaction_completed(tx_hash).await.unwrap();
+
+    // The contract will compute the full commitment and insert it into the Merkle tree;
+    // we repeat the same computation here for consistency
+    let full_commitment =
+        compute_wallet_commitment_from_private(public_shares, private_shares_commitment);
+    Ok(full_commitment)
+}
+
+/// Create a dummy R1CS proof
+fn dummy_r1cs_proof() -> R1CSProof {
+    R1CSProof {
+        A_I1: StarkPoint::identity(),
+        A_O1: StarkPoint::identity(),
+        S1: StarkPoint::identity(),
+        A_I2: StarkPoint::identity(),
+        A_O2: StarkPoint::identity(),
+        S2: StarkPoint::identity(),
+        T_1: StarkPoint::identity(),
+        T_3: StarkPoint::identity(),
+        T_4: StarkPoint::identity(),
+        T_5: StarkPoint::identity(),
+        T_6: StarkPoint::identity(),
+        t_x: Scalar::one(),
+        t_x_blinding: Scalar::one(),
+        e_blinding: Scalar::one(),
+        ipp_proof: dummy_ip_proof(),
+    }
+}
+
+/// Create a dummy inner product proof
+fn dummy_ip_proof() -> InnerProductProof {
+    InnerProductProof {
+        L_vec: vec![StarkPoint::identity()],
+        R_vec: vec![StarkPoint::identity()],
+        a: Scalar::one(),
+        b: Scalar::one(),
+    }
+}

--- a/starknet-client/src/client.rs
+++ b/starknet-client/src/client.rs
@@ -77,6 +77,11 @@ impl StarknetClientConfig {
         !self.starknet_pkeys.is_empty() && !self.starknet_account_addresses.is_empty()
     }
 
+    /// Get the darkpool contract address as a `StarknetFieldElement`
+    pub fn contract_address(&self) -> StarknetFieldElement {
+        StarknetFieldElement::from_hex_be(&self.contract_addr).unwrap()
+    }
+
     /// Create a new JSON-RPC client using the API credentials in the config
     ///
     /// Returns `None` if the config does not specify the correct credentials
@@ -145,10 +150,7 @@ impl StarknetClient {
         let accounts = Arc::new(accounts);
 
         // Parse the contract address
-        let contract_address: StarknetFieldElement =
-            StarknetFieldElement::from_str(&config.contract_addr).unwrap_or_else(|_| {
-                panic!("could not parse contract address {}", config.contract_addr)
-            });
+        let contract_address = config.contract_address();
 
         Self {
             config,

--- a/starknet-client/src/client/chain_state.rs
+++ b/starknet-client/src/client/chain_state.rs
@@ -186,11 +186,6 @@ impl StarknetClient {
     ) -> Result<BigUint, StarknetClientError> {
         let commitment_starknet_felt = scalar_to_starknet_felt(&commitment);
 
-        log::info!(
-            "searching for commitment: 0x{:x}",
-            starknet_felt_to_biguint(&commitment_starknet_felt)
-        );
-
         // Paginate through events in the contract, searching for the Merkle tree insertion event that
         // corresponds to the given commitment
         //
@@ -238,7 +233,7 @@ impl StarknetClient {
 
         // Paginate backwards in block history
         let earliest_block = self.config.earliest_block();
-        'outer: for end_block in (earliest_block..current_block)
+        'outer: for end_block in (earliest_block..=current_block)
             .rev()
             .step_by(BLOCK_PAGINATION_WINDOW)
         {

--- a/starknet-client/src/lib.rs
+++ b/starknet-client/src/lib.rs
@@ -63,9 +63,9 @@ lazy_static! {
     // ------------------------
 
     /// The value of an empty leaf in the Merkle tree
-    static ref EMPTY_LEAF_VALUE: Scalar = {
+    pub static ref EMPTY_LEAF_VALUE: Scalar = {
         BigUint::from_str(
-            "306932273398430716639340090025251549301604242969558673011416862133942957551"
+            "306932273398430716639340090025251550554329269971178413658580639401611971225"
         )
         .unwrap()
         .into()
@@ -78,9 +78,10 @@ lazy_static! {
     pub static ref DEFAULT_AUTHENTICATION_PATH: [Scalar; MERKLE_HEIGHT] = {
         let mut values = Vec::with_capacity(MERKLE_HEIGHT);
 
-        let curr_val = *EMPTY_LEAF_VALUE;
+        let mut curr_val = *EMPTY_LEAF_VALUE;
         for _ in 0..MERKLE_HEIGHT {
-            values.push(compute_poseidon_hash(&[curr_val, curr_val]));
+            values.push(curr_val);
+            curr_val = compute_poseidon_hash(&[curr_val, curr_val]);
         }
 
         values.try_into().unwrap()

--- a/task-driver/integration/create_new_wallet.rs
+++ b/task-driver/integration/create_new_wallet.rs
@@ -2,7 +2,7 @@
 
 use eyre::{eyre, Result};
 use task_driver::create_new_wallet::NewWalletTask;
-use test_helpers::{integration_test_async, types::IntegrationTest};
+use test_helpers::integration_test_async;
 
 use crate::{helpers::create_empty_api_wallet, IntegrationTestArgs};
 

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -25,7 +25,7 @@ use test_helpers::{
     contracts::parse_addr_from_deployments_file, integration_test, integration_test_main,
 };
 use tracing::log::LevelFilter;
-use util::runtime::await_result;
+use util::runtime::block_on_result;
 
 /// The hostport that the test expects a local devnet node to be running on
 ///
@@ -148,7 +148,7 @@ fn test_dummy(test_args: IntegrationTestArgs) -> Result<()> {
     let mut rng = thread_rng();
     let random_nullifier = Scalar::random(&mut rng);
 
-    let res = await_result(client.check_nullifier_unused(random_nullifier))?;
+    let res = block_on_result(client.check_nullifier_unused(random_nullifier))?;
 
     if res {
         Ok(())

--- a/test-helpers/src/assertions.rs
+++ b/test-helpers/src/assertions.rs
@@ -2,7 +2,7 @@
 
 /// Assert that a boolean value is true, return an error otherwise
 #[macro_export]
-macro_rules! assert_true {
+macro_rules! assert_true_result {
     ($x:expr) => {
         if $x {
             Ok(())
@@ -17,7 +17,7 @@ macro_rules! assert_true {
 
 /// Assert that two values are equal, return an error otherwise
 #[macro_export]
-macro_rules! assert_eq {
+macro_rules! assert_eq_result {
     ($x:expr, $y:expr) => {
         if $x == $y {
             Ok(())

--- a/test-helpers/src/types.rs
+++ b/test-helpers/src/types.rs
@@ -10,7 +10,7 @@ use futures::Future;
 #[macro_export]
 macro_rules! integration_test {
     ($test_fn:ident) => {
-        inventory::submit!(crate::TestWrapper(IntegrationTest {
+        inventory::submit!(crate::TestWrapper(test_helpers::types::IntegrationTest {
             name: std::concat! {std::module_path!(), "::", stringify!($test_fn)},
             test_fn: test_helpers::types::IntegrationTestFn::SynchronousFn($test_fn),
         }));
@@ -21,7 +21,7 @@ macro_rules! integration_test {
 #[macro_export]
 macro_rules! integration_test_async {
     ($test_fn:ident) => {
-        inventory::submit!(crate::TestWrapper(IntegrationTest {
+        inventory::submit!(crate::TestWrapper(test_helpers::types::IntegrationTest {
             name: std::concat! {std::module_path!(), "::", stringify!($test_fn)},
             test_fn: test_helpers::types::IntegrationTestFn::AsynchronousFn(move |args| {
                 std::boxed::Box::pin($test_fn(args))

--- a/util/src/runtime.rs
+++ b/util/src/runtime.rs
@@ -6,11 +6,11 @@ use futures::future::join_all;
 use tokio::runtime::Handle;
 
 /// Block the Tokio runtime on a future, returning the result
-pub fn await_result<T, F: Future<Output = T>>(res: F) -> T {
+pub fn block_on_result<T, F: Future<Output = T>>(res: F) -> T {
     Handle::current().block_on(res)
 }
 
 /// Block the Tokio runtime on a collection of futures, returning the results
-pub fn await_results<T, F: Future<Output = T>>(res: Vec<F>) -> Vec<T> {
+pub fn block_on_results<T, F: Future<Output = T>>(res: Vec<F>) -> Vec<T> {
     Handle::current().block_on(join_all(res))
 }


### PR DESCRIPTION
### Purpose
This PR adds integration tests for:
- Fining a wallet commitment in the contract state
- Finding a Merkle path in the contract state
- Recovering wallet shares from a transaction

This PR also restructures the way in which calldata is parsed from `InvokeV1` transactions.

### Testing
- Unit and integration tests pass