### PR TITLE
statev2: proto: Add proto definitions for all existing state transitions

### DIFF
--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # === Proto Dependencies === #
 bytes = "1.5"
+derive_builder = "0.12"
 prost = "0.12"
 
 # === Workspace Dependencies === #

--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -4,8 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Proto Dependencies === #
 bytes = "1.5"
 prost = "0.12"
+
+# === Workspace Dependencies === #
+common = { path = "../../common" }
+
+# === Misc Dependencies === #
+eyre = { workspace = true }
+mpc-stark = "0.2"
+uuid = "1.1.2"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/statev2/proto/build.rs
+++ b/statev2/proto/build.rs
@@ -1,7 +1,27 @@
+//! Builder for the state crate's protos
+
 use std::io::Result;
+
+use prost_build::Config;
 
 /// Build the protos for the state crate
 fn main() -> Result<()> {
-    prost_build::compile_protos(&["proto/state_transitions.proto"], &["proto/"])?;
+    let mut builder_config = Config::default();
+    // Derive a builder pattern for each generated message
+    // The builder options enabled are:
+    // - Use the owned pattern, i.e. each setter consumes the builder and returns a new one
+    // - Allow uninitialized fields by deferring to the struct default implementation
+    // - Strip options; i.e. setters do no take `Option<T>` but `T` for optional fields, which is the
+    //   case for most prost-generated fields
+    let builder_pattern_targets = ".";
+    builder_config.message_attribute(
+        builder_pattern_targets,
+        "#[derive(derive_builder::Builder)]",
+    );
+    builder_config.message_attribute(builder_pattern_targets, "#[builder(pattern = \"owned\")]");
+    builder_config.message_attribute(builder_pattern_targets, "#[builder(default)]");
+    builder_config.message_attribute(builder_pattern_targets, "#[builder(setter(strip_option))]");
+
+    builder_config.compile_protos(&["proto/state_transitions.proto"], &["proto/"])?;
     Ok(())
 }

--- a/statev2/proto/proto/common.proto
+++ b/statev2/proto/proto/common.proto
@@ -1,0 +1,31 @@
+/// Defines common types that may be used between proto messages
+syntax = "proto3";
+package state;
+
+/// A cluster ID type
+message ClusterId {
+    string id = 1;
+}
+
+/// A peer ID in the libp2p format
+message PeerId {
+    string id = 1;
+}
+
+/// A UUID type
+message ProtoUuid {
+    /// The underlying string serialized UUID
+    string value = 1;
+}
+
+/// Represents a `Scalar` type as used throughout the Renegade system
+message ProtoScalar {
+    /// The bytes underlying the serialization of the Scalar
+    bytes value = 1;
+}
+
+/// Represents a `BigUint` serialized in little-endian order
+message ProtoBigInt {
+    /// The bytes underlying the serialization of the BigUint
+    bytes value = 1;
+}

--- a/statev2/proto/proto/orders.proto
+++ b/statev2/proto/proto/orders.proto
@@ -1,0 +1,67 @@
+/// Defines orderbook metadata message types
+syntax = "proto3";
+package state;
+
+import "common.proto";
+
+// ---------
+// | Types |
+// ---------
+
+/// The state of the order in the network
+enum NetworkOrderState {
+    /// The received state indicates that the local node knows about the order, but
+    /// has not received a proof of `VALID COMMITMENTS` to indicate that this order
+    /// is a valid member of the state tree
+    ///
+    /// Orders in the received state cannot yet be matched against
+    Received = 0;
+    /// The verified state indicates that a proof of `VALID COMMITMENTS` has been received
+    /// and verified by the local node
+    ///
+    /// Orders in the Verified state are ready to be matched
+    Verified = 1;
+    /// A cancelled order is invalidated because a nullifier for the wallet was submitted
+    /// on-chain
+    Cancelled = 2;
+}
+
+/// An order that has been allocated in the network
+message NetworkOrder {
+    /// The order's ID
+    ProtoUuid id = 1;
+    /// The public shares nullifier of the wallet holding this order
+    ProtoScalar nullifier = 2;
+    /// The cluster managing the order
+    ClusterId cluster = 3;
+    /// The state of the order in the network
+    NetworkOrderState state = 4;
+    /// The proof payload of `VALID COMMITMENTS` for this order
+    /// and `VALID REBLIND` for the containing wallet
+    bytes proof = 5;
+}
+
+// -------------
+// | Interface |
+// -------------
+
+/// Add an order to the book
+message AddOrder {
+    /// The order to add
+    NetworkOrder order = 1;
+}
+
+/// Add a validity proof for an order
+message AddOrderValidityProof {
+    /// The ID of the order to add a proof for
+    ProtoUuid order_id = 1;
+    /// The proof payload of `VALID COMMITMENTS` for this order
+    /// and `VALID REBLIND` for the containing wallet
+    bytes proof = 2;
+}
+
+/// Nullify all orders that are indexed by a given nullifier
+message NullifyOrders {
+    /// The nullifier to nullify orders by
+    bytes nullifier = 1;
+}

--- a/statev2/proto/proto/peers.proto
+++ b/statev2/proto/proto/peers.proto
@@ -1,0 +1,38 @@
+/// Defines p2p metadata message types
+syntax = "proto3";
+package state;
+
+import "common.proto";
+
+// ---------
+// | Types |
+// ---------
+
+/// Represents the metadata known about a peer in the network
+message PeerInfo {
+    /// The ID of the peer as a libp2p PeerId
+    PeerId peer_id = 1;    
+    /// The known, dialable address of the peer
+    string addr = 2;
+    /// The ID of the cluster that the peer belongs to
+    ClusterId cluster_id = 3;
+    /// The signature of the cluster auth message, authenticating this peer
+    /// into its cluster
+    bytes cluster_auth_sig = 4;
+}
+
+// -------------
+// | Interface |
+// -------------
+
+// Add a set of new peers to the peer index
+message AddPeers {
+    // The ID of the peer in the libp2p PeerId format
+    repeated PeerInfo peers = 1; 
+}
+
+// Remove a peer from the peer index
+message RemovePeer {
+    // The ID of the peer in the libp2p PeerId format
+    string peer_id = 1;
+}

--- a/statev2/proto/proto/state_transitions.proto
+++ b/statev2/proto/proto/state_transitions.proto
@@ -1,15 +1,8 @@
 syntax = "proto3";
-package state_transitions;
+package state;
 
+import "peers.proto";
+import "common.proto";
+import "orders.proto";
+import "wallet.proto";
 import "google/protobuf/empty.proto";
-
-
-/// Add a new cluter peer to the new peer index
-message NewPeer {
-    /// The ID of the peer in the libp2p PeerId format
-    string peer_id = 1;
-}
-
-service ClusterStateTransitions {
-    rpc AddPeer(NewPeer) returns (google.protobuf.Empty);
-}

--- a/statev2/proto/proto/wallet.proto
+++ b/statev2/proto/proto/wallet.proto
@@ -1,0 +1,133 @@
+/// Defines wallet management messages and types
+syntax = "proto3";
+package state;
+
+import "common.proto";
+
+// ---------
+// | Types |
+// ---------
+
+/// The side of an order
+enum OrderSide {
+    /// Buy side
+    BUY = 0;
+    /// Sell side
+    SELL = 1;
+}
+
+/// The order type 
+message Order {
+    /// The mint of the quote token 
+    ProtoBigInt quote_mint = 1;
+    /// The mint of the base token
+    ProtoBigInt base_mint = 2;
+    /// The side of the order
+    OrderSide side = 3;
+    /// The amount of the order
+    uint64 amount = 4;
+    /// The worst case price that the user is willing to accept on this order
+    double worse_cast_price = 5;
+    /// A timestamp indicating when the order was placed
+    uint64 timestamp = 6;
+}
+
+/// The balance type 
+message Balance {
+    /// The mint of the token this balance represents
+    ProtoBigInt mint = 1;
+    /// The amount held by the balance
+    uint64 amount = 2;
+}
+
+/// The fee type
+///
+/// TODO: Remove this after fee implementation in favor of new design
+message Fee {
+    /// The public settle key of the cluster collecting fees
+    ProtoBigInt settle_key = 1;
+    /// The mint of the token used 
+    ProtoBigInt gas_addr = 2;
+    /// The amount of gas authorized on a given match
+    uint64 gas_amount = 3;
+    /// The percentage fee that may be taken on a match
+    double percentage_fee = 4;
+}
+
+/// The public keychain, represents the public keys for wallet operations
+message PublicKeyChain {
+    /// The serialization of the public root key
+    bytes pk_root = 1;
+    /// The serialization of the public match key
+    bytes pk_match = 2;
+}
+
+/// The secret keychain, represents the secret keys for wallet operations
+message PrivateKeyChain {
+    /// The serialization of the secret root key
+    bytes sk_root = 1;
+    /// The serialization of the secret match key
+    bytes sk_match = 2;
+}
+
+/// The keychain type, representing both public and secret keys for wallet operations
+message KeyChain {
+    /// The public wallet keys
+    PublicKeyChain public_keys = 1;
+    /// The secret wallet keys
+    PrivateKeyChain secret_keys = 2;
+}
+
+/// The metadata about the wallet's state in the p2p net
+message WalletMetadata {
+    /// The peers replicating the wallet
+    repeated PeerId replicas = 1;
+}
+
+/// A wallet's authentication path in the Merkle tree
+message WalletAuthenticationPath {
+    /// The siblings to each node in the wallet commitment's insertion path
+    repeated ProtoScalar path_siblings = 1;
+    /// The index in which the wallet commitment was inserted
+    uint64 leaf_index = 2;
+    /// The value of the commitment
+    ProtoScalar value = 3;
+}
+
+/// The wallet type as it is indexed in the global state
+message Wallet {
+    /// The ID of the wallet
+    ProtoUuid id = 1;
+    /// The orders in the wallet
+    repeated Order orders = 2;
+    /// The balances in the wallet
+    repeated Balance balances = 3;
+    /// The fees authorized by the wallet
+    repeated Fee fees = 4;
+    /// The wallet's keychain
+    KeyChain keychain = 5;
+    /// The wallet blinder 
+    ProtoScalar blinder = 6;
+    /// The private shares of the wallet
+    repeated ProtoScalar private_shares = 7;
+    /// The blinded public shares of the wallet
+    repeated ProtoScalar blinded_public_shares = 8;
+    /// The wallet's authentication path
+    WalletAuthenticationPath opening = 9;
+}
+
+// -------------
+// | Interface |
+// -------------
+
+/// Add wallets to the global state
+message AddWallets {
+    /// The wallets to add
+    repeated Wallet wallets = 1;
+}
+
+/// Update a wallet in the global state
+message UpdateWallet {
+    /// The wallets to update
+    Wallet wallet = 1;
+}

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -55,20 +55,22 @@ impl From<ProtoScalar> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use super::{AddOrder, AddPeers, NetworkOrder, PeerInfo};
+    use crate::{AddOrderBuilder, AddPeersBuilder, NetworkOrderBuilder, PeerInfoBuilder};
+
+    use super::{AddOrder, AddPeers};
     use prost::Message;
 
     /// Tests the add new peer message
     #[test]
     fn test_new_peer_serialization() {
-        let msg = AddPeers {
-            peers: vec![PeerInfo {
-                peer_id: Some("1234".to_string().into()),
-                addr: "127.0.0.1:5000".to_string(),
-                cluster_id: Some("1234".to_string().into()),
-                cluster_auth_sig: vec![],
-            }],
-        };
+        let new_peer = PeerInfoBuilder::default()
+            .peer_id("1234".to_string().into())
+            .build()
+            .unwrap();
+        let msg = AddPeersBuilder::default()
+            .peers(vec![new_peer])
+            .build()
+            .unwrap();
 
         let bytes = msg.encode_to_vec();
         let recovered: AddPeers = AddPeers::decode(bytes.as_slice()).unwrap();
@@ -79,12 +81,11 @@ mod tests {
     /// Tests the add new order message
     #[test]
     fn test_new_order_serialization() {
-        let msg = AddOrder {
-            order: Some(NetworkOrder {
-                id: Some("1234".to_string().into()),
-                ..Default::default()
-            }),
-        };
+        let order = NetworkOrderBuilder::default()
+            .id("1234".to_string().into())
+            .build()
+            .unwrap();
+        let msg = AddOrderBuilder::default().order(order).build().unwrap();
 
         let bytes = msg.encode_to_vec();
         let recovered: AddOrder = AddOrder::decode(bytes.as_slice()).unwrap();

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -1,28 +1,93 @@
+use mpc_stark::algebra::scalar::Scalar;
+use uuid::{Error as UuidError, Uuid};
+
+pub use protos::*;
+
 #[deny(missing_docs)]
 #[deny(clippy::missing_docs_in_private_items)]
 #[deny(unsafe_code)]
 
 /// Protobuf definitions for state transitions
+#[allow(missing_docs)]
+#[allow(clippy::missing_docs_in_private_items)]
 mod protos {
-    include!(concat!(env!("OUT_DIR"), "/state_transitions.rs"));
+    include!(concat!(env!("OUT_DIR"), "/state.rs"));
 }
 
-pub use protos::*;
+// --------------------
+// | Type Definitions |
+// --------------------
+
+/// PeerId
+impl From<String> for PeerId {
+    fn from(id: String) -> Self {
+        Self { id }
+    }
+}
+
+/// ClusterId
+impl From<String> for ClusterId {
+    fn from(id: String) -> Self {
+        Self { id }
+    }
+}
+
+/// UUID
+impl From<String> for ProtoUuid {
+    fn from(value: String) -> Self {
+        Self { value }
+    }
+}
+
+impl TryFrom<ProtoUuid> for Uuid {
+    type Error = UuidError;
+    fn try_from(uuid: ProtoUuid) -> Result<Self, Self::Error> {
+        Uuid::parse_str(&uuid.value)
+    }
+}
+
+/// Scalar
+impl From<ProtoScalar> for Scalar {
+    fn from(scalar: ProtoScalar) -> Self {
+        Scalar::from_be_bytes_mod_order(&scalar.value)
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::NewPeer;
+    use super::{AddOrder, AddPeers, NetworkOrder, PeerInfo};
     use prost::Message;
 
     /// Tests the add new peer message
     #[test]
     fn test_new_peer_serialization() {
-        let msg = NewPeer {
-            peer_id: "test".to_string(),
+        let msg = AddPeers {
+            peers: vec![PeerInfo {
+                peer_id: Some("1234".to_string().into()),
+                addr: "127.0.0.1:5000".to_string(),
+                cluster_id: Some("1234".to_string().into()),
+                cluster_auth_sig: vec![],
+            }],
         };
 
         let bytes = msg.encode_to_vec();
-        let recovered: NewPeer = NewPeer::decode(bytes.as_slice()).unwrap();
+        let recovered: AddPeers = AddPeers::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(msg, recovered);
+    }
+
+    /// Tests the add new order message
+    #[test]
+    fn test_new_order_serialization() {
+        let msg = AddOrder {
+            order: Some(NetworkOrder {
+                id: Some("1234".to_string().into()),
+                ..Default::default()
+            }),
+        };
+
+        let bytes = msg.encode_to_vec();
+        let recovered: AddOrder = AddOrder::decode(bytes.as_slice()).unwrap();
 
         assert_eq!(msg, recovered);
     }


### PR DESCRIPTION
### Purpose
This PR adds protobuf definitions for all state types that currently have setter methods in the existing state implementation.

As well, this PR derives a builder pattern for all generated protobuf types.

### Testing
- Unit and integration tests pass
- Tested the builder pattern