### PR TITLE
external-api, handshake-manager: Update `Order` API assumptions to match SDK

### DIFF
--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -188,7 +188,7 @@ impl From<(OrderIdentifier, IndexedOrder)> for Order {
             quote_mint: order.quote_mint,
             base_mint: order.base_mint,
             side: order.side,
-            type_: OrderType::Limit,
+            type_: OrderType::Midpoint,
             worst_case_price: order.worst_case_price,
             amount: BigUint::from(order.amount),
             timestamp: order.timestamp,

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -718,8 +718,8 @@ impl HandshakeExecutor {
     fn token_pair_for_order(&self, order: &Order) -> (Token, Token) {
         match self.chain_id {
             ChainId::AlphaGoerli | ChainId::Devnet => (
-                Token::from_starknet_goerli_addr_biguint(&order.base_mint),
-                Token::from_starknet_goerli_addr_biguint(&order.quote_mint),
+                Token::from_addr_biguint(&order.base_mint),
+                Token::from_addr_biguint(&order.quote_mint),
             ),
             _ => todo!("Implement price remapping for {:?}", self.chain_id),
         }


### PR DESCRIPTION
### Purpose
This PR makes two small changes to match assumptions made in the javascript SDK:
- Order mints are specified by their ETH-L1 addresses, not the Starknet address
- Default order type must be changed to `OrderType::Midpoint` now that we only support midpoint addresses, this field is displayed on the client side

### Testing
- All unit tests pass