### PR TITLE
circuits: mpc-circuits: match: Compute protocol fee takes in MPC circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 **/target
 **/build
 **/no_commit
+**/.DS_store
+
 Cargo.lock
+
 .idea
 .vscode
+
 *.sw[a-p]
 secrets.env
 **/flamegraph.svg

--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -405,9 +405,30 @@ impl<L: LinearCombinationLike> Sub<Variable> for FixedPointVar<L> {
     }
 }
 
+impl AuthenticatedFixedPoint {
+    /// Convert an integer value into its fixed point representation
+    pub fn from_integer(val: &AuthenticatedScalarResult) -> Self {
+        Self {
+            repr: *TWO_TO_M_SCALAR * val,
+        }
+    }
+}
+
 impl From<AuthenticatedScalarResult> for AuthenticatedFixedPoint {
     fn from(val: AuthenticatedScalarResult) -> Self {
         Self { repr: val }
+    }
+}
+
+impl Mul<&FixedPoint> for &AuthenticatedFixedPoint {
+    type Output = AuthenticatedFixedPoint;
+
+    fn mul(self, rhs: &FixedPoint) -> Self::Output {
+        // Multiply representations directly then reduce
+        let res_repr = self.repr.clone() * rhs.repr;
+        AuthenticatedFixedPoint {
+            repr: *TWO_TO_NEG_M * res_repr,
+        }
     }
 }
 

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -51,6 +51,11 @@ pub struct MatchResult {
     /// sells the quote; 1 implies that party 2 buys the base and sells the quote
     pub direction: u64, // Binary
 
+    /// The amount of the quote token paid to the protocol in fee
+    pub protocol_quote_fee_amount: u64,
+    /// The amount of the base token paid to the protocol in fee
+    pub protocol_base_fee_amount: u64,
+
     /// The following are supporting variables, derivable from the above, but useful for
     /// shrinking the size of the zero knowledge circuit. As well, they are computed during
     /// the course of the MPC, so it incurs no extra cost to include them in the witness

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -62,6 +62,8 @@ pub fn get_dummy_singleprover_witness() -> ValidMatchMpcWitness {
             quote_amount: Scalar::one().to_linkable(),
             base_amount: Scalar::one().to_linkable(),
             direction: Scalar::one().to_linkable(),
+            protocol_quote_fee_amount: Scalar::one().to_linkable(),
+            protocol_base_fee_amount: Scalar::one().to_linkable(),
             max_minus_min_amount: Scalar::one().to_linkable(),
             min_amount_order_index: Scalar::one().to_linkable(),
         },

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -192,7 +192,7 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
                 base_mint: 2u8.into(),
                 side: sel!(OrderSide::Buy, OrderSide::Sell),
                 worst_case_price: FixedPoint::from_integer(sel!(15, 5)),
-                amount: sel!(20, 30),
+                amount: sel!(20_000, 30_000),
                 timestamp: 0, // unused
             },
             10, /* execution_price */
@@ -204,7 +204,7 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
                 base_mint: 2u8.into(),
                 side: sel!(OrderSide::Sell, OrderSide::Buy),
                 worst_case_price: FixedPoint::from_integer(sel!(5, 15)),
-                amount: 15,
+                amount: 15_000,
                 timestamp: 0, // unused
             },
             10, /* execution_price */
@@ -217,18 +217,22 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
         MatchResult {
             quote_mint: BigUint::from(1u8),
             base_mint: BigUint::from(2u8),
-            quote_amount: 200,
-            base_amount: 20,
+            quote_amount: 200_000,
+            base_amount: 20_000,
             direction: 0,
-            max_minus_min_amount: 10,
+            protocol_quote_fee_amount: 59,
+            protocol_base_fee_amount: 5,
+            max_minus_min_amount: 10_000,
             min_amount_order_index: 0,
         },
         MatchResult {
             quote_mint: BigUint::from(1u8),
             base_mint: BigUint::from(2u8),
-            quote_amount: 150,
-            base_amount: 15,
+            quote_amount: 150_000,
+            base_amount: 15_000,
             direction: 1,
+            protocol_quote_fee_amount: 44,
+            protocol_base_fee_amount: 4,
             max_minus_min_amount: 0,
             min_amount_order_index: 1,
         },

--- a/circuits/integration/zk_circuits/valid_match_mpc.rs
+++ b/circuits/integration/zk_circuits/valid_match_mpc.rs
@@ -127,6 +127,8 @@ async fn match_orders(
         base_amount: min_base_amount,
         quote_amount,
         direction: party0_order.side.into(),
+        protocol_base_fee_amount: 0,
+        protocol_quote_fee_amount: 0,
         max_minus_min_amount: cmp::max(party0_max_amount, party1_max_amount) - min_base_amount,
         min_amount_order_index: if party0_max_amount == min_base_amount {
             0

--- a/circuits/src/mpc_circuits/match.rs
+++ b/circuits/src/mpc_circuits/match.rs
@@ -1,9 +1,12 @@
 //! Groups logic related to the match computation circuit
 
 use circuit_types::{
-    fixed_point::AuthenticatedFixedPoint, order::AuthenticatedLinkableOrder,
-    r#match::AuthenticatedMatchResult, AMOUNT_BITS,
+    fixed_point::{AuthenticatedFixedPoint, FixedPoint},
+    order::AuthenticatedLinkableOrder,
+    r#match::AuthenticatedMatchResult,
+    AMOUNT_BITS,
 };
+use constants::PROTOCOL_FEE;
 use mpc_stark::{
     algebra::{authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar},
     MpcFabric,
@@ -38,7 +41,17 @@ pub fn compute_match(
     // The amount of quote token exchanged
     // Round down to the nearest integer value
     let quote_exchanged_fp = min_base_amount.clone() * price;
-    let quote_exchanged = FixedPointMpcGadget::as_integer(quote_exchanged_fp, fabric);
+    let quote_exchanged = FixedPointMpcGadget::as_integer(quote_exchanged_fp.clone(), fabric);
+
+    // We compute the protocol fee directly on the `quote_exchanged_fp` before it is rounded to an
+    // integer. This avoids data dependence on the rounding operation, which has round depth logarithmic
+    // in the field size. Computing the protocol fee based on the input to the rounding operation lets us
+    // schedule these operations in parallel
+    let protocol_quote_fee_amount = compute_protocol_fee(&quote_exchanged_fp, fabric);
+    let protocol_base_fee_amount = compute_protocol_fee(
+        &AuthenticatedFixedPoint::from_integer(&min_base_amount),
+        fabric,
+    );
 
     // Zero out the orders if any of the initial checks failed
     AuthenticatedMatchResult {
@@ -47,7 +60,131 @@ pub fn compute_match(
         quote_amount: quote_exchanged,
         base_amount: min_base_amount,
         direction: order1.side.value().clone(),
+        protocol_quote_fee_amount,
+        protocol_base_fee_amount,
         max_minus_min_amount,
         min_amount_order_index: min_index,
+    }
+}
+
+/// Compute the protocol fee for a given match result
+pub fn compute_protocol_fee(
+    token_amount: &AuthenticatedFixedPoint,
+    fabric: &MpcFabric,
+) -> AuthenticatedScalarResult {
+    // Compute the protocol fee
+    let protocol_fee = FixedPoint::from_f64_round_down(PROTOCOL_FEE);
+    let protocol_fee_amount = token_amount * &protocol_fee;
+
+    // Round down to the nearest integral value
+    FixedPointMpcGadget::as_integer(protocol_fee_amount, fabric)
+}
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod tests {
+    use std::cmp;
+
+    use circuit_types::{
+        fixed_point::FixedPoint,
+        order::{Order, OrderSide},
+        r#match::MatchResult,
+        traits::{LinkableBaseType, MpcBaseType, MpcType},
+    };
+    use constants::PROTOCOL_FEE;
+    use lazy_static::lazy_static;
+    use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+    use num_bigint::BigUint;
+    use renegade_crypto::fields::scalar_to_u64;
+    use test_helpers::mpc_network::execute_mock_mpc;
+
+    use crate::mpc_circuits::r#match::compute_match;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    lazy_static! {
+        /// A dummy first order used for testing
+        static ref ORDER1: Order = Order {
+            quote_mint: BigUint::from(1u8),
+            base_mint: BigUint::from(2u8),
+            side: OrderSide::Buy,
+            amount: 100_000,
+            worst_case_price: 15f32.into(),
+            timestamp: 0,
+        };
+        /// A dummy second order that matches with the first
+        static ref ORDER2: Order = Order {
+            side: OrderSide::Sell,
+            amount: 50_000,
+            worst_case_price: 4f32.into(),
+            ..ORDER1.clone()
+        };
+        /// A dummy execution price
+        static ref PRICE: FixedPoint = FixedPoint::from_integer(10);
+    }
+
+    /// Execute a match on the dummy values above and return the match result
+    async fn execute_match_on_orders() -> MatchResult {
+        let (match_res, _) = execute_mock_mpc(|fabric| async move {
+            // Allocate dummy orders and compute a match
+            let o1 = ORDER1.to_linkable().allocate(PARTY0, &fabric);
+            let o2 = ORDER2.to_linkable().allocate(PARTY1, &fabric);
+
+            let amount1 = o1.amount.value().clone();
+            let amount2 = o2.amount.value().clone();
+
+            let price = PRICE.clone().allocate(PARTY0, &fabric);
+
+            let match_res = compute_match(&o1, &o2, &amount1, &amount2, &price, &fabric);
+            match_res.open().await.unwrap()
+        })
+        .await;
+
+        match_res
+    }
+
+    /// Compute the expected protocol fee on a given match amount
+    fn expected_protocol_fee(amount: u64) -> u64 {
+        let fee = FixedPoint::from_f64_round_down(PROTOCOL_FEE);
+        let fee_take = fee * Scalar::from(amount);
+
+        scalar_to_u64(&fee_take.floor())
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// Tests that the match computation correctly computes the volumes matched
+    #[tokio::test]
+    async fn test_match_volumes() {
+        // Get the match result
+        let res = execute_match_on_orders().await;
+
+        // Check the volumes
+        let expected_base = cmp::min(ORDER1.amount, ORDER2.amount);
+        let expected_quote = (*PRICE * Scalar::from(expected_base)).floor();
+
+        assert_eq!(res.quote_amount, scalar_to_u64(&expected_quote));
+        assert_eq!(res.base_amount, expected_base);
+    }
+
+    /// Tests that the match computation correctly computes the protocol fee
+    #[tokio::test]
+    async fn test_match_protocol_fee() {
+        // Get the match result
+        let res = execute_match_on_orders().await;
+
+        // Check the protocol fee amount
+        let expected_quote_fee = expected_protocol_fee(res.quote_amount);
+        let expected_base_fee = expected_protocol_fee(res.base_amount);
+
+        assert_eq!(expected_quote_fee, res.protocol_quote_fee_amount);
+        assert_eq!(expected_base_fee, res.protocol_base_fee_amount);
     }
 }

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -608,6 +608,8 @@ pub mod test_helpers {
             quote_amount: scalar_to_u64(&(price * Scalar::from(order1.amount)).floor()),
             base_amount: min_amount,
             direction: 0,
+            protocol_quote_fee_amount: 0,
+            protocol_base_fee_amount: 0,
             min_amount_order_index: 0,
             max_minus_min_amount: max_amount - min_amount,
         }

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -358,6 +358,8 @@ pub mod test_helpers {
             quote_amount: 5,
             base_amount: 1,
             direction: 0, /* party0 buys base */
+            protocol_quote_fee_amount: 0,
+            protocol_base_fee_amount: 0,
             max_minus_min_amount: 0,
             min_amount_order_index: 0,
         };

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -23,6 +23,9 @@ pub const MERKLE_HEIGHT: usize = 32;
 /// The number of historical roots the contract stores as being valid
 pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 
+/// The percentage fee the protocol takes on each side of a match
+pub const PROTOCOL_FEE: f64 = 0.0003; // 3 basis points
+
 // ----------------------
 // | Starknet Constants |
 // ----------------------


### PR DESCRIPTION
### Purpose
This PR computes the protocol fee takes in the `match` MPC as a publically known fixed point constant multiplied by the volumes of each asset matched.

Relayer fees and the integration of both fee types into the `VALID MATCH MPC` and `VALID SETTLE` circuits will come in a follow up.

### Testing
- Unit and integration tests pass
- Added unit tests for the fee take 