### PR TITLE
docker: frontend-test-stack: Build relayer in release mode

### DIFF
--- a/docker/frontend-test-stack/Dockerfile
+++ b/docker/frontend-test-stack/Dockerfile
@@ -29,7 +29,7 @@ RUN find . -path '*/src/*' -name 'lib.rs' -type f -exec sh -c ': > {}' \;
 
 # Build with a dummy main entrypoint, so that we can cache external dependencies
 RUN echo "fn main() {}" >> core/src/main.rs
-RUN cargo build
+RUN cargo build --release
 
 # Copy the real sources into the build directory and rebuild without the dummy entrypoints
 COPY --from=sources /build .
@@ -39,7 +39,7 @@ ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
 # Build the target
-RUN cargo build
+RUN cargo build --release
 
 # --- EXECUTABLE STAGE --- #
 FROM debian:latest

--- a/docker/frontend-test-stack/config.toml
+++ b/docker/frontend-test-stack/config.toml
@@ -2,7 +2,7 @@ p2p-port = 8000
 http-port = 3000
 websocket-port = 4000
 version = 0
-chain-id = "goerli"
+chain-id = "katana"
 public-ip = "127.0.0.1:8000"
 
 deployments-file = "/deployments/deployments.json"


### PR DESCRIPTION
### Purpose
This PR builds the relayer in release mode and switches the chain ID to katana in the config