### PR TITLE
circuit-types: replaced signing key types with StarkPoint & Scalar

### DIFF
--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 # === Crytography === #
 ark-ff = "0.4"
+ark-ec = "0.4"
 ed25519-dalek = "1.0.1"
 mpc-stark = { workspace = true }
 mpc-bulletproof = { workspace = true }

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -16,6 +16,7 @@ mpc-bulletproof = { workspace = true }
 # === Arithmetic === #
 bigdecimal = "0.3"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
+num-integer = "0.1.45"
 rand = "0.8"
 
 # === Async + Runtime === #

--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -3,8 +3,10 @@
 
 use std::ops::Add;
 
+use ark_ec::models::short_weierstrass::Affine;
+use ark_ff::fields::PrimeField;
 use circuit_macros::circuit_type;
-use ed25519_dalek::PublicKey as DalekKey;
+use lazy_static::lazy_static;
 use mpc_bulletproof::r1cs::{LinearCombination, Variable};
 use mpc_stark::{
     algebra::{
@@ -16,7 +18,6 @@ use mpc_stark::{
 };
 use num_bigint::BigUint;
 use rand::{CryptoRng, RngCore};
-use renegade_crypto::fields::get_scalar_field_modulus;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -29,14 +30,15 @@ use crate::{
     },
 };
 
-use super::{biguint_from_hex_string, biguint_to_hex_string};
-
 /// The number of keys held in a wallet's keychain
 pub const NUM_KEYS: usize = 4;
-/// The number of bytes used in a single scalar to represent a key
-pub const SCALAR_MAX_BYTES: usize = 31;
-/// The number of words needed to represent a non-native root key
-pub const ROOT_KEY_WORDS: usize = 2;
+/// The number of scalar words needed to represent STARK base field element
+pub const FELT_WORDS: usize = 2;
+
+lazy_static! {
+    /// The bit mask for the lower 128 bits of a U256
+    static ref LOW_BIT_MASK: BigUint = (BigUint::from(1u8) << 128) - 1u8;
+}
 
 // -------------
 // | Key Types |
@@ -119,8 +121,17 @@ impl From<SecretIdentificationKey> for Scalar {
     }
 }
 
-/// A non-native key is a key that exists over a non-native field
-/// (i.e. not Starknet Scalar)
+// -----------------
+// | Keychain Type |
+// -----------------
+
+/// An ECDSA public key is an elliptic curve point (in our case a `StarkPoint`),
+/// however, to distinguish from `StarkPoint`s that are used throughout the proof system
+/// but not allocated in the circuits, we represent the point by its affine coordinates.
+///
+/// Since the affine coordinates are elements of the base field, which is larger than the
+/// scalar field, each coordinate is represented using 2 `Scalar`s (one for the lower 128 bits,
+/// the other for the higher 128 bits).
 #[circuit_type(
     serde,
     singleprover_circuit,
@@ -129,105 +140,63 @@ impl From<SecretIdentificationKey> for Scalar {
     linkable,
     secret_share
 )]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct NonNativeKey<const KEY_WORDS: usize> {
-    /// The `Scalar` words used to represent the key
-    ///
-    /// Because the key is a point on a non-native curve, its representation requires
-    /// a bigint like approach
-    pub key_words: [Scalar; KEY_WORDS],
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicSigningKey {
+    pub x: [Scalar; FELT_WORDS],
+    pub y: [Scalar; FELT_WORDS],
 }
 
-impl<const KEY_WORDS: usize> Default for NonNativeKey<KEY_WORDS> {
-    fn default() -> Self {
-        Self {
-            key_words: [Scalar::zero(); KEY_WORDS],
+impl PublicSigningKey {
+    /// Split a biguint into 128-bit scalar words
+    fn split_biguint_into_words(val: &BigUint) -> [Scalar; FELT_WORDS] {
+        let low_mask = val & &*LOW_BIT_MASK;
+        let low: u128 = low_mask.try_into().unwrap();
+        let high: u128 = (val >> 128u32).try_into().unwrap();
+
+        [Scalar::from(low), Scalar::from(high)]
+    }
+
+    /// Combine 128-bit scalar words into a biguint
+    fn combine_words_into_biguint(words: &[Scalar; FELT_WORDS]) -> BigUint {
+        let low_biguint = words[0].to_biguint();
+        let high_biguint = words[1].to_biguint();
+
+        (high_biguint << 128) + low_biguint
+    }
+}
+
+impl From<StarkPoint> for PublicSigningKey {
+    fn from(value: StarkPoint) -> Self {
+        let Affine { x, y, infinity } = value.to_affine();
+        if infinity {
+            Self {
+                x: [Scalar::zero(); 2],
+                y: [Scalar::zero(); 2],
+            }
+        } else {
+            let x_biguint: BigUint = x.into_bigint().into();
+            let x_words = Self::split_biguint_into_words(&x_biguint);
+            let y_biguint: BigUint = y.into_bigint().into();
+            let y_words = Self::split_biguint_into_words(&y_biguint);
+
+            Self {
+                x: x_words,
+                y: y_words,
+            }
         }
     }
 }
 
-impl<const KEY_WORDS: usize> NonNativeKey<KEY_WORDS> {
-    /// Split a biguint into scalar words in little endian order
-    fn split_biguint_into_words(mut val: BigUint) -> [Scalar; KEY_WORDS] {
-        let scalar_mod = get_scalar_field_modulus();
-        let mut res = Vec::with_capacity(KEY_WORDS);
-        for _ in 0..KEY_WORDS {
-            let word = Scalar::from(&val % &scalar_mod);
-            val /= &scalar_mod;
-            res.push(word);
-        }
-
-        res.try_into().unwrap()
-    }
-
-    /// Re-collect the key words into a biguint
-    fn combine_words_into_biguint(&self) -> BigUint {
-        let scalar_mod = get_scalar_field_modulus();
-        self.key_words
-            .iter()
-            .rev()
-            .fold(BigUint::from(0u8), |acc, word| {
-                acc * &scalar_mod + word.to_biguint()
-            })
+impl From<PublicSigningKey> for StarkPoint {
+    fn from(value: PublicSigningKey) -> Self {
+        let x = PublicSigningKey::combine_words_into_biguint(&value.x);
+        let y = PublicSigningKey::combine_words_into_biguint(&value.y);
+        StarkPoint::from_affine_coords(x, y)
     }
 }
-
-impl<const KEY_WORDS: usize> From<&BigUint> for NonNativeKey<KEY_WORDS> {
-    fn from(val: &BigUint) -> Self {
-        Self {
-            key_words: Self::split_biguint_into_words(val.clone()),
-        }
-    }
-}
-
-impl<const KEY_WORDS: usize> From<&NonNativeKey<KEY_WORDS>> for BigUint {
-    fn from(value: &NonNativeKey<KEY_WORDS>) -> Self {
-        value.combine_words_into_biguint()
-    }
-}
-
-impl<const KEY_WORDS: usize> Serialize for NonNativeKey<KEY_WORDS> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // Recover a bigint from the scalar words
-        biguint_to_hex_string(&self.into(), serializer)
-    }
-}
-
-impl<'de, const KEY_WORDS: usize> Deserialize<'de> for NonNativeKey<KEY_WORDS> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let val = biguint_from_hex_string(deserializer)?;
-        Ok(Self::from(&val))
-    }
-}
-
-impl<const KEY_WORDS: usize> From<&NonNativeKey<KEY_WORDS>> for DalekKey {
-    fn from(val: &NonNativeKey<KEY_WORDS>) -> Self {
-        let key_bytes = BigUint::from(val).to_bytes_le();
-        DalekKey::from_bytes(&key_bytes).unwrap()
-    }
-}
-
-impl<const KEY_WORDS: usize> From<DalekKey> for NonNativeKey<KEY_WORDS> {
-    fn from(key: DalekKey) -> Self {
-        let key_bytes = key.as_bytes();
-        Self::from(&BigUint::from_bytes_le(key_bytes))
-    }
-}
-
-// -----------------
-// | Keychain Type |
-// -----------------
 
 /// A type alias for readability
-pub type PublicSigningKey = NonNativeKey<ROOT_KEY_WORDS>;
-/// A type alias for readability
-pub type SecretSigningKey = NonNativeKey<ROOT_KEY_WORDS>;
+pub type SecretSigningKey = Scalar;
 
 /// Represents the base type, defining two keys with different access levels
 ///
@@ -258,22 +227,18 @@ pub struct PublicKeyChain {
 
 #[cfg(test)]
 mod test {
-    use num_bigint::BigUint;
-    use rand::RngCore;
+    use mpc_stark::{algebra::stark_curve::StarkPoint, random_point};
 
-    use super::NonNativeKey;
+    use super::PublicSigningKey;
 
     #[test]
-    fn test_nonnative_to_from_biguint() {
-        let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; 64 /* 512 bits */];
-        rng.fill_bytes(&mut buf);
+    fn test_pub_signing_key_to_from_starkpoint() {
+        let rand_pt = random_point();
 
         // Convert to and from a nonnative key
-        let random_biguint = BigUint::from_bytes_be(&buf);
-        let key: NonNativeKey<3 /* KEY_WORDS */> = (&random_biguint).into();
-        let recovered_biguint: BigUint = (&key).into();
+        let pubkey: PublicSigningKey = rand_pt.into();
+        let recovered_pt: StarkPoint = pubkey.into();
 
-        assert_eq!(random_biguint, recovered_biguint);
+        assert_eq!(rand_pt, recovered_pt);
     }
 }

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -25,7 +25,7 @@ pub mod test_helpers {
     };
     use itertools::Itertools;
     use lazy_static::lazy_static;
-    use mpc_stark::algebra::scalar::Scalar;
+    use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
     use num_bigint::BigUint;
     use rand::thread_rng;
     use renegade_crypto::hash::compute_poseidon_hash;
@@ -41,7 +41,7 @@ pub mod test_helpers {
         // computed correctly
         pub static ref PRIVATE_KEYS: Vec<Scalar> = vec![Scalar::one(); NUM_KEYS];
         pub static ref PUBLIC_KEYS: PublicKeyChain = PublicKeyChain {
-            pk_root: PublicSigningKey::from(&BigUint::from(2u8).pow(256)),
+            pk_root: PublicSigningKey::from(StarkPoint::generator()),
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
         };
         pub static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -296,6 +296,7 @@ pub mod mocks {
     use constants::MERKLE_HEIGHT;
     use indexmap::IndexMap;
     use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+    use num_bigint::BigUint;
     use rand::thread_rng;
     use uuid::Uuid;
 

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -295,8 +295,7 @@ pub mod mocks {
     };
     use constants::MERKLE_HEIGHT;
     use indexmap::IndexMap;
-    use mpc_stark::algebra::scalar::Scalar;
-    use num_bigint::BigUint;
+    use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
     use rand::thread_rng;
     use uuid::Uuid;
 
@@ -315,7 +314,7 @@ pub mod mocks {
             fees: vec![],
             key_chain: KeyChain {
                 public_keys: PublicKeyChain {
-                    pk_root: PublicSigningKey::from(&BigUint::from(0u8)),
+                    pk_root: PublicSigningKey::from(StarkPoint::generator()),
                     pk_match: PublicIdentificationKey::from(Scalar::zero()),
                 },
                 secret_keys: PrivateKeyChain {

--- a/state/src/wallet.rs
+++ b/state/src/wallet.rs
@@ -173,7 +173,6 @@ impl WalletIndex {
 mod tests {
     use common::types::wallet::PrivateKeyChain;
     use mpc_stark::algebra::scalar::Scalar;
-    use num_bigint::BigUint;
     use rand::thread_rng;
 
     /// Test serialization/deserialization of a PrivateKeyChain
@@ -183,7 +182,7 @@ mod tests {
 
         // Test with root specified
         let keychain = PrivateKeyChain {
-            sk_root: Some((&BigUint::from(0u8)).into()),
+            sk_root: Some(Scalar::zero()),
             sk_match: Scalar::random(&mut rng).into(),
         };
         let serialized = serde_json::to_string(&keychain).unwrap();

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 # === Cryptography + Arithmetic === #
-ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 num-bigint = { workspace = true }
 num-traits = "0.2"
 

--- a/workers/api-server/src/lib.rs
+++ b/workers/api-server/src/lib.rs
@@ -80,7 +80,7 @@ fn authenticate_wallet_request(
             })
         })?;
 
-    // TODO: Add STARK ECDSA sigverify check
+    // TODO: Add STARK curve ECDSA sigverify check
 
     Ok(())
 }


### PR DESCRIPTION
This PR updates the `PublicSigningKey` type to be a representation of a `StarkPoint` (namely, the `Scalar`s needed to represent a point's affine coordinates), and the `SecretSigningKey` type to be a `Scalar`, as expected for ECDSA over the STARK curve in accordance with the [IETF spec](datatracker.ietf.org/doc/html/rfc6979).

This PR also stubs out some changes to the API, namely it temporarily removes request signature verification logic, pending a future PR where STARK ECDSA is implemented.

All unit tests pass (including an updated serialization / deserialization test for the `PublicSigningKey`), and the affected integration tests (those in the `circuits` crate) pass.

