### PR TITLE
statev2: applicator: Create state applicator and add peer index setter methods

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,6 +25,7 @@ circuits = { path = "../circuits" }
 circuit-types = { path = "../circuit-types" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 base64 = { version = "0.13" }

--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -16,6 +16,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
+use util::networking::is_dialable_multiaddr;
 
 /// The topic prefix for the cluster management pubsub topic
 ///
@@ -120,6 +121,11 @@ impl PeerInfo {
     /// Get the address stored in the PeerInfo
     pub fn get_addr(&self) -> Multiaddr {
         self.addr.clone()
+    }
+
+    /// Returns whether or not the peer's address is dialable
+    pub fn is_dialable(&self, allow_local: bool) -> bool {
+        is_dialable_multiaddr(&self.addr, allow_local)
     }
 
     /// Get the ID of the cluster this peer belongs to

--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -222,6 +222,15 @@ impl<'de> Visitor<'de> for PeerIDVisitor {
         formatter.write_str("a libp2p::PeerID encoded as a byte array")
     }
 
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: SerdeErr,
+    {
+        PeerId::from_bytes(v)
+            .map(WrappedPeerId)
+            .map_err(|e| SerdeErr::custom(format!("deserializing byte array to PeerID: {e:?}")))
+    }
+
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: serde::de::SeqAccess<'de>,

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -2,7 +2,7 @@
 
 use common::types::{
     exchange::PriceReport,
-    gossip::PeerInfo,
+    gossip::{PeerInfo, WrappedPeerId},
     network_order::NetworkOrder,
     tasks::TaskIdentifier,
     token::Token,
@@ -87,7 +87,7 @@ pub enum SystemBusMessage {
     /// A peer was expired after successive heartbeat failures
     PeerExpired {
         /// The expired peer
-        peer: PeerInfo,
+        peer: WrappedPeerId,
     },
 
     // -- Price Report -- //

--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -263,7 +263,7 @@ impl RelayerState {
         if let Some(peer) = expired_peer {
             self.system_bus.publish(
                 NETWORK_TOPOLOGY_TOPIC.to_string(),
-                SystemBusMessage::PeerExpired { peer },
+                SystemBusMessage::PeerExpired { peer: peer.peer_id },
             );
         }
     }

--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "state_proto"
+name = "state-proto"
 version = "0.1.0"
 edition = "2021"
 
@@ -14,6 +14,7 @@ common = { path = "../../common" }
 
 # === Misc Dependencies === #
 eyre = { workspace = true }
+multiaddr = "0.17"
 mpc-stark = "0.2"
 uuid = "1.1.2"
 

--- a/statev2/proto/src/error.rs
+++ b/statev2/proto/src/error.rs
@@ -6,7 +6,10 @@ use std::{error::Error, fmt::Display};
 #[derive(Clone, Debug)]
 pub enum StateProtoError {
     /// A field is missing from a proto
-    MissingField { field_name: String },
+    MissingField {
+        /// The missing field
+        field_name: String,
+    },
     /// An error parsing a proto message into a runtime type
     ParseError(String),
 }

--- a/statev2/proto/src/error.rs
+++ b/statev2/proto/src/error.rs
@@ -1,0 +1,20 @@
+//! Error types emitted by proto parsing code
+
+use std::{error::Error, fmt::Display};
+
+/// The error type emitted when operations on protos fail
+#[derive(Clone, Debug)]
+pub enum StateProtoError {
+    /// A field is missing from a proto
+    MissingField { field_name: String },
+    /// An error parsing a proto message into a runtime type
+    ParseError(String),
+}
+
+impl Display for StateProtoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for StateProtoError {}

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -1,3 +1,9 @@
+//! Defines proto types for state transitions and type operations on them
+
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(unsafe_code)]
+
 use std::{str::FromStr, sync::atomic::AtomicU64};
 
 use common::types::gossip::{
@@ -10,10 +16,6 @@ use uuid::{Error as UuidError, Uuid};
 
 pub use protos::*;
 pub mod error;
-
-#[deny(missing_docs)]
-#[deny(clippy::missing_docs_in_private_items)]
-#[deny(unsafe_code)]
 
 /// Protobuf definitions for state transitions
 #[allow(missing_docs)]

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -14,7 +14,18 @@ libmdbx = "0.3"
 protobuf = "2.0"
 serde = { workspace = true, features = ["derive"] }
 
+# === Messaging + Concurrency === #
+tokio = { workspace = true }
+
+# === Workspace Dependencies === #
+common = { path = "../../common" }
+external-api = { path = "../../external-api" }
+job-types = { path = "../../workers/job-types" }
+state-proto = { path = "../proto" }
+system-bus = { path = "../../system-bus" }
+
 # === Misc === #
+itertools = "0.10"
 slog = "2.2"
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -32,5 +32,6 @@ tracing-slog = "0.2"
 
 [dev-dependencies]
 crossbeam = "0.8"
+multiaddr = "0.17"
 tempfile = "3.8"
 rand = { workspace = true }

--- a/statev2/state/src/applicator/error.rs
+++ b/statev2/state/src/applicator/error.rs
@@ -1,0 +1,32 @@
+//! Error types emitted by the state applicator
+
+use std::{error::Error, fmt::Display};
+
+use state_proto::error::StateProtoError;
+
+use crate::storage::error::StorageError;
+
+/// The error type emitted by the replication layer
+#[derive(Debug)]
+pub enum StateApplicatorError {
+    /// An error interacting with storage
+    Storage(StorageError),
+    /// An error parsing a message separately from proto errors
+    Parse(String),
+    /// An error processing a proto
+    Proto(StateProtoError),
+}
+
+impl Display for StateApplicatorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for StateApplicatorError {}
+
+impl From<StorageError> for StateApplicatorError {
+    fn from(value: StorageError) -> Self {
+        Self::Storage(value)
+    }
+}

--- a/statev2/state/src/applicator/error.rs
+++ b/statev2/state/src/applicator/error.rs
@@ -6,7 +6,7 @@ use state_proto::error::StateProtoError;
 
 use crate::storage::error::StorageError;
 
-/// The error type emitted by the replication layer
+/// The error type emitted by the storage applicator
 #[derive(Debug)]
 pub enum StateApplicatorError {
     /// An error interacting with storage

--- a/statev2/state/src/applicator/mod.rs
+++ b/statev2/state/src/applicator/mod.rs
@@ -76,3 +76,25 @@ impl StateApplicator {
         &self.config.system_bus
     }
 }
+
+#[cfg(test)]
+mod test_helpers {
+    use std::sync::Arc;
+
+    use system_bus::SystemBus;
+
+    use crate::test_helpers::mock_db;
+
+    use super::{StateApplicator, StateApplicatorConfig};
+
+    /// Create a mock `StateApplicator`
+    pub(crate) fn mock_applicator() -> StateApplicator {
+        let config = StateApplicatorConfig {
+            allow_local: true,
+            db: Arc::new(mock_db()),
+            system_bus: SystemBus::new(),
+        };
+
+        StateApplicator::new(config).unwrap()
+    }
+}

--- a/statev2/state/src/applicator/mod.rs
+++ b/statev2/state/src/applicator/mod.rs
@@ -1,0 +1,78 @@
+//! The state applicator applies updates that have been committed to by the raft group
+//! to the global state, persisting them to local storage
+
+use std::sync::Arc;
+
+use external_api::bus_message::SystemBusMessage;
+use system_bus::SystemBus;
+
+use crate::storage::db::DB;
+
+use self::error::StateApplicatorError;
+
+pub mod error;
+pub mod peer_index;
+
+// -------------
+// | Constants |
+// -------------
+
+/// A type alias for the result type given by the applicator
+pub(crate) type Result<T> = std::result::Result<T, StateApplicatorError>;
+
+/// The name of the db table that stores peer information
+pub(crate) const PEER_INFO_TABLE: &str = "peer-info";
+/// The name of the db table that stores cluster membership information
+pub(crate) const CLUSTER_MEMBERSHIP_TABLE: &str = "cluster-membership";
+
+/// The config for the state applicator
+#[derive(Clone)]
+pub struct StateApplicatorConfig {
+    /// Whether or not to allow peers on the localhost
+    pub allow_local: bool,
+    /// A handle to the database underlying the storage layer
+    db: Arc<DB>,
+    /// A handle to the system bus used for internal pubsub
+    system_bus: SystemBus<SystemBusMessage>,
+}
+
+/// The applicator applies state updates to the global state and persists them to local storage
+/// after consensus has been formed on the updates
+///
+/// If we view our state implementation as a distributed log forming consensus over the ordering of RPC
+/// executions, then the `StateApplicator` can be thought of as the RPC server that executes the RPCs
+/// after their consensus has been formed
+#[derive(Clone)]
+pub struct StateApplicator {
+    /// The config for the applicator
+    config: StateApplicatorConfig,
+}
+
+impl StateApplicator {
+    /// Create a new state applicator
+    pub fn new(config: StateApplicatorConfig) -> Result<Self> {
+        Self::create_db_tables(&config.db)?;
+
+        Ok(Self { config })
+    }
+
+    /// Create tables in the DB if not already created
+    fn create_db_tables(db: &DB) -> Result<()> {
+        for table in [PEER_INFO_TABLE, CLUSTER_MEMBERSHIP_TABLE].iter() {
+            db.create_table(table)
+                .map_err(Into::<StateApplicatorError>::into)?;
+        }
+
+        Ok(())
+    }
+
+    /// Get a reference to the db
+    fn db(&self) -> &DB {
+        &self.config.db
+    }
+
+    /// Get a reference to the system bus
+    fn system_bus(&self) -> &SystemBus<SystemBusMessage> {
+        &self.config.system_bus
+    }
+}

--- a/statev2/state/src/applicator/peer_index.rs
+++ b/statev2/state/src/applicator/peer_index.rs
@@ -1,0 +1,114 @@
+//! Applicator methods for the peer index, separated out for discoverability
+
+use std::str::FromStr;
+
+use crate::storage::db::DbTxn;
+
+use super::{
+    error::StateApplicatorError, Result, StateApplicator, CLUSTER_MEMBERSHIP_TABLE, PEER_INFO_TABLE,
+};
+use common::types::gossip::{PeerInfo, WrappedPeerId};
+use external_api::bus_message::{SystemBusMessage, NETWORK_TOPOLOGY_TOPIC};
+use itertools::Itertools;
+use libmdbx::RW;
+use state_proto::{AddPeers as AddPeersMsg, RemovePeer as RemovePeerMsg};
+
+impl StateApplicator {
+    // -------------
+    // | Interface |
+    // -------------
+
+    /// Add new peers to the peer index
+    pub fn add_peers(&self, msg: AddPeersMsg) -> Result<()> {
+        let tx = self
+            .db()
+            .new_write_tx()
+            .map_err(StateApplicatorError::Storage)?;
+
+        // Index each peer
+        for peer in msg.peers.into_iter() {
+            // Parse the peer info and mark a successful heartbeat
+            let peer_info = PeerInfo::try_from(peer).map_err(StateApplicatorError::Proto)?;
+            peer_info.successful_heartbeat();
+
+            // Do not index the peer if the given address is not dialable
+            if !peer_info.is_dialable(self.config.allow_local) {
+                continue;
+            }
+
+            // Add the peer to the store
+            Self::add_peer_with_tx(peer_info.clone(), &tx)?;
+            self.system_bus().publish(
+                NETWORK_TOPOLOGY_TOPIC.to_string(),
+                SystemBusMessage::NewPeer { peer: peer_info },
+            );
+        }
+
+        tx.commit().map_err(StateApplicatorError::Storage)
+    }
+
+    /// Remove a peer from the peer index
+    pub fn remove_peer(&mut self, msg: RemovePeerMsg) -> Result<()> {
+        let peer_id = WrappedPeerId::from_str(&msg.peer_id)
+            .map_err(|e| StateApplicatorError::Parse(format!("PeerId: {}", e)))?;
+        let tx = self
+            .db()
+            .new_write_tx()
+            .map_err(StateApplicatorError::Storage)?;
+
+        Self::remove_peer_with_tx(peer_id, &tx)?;
+        tx.commit().map_err(StateApplicatorError::Storage)?;
+
+        // Push a message to the bus
+        self.system_bus().publish(
+            NETWORK_TOPOLOGY_TOPIC.to_string(),
+            SystemBusMessage::PeerExpired { peer: peer_id },
+        );
+        Ok(())
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Add a single peer to the global state
+    fn add_peer_with_tx(peer: PeerInfo, tx: &DbTxn<'_, RW>) -> Result<()> {
+        // Add the peer to the peer index
+        tx.write(PEER_INFO_TABLE, &peer.peer_id, &peer)
+            .map_err(StateApplicatorError::Storage)?;
+
+        // Read in the cluster peers list and append the new peer
+        let cluster_id = &peer.cluster_id;
+        let peer_id = peer.peer_id;
+
+        let mut peers: Vec<WrappedPeerId> = tx
+            .read(CLUSTER_MEMBERSHIP_TABLE, cluster_id)?
+            .unwrap_or_default();
+        if !peers.contains(&peer_id) {
+            peers.push(peer_id);
+            tx.write(CLUSTER_MEMBERSHIP_TABLE, cluster_id, &peers)?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove a single peer from the global state
+    fn remove_peer_with_tx(peer_id: WrappedPeerId, tx: &DbTxn<'_, RW>) -> Result<()> {
+        // Remove the peer from the peer index
+        if let Some(info) = tx.read::<_, PeerInfo>(PEER_INFO_TABLE, &peer_id)? {
+            tx.delete(PEER_INFO_TABLE, &peer_id)
+                .map_err(StateApplicatorError::Storage)?;
+
+            // Remove the peer from its cluster's list
+            let cluster_id = info.cluster_id;
+            let peers: Vec<WrappedPeerId> = tx
+                .read(CLUSTER_MEMBERSHIP_TABLE, &cluster_id)?
+                .unwrap_or_default();
+
+            let peers = peers.into_iter().filter(|p| p != &peer_id).collect_vec();
+            tx.write(CLUSTER_MEMBERSHIP_TABLE, &cluster_id, &peers)?;
+        }
+
+        Ok(())
+    }
+}

--- a/statev2/state/src/lib.rs
+++ b/statev2/state/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(let_chains)]
 #![feature(io_error_more)]
 
+pub mod applicator;
 pub mod replication;
 pub mod storage;
 

--- a/statev2/state/src/storage/db.rs
+++ b/statev2/state/src/storage/db.rs
@@ -236,7 +236,7 @@ impl<'db> DbTxn<'db, RW> {
         // Delete the value
         let table = self.open_table(table_name)?;
         self.txn
-            .del(&table, &key_bytes, None /* data */)
+            .del(&table, key_bytes, None /* data */)
             .map_err(StorageError::TxOp)
     }
 


### PR DESCRIPTION
### Purpose
The `StateApplicator` is in charge of appling state transitions to the storage layer. If we think of our state primitive as a distributed log that forms consensus over a sequence of state transition RPCs, the `StateApplicator` is then the RPC server executing these requests.

This PR also adds setters for the `PeerIndex` methods that store peer information and cluster membership information

### Testing
- Unit and integration tests pass
- Tested peer addition and removal