### PR TITLE
circuits: mpc-circuits: match: Compute relayer fee takes in MPC circuit

### DIFF
--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -199,6 +199,13 @@ impl Mul<Scalar> for FixedPoint {
     }
 }
 
+impl Mul<FixedPoint> for FixedPoint {
+    type Output = FixedPoint;
+    fn mul(self, rhs: FixedPoint) -> Self::Output {
+        self.mul_fixed_point(rhs)
+    }
+}
+
 impl Neg for FixedPoint {
     type Output = FixedPoint;
     fn neg(self) -> Self::Output {

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -56,6 +56,11 @@ pub struct MatchResult {
     /// The amount of the base token paid to the protocol in fee
     pub protocol_base_fee_amount: u64,
 
+    /// The amount that the first party owes to their relayer in fee
+    pub party0_relayer_fee_amount: u64,
+    /// The amount that the second party owes to their relayer in fee
+    pub party1_relayer_fee_amount: u64,
+
     /// The following are supporting variables, derivable from the above, but useful for
     /// shrinking the size of the zero knowledge circuit. As well, they are computed during
     /// the course of the MPC, so it incurs no extra cost to include them in the witness

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -101,6 +101,11 @@ pub enum OrderSide {
 }
 
 impl OrderSide {
+    /// Return whether the order is a buy side order
+    pub fn is_buy(&self) -> bool {
+        *self == OrderSide::Buy
+    }
+
     /// Return the opposite direction to self
     pub fn opposite(&self) -> OrderSide {
         match self {

--- a/circuits/benches/full_match.rs
+++ b/circuits/benches/full_match.rs
@@ -40,14 +40,25 @@ async fn run_match_with_delay(delay: Duration) -> Duration {
             let order1 = Order::default().to_linkable().allocate(PARTY0, &fabric);
             let balance1 = Balance::default().to_linkable().allocate(PARTY0, &fabric);
             let amount1 = Scalar::one().allocate(PARTY0, &fabric);
+            let relayer0_fee_term = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
 
             let order2 = Order::default().to_linkable().allocate(PARTY1, &fabric);
             let balance2 = Balance::default().to_linkable().allocate(PARTY1, &fabric);
             let amount2 = Scalar::one().allocate(PARTY1, &fabric);
             let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
+            let relayer1_fee_term = FixedPoint::from_integer(1).allocate(PARTY1, &fabric);
 
             // Run the MPC to generate a witness for the proof
-            let match_res = compute_match(&order1, &order2, &amount1, &amount2, &price, &fabric);
+            let match_res = compute_match(
+                &order1,
+                &order2,
+                &amount1,
+                &amount2,
+                &price,
+                &relayer0_fee_term,
+                &relayer1_fee_term,
+                &fabric,
+            );
 
             // Generate a proof of `VALID MATCH MPC`
             let witness = AuthenticatedValidMatchMpcWitness {

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -64,6 +64,8 @@ pub fn get_dummy_singleprover_witness() -> ValidMatchMpcWitness {
             direction: Scalar::one().to_linkable(),
             protocol_quote_fee_amount: Scalar::one().to_linkable(),
             protocol_base_fee_amount: Scalar::one().to_linkable(),
+            party0_relayer_fee_amount: Scalar::one().to_linkable(),
+            party1_relayer_fee_amount: Scalar::one().to_linkable(),
             max_minus_min_amount: Scalar::one().to_linkable(),
             min_amount_order_index: Scalar::one().to_linkable(),
         },
@@ -93,11 +95,14 @@ pub fn bench_match_mpc_with_delay(c: &mut Criterion, delay: Duration) {
                         let o2 = Order::default().to_linkable().allocate(PARTY1, &fabric);
                         let amount1 = Scalar::one().allocate(PARTY0, &fabric);
                         let amount2 = Scalar::one().allocate(PARTY1, &fabric);
+                        let fee_term1 = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
+                        let fee_term2 = FixedPoint::from_integer(1).allocate(PARTY1, &fabric);
                         let price = FixedPoint::from_integer(1).allocate(PARTY0, &fabric);
 
                         // Run the MPC
-                        let match_res =
-                            compute_match(&o1, &o2, &amount1, &amount2, &price, &fabric);
+                        let match_res = compute_match(
+                            &o1, &o2, &amount1, &amount2, &price, &fee_term1, &fee_term2, &fabric,
+                        );
 
                         // Open the result
                         let _open = match_res.open_and_authenticate().await;

--- a/circuits/integration/mpc_circuits/match.rs
+++ b/circuits/integration/mpc_circuits/match.rs
@@ -122,6 +122,10 @@ async fn test_match_no_match(test_args: IntegrationTestArgs) -> Result<()> {
         let price1 = FixedPoint::from_integer(my_price).allocate(PARTY0, fabric);
         let price2 = FixedPoint::from_integer(my_price).allocate(PARTY1, fabric);
 
+        // Allocate relayer fee terms in the network
+        let relayer0_fee_term = FixedPoint::from_integer(0).allocate(PARTY0, fabric);
+        let relayer1_fee_term = FixedPoint::from_integer(0).allocate(PARTY1, fabric);
+
         // Compute matches
         let res = compute_match(
             &order1,
@@ -129,6 +133,8 @@ async fn test_match_no_match(test_args: IntegrationTestArgs) -> Result<()> {
             order1.amount.value(),
             order2.amount.value(),
             &price1, // Use the first party's price
+            &relayer0_fee_term,
+            &relayer1_fee_term,
             fabric,
         );
 
@@ -222,6 +228,8 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
             direction: 0,
             protocol_quote_fee_amount: 59,
             protocol_base_fee_amount: 5,
+            party0_relayer_fee_amount: 0,
+            party1_relayer_fee_amount: 0,
             max_minus_min_amount: 10_000,
             min_amount_order_index: 0,
         },
@@ -233,6 +241,8 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
             direction: 1,
             protocol_quote_fee_amount: 44,
             protocol_base_fee_amount: 4,
+            party0_relayer_fee_amount: 0,
+            party1_relayer_fee_amount: 0,
             max_minus_min_amount: 0,
             min_amount_order_index: 1,
         },
@@ -248,6 +258,9 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
         let order1 = my_order.to_linkable().allocate(PARTY0, fabric);
         let order2 = my_order.to_linkable().allocate(PARTY1, fabric);
 
+        let relayer0_fee_term = FixedPoint::from_integer(0).allocate(PARTY0, fabric);
+        let relayer1_fee_term = FixedPoint::from_integer(0).allocate(PARTY1, fabric);
+
         // Compute matches
         let res = compute_match(
             &order1,
@@ -255,6 +268,8 @@ async fn test_match_valid_match(test_args: IntegrationTestArgs) -> Result<()> {
             order1.amount.value(),
             order2.amount.value(),
             &price1,
+            &relayer0_fee_term,
+            &relayer1_fee_term,
             fabric,
         )
         .open_and_authenticate()

--- a/circuits/src/zk_circuits/valid_match_mpc.rs
+++ b/circuits/src/zk_circuits/valid_match_mpc.rs
@@ -610,6 +610,8 @@ pub mod test_helpers {
             direction: 0,
             protocol_quote_fee_amount: 0,
             protocol_base_fee_amount: 0,
+            party0_relayer_fee_amount: 0,
+            party1_relayer_fee_amount: 0,
             min_amount_order_index: 0,
             max_minus_min_amount: max_amount - min_amount,
         }

--- a/circuits/src/zk_circuits/valid_settle.rs
+++ b/circuits/src/zk_circuits/valid_settle.rs
@@ -360,6 +360,8 @@ pub mod test_helpers {
             direction: 0, /* party0 buys base */
             protocol_quote_fee_amount: 0,
             protocol_base_fee_amount: 0,
+            party0_relayer_fee_amount: 0,
+            party1_relayer_fee_amount: 0,
             max_minus_min_amount: 0,
             min_amount_order_index: 0,
         };


### PR DESCRIPTION
### Purpose
This PR adds the computation of the relayer fee take to the match mpc. This is concretely done as follows: the relayers each input a fee term to the MPC which is multiplied by the base amount in the match. The implicit assumption is that the buy side relayer (sells the quote token to buy the base) has pre-multiplied the fee take by the execution price to change units into the quote token. This assumption is constrained in the match proof that follows.

Integration of this fee computation and the protocol fee computation into the proofs of `VALID MATCH MPC` and `VALID SETTLE` will be done in a follow up.

### Testing
- Unit and integration tests pass
- CI will fail until the fee implementation is further along