### PR TITLE
reverted circuit-types stark curve ecdsa keychain changes

### DIFF
--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 # === Crytography === #
 ark-ff = "0.4"
-ark-ec = "0.4"
 ed25519-dalek = "1.0.1"
 mpc-stark = { workspace = true }
 mpc-bulletproof = { workspace = true }
@@ -16,7 +15,6 @@ mpc-bulletproof = { workspace = true }
 # === Arithmetic === #
 bigdecimal = "0.3"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
-num-integer = "0.1.45"
 rand = "0.8"
 
 # === Async + Runtime === #

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -25,7 +25,7 @@ pub mod test_helpers {
     };
     use itertools::Itertools;
     use lazy_static::lazy_static;
-    use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+    use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
     use rand::thread_rng;
     use renegade_crypto::hash::compute_poseidon_hash;
@@ -41,7 +41,7 @@ pub mod test_helpers {
         // computed correctly
         pub static ref PRIVATE_KEYS: Vec<Scalar> = vec![Scalar::one(); NUM_KEYS];
         pub static ref PUBLIC_KEYS: PublicKeyChain = PublicKeyChain {
-            pk_root: PublicSigningKey::from(StarkPoint::generator()),
+            pk_root: PublicSigningKey::from(&BigUint::from(2u8).pow(256)),
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
         };
         pub static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -295,7 +295,7 @@ pub mod mocks {
     };
     use constants::MERKLE_HEIGHT;
     use indexmap::IndexMap;
-    use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
+    use mpc_stark::algebra::scalar::Scalar;
     use num_bigint::BigUint;
     use rand::thread_rng;
     use uuid::Uuid;
@@ -315,7 +315,7 @@ pub mod mocks {
             fees: vec![],
             key_chain: KeyChain {
                 public_keys: PublicKeyChain {
-                    pk_root: PublicSigningKey::from(StarkPoint::generator()),
+                    pk_root: PublicSigningKey::from(&BigUint::from(0u8)),
                     pk_match: PublicIdentificationKey::from(Scalar::zero()),
                 },
                 secret_keys: PrivateKeyChain {

--- a/state/src/wallet.rs
+++ b/state/src/wallet.rs
@@ -173,6 +173,7 @@ impl WalletIndex {
 mod tests {
     use common::types::wallet::PrivateKeyChain;
     use mpc_stark::algebra::scalar::Scalar;
+    use num_bigint::BigUint;
     use rand::thread_rng;
 
     /// Test serialization/deserialization of a PrivateKeyChain
@@ -182,7 +183,7 @@ mod tests {
 
         // Test with root specified
         let keychain = PrivateKeyChain {
-            sk_root: Some(Scalar::zero()),
+            sk_root: Some((&BigUint::from(0u8)).into()),
             sk_match: Scalar::random(&mut rng).into(),
         };
         let serialized = serde_json::to_string(&keychain).unwrap();

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # === Cryptography + Arithmetic === #
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 num-bigint = { workspace = true }
 num-traits = "0.2"
 

--- a/workers/api-server/src/lib.rs
+++ b/workers/api-server/src/lib.rs
@@ -11,6 +11,7 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use circuit_types::keychain::PublicSigningKey;
+use ed25519_dalek::{Digest, PublicKey, Sha512, Signature};
 use hyper::{HeaderMap, StatusCode};
 
 use self::error::ApiServerError;
@@ -26,25 +27,25 @@ const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
 /// Header name for the expiration timestamp of a signature
 const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
 
-// /// Error displayed when the signature format is invalid
-// const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
+/// Error displayed when the signature format is invalid
+const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
 /// Error displayed when the signature header is missing
 const ERR_SIG_HEADER_MISSING: &str = "signature missing from request";
 /// Error displayed when the signature expiration header is missing
 const ERR_SIG_EXPIRATION_MISSING: &str = "signature expiration missing from headers";
 /// Error displayed when the expiration format is invalid
 const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiration timestamp";
-// /// Error displayed when signature verification fails on a request
-// const ERR_SIG_VERIFICATION_FAILED: &str = "signature verification failed";
+/// Error displayed when signature verification fails on a request
+const ERR_SIG_VERIFICATION_FAILED: &str = "signature verification failed";
 
 /// A helper to authenticate a request via expiring signatures using the method below
 fn authenticate_wallet_request(
     headers: HeaderMap,
-    _body: &[u8],
-    _pk_root: &PublicSigningKey,
+    body: &[u8],
+    pk_root: &PublicSigningKey,
 ) -> Result<(), ApiServerError> {
     // Parse the signature and the expiration timestamp from the header
-    let _signature = headers
+    let signature = headers
         .get(RENEGADE_AUTH_HEADER_NAME)
         .ok_or_else(|| {
             ApiServerError::HttpStatusCode(
@@ -63,7 +64,7 @@ fn authenticate_wallet_request(
         })?;
 
     // Parse the expiration into a timestamp
-    let _expiration = sig_expiration
+    let expiration = sig_expiration
         .to_str()
         .map_err(|_| {
             ApiServerError::HttpStatusCode(
@@ -80,9 +81,16 @@ fn authenticate_wallet_request(
             })
         })?;
 
-    // TODO: Add STARK curve ECDSA sigverify check
-
-    Ok(())
+    // Recover a public key from the byte packed scalar representing the public key
+    let root_key: PublicKey = pk_root.into();
+    if !validate_expiring_signature(body, expiration, signature, root_key)? {
+        Err(ApiServerError::HttpStatusCode(
+            StatusCode::UNAUTHORIZED,
+            ERR_SIG_VERIFICATION_FAILED.to_string(),
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 /// A helper to verify a signature on a request body
@@ -90,11 +98,11 @@ fn authenticate_wallet_request(
 /// The signature should be a sponge hash of the serialized request body
 /// and a unix timestamp representing the expiration of the signature. A
 /// call to this method after the expiration timestamp should return false
-fn _validate_expiring_signature(
-    _body: &[u8],
+fn validate_expiring_signature(
+    body: &[u8],
     expiration_timestamp: u64,
-    _signature: &[u8],
-    _pk_root: PublicSigningKey,
+    signature: &[u8],
+    pk_root: PublicKey,
 ) -> Result<bool, ApiServerError> {
     // Check the expiration timestamp
     let now = SystemTime::now();
@@ -105,9 +113,17 @@ fn _validate_expiring_signature(
         return Ok(false);
     }
 
-    // TODO: Hash the body and the expiration timestamp into a digest to check the signature against
+    // Hash the body and the expiration timestamp into a digest to check the signature against
+    let mut hasher = Sha512::default();
+    hasher.update(body);
+    hasher.update(expiration_timestamp.to_le_bytes());
 
-    // TODO: Check the signature
+    // Check the signature
+    let sig: Signature = serde_json::from_slice(signature).map_err(|_| {
+        ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, ERR_SIG_FORMAT_INVALID.to_string())
+    })?;
 
-    Ok(true)
+    Ok(pk_root
+        .verify_prehashed(hasher, None /* context */, &sig)
+        .is_ok())
 }


### PR DESCRIPTION
This PR reverts the last two commits, which introduced changes to the signing key types in anticipation of the implementation of ECDSA over the STARK curve.

This was reverted to keep `main` stable for our upcoming demo.

The changes will be preserved & built on top of in a separate branch.