### PR TITLE
statev2: storage: cursor: Add `Cursor` implementation

### DIFF
--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -3,4 +3,26 @@
 //! We store our relayer state in an embedded database using `libmdbx` as the underlying storage
 //! engine. The database is then replicated by a raft instance at higher layers in the application
 
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(unsafe_code)]
+
 pub mod storage;
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use tempfile::tempdir;
+
+    use crate::storage::db::{DbConfig, DB};
+
+    /// Create a mock database in a temporary location
+    pub fn mock_db() -> DB {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().to_str().unwrap();
+
+        DB::new(DbConfig {
+            path: path.to_string(),
+        })
+        .unwrap()
+    }
+}

--- a/statev2/src/storage/cursor.rs
+++ b/statev2/src/storage/cursor.rs
@@ -1,0 +1,163 @@
+//! Defines a cursor in the database
+//!
+//! This cursor implementation is a thin wrapper around the `mdbx` cursor that provides
+//! serialization and deserialization of the keys and values in the database
+
+use std::marker::PhantomData;
+
+use libmdbx::{Cursor, TransactionKind, WriteFlags, RW};
+
+use crate::storage::{db::deserialize_value, error::StorageError};
+
+use super::{
+    db::serialize_value,
+    traits::{Key, Value},
+    CowBuffer,
+};
+
+/// A cursor in a table
+pub struct DbCursor<'txn, Tx: TransactionKind, K: Key, V: Value> {
+    /// The underlying cursor
+    inner: Cursor<'txn, Tx>,
+    /// A phantom data field to hold the deserialized type of the table
+    _phantom: PhantomData<(K, V)>,
+}
+
+/// Query methods
+impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
+    /// Constructor
+    pub fn new(cursor: Cursor<'txn, Tx>) -> Self {
+        Self {
+            inner: cursor,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Seek to the first key in the table and return it's kv pair
+    pub fn first(&mut self) -> Result<Option<(K, V)>, StorageError> {
+        let res = self
+            .inner
+            .first::<CowBuffer, CowBuffer>()
+            .map_err(StorageError::TxOp)?;
+
+        res.map(|(k, v)| Self::deserialize_key_value(k, v))
+            .transpose()
+    }
+
+    /// Get the key/value at the current position
+    pub fn get_current(&mut self) -> Result<Option<(K, V)>, StorageError> {
+        let res = self
+            .inner
+            .get_current::<CowBuffer, CowBuffer>()
+            .map_err(StorageError::TxOp)?;
+
+        res.map(|(k, v)| Self::deserialize_key_value(k, v))
+            .transpose()
+    }
+
+    /// Position the cursor at the previous key value pair and return it
+    pub fn prev(&mut self) -> Result<Option<(K, V)>, StorageError> {
+        let res = self
+            .inner
+            .prev::<CowBuffer, CowBuffer>()
+            .map_err(StorageError::TxOp)?;
+
+        res.map(|(k, v)| Self::deserialize_key_value(k, v))
+            .transpose()
+    }
+
+    /// Position the cursor at a specific key
+    pub fn seek(&mut self, k: K) -> Result<Option<(K, V)>, StorageError> {
+        let k_bytes = serialize_value(&k)?;
+
+        self.inner
+            .set_key::<CowBuffer, CowBuffer>(&k_bytes)
+            .map_err(StorageError::TxOp)?
+            .map(|(k, v)| Self::deserialize_key_value(k, v))
+            .transpose()
+    }
+
+    /// Position at the first key greater than or equal to the given key
+    pub fn seek_geq(&mut self, k: K) -> Result<Option<(K, V)>, StorageError> {
+        let k_bytes = serialize_value(&k)?;
+
+        self.inner
+            .set_range::<CowBuffer, CowBuffer>(&k_bytes)
+            .map_err(StorageError::TxOp)?
+            .map(|(k, v)| Self::deserialize_key_value(k, v))
+            .transpose()
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Deserialize a key-value pair to the type of the cursor
+    fn deserialize_key_value(
+        k_buffer: CowBuffer,
+        v_buffer: CowBuffer,
+    ) -> Result<(K, V), StorageError> {
+        Ok((deserialize_value(&k_buffer)?, deserialize_value(&v_buffer)?))
+    }
+}
+
+/// Mutation methods
+impl<'txn, K: Key, V: Value> DbCursor<'txn, RW, K, V> {
+    /// Insert a key/value pair into the table, the cursor will be positioned at the inserted key
+    /// or near it when this method fails
+    pub fn put(&mut self, k: K, v: V) -> Result<(), StorageError> {
+        let k_bytes = serialize_value(&k)?;
+        let v_bytes = serialize_value(&v)?;
+
+        self.inner
+            .put(&k_bytes, &v_bytes, WriteFlags::default())
+            .map_err(StorageError::TxOp)
+    }
+
+    /// Delete the current key/value pair
+    pub fn delete(&mut self) -> Result<(), StorageError> {
+        self.inner
+            .del(WriteFlags::default())
+            .map_err(StorageError::TxOp)
+    }
+}
+
+impl<'txn, T: TransactionKind, K: Key, V: Value> Iterator for DbCursor<'txn, T, K, V> {
+    type Item = Result<(K, V), StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.inner.next().map_err(StorageError::TxOp);
+        if let Err(e) = res {
+            return Some(Err(e));
+        }
+
+        let res = res.unwrap();
+        res.map(|(k, v)| Self::deserialize_key_value(k, v))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_helpers::mock_db;
+
+    /// The name of the table used for testing
+    const TEST_TABLE: &str = "test-table";
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// Test the `first` method of a cursor
+    #[test]
+    fn test_empty_table() {
+        let db = mock_db();
+        db.create_table(TEST_TABLE).unwrap();
+
+        // Read the first key, it should be `None`
+        let tx = db.new_read_tx().unwrap();
+        let mut cursor = tx.cursor::<String /* key */, String /* value */>(TEST_TABLE).unwrap();
+        let first = cursor.first().unwrap();
+
+        assert!(first.is_none());
+    }
+}

--- a/statev2/src/storage/error.rs
+++ b/statev2/src/storage/error.rs
@@ -8,6 +8,7 @@ use flexbuffers::{
 };
 use libmdbx::Error as MdbxError;
 
+/// The error type emitted by the storage layer
 #[derive(Debug)]
 pub enum StorageError {
     /// Error creating a new transaction in the database

--- a/statev2/src/storage/mod.rs
+++ b/statev2/src/storage/mod.rs
@@ -1,6 +1,12 @@
 //! Defines the access patterns and interface to the durable storage layer
 //! concretely implemented as an `mdbx` instance
 
+use std::borrow::Cow;
+
+pub mod cursor;
 pub mod db;
 pub mod error;
 pub mod traits;
+
+/// A type alias used for reading from the database
+type CowBuffer<'a> = Cow<'a, [u8]>;


### PR DESCRIPTION
### Purpose
This PR adds an initial `Cursor` implementation on top of the database. This wraps an internal cursor and provides a serialization/deserialization layer on top of the cursor.

We could have used the `libdmbx::orm` module to do this ([link](https://docs.rs/libmdbx/latest/libmdbx/orm/index.html)), but this is a bit restrictive in that *all* tables must have a model at database creation time. Some tables will store heterogenous data (e.g. metadata tables), so the ORM doesn't quite give us what we want.

### Testing
- Unit and integration tests pass
- Planning to add more tests in a follow up PR