### PR TITLE
task-driver: integration: update-wallet: Add additional tests with ERC20 deposit + withdrawal

### DIFF
--- a/bin/cargo-integrate
+++ b/bin/cargo-integrate
@@ -14,8 +14,10 @@ fi
 export DOCKER_BUILDKIT=1
 
 # Bring up the compose file for the target package
+compose_file="$2"/docker-compose.yml
+docker-compose --file $compose_file down --volumes
 docker-compose \
-  --file "$2"/docker-compose.yml \
+  --file $compose_file \
   up \
   --remove-orphans \
   --build \

--- a/starknet-client/src/client/chain_state.rs
+++ b/starknet-client/src/client/chain_state.rs
@@ -41,7 +41,7 @@ use super::{
 };
 impl StarknetClient {
     /// Helper to make a view call to the contract
-    pub(crate) async fn call_contract(
+    pub async fn call_contract(
         &self,
         call: FunctionCall,
     ) -> Result<Vec<StarknetFieldElement>, StarknetClientError> {
@@ -52,7 +52,7 @@ impl StarknetClient {
     }
 
     /// Helper to setup a contract call with the correct max fee and account nonce
-    pub(crate) async fn execute_transaction(
+    pub async fn execute_transaction(
         &self,
         call: Call,
     ) -> Result<TransactionHash, StarknetClientError> {

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -48,6 +48,7 @@ eyre = { workspace = true }
 inventory = "0.3"
 
 lazy_static = "1.4"
+num-traits = "0.2"
 
 rand = { workspace = true }
 test-helpers = { path = "../test-helpers" }

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -47,6 +47,8 @@ colored = "2"
 eyre = { workspace = true }
 inventory = "0.3"
 
+lazy_static = "1.4"
+
 rand = { workspace = true }
 test-helpers = { path = "../test-helpers" }
 util = { path = "../util" }

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -65,6 +65,18 @@ struct CliArgs {
     /// If not provided, the test will deploy a new darkpool contract
     #[arg(long)]
     darkpool_addr: Option<String>,
+    /// The address of a dummy ERC-20 token deployed on the devnet node
+    ///
+    /// It is assumed that the given account address has a balance of this token
+    /// on the devnet node. This is generally true for default values; i.e. pre-deployed
+    /// accounts with the default $ETH ERC-20 token
+    ///
+    /// Defaults to the ETH base token address with the same address as on Goerli
+    #[arg(
+        long,
+        default_value = "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+    )]
+    erc20_addr: String,
     /// The location of a `deployments.json` file that contains the addresses of the
     /// deployed contracts
     #[arg(long)]
@@ -86,6 +98,10 @@ struct CliArgs {
 /// The arguments provided to every integration test
 #[derive(Clone)]
 struct IntegrationTestArgs {
+    /// The address of a pre-deployed ERC20 for testing
+    erc20_addr: String,
+    /// The client's account address
+    account_addr: String,
     /// The starknet client that resolves to a locally running devnet node
     starknet_client: StarknetClient,
     /// A sender to the network manager's work queue
@@ -115,6 +131,8 @@ impl From<CliArgs> for IntegrationTestArgs {
         MockProofManager::start(job_receiver);
 
         Self {
+            erc20_addr: test_args.erc20_addr.clone(),
+            account_addr: test_args.starknet_account_addr.clone(),
             starknet_client: setup_starknet_client_mock(test_args),
             network_sender,
             _network_receiver: Arc::new(network_receiver),

--- a/task-driver/integration/tests/update_wallet.rs
+++ b/task-driver/integration/tests/update_wallet.rs
@@ -1,11 +1,14 @@
 //! Integration tests for the `UpdateWallet` task
 
 use circuit_types::{
+    fee::Fee,
     fixed_point::FixedPoint,
     order::{Order, OrderSide},
 };
 use eyre::Result;
+use lazy_static::lazy_static;
 use mpc_stark::algebra::scalar::Scalar;
+use num_bigint::BigUint;
 use rand::thread_rng;
 use task_driver::update_wallet::UpdateWalletTask;
 use test_helpers::{assert_true_result, integration_test_async};
@@ -18,6 +21,26 @@ use crate::{
     },
     IntegrationTestArgs,
 };
+
+lazy_static! {
+    /// A dummy order that is allocated in a wallet as an update
+    static ref DUMMY_ORDER: Order = Order {
+        quote_mint: 0u8.into(),
+        base_mint: 1u8.into(),
+        side: OrderSide::Buy,
+        amount: 10,
+        worst_case_price: FixedPoint::from_integer(10),
+        timestamp: get_current_time_seconds(),
+    };
+
+    /// A dummy fee that is allocated in a wallet
+    static ref DUMMY_FEE: Fee = Fee {
+        gas_addr: BigUint::from(0u8),
+        gas_token_amount: 10,
+        settle_key: BigUint::from(15u8),
+        percentage_fee: FixedPoint::from_f32_round_down(0.01),
+    };
+}
 
 /// Tests updating a wallet then recovering it from on-chain state
 async fn test_update_wallet_then_recover(test_args: IntegrationTestArgs) -> Result<()> {
@@ -69,17 +92,7 @@ async fn test_update_wallet__place_order(test_args: IntegrationTestArgs) -> Resu
 
     // Update the wallet by inserting an order
     let old_wallet = wallet.clone();
-    wallet.orders.insert(
-        Uuid::new_v4(),
-        Order {
-            quote_mint: 0u8.into(),
-            base_mint: 1u8.into(),
-            side: OrderSide::Buy,
-            amount: 10,
-            worst_case_price: FixedPoint::from_integer(10),
-            timestamp: get_current_time_seconds(),
-        },
-    );
+    wallet.orders.insert(Uuid::new_v4(), DUMMY_ORDER.clone());
     wallet.reblind_wallet();
 
     let task = UpdateWalletTask::new(
@@ -101,3 +114,122 @@ async fn test_update_wallet__place_order(test_args: IntegrationTestArgs) -> Resu
     lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
 }
 integration_test_async!(test_update_wallet__place_order);
+
+/// Tests cancelling an order in a wallet
+#[allow(non_snake_case)]
+async fn test_update_wallet__cancel_order(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+    let mut rng = thread_rng();
+
+    // Create a new wallet with a non-empty order and post it on-chain
+    let blinder_seed = Scalar::random(&mut rng);
+    let share_seed = Scalar::random(&mut rng);
+    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
+
+    let order_id = Uuid::new_v4();
+    wallet.orders.insert(order_id, DUMMY_ORDER.clone());
+
+    allocate_wallet_in_darkpool(&wallet, client).await?;
+
+    // Update the wallet by removing an order
+    let old_wallet = wallet.clone();
+    wallet.orders.remove(&order_id);
+    wallet.reblind_wallet();
+
+    let task = UpdateWalletTask::new(
+        get_current_time_seconds(),
+        None, /* external_transfer */
+        old_wallet,
+        wallet.clone(),
+        client.clone(),
+        test_args.network_sender.clone(),
+        test_args.global_state.clone(),
+        test_args.proof_job_queue.clone(),
+    )?;
+
+    let (_task_id, handle) = test_args.driver.start_task(task).await;
+    let success = handle.await?;
+    assert_true_result!(success)?;
+
+    // Now attempt to lookup the wallet and verify its correctness
+    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+}
+integration_test_async!(test_update_wallet__cancel_order);
+
+/// Tests updating a wallet by adding a fee to the wallet
+#[allow(non_snake_case)]
+async fn test_update_wallet__add_fee(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+    let mut rng = thread_rng();
+
+    // Create a new wallet and post it on-chain
+    let blinder_seed = Scalar::random(&mut rng);
+    let share_seed = Scalar::random(&mut rng);
+    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
+
+    allocate_wallet_in_darkpool(&wallet, client).await?;
+
+    // Update the wallet by adding a fee
+    let old_wallet = wallet.clone();
+    wallet.fees.push(DUMMY_FEE.clone());
+    wallet.reblind_wallet();
+
+    let task = UpdateWalletTask::new(
+        get_current_time_seconds(),
+        None, /* external_transfer */
+        old_wallet,
+        wallet.clone(),
+        client.clone(),
+        test_args.network_sender.clone(),
+        test_args.global_state.clone(),
+        test_args.proof_job_queue.clone(),
+    )?;
+
+    let (_task_id, handle) = test_args.driver.start_task(task).await;
+    let success = handle.await?;
+    assert_true_result!(success)?;
+
+    // Now attempt to lookup the wallet and verify its correctness
+    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+}
+integration_test_async!(test_update_wallet__add_fee);
+
+/// Tests updating a wallet by removing a fee from the wallet
+#[allow(non_snake_case)]
+async fn test_update_wallet__remove_fee(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+    let mut rng = thread_rng();
+
+    // Create a new wallet with a non-empty fee and post it on-chain
+    let blinder_seed = Scalar::random(&mut rng);
+    let share_seed = Scalar::random(&mut rng);
+    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
+
+    wallet.fees.push(DUMMY_FEE.clone());
+
+    allocate_wallet_in_darkpool(&wallet, client).await?;
+
+    // Update the wallet by removing a fee
+    let old_wallet = wallet.clone();
+    wallet.fees.pop();
+    wallet.reblind_wallet();
+
+    let task = UpdateWalletTask::new(
+        get_current_time_seconds(),
+        None, /* external_transfer */
+        old_wallet,
+        wallet.clone(),
+        client.clone(),
+        test_args.network_sender.clone(),
+        test_args.global_state.clone(),
+        test_args.proof_job_queue.clone(),
+    )?;
+
+    let (_task_id, handle) = test_args.driver.start_task(task).await;
+    let success = handle.await?;
+    assert_true_result!(success)?;
+
+    // Now attempt to lookup the wallet and verify its correctness
+    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+}
+integration_test_async!(test_update_wallet__remove_fee);

--- a/task-driver/integration/tests/update_wallet.rs
+++ b/task-driver/integration/tests/update_wallet.rs
@@ -1,10 +1,13 @@
 //! Integration tests for the `UpdateWallet` task
 
 use circuit_types::{
+    balance::Balance,
     fee::Fee,
     fixed_point::FixedPoint,
     order::{Order, OrderSide},
+    transfers::{ExternalTransfer, ExternalTransferDirection},
 };
+use common::types::wallet::Wallet;
 use eyre::Result;
 use lazy_static::lazy_static;
 use mpc_stark::algebra::scalar::Scalar;
@@ -17,7 +20,8 @@ use uuid::Uuid;
 
 use crate::{
     helpers::{
-        allocate_wallet_in_darkpool, empty_wallet_from_seed, lookup_wallet_and_check_result,
+        allocate_wallet_in_darkpool, biguint_from_hex_string, empty_wallet_from_seed,
+        increase_erc20_allowance, lookup_wallet_and_check_result, new_wallet_in_darkpool,
     },
     IntegrationTestArgs,
 };
@@ -42,26 +46,23 @@ lazy_static! {
     };
 }
 
-/// Tests updating a wallet then recovering it from on-chain state
-async fn test_update_wallet_then_recover(test_args: IntegrationTestArgs) -> Result<()> {
+// -----------
+// | Helpers |
+// -----------
+
+/// Perform a wallet update task and verify that it succeeds
+async fn execute_wallet_update(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    transfer: Option<ExternalTransfer>,
+    test_args: IntegrationTestArgs,
+) -> Result<()> {
     let client = &test_args.starknet_client;
-    let mut rng = thread_rng();
-
-    // Create a new wallet and post it on-chain
-    let blinder_seed = Scalar::random(&mut rng);
-    let share_seed = Scalar::random(&mut rng);
-    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
-
-    allocate_wallet_in_darkpool(&wallet, client).await?;
-
-    // Update the wallet by reblinding it
-    let old_wallet = wallet.clone();
-    wallet.reblind_wallet();
     let task = UpdateWalletTask::new(
         get_current_time_seconds(),
-        None, /* external_transfer */
+        transfer,
         old_wallet,
-        wallet.clone(),
+        new_wallet,
         client.clone(),
         test_args.network_sender.clone(),
         test_args.global_state.clone(),
@@ -70,48 +71,73 @@ async fn test_update_wallet_then_recover(test_args: IntegrationTestArgs) -> Resu
 
     let (_task_id, handle) = test_args.driver.start_task(task).await;
     let success = handle.await?;
-    assert_true_result!(success)?;
+    assert_true_result!(success)
+}
 
-    // Now attempt to lookup the wallet and verify its construction
-    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+/// Execute a wallet update, then lookup the new wallet from on-chain state and verify it has
+/// been correctly constructed
+async fn execute_wallet_update_and_verify_shares(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    transfer: Option<ExternalTransfer>,
+    blinder_seed: Scalar,
+    share_seed: Scalar,
+    test_args: IntegrationTestArgs,
+) -> Result<()> {
+    execute_wallet_update(old_wallet, new_wallet.clone(), transfer, test_args.clone()).await?;
+    lookup_wallet_and_check_result(&new_wallet, blinder_seed, share_seed, test_args).await
+}
+
+// ---------
+// | Tests |
+// ---------
+
+/// Tests updating a wallet then recovering it from on-chain state
+async fn test_update_wallet_then_recover(test_args: IntegrationTestArgs) -> Result<()> {
+    // Create a new wallet and post it on-chain
+    let client = &test_args.starknet_client;
+    let (mut wallet, blinder_seed, share_seed) = new_wallet_in_darkpool(client).await?;
+
+    // Update the wallet by reblinding it
+    let old_wallet = wallet.clone();
+    wallet.reblind_wallet();
+    execute_wallet_update_and_verify_shares(
+        old_wallet,
+        wallet,
+        None, /* transfer */
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
 }
 integration_test_async!(test_update_wallet_then_recover);
+
+// ----------
+// | Orders |
+// ----------
 
 /// Tests placing an order in a wallet
 #[allow(non_snake_case)]
 async fn test_update_wallet__place_order(test_args: IntegrationTestArgs) -> Result<()> {
-    let client = &test_args.starknet_client;
-    let mut rng = thread_rng();
-
     // Create a new wallet and post it on-chain
-    let blinder_seed = Scalar::random(&mut rng);
-    let share_seed = Scalar::random(&mut rng);
-    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
-
-    allocate_wallet_in_darkpool(&wallet, client).await?;
+    let client = &test_args.starknet_client;
+    let (mut wallet, blinder_seed, share_seed) = new_wallet_in_darkpool(client).await?;
 
     // Update the wallet by inserting an order
     let old_wallet = wallet.clone();
     wallet.orders.insert(Uuid::new_v4(), DUMMY_ORDER.clone());
     wallet.reblind_wallet();
 
-    let task = UpdateWalletTask::new(
-        get_current_time_seconds(),
-        None, /* external_transfer */
+    execute_wallet_update_and_verify_shares(
         old_wallet,
-        wallet.clone(),
-        client.clone(),
-        test_args.network_sender.clone(),
-        test_args.global_state.clone(),
-        test_args.proof_job_queue.clone(),
-    )?;
-
-    let (_task_id, handle) = test_args.driver.start_task(task).await;
-    let success = handle.await?;
-    assert_true_result!(success)?;
-
-    // Now attempt to lookup the wallet and verify its correctness
-    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+        wallet,
+        None, /* transfer */
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
 }
 integration_test_async!(test_update_wallet__place_order);
 
@@ -136,61 +162,43 @@ async fn test_update_wallet__cancel_order(test_args: IntegrationTestArgs) -> Res
     wallet.orders.remove(&order_id);
     wallet.reblind_wallet();
 
-    let task = UpdateWalletTask::new(
-        get_current_time_seconds(),
-        None, /* external_transfer */
+    execute_wallet_update_and_verify_shares(
         old_wallet,
-        wallet.clone(),
-        client.clone(),
-        test_args.network_sender.clone(),
-        test_args.global_state.clone(),
-        test_args.proof_job_queue.clone(),
-    )?;
-
-    let (_task_id, handle) = test_args.driver.start_task(task).await;
-    let success = handle.await?;
-    assert_true_result!(success)?;
-
-    // Now attempt to lookup the wallet and verify its correctness
-    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+        wallet,
+        None, /* transfer */
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
 }
 integration_test_async!(test_update_wallet__cancel_order);
+
+// --------
+// | Fees |
+// --------
 
 /// Tests updating a wallet by adding a fee to the wallet
 #[allow(non_snake_case)]
 async fn test_update_wallet__add_fee(test_args: IntegrationTestArgs) -> Result<()> {
-    let client = &test_args.starknet_client;
-    let mut rng = thread_rng();
-
     // Create a new wallet and post it on-chain
-    let blinder_seed = Scalar::random(&mut rng);
-    let share_seed = Scalar::random(&mut rng);
-    let mut wallet = empty_wallet_from_seed(blinder_seed, share_seed);
-
-    allocate_wallet_in_darkpool(&wallet, client).await?;
+    let client = &test_args.starknet_client;
+    let (mut wallet, blinder_seed, share_seed) = new_wallet_in_darkpool(client).await?;
 
     // Update the wallet by adding a fee
     let old_wallet = wallet.clone();
     wallet.fees.push(DUMMY_FEE.clone());
     wallet.reblind_wallet();
 
-    let task = UpdateWalletTask::new(
-        get_current_time_seconds(),
-        None, /* external_transfer */
+    execute_wallet_update_and_verify_shares(
         old_wallet,
-        wallet.clone(),
-        client.clone(),
-        test_args.network_sender.clone(),
-        test_args.global_state.clone(),
-        test_args.proof_job_queue.clone(),
-    )?;
-
-    let (_task_id, handle) = test_args.driver.start_task(task).await;
-    let success = handle.await?;
-    assert_true_result!(success)?;
-
-    // Now attempt to lookup the wallet and verify its correctness
-    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+        wallet,
+        None, /* transfer */
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
 }
 integration_test_async!(test_update_wallet__add_fee);
 
@@ -214,22 +222,82 @@ async fn test_update_wallet__remove_fee(test_args: IntegrationTestArgs) -> Resul
     wallet.fees.pop();
     wallet.reblind_wallet();
 
-    let task = UpdateWalletTask::new(
-        get_current_time_seconds(),
-        None, /* external_transfer */
+    execute_wallet_update_and_verify_shares(
         old_wallet,
-        wallet.clone(),
-        client.clone(),
-        test_args.network_sender.clone(),
-        test_args.global_state.clone(),
-        test_args.proof_job_queue.clone(),
-    )?;
-
-    let (_task_id, handle) = test_args.driver.start_task(task).await;
-    let success = handle.await?;
-    assert_true_result!(success)?;
-
-    // Now attempt to lookup the wallet and verify its correctness
-    lookup_wallet_and_check_result(&wallet, blinder_seed, share_seed, test_args).await
+        wallet,
+        None, /* transfer */
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
 }
 integration_test_async!(test_update_wallet__remove_fee);
+
+// ------------
+// | Balances |
+// ------------
+
+/// Tests updating a wallet by depositing into the pool
+#[allow(non_snake_case)]
+async fn test_update_wallet__deposit_and_withdraw(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.starknet_client;
+
+    // Create a new wallet and post it on-chain
+    let (mut wallet, blinder_seed, share_seed) = new_wallet_in_darkpool(client).await?;
+
+    // Update the wallet by depositing into the pool
+    let old_wallet = wallet.clone();
+
+    let mint = biguint_from_hex_string(&test_args.erc20_addr);
+    let amount = 10u64;
+
+    wallet.balances.insert(
+        mint.clone(),
+        Balance {
+            mint: mint.clone(),
+            amount,
+        },
+    );
+    wallet.reblind_wallet();
+
+    // Approve the deposit on the ERC20 contract
+    increase_erc20_allowance(amount, test_args.clone()).await?;
+
+    let account_addr = biguint_from_hex_string(&test_args.account_addr);
+    execute_wallet_update_and_verify_shares(
+        old_wallet,
+        wallet.clone(),
+        Some(ExternalTransfer {
+            mint: mint.clone(),
+            amount: amount.into(),
+            account_addr: account_addr.clone(),
+            direction: ExternalTransferDirection::Deposit,
+        }),
+        blinder_seed,
+        share_seed,
+        test_args.clone(),
+    )
+    .await?;
+
+    // Now, withdraw the same amount
+    let old_wallet = wallet.clone();
+    wallet.balances.remove(&mint);
+    wallet.reblind_wallet();
+
+    execute_wallet_update_and_verify_shares(
+        old_wallet,
+        wallet,
+        Some(ExternalTransfer {
+            mint,
+            amount: amount.into(),
+            account_addr,
+            direction: ExternalTransferDirection::Withdrawal,
+        }),
+        blinder_seed,
+        share_seed,
+        test_args,
+    )
+    .await
+}
+integration_test_async!(test_update_wallet__deposit_and_withdraw);

--- a/test-helpers/src/macros.rs
+++ b/test-helpers/src/macros.rs
@@ -88,7 +88,7 @@ macro_rules! integration_test_main {
                 for test_wrapper in inventory::iter::<TestWrapper>.into_iter() {
                     let test = &test_wrapper.0;
                     if args.borrow().test.is_some()
-                        && args.borrow().test.as_deref().unwrap() != test.name
+                        && !test.name.contains(args.borrow().test.as_deref().unwrap())
                     {
                         continue;
                     }


### PR DESCRIPTION
### Purpose
This PR adds additional `update-wallet` tests including:
- Adding and removing fees
- Depositing and withdrawing balances from the pool. This makes use of the pre-deployed `ETH` ERC-20 on the katana devnet node

### Testing
- Unit and integration tests pass