### PR TITLE
statev2: replication: log-store: Add `LogStore` implementation

### DIFF
--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -5,9 +5,13 @@ edition = "2021"
 
 [dependencies]
 
+# === Replication === #
+raft = "0.7"
+
 # === Storage === #
 flexbuffers = "2.0"
 libmdbx = "0.3"
+protobuf = "2.0"
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
 
+pub mod replication;
 pub mod storage;
 
 #[cfg(test)]

--- a/statev2/src/replication/error.rs
+++ b/statev2/src/replication/error.rs
@@ -1,0 +1,37 @@
+//! Defines error types emitted by the replication layer
+
+use raft::{Error as RaftError, StorageError as RaftStorageError};
+use std::{error::Error, fmt::Display};
+
+use crate::storage::error::StorageError;
+
+/// The error type emitted by the replication layer
+#[derive(Debug)]
+pub enum ReplicationError {
+    /// A value was not found in storage
+    EntryNotFound,
+    /// Error parsing a stored value
+    ParseValue(String),
+    /// An error interacting with storage
+    Storage(StorageError),
+}
+
+impl Display for ReplicationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for ReplicationError {}
+
+impl From<ReplicationError> for RaftError {
+    fn from(value: ReplicationError) -> Self {
+        match value {
+            ReplicationError::EntryNotFound => RaftError::Store(RaftStorageError::Unavailable),
+            ReplicationError::Storage(e) => e.into(),
+            ReplicationError::ParseValue(s) => RaftError::Store(RaftStorageError::Other(Box::new(
+                ReplicationError::ParseValue(s),
+            ))),
+        }
+    }
+}

--- a/statev2/src/replication/log_store.rs
+++ b/statev2/src/replication/log_store.rs
@@ -1,0 +1,233 @@
+//! Defines the storage layer for the `raft` implementation. We store logs, snapshots,
+//! metadata, etc in the storage layer -- concretely an embedded KV store
+
+use std::sync::Arc;
+
+use libmdbx::{TransactionKind, RO};
+use protobuf::Message;
+use raft::{
+    prelude::{
+        ConfState, Entry as RaftEntry, HardState, Snapshot as RaftSnapshot, SnapshotMetadata,
+    },
+    Error as RaftError, GetEntriesContext, RaftState, Result as RaftResult, Storage,
+    StorageError as RaftStorageError,
+};
+
+use crate::storage::{
+    cursor::DbCursor,
+    db::{DbTxn, DB},
+    ProtoStorageWrapper,
+};
+
+use super::error::ReplicationError;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The name of the raft metadata table in the database
+pub const RAFT_METADATA_TABLE: &str = "raft-metadata";
+/// The name of the raft logs table in the database
+pub const RAFT_LOGS_TABLE: &str = "raft-logs";
+
+/// The name of the raft hard state key in the KV store
+pub const HARD_STATE_KEY: &str = "hard-state";
+/// The name of the raft conf state key in the KV store
+pub const CONF_STATE_KEY: &str = "conf-state";
+/// The name of the snapshot metadata key in the KV store
+pub const SNAPSHOT_METADATA_KEY: &str = "snapshot-metadata";
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Parse a raft LSN from a string
+fn parse_lsn(s: &str) -> Result<u64, ReplicationError> {
+    s.parse::<u64>()
+        .map_err(|_| ReplicationError::ParseValue(s.to_string()))
+}
+
+/// Format a raft LSN as a string
+fn lsn_to_key(lsn: u64) -> String {
+    lsn.to_string()
+}
+
+// -------------
+// | Log Store |
+// -------------
+
+/// The central storage abstraction, wraps a KV database
+pub struct LogStore {
+    /// The underlying database reference
+    db: Arc<DB>,
+}
+
+impl LogStore {
+    /// Constructor
+    pub fn new(db: Arc<DB>) -> Result<Self, ReplicationError> {
+        // Create the logs table in the db
+        db.create_table(RAFT_METADATA_TABLE)
+            .map_err(ReplicationError::Storage)?;
+
+        Ok(Self { db })
+    }
+
+    /// Read a log entry, returning an error if an entry does not exist for the given index
+    pub fn read_log_entry(&self, index: u64) -> Result<RaftEntry, ReplicationError> {
+        let tx = self.db.new_read_tx().map_err(ReplicationError::Storage)?;
+        let entry: ProtoStorageWrapper<RaftEntry> = tx
+            .read(RAFT_LOGS_TABLE, &lsn_to_key(index))
+            .map_err(ReplicationError::Storage)?
+            .ok_or_else(|| ReplicationError::EntryNotFound)?;
+
+        Ok(entry.into_inner())
+    }
+
+    /// A helper to construct a cursor over the logs
+    fn logs_cursor<T: TransactionKind>(
+        &self,
+        tx: &DbTxn<'_, T>,
+    ) -> Result<DbCursor<'_, T, String, ProtoStorageWrapper<RaftEntry>>, ReplicationError> {
+        tx.cursor(RAFT_LOGS_TABLE)
+            .map_err(ReplicationError::Storage)
+    }
+}
+
+impl Storage for LogStore {
+    /// Returns the initial raft state
+    fn initial_state(&self) -> RaftResult<RaftState> {
+        // Read the hard state
+        let tx = self.db.new_read_tx().map_err(RaftError::from)?;
+        let hard_state: ProtoStorageWrapper<HardState> = tx
+            .read(RAFT_METADATA_TABLE, &HARD_STATE_KEY.to_string())
+            .map_err(RaftError::from)?
+            .unwrap_or_default();
+        let conf_state: ProtoStorageWrapper<ConfState> = tx
+            .read(RAFT_METADATA_TABLE, &CONF_STATE_KEY.to_string())
+            .map_err(RaftError::from)?
+            .unwrap_or_default();
+
+        Ok(RaftState {
+            hard_state: hard_state.into_inner(),
+            conf_state: conf_state.into_inner(),
+        })
+    }
+
+    /// Returns the log entries between two indices, capped at a max size
+    /// in bytes
+    ///
+    /// Entries are in the range [low, high) and are returned in ascending order
+    fn entries(
+        &self,
+        low: u64,
+        high: u64,
+        max_size: impl Into<Option<u64>>,
+        _context: GetEntriesContext,
+    ) -> RaftResult<Vec<RaftEntry>> {
+        let tx = self.db.new_read_tx().map_err(RaftError::from)?;
+        let mut cursor = self.logs_cursor(&tx)?;
+
+        // Seek the cursor to the first entry in the range
+        cursor.seek_geq(&lsn_to_key(low)).map_err(RaftError::from)?;
+
+        let mut entries = Vec::new();
+        let mut remaining_space = max_size.into().map(|v| v as u32).unwrap_or(u32::MAX);
+
+        for record in cursor.map(|entry| {
+            entry
+                .map_err(RaftError::from)
+                .map(|(key, value)| (key, value.into_inner()))
+        }) {
+            let (key, entry) = record?;
+            let lsn = parse_lsn(&key).map_err(RaftError::from)?;
+
+            // If we've reached the end of the range, break
+            if lsn >= high {
+                break;
+            }
+
+            // If we've reached the max size, break
+            let size = entry.compute_size();
+            if size > remaining_space {
+                break;
+            }
+
+            // Otherwise, add the entry to the list and update the remaining space
+            entries.push(entry);
+            remaining_space -= size;
+        }
+
+        Ok(entries)
+    }
+
+    /// Returns the term for a given index in the log
+    fn term(&self, idx: u64) -> RaftResult<u64> {
+        self.read_log_entry(idx)
+            .map_err(RaftError::from)
+            .map(|entry| entry.term)
+    }
+
+    fn first_index(&self) -> RaftResult<u64> {
+        let tx = self.db.new_read_tx().map_err(RaftError::from)?;
+        let mut cursor = self.logs_cursor::<RO>(&tx).map_err(RaftError::from)?;
+
+        match cursor.seek_first().map_err(RaftError::from)? {
+            Some((key, _)) => parse_lsn(&key).map_err(RaftError::from),
+            None => Ok(0),
+        }
+    }
+
+    fn last_index(&self) -> RaftResult<u64> {
+        let tx = self.db.new_read_tx().map_err(RaftError::from)?;
+        let mut cursor = self.logs_cursor::<RO>(&tx).map_err(RaftError::from)?;
+
+        match cursor.seek_last().map_err(RaftError::from)? {
+            Some((key, _)) => parse_lsn(&key).map_err(RaftError::from),
+            None => Ok(0),
+        }
+    }
+
+    /// Returns the most recent snapshot of the consensus state
+    ///
+    /// A snapshot index mustn't be less than `request_index`
+    ///
+    /// The `to` field indicates the peer this will be sent to, unused here
+    fn snapshot(&self, request_index: u64, _to: u64) -> RaftResult<RaftSnapshot> {
+        // Read the snapshot metadata from the metadata table
+        let tx = self.db.new_read_tx().map_err(RaftError::from)?;
+        let metadata: SnapshotMetadata = tx
+            .read(RAFT_METADATA_TABLE, &SNAPSHOT_METADATA_KEY.to_string())
+            .map_err(RaftError::from)?
+            .map(|value: ProtoStorageWrapper<SnapshotMetadata>| value.into_inner())
+            .ok_or_else(|| RaftError::Store(RaftStorageError::SnapshotTemporarilyUnavailable))?;
+
+        if metadata.index < request_index {
+            return Err(RaftError::Store(
+                RaftStorageError::SnapshotTemporarilyUnavailable,
+            ));
+        }
+
+        let mut snap = RaftSnapshot::new();
+        snap.set_metadata(metadata);
+
+        Ok(snap)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::test_helpers::mock_db;
+
+    use super::LogStore;
+
+    /// Test that creating the log store works
+    ///
+    /// TODO: Remove me
+    #[test]
+    fn test_constructor() {
+        let db = Arc::new(mock_db());
+        let _store = LogStore::new(db).unwrap();
+    }
+}

--- a/statev2/src/replication/mod.rs
+++ b/statev2/src/replication/mod.rs
@@ -1,0 +1,7 @@
+//! Defines replication primitives for the relayer state on top of a
+//! base raft implementation. Raft provides a consistent, distributed log
+//! with serializable access. We describe state transitions and persist these
+//! to the raft log
+
+pub mod error;
+pub mod log_store;

--- a/statev2/src/storage/error.rs
+++ b/statev2/src/storage/error.rs
@@ -7,6 +7,7 @@ use flexbuffers::{
     SerializationError as FlexbuffersSerializationError,
 };
 use libmdbx::Error as MdbxError;
+use raft::{Error as RaftError, StorageError as RaftStorageError};
 
 /// The error type emitted by the storage layer
 #[derive(Debug)]
@@ -36,3 +37,9 @@ impl Display for StorageError {
 }
 
 impl Error for StorageError {}
+
+impl From<StorageError> for RaftError {
+    fn from(value: StorageError) -> Self {
+        RaftError::Store(RaftStorageError::Other(Box::new(value)))
+    }
+}

--- a/statev2/src/storage/mod.rs
+++ b/statev2/src/storage/mod.rs
@@ -3,6 +3,9 @@
 
 use std::borrow::Cow;
 
+use protobuf::Message;
+use serde::{ser::Error as SerializeError, Serialize};
+
 pub mod cursor;
 pub mod db;
 pub mod error;
@@ -10,3 +13,45 @@ pub mod traits;
 
 /// A type alias used for reading from the database
 type CowBuffer<'a> = Cow<'a, [u8]>;
+
+/// A wrapper struct that allows us to implement serde traits on a protobuf `Message`
+/// which lets us store protobuf messages in the database
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProtoStorageWrapper<T: Message>(pub T);
+impl<T: Message> ProtoStorageWrapper<T> {
+    /// Unwraps the inner protobuf message
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Message> Default for ProtoStorageWrapper<T> {
+    fn default() -> Self {
+        Self(T::new())
+    }
+}
+
+impl<T: Message> Serialize for ProtoStorageWrapper<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let bytes = self.0.write_to_bytes().map_err(SerializeError::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de, T: Message> serde::Deserialize<'de> for ProtoStorageWrapper<T> {
+    fn deserialize<D>(deserializer: D) -> Result<ProtoStorageWrapper<T>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = <&[u8]>::deserialize(deserializer)?;
+
+        let mut msg = T::new();
+        msg.merge_from_bytes(bytes)
+            .map_err(serde::de::Error::custom)?;
+
+        Ok(ProtoStorageWrapper(msg))
+    }
+}


### PR DESCRIPTION
### Purpose
The `raft` needs a [`Storage`](https://docs.rs/raft/latest/raft/storage/trait.Storage.html) impl to read its log, metadata, snapshots, etc from. Concretely we use the embedded `mdbx` instance in the storage layer as the underlying persistence mechanism. 

This means that the DB serves two purposes:
- Store the state machine of the relayer and its cluster
- Store the raft log and metadata used to form consensus over the relayer's state machine

This PR implements the `Storage` trait for `LogStore` which functions as the plumbing between the storage and replication layers.

### Testing
- Will add tests in a follow up PR