### PR TITLE
docker: devnet: Deploy USDC erc20 with devnet setup

### DIFF
--- a/docker/devnet/setup-sequencer.sh
+++ b/docker/devnet/setup-sequencer.sh
@@ -23,6 +23,7 @@ cargo run -- \
     --dump-deployments \
     --artifacts-path /artifacts \
     -c darkpool \
+    -c usdc \
     --network localhost \
     --address 0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0 \
     --private-key 0x300001800000000300000180000000000030000000000003006001800006600


### PR DESCRIPTION
### Purpose
This PR deploys an ERC20 contract for a USDC token to the Katana devnet. 

### Testing
- Ran the devnet node and ran a few ERC20 calls against the Katana node using `starkli`