### PR TITLE
statev2: replication: raft-node: Add initial raft node implementation

### DIFF
--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -14,6 +14,11 @@ libmdbx = "0.3"
 protobuf = "2.0"
 serde = { workspace = true, features = ["derive"] }
 
+# === Misc === #
+slog = "2.2"
+tracing = { workspace = true }
+tracing-slog = "0.2"
+
 [dev-dependencies]
 tempfile = "3.8"
 rand = { workspace = true }

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
+#![allow(incomplete_features)]
+#![feature(let_chains)]
 
 pub mod replication;
 pub mod storage;

--- a/statev2/src/replication/error.rs
+++ b/statev2/src/replication/error.rs
@@ -12,6 +12,8 @@ pub enum ReplicationError {
     EntryNotFound,
     /// Error parsing a stored value
     ParseValue(String),
+    /// An error from the raft library
+    Raft(RaftError),
     /// An error interacting with storage
     Storage(StorageError),
 }
@@ -28,6 +30,7 @@ impl From<ReplicationError> for RaftError {
     fn from(value: ReplicationError) -> Self {
         match value {
             ReplicationError::EntryNotFound => RaftError::Store(RaftStorageError::Unavailable),
+            ReplicationError::Raft(e) => e,
             ReplicationError::Storage(e) => e.into(),
             ReplicationError::ParseValue(s) => RaftError::Store(RaftStorageError::Other(Box::new(
                 ReplicationError::ParseValue(s),

--- a/statev2/src/replication/mod.rs
+++ b/statev2/src/replication/mod.rs
@@ -5,3 +5,4 @@
 
 pub mod error;
 pub mod log_store;
+pub mod raft_node;

--- a/statev2/src/replication/raft_node.rs
+++ b/statev2/src/replication/raft_node.rs
@@ -1,0 +1,66 @@
+//! A raft node that processes events from the consensus layer and the network, and handles
+//! interactions with storage
+
+use std::sync::Arc;
+
+use raft::{Config as RaftConfig, RawNode};
+use slog::Logger;
+use tracing_slog::TracingSlogDrain;
+
+use crate::storage::db::DB;
+
+use super::{error::ReplicationError, log_store::LogStore};
+
+// -------------
+// | Raft Node |
+// -------------
+
+/// A raft node that replicates the relayer's state machine
+pub struct ReplicationNode {
+    /// The inner raft node
+    _inner: RawNode<LogStore>,
+}
+
+impl ReplicationNode {
+    /// Creates a new replication node
+    pub fn new(db: Arc<DB>, config: &RaftConfig) -> Result<Self, ReplicationError> {
+        // Build the log store on top of the DB
+        let store = LogStore::new(db)?;
+
+        // Build an slog logger and connect it to the tracing logger
+        let tracing_drain = TracingSlogDrain;
+        let logger = Logger::root(tracing_drain, slog::o!());
+
+        // Build raft node
+        let node = RawNode::new(config, store, &logger).map_err(ReplicationError::Raft)?;
+
+        Ok(Self { _inner: node })
+    }
+}
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod test {
+    use raft::Config as RaftConfig;
+    use std::sync::Arc;
+
+    use crate::test_helpers::mock_db;
+
+    use super::ReplicationNode;
+
+    /// A local node ID for testing
+    const NODE_ID: u64 = 1;
+
+    /// Tests that the constructor works properly, largely this means testing that the `LogStore`
+    /// initialization is compatible with the `raft` setup
+    #[test]
+    fn test_constructor() {
+        let db = Arc::new(mock_db());
+        let config = RaftConfig::new(NODE_ID);
+
+        let _node = ReplicationNode::new(db, &config).unwrap();
+    }
+}

--- a/statev2/src/storage/db.rs
+++ b/statev2/src/storage/db.rs
@@ -52,9 +52,6 @@ pub struct DbConfig {
 pub struct DB {
     /// The underlying `mdbx` instance
     db: Database<WriteMap>,
-    /// The config for the database
-    #[allow(unused)]
-    config: DbConfig,
 }
 
 impl DB {
@@ -66,7 +63,7 @@ impl DB {
             .open(db_path)
             .map_err(StorageError::OpenDb)?;
 
-        Ok(Self { db, config })
+        Ok(Self { db })
     }
 
     /// Create a new table in the database


### PR DESCRIPTION
### Purpose
This PR takes the first steps towards including the `raft` consensus engine in our `statev2` replication layer. This involves a few changes to the `LogStore` implementation to bring it into compatibility with the `RaftNode`'s use. Specifically we:
- Apply a default snapshot when the `LogStore` is initialized
- Fall back to this default when other values are not available in storage

### Testing
- All unit and integration tests pass