### PR TITLE
storage: cursor: Add cursor unit tests

### DIFF
--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -12,3 +12,4 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.8"
+rand = { workspace = true }


### PR DESCRIPTION
### Purpose
This PR adds a full unit test suite for the `Cursor` interface. Of particular interest is sorted iteration: we currently sort numeric keys by casting them to a string. This is okay for now, but should we want more advanced sorting we can implement a hook into the [`MDBX_DUPSORT`](https://erthink.github.io/libmdbx/group__c__dbi.html#ggafe3bddb297b3ab0d828a487c5726f76aaed33d978b4e23b7c1659e8106e9c7acd:~:text=comparison%20for%20keys.-,MDBX_DUPSORT,-Use%20sorted%20duplicates) interface.