### PR TITLE
statev2: replication: raft-node: Add raft loop handler implmentation

### DIFF
--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -16,9 +16,10 @@ serde = { workspace = true, features = ["derive"] }
 
 # === Misc === #
 slog = "2.2"
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
 
 [dev-dependencies]
+crossbeam = "0.8"
 tempfile = "3.8"
 rand = { workspace = true }

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(unsafe_code)]
 #![allow(incomplete_features)]
 #![feature(let_chains)]
+#![feature(io_error_more)]
 
 pub mod replication;
 pub mod storage;

--- a/statev2/src/replication/error.rs
+++ b/statev2/src/replication/error.rs
@@ -1,6 +1,7 @@
 //! Defines error types emitted by the replication layer
 
 use raft::{Error as RaftError, StorageError as RaftStorageError};
+use std::io::Error as IOError;
 use std::{error::Error, fmt::Display};
 
 use crate::storage::error::StorageError;
@@ -14,6 +15,10 @@ pub enum ReplicationError {
     ParseValue(String),
     /// An error from the raft library
     Raft(RaftError),
+    /// An error receiving a message
+    RecvMessage(IOError),
+    /// An error sending a message
+    SendMessage(IOError),
     /// An error interacting with storage
     Storage(StorageError),
 }
@@ -35,6 +40,7 @@ impl From<ReplicationError> for RaftError {
             ReplicationError::ParseValue(s) => RaftError::Store(RaftStorageError::Other(Box::new(
                 ReplicationError::ParseValue(s),
             ))),
+            ReplicationError::SendMessage(e) | ReplicationError::RecvMessage(e) => RaftError::Io(e),
         }
     }
 }

--- a/statev2/src/replication/mod.rs
+++ b/statev2/src/replication/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod error;
 pub mod log_store;
+pub mod network;
 pub mod raft_node;

--- a/statev2/src/replication/network.rs
+++ b/statev2/src/replication/network.rs
@@ -1,0 +1,88 @@
+//! The network abstraction of the replication layer; defines the interface for
+//! sending and receiving raft messages from cluster peers
+
+use raft::prelude::Message as RaftMessage;
+
+use super::error::ReplicationError;
+
+/// The central trait that must be implemented by any networking layer used
+/// by the replication layer
+pub trait RaftNetwork {
+    /// The error type emitted by the network implementation
+    type Error: Into<ReplicationError>;
+
+    /// Send a raft message to a peer
+    ///
+    /// This method MAY NOT not block
+    fn send(&mut self, message: RaftMessage) -> Result<(), Self::Error>;
+
+    /// Receive a raft message from the network
+    ///
+    /// This method MAY block
+    fn recv(&mut self) -> Result<Option<RaftMessage>, Self::Error>;
+
+    /// Attempt to receive a raft message from the network
+    ///
+    /// This method MAY NOT block
+    fn try_recv(&mut self) -> Result<Option<RaftMessage>, Self::Error>;
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use crossbeam::channel::{
+        Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,
+    };
+    use raft::prelude::Message as RaftMessage;
+    use std::io::{Error as IOError, ErrorKind};
+
+    use crate::replication::error::ReplicationError;
+
+    use super::RaftNetwork;
+
+    /// A mock network that is brokered by two channels
+    pub struct MockNetwork {
+        /// The sender channel
+        sender: CrossbeamSender<RaftMessage>,
+        /// The receiver channel                                    
+        receiver: CrossbeamReceiver<RaftMessage>,
+    }
+
+    impl MockNetwork {
+        /// Constructor
+        pub fn new(
+            sender: CrossbeamSender<RaftMessage>,
+            receiver: CrossbeamReceiver<RaftMessage>,
+        ) -> Self {
+            Self { sender, receiver }
+        }
+    }
+
+    impl RaftNetwork for MockNetwork {
+        type Error = ReplicationError;
+
+        fn send(&mut self, message: RaftMessage) -> Result<(), Self::Error> {
+            self.sender
+                .send(message)
+                .map_err(|e| ReplicationError::SendMessage(IOError::new(ErrorKind::NetworkDown, e)))
+        }
+
+        fn recv(&mut self) -> Result<Option<RaftMessage>, Self::Error> {
+            self.receiver
+                .recv()
+                .map_err(|e| ReplicationError::RecvMessage(IOError::new(ErrorKind::NetworkDown, e)))
+                .map(Some)
+        }
+
+        fn try_recv(&mut self) -> Result<Option<RaftMessage>, Self::Error> {
+            let res = self.receiver.try_recv();
+            match res {
+                Ok(message) => Ok(Some(message)),
+                Err(TryRecvError::Empty) => Ok(None),
+                Err(e) => Err(ReplicationError::RecvMessage(IOError::new(
+                    ErrorKind::NetworkDown,
+                    e,
+                ))),
+            }
+        }
+    }
+}

--- a/statev2/src/replication/raft_node.rs
+++ b/statev2/src/replication/raft_node.rs
@@ -1,29 +1,44 @@
 //! A raft node that processes events from the consensus layer and the network, and handles
 //! interactions with storage
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
 
-use raft::{Config as RaftConfig, RawNode};
+use protobuf::Message;
+use raft::{
+    prelude::{ConfChange, Entry, EntryType, HardState, Message as RaftMessage, Snapshot},
+    Config as RaftConfig, RawNode,
+};
 use slog::Logger;
 use tracing_slog::TracingSlogDrain;
 
 use crate::storage::db::DB;
 
-use super::{error::ReplicationError, log_store::LogStore};
+use super::{error::ReplicationError, log_store::LogStore, network::RaftNetwork};
 
 // -------------
 // | Raft Node |
 // -------------
 
+/// The interval at which to tick the raft node
+const RAFT_TICK_INTERVAL_MS: u64 = 100; // 100 ms
+/// The interval at which to poll for new inbound messages
+const RAFT_POLL_INTERVAL_MS: u64 = 10; // 10 ms
+
 /// A raft node that replicates the relayer's state machine
-pub struct ReplicationNode {
+pub struct ReplicationNode<N: RaftNetwork> {
     /// The inner raft node
-    _inner: RawNode<LogStore>,
+    inner: RawNode<LogStore>,
+    /// The networking layer backing the raft node
+    network: N,
 }
 
-impl ReplicationNode {
+impl<N: RaftNetwork> ReplicationNode<N> {
     /// Creates a new replication node
-    pub fn new(db: Arc<DB>, config: &RaftConfig) -> Result<Self, ReplicationError> {
+    pub fn new(db: Arc<DB>, network: N, config: &RaftConfig) -> Result<Self, ReplicationError> {
         // Build the log store on top of the DB
         let store = LogStore::new(db)?;
 
@@ -34,7 +49,151 @@ impl ReplicationNode {
         // Build raft node
         let node = RawNode::new(config, store, &logger).map_err(ReplicationError::Raft)?;
 
-        Ok(Self { _inner: node })
+        Ok(Self {
+            inner: node,
+            network,
+        })
+    }
+
+    /// The main loop of the raft consensus engine, we tick the state machine every
+    /// `RAFT_TICK_INTERVAL_MS` milliseconds
+    pub fn run(mut self) -> Result<(), ReplicationError> {
+        let tick_interval = Duration::from_millis(RAFT_TICK_INTERVAL_MS);
+        let poll_interval = Duration::from_millis(RAFT_POLL_INTERVAL_MS);
+
+        let mut last_tick = Instant::now();
+
+        loop {
+            thread::sleep(poll_interval);
+
+            // Check for new messages
+            while let Some(msg) = self.network.try_recv().map_err(Into::into)? {
+                self.inner.step(msg).map_err(ReplicationError::Raft)?;
+            }
+
+            // Tick the raft node after the sleep interval has elapsed
+            if last_tick.elapsed() >= tick_interval {
+                self.inner.tick();
+                self.process_ready_state()?;
+
+                last_tick = Instant::now();
+            }
+        }
+    }
+
+    /// Process the ready state of the node
+    ///
+    /// The ready state includes a collection of all state transition events that have occurred
+    /// since the last time the ready state was polled. This includes:
+    ///     - Messages to be sent to other nodes
+    ///     - Snapshots from the leader
+    ///     - Committed entries
+    ///     - New entries that should be appended to the log, but not yet applied
+    ///     - `HardState` changes, e.g. new leader, new commit index, etc
+    /// and more. For mor information see:
+    ///     https://docs.rs/raft/latest/raft/index.html#processing-the-ready-state
+    fn process_ready_state(&mut self) -> Result<(), ReplicationError> {
+        if !self.inner.has_ready() {
+            return Ok(());
+        }
+
+        let mut ready = self.inner.ready();
+
+        // Send outbound messages
+        self.send_outbound_messages(ready.take_messages())?;
+
+        // Apply snapshot
+        if !ready.snapshot().is_empty() {
+            self.apply_snapshot(ready.snapshot());
+        }
+
+        // Commit entries
+        self.commit_entries(ready.take_committed_entries())?;
+
+        // Append new entries to the raft log
+        self.append_entries(ready.take_entries())?;
+
+        // Update the raft hard state
+        if let Some(hard_state) = ready.hs().cloned() {
+            self.update_hard_state(hard_state)?;
+        }
+
+        // Send persisted messages to peers
+        self.send_outbound_messages(ready.take_persisted_messages())?;
+
+        // Advance the raft node and handle the outbound messages and committed entires
+        // that are stored in the resultant `LightReady`
+        let mut light_ready = self.inner.advance(ready);
+        self.send_outbound_messages(light_ready.take_messages())?;
+        self.commit_entries(light_ready.take_committed_entries())?;
+        self.inner.advance_apply();
+
+        Ok(())
+    }
+
+    /// Send outbound messages from the raft ready state
+    fn send_outbound_messages(
+        &mut self,
+        messages: Vec<RaftMessage>,
+    ) -> Result<(), ReplicationError> {
+        for message in messages {
+            self.network.send(message).map_err(|e| e.into())?;
+        }
+
+        Ok(())
+    }
+
+    /// Apply a raft snapshot from the ready state
+    fn apply_snapshot(&mut self, snapshot: &Snapshot) {
+        self.inner.mut_store().apply_snapshot(snapshot);
+    }
+
+    /// Commit entries from the ready state and apply them to the state machine
+    fn commit_entries(&mut self, entries: Vec<Entry>) -> Result<(), ReplicationError> {
+        for entry in entries.into_iter() {
+            if entry.get_data().is_empty() {
+                // Upon new leader election, the leader sends an empty entry
+                // as a heartbeat to each follower. No processing is needed
+                continue;
+            }
+
+            match entry.get_entry_type() {
+                EntryType::EntryNormal => {
+                    // Apply a normal entry to the state machine
+                    // TODO: Implement this after defining our state transitions
+                }
+                EntryType::EntryConfChange | EntryType::EntryConfChangeV2 => {
+                    // Apply a config change entry to the state machine
+                    let mut config_change = ConfChange::new();
+                    config_change
+                        .merge_from_bytes(entry.get_data())
+                        .map_err(|e| ReplicationError::ParseValue(e.to_string()))?;
+
+                    // Forward the config change to the consensus engine
+                    let config_state = self
+                        .inner
+                        .apply_conf_change(&config_change)
+                        .map_err(ReplicationError::Raft)?;
+
+                    // Store the new config in the log store
+                    self.inner.mut_store().apply_config_state(config_state)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Append new log entries from the ready state
+    ///
+    /// These entries are not yet committed and should not yet be applied to the state machine
+    fn append_entries(&mut self, entries: Vec<Entry>) -> Result<(), ReplicationError> {
+        self.inner.mut_store().append_log_entries(entries)
+    }
+
+    /// Update the hard state from the ready state
+    fn update_hard_state(&mut self, hard_state: HardState) -> Result<(), ReplicationError> {
+        self.inner.mut_store().apply_hard_state(hard_state)
     }
 }
 
@@ -47,7 +206,7 @@ mod test {
     use raft::Config as RaftConfig;
     use std::sync::Arc;
 
-    use crate::test_helpers::mock_db;
+    use crate::{replication::network::test_helpers::MockNetwork, test_helpers::mock_db};
 
     use super::ReplicationNode;
 
@@ -61,6 +220,11 @@ mod test {
         let db = Arc::new(mock_db());
         let config = RaftConfig::new(NODE_ID);
 
-        let _node = ReplicationNode::new(db, &config).unwrap();
+        // Setup a dummy network, for this test it is okay if both ends resolve
+        // to the same channel
+        let (network_out, network_in) = crossbeam::channel::unbounded();
+        let net = MockNetwork::new(network_out, network_in);
+
+        let _node = ReplicationNode::new(db, net, &config).unwrap();
     }
 }


### PR DESCRIPTION
### Purpose
This PR implements the main driver loop for the raft consensus engine. This event loop effectively serves two purposes:
- Poll for inbound messages from the network
- Process the ready state from the consensus engine, this involves:
    - Handling outbound messages to peers, generated by the consensus engine
    - Committing log entries and applying them to the state machine
    - Appending new (uncommitted) log entries to the persisted log
    - Applying config and hard state changes

This process connects the raft consensus engine to the storage and networking layers.

### Testing
- All unit and integration tests pass
- Testing of the event loop will be done via the functional unit imposed by defining *our* state transitions, so for now it is expected that this implementation is buggy
