### PR TITLE
common: types: proof-bundles: Allocate all proof bundles on heap

### DIFF
--- a/starknet-client/integration/helpers.rs
+++ b/starknet-client/integration/helpers.rs
@@ -11,7 +11,7 @@ use circuit_types::{
 use circuits::zk_circuits::valid_wallet_create::{
     ValidWalletCreateStatement, ValidWalletCreateWitnessCommitment,
 };
-use common::types::proof_bundles::{mocks::dummy_r1cs_proof, ValidWalletCreateBundle};
+use common::types::proof_bundles::{mocks::dummy_r1cs_proof, GenericValidWalletCreateBundle};
 use eyre::Result;
 use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
 use rand::thread_rng;
@@ -30,7 +30,7 @@ pub async fn deploy_new_wallet(
         .new_wallet(
             private_shares_commitment,
             public_shares.clone(),
-            ValidWalletCreateBundle {
+            Box::new(GenericValidWalletCreateBundle {
                 statement: ValidWalletCreateStatement {
                     private_shares_commitment,
                     public_wallet_shares: public_shares.clone(),
@@ -39,7 +39,7 @@ pub async fn deploy_new_wallet(
                     &mut iter::repeat(StarkPoint::identity()),
                 ),
                 proof: dummy_r1cs_proof(),
-            },
+            }),
         )
         .await?;
     client.poll_transaction_completed(tx_hash).await?;

--- a/task-driver/src/initialize_state.rs
+++ b/task-driver/src/initialize_state.rs
@@ -4,7 +4,6 @@
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter, Result as FmtResult},
-    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -235,7 +234,7 @@ impl InitializeStateTask {
             )
             .map_err(InitializeStateTaskError::ProveValidReblind)?;
 
-            let wallet_reblind_witness = Arc::new(reblind_witness);
+            let wallet_reblind_witness = Box::new(reblind_witness);
             reblind_response_channels.push((wallet.wallet_id, response_channel));
 
             // Create a proof of `VALID COMMITMENTS` for each order
@@ -250,7 +249,7 @@ impl InitializeStateTask {
                 )
                 .map_err(InitializeStateTaskError::ProveValidCommitments)?;
 
-                let order_commitment_witness = Arc::new(commitments_witness);
+                let order_commitment_witness = Box::new(commitments_witness);
 
                 // Attach a copy of the witness to the locally managed state
                 // This witness is referenced by match computations which compute linkable commitments
@@ -281,7 +280,7 @@ impl InitializeStateTask {
                 .await
                 .map_err(|err| InitializeStateTaskError::ProveValidReblind(err.to_string()))?
                 .into();
-            reblind_proofs.insert(wallet_id, Arc::new(proof));
+            reblind_proofs.insert(wallet_id, Box::new(proof));
         }
 
         // Await a proof response for each order then attach it to the order index entry
@@ -295,7 +294,7 @@ impl InitializeStateTask {
             // Add proofs to the global state, the local node will gossip these around
             let reblind_proof = reblind_proofs.get(&wallet_id).unwrap().clone();
             let proof_bundle = OrderValidityProofBundle {
-                commitment_proof: Arc::new(proof_bundle),
+                commitment_proof: Box::new(proof_bundle),
                 reblind_proof,
             };
             self.global_state

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -22,7 +22,9 @@ use circuits::{
 };
 use common::types::{
     handshake::{HandshakeResult, HandshakeState},
-    proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle, ValidMatchMpcBundle},
+    proof_bundles::{
+        GenericValidMatchMpcBundle, OrderValidityProofBundle, OrderValidityWitnessBundle,
+    },
 };
 use crossbeam::channel::{bounded, Receiver};
 use mpc_bulletproof::r1cs::R1CSProof;
@@ -338,11 +340,11 @@ impl HandshakeExecutor {
 
         Ok(Box::new(HandshakeResult {
             match_: match_res_open,
-            match_proof: ValidMatchMpcBundle {
+            match_proof: Box::new(GenericValidMatchMpcBundle {
                 commitment,
                 statement: (),
                 proof,
-            },
+            }),
             party0_share_nullifier: handshake_state.local_share_nullifier,
             party1_share_nullifier: handshake_state.peer_share_nullifier,
             party0_reblinded_shares: party0_public_shares,

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -17,6 +17,8 @@ use circuits::zk_circuits::{
     },
 };
 use common::types::proof_bundles::{
+    GenericValidCommitmentsBundle, GenericValidMatchMpcBundle, GenericValidReblindBundle,
+    GenericValidSettleBundle, GenericValidWalletCreateBundle, GenericValidWalletUpdateBundle,
     ProofBundle, ValidCommitmentsBundle, ValidMatchMpcBundle, ValidReblindBundle,
     ValidSettleBundle, ValidWalletCreateBundle, ValidWalletUpdateBundle,
 };
@@ -137,11 +139,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<SizedValidWalletCreate>(witness);
         let proof = create_mock_proof();
 
-        ValidWalletCreateBundle {
+        Box::new(GenericValidWalletCreateBundle {
             statement,
             commitment,
             proof,
-        }
+        })
     }
 
     /// Generate a dummy proof of `VALID WALLET UPDATE`
@@ -152,11 +154,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<SizedValidWalletUpdate>(witness);
         let proof = create_mock_proof();
 
-        ValidWalletUpdateBundle {
+        Box::new(GenericValidWalletUpdateBundle {
             statement,
             commitment,
             proof,
-        }
+        })
     }
 
     /// Generate a dummy proof of `VALID REBLIND`
@@ -167,11 +169,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<SizedValidReblind>(witness);
         let proof = create_mock_proof();
 
-        ValidReblindBundle {
+        Box::new(GenericValidReblindBundle {
             statement,
             commitment,
             proof,
-        }
+        })
     }
 
     /// Create a dummy proof of `VALID COMMITMENTS`
@@ -182,11 +184,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<SizedValidCommitments>(witness);
         let proof = create_mock_proof();
 
-        ValidCommitmentsBundle {
+        Box::new(GenericValidCommitmentsBundle {
             statement,
             commitment,
             proof,
-        }
+        })
     }
 
     /// Create a dummy proof of `VALID MATCH MPC`
@@ -194,11 +196,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<ValidMatchMpcSingleProver>(witness);
         let proof = create_mock_proof();
 
-        ValidMatchMpcBundle {
+        Box::new(GenericValidMatchMpcBundle {
             commitment,
             statement: (),
             proof,
-        }
+        })
     }
 
     /// Create a dummy proof of `VALID SETTLE`
@@ -209,11 +211,11 @@ impl MockProofManager {
         let commitment = create_mock_commitment::<SizedValidSettle>(witness);
         let proof = create_mock_proof();
 
-        ValidSettleBundle {
+        Box::new(GenericValidSettleBundle {
             statement,
             commitment,
             proof,
-        }
+        })
     }
 }
 

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -23,6 +23,8 @@ use circuits::{
 };
 use common::types::{
     proof_bundles::{
+        GenericValidCommitmentsBundle, GenericValidMatchMpcBundle, GenericValidReblindBundle,
+        GenericValidSettleBundle, GenericValidWalletCreateBundle, GenericValidWalletUpdateBundle,
         ProofBundle, ValidCommitmentsBundle, ValidMatchMpcBundle, ValidReblindBundle,
         ValidSettleBundle, ValidWalletCreateBundle, ValidWalletUpdateBundle,
     },
@@ -158,11 +160,11 @@ impl ProofManager {
         >(witness, statement.clone())
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidWalletCreateBundle {
+        Ok(Box::new(GenericValidWalletCreateBundle {
             commitment,
             statement,
             proof,
-        })
+        }))
     }
 
     /// Create a proof of `VALID REBLIND`
@@ -176,11 +178,11 @@ impl ProofManager {
         >(witness, statement.clone())
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidReblindBundle {
+        Ok(Box::new(GenericValidReblindBundle {
             commitment: witness_comm,
             statement,
             proof,
-        })
+        }))
     }
 
     /// Create a proof of `VALID COMMITMENTS`
@@ -194,11 +196,11 @@ impl ProofManager {
         >(witness, statement.clone())
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidCommitmentsBundle {
+        Ok(Box::new(GenericValidCommitmentsBundle {
             commitment: witness_comm,
             statement,
             proof,
-        })
+        }))
     }
 
     /// Create a proof of `VALID WALLET UPDATE`
@@ -211,11 +213,11 @@ impl ProofManager {
         >(witness, statement.clone())
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidWalletUpdateBundle {
+        Ok(Box::new(GenericValidWalletUpdateBundle {
             commitment: witness_comm,
             statement,
             proof,
-        })
+        }))
     }
 
     /// Create a proof of `VALID MATCH MPC`
@@ -225,11 +227,11 @@ impl ProofManager {
         let (witness_comm, proof) = singleprover_prove::<ValidMatchMpcSingleProver>(witness, ())
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidMatchMpcBundle {
+        Ok(Box::new(GenericValidMatchMpcBundle {
             commitment: witness_comm,
             statement: (),
             proof,
-        })
+        }))
     }
 
     /// Create a proof of `VALID SETTLE`
@@ -242,10 +244,10 @@ impl ProofManager {
         >(witness, statement.clone())
         .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(ValidSettleBundle {
+        Ok(Box::new(GenericValidSettleBundle {
             commitment: witness_comm,
             statement,
             proof,
-        })
+        }))
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the runtime representation of all proof types to be heap-allocated. This avoids stack overflows (especially in Tokio contexts) and crowding the stack with infrequently accessed values.

### Testing
- All unit and integration tests pass