### PR TITLE
task-driver: Do not await transaction finality

### DIFF
--- a/task-driver/src/create_new_wallet.rs
+++ b/task-driver/src/create_new_wallet.rs
@@ -273,11 +273,7 @@ impl NewWalletTask {
             .map_err(|err| NewWalletTaskError::Starknet(err.to_string()))?;
         log::info!("tx hash: 0x{:x}", starknet_felt_to_biguint(&tx_hash));
 
-        self.starknet_client
-            .poll_transaction_completed(tx_hash)
-            .await
-            .map_err(|err| NewWalletTaskError::Starknet(err.to_string()))?;
-
+        // TODO: Fix the polling method and await finality here
         Ok(())
     }
 

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -304,11 +304,8 @@ impl SettleMatchTask {
         let tx_hash =
             tx_submit_res.map_err(|err| SettleMatchTaskError::StarknetClient(err.to_string()))?;
 
+        // TODO: Fix the polling method and await finality here
         log::info!("tx hash: 0x{:x}", starknet_felt_to_biguint(&tx_hash));
-        self.starknet_client
-            .poll_transaction_completed(tx_hash)
-            .await
-            .map_err(|err| SettleMatchTaskError::StarknetClient(err.to_string()))?;
 
         // If the transaction was successful, cancel all orders on both nullifiers, await new validity proofs
         self.global_state

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -42,6 +42,7 @@ use tokio::{
     sync::{mpsc::UnboundedSender as TokioSender, oneshot},
     task::JoinHandle as TokioJoinHandle,
 };
+use tracing::log;
 
 // -------------
 // | Constants |
@@ -384,11 +385,9 @@ impl SettleMatchInternalTask {
         }
         let tx_hash =
             tx_submit_res.map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
+        log::info!("tx hash: 0x{tx_hash:x}");
 
-        self.starknet_client
-            .poll_transaction_completed(tx_hash)
-            .await
-            .map_err(|err| SettleMatchInternalTaskError::Starknet(err.to_string()))?;
+        // TODO: Fix the polling method and await finality here
 
         // If the transaction is successful, cancel all orders on the old wallet nullifiers
         // and await new validity proofs

--- a/task-driver/src/update_wallet.rs
+++ b/task-driver/src/update_wallet.rs
@@ -298,12 +298,7 @@ impl UpdateWalletTask {
             .map_err(|err| UpdateWalletTaskError::StarknetClient(err.to_string()))?;
         log::info!("tx hash: 0x{:x}", starknet_felt_to_biguint(&tx_hash));
 
-        // Await transaction completion
-        self.starknet_client
-            .poll_transaction_completed(tx_hash)
-            .await
-            .map_err(|err| UpdateWalletTaskError::StarknetClient(err.to_string()))?;
-
+        // TODO: Fix the polling method and await finality here
         Ok(())
     }
 


### PR DESCRIPTION
### Purpose
This PR removes calls to `StarknetClient::poll_transaction_completed` for now. This method needs refactoring and must paper over some API changes upsteam, so for now we simply do not call it.

The implication of not waiting for finality is that the next step of each task (finding Merkle paths) will likely fail and need to be retried a few times as the network finalizes and gossips the transaction.