### PR TITLE
api-server: replaced wallet request auth w/ stark curve ecdsa

### DIFF
--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -164,8 +164,8 @@ impl PublicSigningKey {
     }
 }
 
-impl From<StarkPoint> for PublicSigningKey {
-    fn from(value: StarkPoint) -> Self {
+impl From<&StarkPoint> for PublicSigningKey {
+    fn from(value: &StarkPoint) -> Self {
         let Affine { x, y, infinity } = value.to_affine();
         assert!(!infinity, "public key cannot be additive identity");
 
@@ -181,8 +181,8 @@ impl From<StarkPoint> for PublicSigningKey {
     }
 }
 
-impl From<PublicSigningKey> for StarkPoint {
-    fn from(value: PublicSigningKey) -> Self {
+impl From<&PublicSigningKey> for StarkPoint {
+    fn from(value: &PublicSigningKey) -> Self {
         let x = PublicSigningKey::combine_words_into_biguint(&value.x);
         let y = PublicSigningKey::combine_words_into_biguint(&value.y);
         StarkPoint::from_affine_coords(x, y)
@@ -230,8 +230,8 @@ mod test {
         let rand_pt = random_point();
 
         // Convert to and from a nonnative key
-        let pubkey: PublicSigningKey = rand_pt.into();
-        let recovered_pt: StarkPoint = pubkey.into();
+        let pubkey: PublicSigningKey = (&rand_pt).into();
+        let recovered_pt: StarkPoint = (&pubkey).into();
 
         assert_eq!(rand_pt, recovered_pt);
     }

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -41,7 +41,7 @@ pub mod test_helpers {
         // computed correctly
         pub static ref PRIVATE_KEYS: Vec<Scalar> = vec![Scalar::one(); NUM_KEYS];
         pub static ref PUBLIC_KEYS: PublicKeyChain = PublicKeyChain {
-            pk_root: PublicSigningKey::from(StarkPoint::generator()),
+            pk_root: PublicSigningKey::from(&StarkPoint::generator()),
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
         };
         pub static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -315,7 +315,7 @@ pub mod mocks {
             fees: vec![],
             key_chain: KeyChain {
                 public_keys: PublicKeyChain {
-                    pk_root: PublicSigningKey::from(StarkPoint::generator()),
+                    pk_root: PublicSigningKey::from(&StarkPoint::generator()),
                     pk_match: PublicIdentificationKey::from(Scalar::zero()),
                 },
                 secret_keys: PrivateKeyChain {

--- a/renegade-crypto/src/ecdsa.rs
+++ b/renegade-crypto/src/ecdsa.rs
@@ -108,23 +108,19 @@ fn verify_signature(hash: &Scalar, signature: &Signature, public_key: &StarkPoin
 }
 
 /// Verifies an ECDSA signature over a message that has been serialized into a sequence of bytes
-pub fn verify_signed_bytes_message(
-    message: &[u8],
-    signature: &Signature,
-    public_key: &StarkPoint,
-) -> bool {
-    let h = compute_bytes_hash(message);
-    verify_signature(&h, signature, public_key)
+pub fn verify_signed_bytes(message: &[u8], signature: &Signature, public_key: &StarkPoint) -> bool {
+    let hash = compute_bytes_hash(message);
+    verify_signature(&hash, signature, public_key)
 }
 
 /// Verifies an ECDSA signature over a message that has been serialized into a sequence of bytes
-pub fn verify_signed_scalar_message(
+pub fn verify_signed_message(
     message: &[Scalar],
     signature: &Signature,
     public_key: &StarkPoint,
 ) -> bool {
-    let h = compute_message_hash(message);
-    verify_signature(&h, signature, public_key)
+    let hash = compute_message_hash(message);
+    verify_signature(&hash, signature, public_key)
 }
 
 #[cfg(test)]
@@ -142,11 +138,7 @@ mod tests {
 
         let message = b"Hello, world!";
         let signature = sign_bytes_message(message, &secret_key);
-        assert!(verify_signed_bytes_message(
-            message,
-            &signature,
-            &public_key
-        ));
+        assert!(verify_signed_bytes(message, &signature, &public_key));
     }
 
     #[test]
@@ -160,11 +152,7 @@ mod tests {
         let mut signature = sign_bytes_message(message, &secret_key);
         signature.r += Scalar::random(&mut rng);
 
-        assert!(!verify_signed_bytes_message(
-            message,
-            &signature,
-            &public_key
-        ));
+        assert!(!verify_signed_bytes(message, &signature, &public_key));
     }
 
     #[test]
@@ -178,11 +166,7 @@ mod tests {
             .take(10)
             .collect_vec();
         let signature = sign_scalar_message(&message, &secret_key);
-        assert!(verify_signed_scalar_message(
-            &message,
-            &signature,
-            &public_key
-        ));
+        assert!(verify_signed_message(&message, &signature, &public_key));
     }
 
     #[test]
@@ -198,10 +182,6 @@ mod tests {
         let mut signature = sign_scalar_message(&message, &secret_key);
         signature.r += Scalar::random(&mut rng);
 
-        assert!(!verify_signed_scalar_message(
-            &message,
-            &signature,
-            &public_key
-        ));
+        assert!(!verify_signed_message(&message, &signature, &public_key));
     }
 }

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # === Cryptography + Arithmetic === #
 num-bigint = { workspace = true }
 num-traits = "0.2"
+mpc-stark = { workspace = true }
 
 # === HTTP + Websocket === #
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }


### PR DESCRIPTION
This PR replaces the wallet request authentication logic with STARK curve ECDSA signature verification.

There are no tests for the API server crate, so these changes will have to be tested ad-hoc when they are integrated into the client