### PR TITLE
circuit-types, circuits: Update `Wallet` and `Balance` structs for fee impl

### DIFF
--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -48,6 +48,10 @@ pub struct Balance {
     pub mint: BigUint,
     /// The amount of the given token stored in this balance
     pub amount: u64,
+    /// The amount currently owed in fees to the protocol
+    pub protocol_fee_balance: u64,
+    /// The amount currently owned in fees to the managing relayer cluster
+    pub relayer_fee_balance: u64,
 }
 
 impl Balance {

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -47,11 +47,13 @@ async fn test_match_no_match(test_args: IntegrationTestArgs) -> Result<()> {
     let my_balance = sel!(
         Balance {
             mint: BigUint::from(1u8),
-            amount: 200
+            amount: 200,
+            ..Default::default()
         },
         Balance {
             mint: BigUint::from(2u8),
-            amount: 200
+            amount: 200,
+            ..Default::default()
         }
     )
     .to_linkable();

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -79,6 +79,7 @@ fn create_test_balance(party_id: u64) -> Balance {
     Balance {
         mint: sel!(party_id, 1u8.into(), 2u8.into()),
         amount: 200,
+        ..Default::default()
     }
 }
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -45,10 +45,12 @@ pub mod test_helpers {
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
         };
         pub static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
-            Balance { mint: 1u8.into(), amount: 5 },
+            Balance { mint: 1u8.into(), amount: 5, protocol_fee_balance: 0, relayer_fee_balance: 0 },
             Balance {
                 mint: 2u8.into(),
-                amount: 10
+                amount: 10,
+                protocol_fee_balance: 0,
+                relayer_fee_balance: 0,
             }
         ];
         pub static ref INITIAL_ORDERS: [Order; MAX_ORDERS] = [
@@ -80,8 +82,9 @@ pub mod test_helpers {
         pub static ref INITIAL_WALLET: SizedWallet = Wallet {
             balances: INITIAL_BALANCES.clone(),
             orders: INITIAL_ORDERS.clone(),
-            fees: INITIAL_FEES.clone(),
+            match_fee: FixedPoint::from(0.01),
             keys: PUBLIC_KEYS.clone(),
+            managing_cluster: PUBLIC_KEYS.pk_root.clone(),
             blinder: Scalar::from(42u64)
         };
     }

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -579,6 +579,7 @@ pub mod test_helpers {
         let balance1 = Balance {
             mint: 1u8.into(),
             amount: 300,
+            ..Default::default()
         }
         .to_linkable();
 
@@ -594,6 +595,7 @@ pub mod test_helpers {
         let balance2 = Balance {
             mint: 2u8.into(),
             amount: 300,
+            ..Default::default()
         }
         .to_linkable();
 

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -806,6 +806,7 @@ mod test {
         new_wallet.balances[1] = Balance {
             mint: withdrawn_mint.clone(),
             amount: 1,
+            ..new_wallet.balances[1].clone()
         };
 
         // Build a valid transfer
@@ -834,6 +835,7 @@ mod test {
         new_wallet.balances[1] = Balance {
             mint: withdrawn_mint.clone(),
             amount: 2, // Added an extra unit of balance
+            ..new_wallet.balances[1].clone()
         };
 
         // Build a valid transfer


### PR DESCRIPTION
### Purpose
This PR changes the structure of the `Wallet` and `Balance` types to begin implementation of the fee design. These structural changes simplify fees to a single fixed point take that a relayer may capture. As well, we introduce the notion of a `managing_cluster` to the `Wallet`.

This PR also removes many of the fee-centric constraints in the circuit so that the crates compile. These circuits will be updated in follow up PRs

### Testing
- Unit and integration tests pass for `circuits` and `circuit-types`
- CI will remain red while the code is in an intermediate state