### PR TITLE
statev2: db: Add transaction semantics and full functionality test cases

### DIFF
--- a/statev2/src/storage/error.rs
+++ b/statev2/src/storage/error.rs
@@ -22,6 +22,8 @@ pub enum StorageError {
     OpenTable(MdbxError),
     /// Error serializing a value for storage
     Serialization(FlexbuffersSerializationError),
+    /// Error syncing the database
+    Sync(MdbxError),
     /// Error while performing a transaction operation
     TxOp(MdbxError),
 }


### PR DESCRIPTION
### Purpose
This PR adds a set of transactional semantics over the `mdbx` database wrapper. Together these wrappers effectively provide a cleaner (fewer flags) interface to the db, and automatic serialization/deserialization to the caller's expected type. This thin wrapper will be composed into higher layers of abstraction by the replication layer and application logic.

As well, this PR adds a number of tests for various basic cases as well as transaction isolation, crash recovery, etc.

### Testing
- Unit and integration tests pass