### PR TITLE
statev2: applicator: order-book: Add order book state transition handlers

### DIFF
--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -16,6 +16,7 @@ common = { path = "../../common" }
 eyre = { workspace = true }
 multiaddr = "0.17"
 mpc-stark = "0.2"
+serde_json = "1.0"
 uuid = "1.1.2"
 
 [build-dependencies]

--- a/statev2/proto/proto/orders.proto
+++ b/statev2/proto/proto/orders.proto
@@ -63,5 +63,5 @@ message AddOrderValidityProof {
 /// Nullify all orders that are indexed by a given nullifier
 message NullifyOrders {
     /// The nullifier to nullify orders by
-    bytes nullifier = 1;
+    ProtoScalar nullifier = 1;
 }

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 external-api = { path = "../../external-api" }
 job-types = { path = "../../workers/job-types" }
 state-proto = { path = "../proto" }
@@ -26,6 +27,7 @@ system-bus = { path = "../../system-bus" }
 
 # === Misc === #
 itertools = "0.10"
+mpc-stark = "0.2"
 slog = "2.2"
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
@@ -35,3 +37,4 @@ crossbeam = "0.8"
 multiaddr = "0.17"
 tempfile = "3.8"
 rand = { workspace = true }
+uuid = "1.4"

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -3,6 +3,10 @@ name = "statev2"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Used to enable mocks from other crates in tests
+all-tests = ["common/mocks"]
+
 [dependencies]
 
 # === Replication === #
@@ -28,9 +32,11 @@ system-bus = { path = "../../system-bus" }
 # === Misc === #
 itertools = "0.10"
 mpc-stark = "0.2"
+serde_json = "1.0"
 slog = "2.2"
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
+uuid = "1.1.2"
 
 [dev-dependencies]
 crossbeam = "0.8"

--- a/statev2/state/src/applicator/error.rs
+++ b/statev2/state/src/applicator/error.rs
@@ -9,6 +9,8 @@ use crate::storage::error::StorageError;
 /// The error type emitted by the storage applicator
 #[derive(Debug)]
 pub enum StateApplicatorError {
+    /// Missing keys in the database necessary for a tx
+    MissingEntry(String),
     /// An error interacting with storage
     Storage(StorageError),
     /// An error parsing a message separately from proto errors

--- a/statev2/state/src/applicator/mod.rs
+++ b/statev2/state/src/applicator/mod.rs
@@ -11,6 +11,7 @@ use crate::storage::db::DB;
 use self::error::StateApplicatorError;
 
 pub mod error;
+pub mod order_book;
 pub mod peer_index;
 
 // -------------
@@ -24,6 +25,10 @@ pub(crate) type Result<T> = std::result::Result<T, StateApplicatorError>;
 pub(crate) const PEER_INFO_TABLE: &str = "peer-info";
 /// The name of the db table that stores cluster membership information
 pub(crate) const CLUSTER_MEMBERSHIP_TABLE: &str = "cluster-membership";
+/// The name of the db table that stores order and cluster priorities
+pub(crate) const PRIORITIES_TABLE: &str = "priorities";
+/// The name of the table that stores orders by their ID
+pub(crate) const ORDERS_TABLE: &str = "orders";
 
 /// The config for the state applicator
 #[derive(Clone)]
@@ -58,7 +63,14 @@ impl StateApplicator {
 
     /// Create tables in the DB if not already created
     fn create_db_tables(db: &DB) -> Result<()> {
-        for table in [PEER_INFO_TABLE, CLUSTER_MEMBERSHIP_TABLE].iter() {
+        for table in [
+            PEER_INFO_TABLE,
+            CLUSTER_MEMBERSHIP_TABLE,
+            PRIORITIES_TABLE,
+            ORDERS_TABLE,
+        ]
+        .iter()
+        {
             db.create_table(table)
                 .map_err(Into::<StateApplicatorError>::into)?;
         }

--- a/statev2/state/src/applicator/order_book.rs
+++ b/statev2/state/src/applicator/order_book.rs
@@ -1,0 +1,242 @@
+//! Applicator methods for the network order book, separated out for discoverability
+//!
+//! TODO: For the order book in particular, it is likely to our advantage to index orders outside
+//! of the DB as well in an in-memory data structure for efficient lookup
+
+use common::types::{gossip::ClusterId, network_order::NetworkOrder, wallet::OrderIdentifier};
+use constants::ORDER_STATE_CHANGE_TOPIC;
+use external_api::bus_message::SystemBusMessage;
+use libmdbx::{TransactionKind, RW};
+use mpc_stark::algebra::scalar::Scalar;
+use serde::{Deserialize, Serialize};
+use state_proto::{
+    AddOrder as AddOrderMsg, AddOrderValidityProof as AddOrderValidityProofMsg,
+    NullifyOrders as NullifyOrdersMsg,
+};
+
+use crate::{
+    applicator::{error::StateApplicatorError, ORDERS_TABLE, PRIORITIES_TABLE},
+    storage::db::DbTxn,
+};
+
+use super::{Result, StateApplicator};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The default priority for a cluster
+const CLUSTER_DEFAULT_PRIORITY: u32 = 1;
+/// The default priority for an order
+const ORDER_DEFAULT_PRIORITY: u32 = 1;
+
+/// The error message emitted when an order is missing from the message
+const ERR_ORDER_MISSING: &str = "Order missing from message";
+
+// ----------------------------
+// | Orderbook Implementation |
+// ----------------------------
+
+/// A type that represents the priority for an order, including its cluster
+/// priority
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderPriority {
+    /// The priority of the cluster that the order is managed by
+    cluster_priority: u32,
+    /// The priority of the order itself
+    order_priority: u32,
+}
+
+impl Default for OrderPriority {
+    fn default() -> Self {
+        OrderPriority {
+            cluster_priority: CLUSTER_DEFAULT_PRIORITY,
+            order_priority: ORDER_DEFAULT_PRIORITY,
+        }
+    }
+}
+
+impl OrderPriority {
+    /// Compute the effective scheduling priority for an order
+    pub fn get_effective_priority(&self) -> u32 {
+        self.cluster_priority * self.order_priority
+    }
+}
+
+impl StateApplicator {
+    // -------------
+    // | Interface |
+    // -------------
+
+    /// Add a new order to the network order book
+    pub fn new_order(&self, msg: AddOrderMsg) -> Result<()> {
+        // Parse the order from the message to a runtime type
+        let order: NetworkOrder = msg
+            .order
+            .ok_or_else(|| StateApplicatorError::Parse(ERR_ORDER_MISSING.to_string()))
+            .and_then(|order| NetworkOrder::try_from(order).map_err(StateApplicatorError::Proto))?;
+
+        // Index the order
+        let tx = self
+            .db()
+            .new_write_tx()
+            .map_err(StateApplicatorError::Storage)?;
+        Self::write_order_priority_with_tx(&order, &tx)?;
+        Self::add_order_with_tx(&order, &tx)?;
+
+        tx.commit().map_err(StateApplicatorError::Storage)?;
+
+        // Push a message to the bus
+        self.system_bus().publish(
+            ORDER_STATE_CHANGE_TOPIC.to_string(),
+            SystemBusMessage::NewOrder { order },
+        );
+        Ok(())
+    }
+
+    /// Add a validity proof for an order
+    pub fn add_order_validity_proof(&self, msg: AddOrderValidityProofMsg) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Nullify orders indexed by a given wallet share nullifier
+    pub fn nullify_orders(&self, msg: NullifyOrdersMsg) -> Result<()> {
+        unimplemented!()
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Get the priority of a cluster
+    fn get_cluster_priority_with_tx<T: TransactionKind>(
+        cluster_id: &ClusterId,
+        tx: &DbTxn<'_, T>,
+    ) -> Result<u32> {
+        tx.read(PRIORITIES_TABLE, cluster_id)
+            .map_err(StateApplicatorError::Storage)
+            .map(|priority| priority.unwrap_or(CLUSTER_DEFAULT_PRIORITY))
+    }
+
+    /// Write an order priority to the DB
+    fn write_order_priority_with_tx(order: &NetworkOrder, tx: &DbTxn<'_, RW>) -> Result<()> {
+        // Lookup the cluster priority and write the order's priority
+        let cluster_priority = Self::get_cluster_priority_with_tx(&order.cluster, tx)?;
+        let priority = OrderPriority {
+            cluster_priority,
+            order_priority: ORDER_DEFAULT_PRIORITY,
+        };
+
+        tx.write(PRIORITIES_TABLE, &order.id, &priority)
+            .map_err(StateApplicatorError::Storage)
+    }
+
+    /// Add an order to the book
+    ///
+    /// TODO: For an initial implementation we do not re-index based on local orders or
+    /// verified orders. This will be added with the getter implementations
+    fn add_order_with_tx(order: &NetworkOrder, tx: &DbTxn<'_, RW>) -> Result<()> {
+        // Write the order to storage
+        let order_key = Self::order_key(&order.id);
+        tx.write(ORDERS_TABLE, &order_key, order)
+            .map_err(StateApplicatorError::Storage)?;
+
+        // Add the order to the set of orders indexed by the nullifier
+        let nullifier_key = Self::nullifier_key(order.public_share_nullifier);
+        let mut nullifier_set: Vec<OrderIdentifier> = tx
+            .read(ORDERS_TABLE, &nullifier_key)
+            .map_err(StateApplicatorError::Storage)?
+            .unwrap_or_default();
+        if !nullifier_set.contains(&order.id) {
+            nullifier_set.push(order.id);
+            tx.write(ORDERS_TABLE, &nullifier_key, &nullifier_set)
+                .map_err(StateApplicatorError::Storage)?;
+        }
+
+        Ok(())
+    }
+
+    /// Create an order key from an order ID
+    fn order_key(id: &OrderIdentifier) -> String {
+        format!("order:{id}")
+    }
+
+    /// Create a nullifier key from a nullifier
+    fn nullifier_key(nullifier: Scalar) -> String {
+        format!("nullifier:{nullifier}")
+    }
+}
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod test {
+    use common::types::{network_order::NetworkOrder, wallet::OrderIdentifier};
+    use mpc_stark::algebra::scalar::Scalar;
+    use rand::thread_rng;
+    use state_proto::{AddOrder, NetworkOrderBuilder, NetworkOrderState};
+    use uuid::Uuid;
+
+    use crate::applicator::{
+        order_book::OrderPriority, test_helpers::mock_applicator, StateApplicator, ORDERS_TABLE,
+        PRIORITIES_TABLE,
+    };
+
+    /// Creates a dummy `AddOrder` message for testing
+    fn add_order_msg() -> AddOrder {
+        let mut rng = thread_rng();
+        let order = NetworkOrderBuilder::default()
+            .id(Uuid::new_v4().into())
+            .cluster("cluster".to_string().into())
+            .nullifier(Scalar::random(&mut rng).into())
+            .state(NetworkOrderState::Received.into())
+            .build()
+            .unwrap();
+
+        AddOrder { order: Some(order) }
+    }
+
+    /// Tests adding an order to the order book
+    #[test]
+    fn test_add_order() {
+        let applicator = mock_applicator();
+
+        // Add an order to the book
+        let msg = add_order_msg();
+        applicator.new_order(msg.clone()).unwrap();
+
+        // Verify the order is indexed
+        let db = applicator.db();
+
+        let expected_order: NetworkOrder = msg.order.unwrap().try_into().unwrap();
+        let order = db
+            .read::<_, NetworkOrder>(
+                ORDERS_TABLE,
+                &StateApplicator::order_key(&expected_order.id),
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(order, expected_order);
+
+        // Verify that the order is indexed by its nullifier
+        let orders: Vec<OrderIdentifier> = db
+            .read(
+                ORDERS_TABLE,
+                &StateApplicator::nullifier_key(expected_order.public_share_nullifier),
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(orders, vec![expected_order.id]);
+
+        // Verify that the priority of the order is set to the default
+        let priority: OrderPriority = db
+            .read(PRIORITIES_TABLE, &expected_order.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(priority, OrderPriority::default());
+    }
+}

--- a/statev2/state/src/lib.rs
+++ b/statev2/state/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(incomplete_features)]
 #![feature(let_chains)]
 #![feature(io_error_more)]
+#![feature(generic_const_exprs)]
 
 pub mod applicator;
 pub mod replication;

--- a/statev2/state/src/storage/db.rs
+++ b/statev2/state/src/storage/db.rs
@@ -18,7 +18,7 @@ use super::{
 };
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 2;
+const NUM_TABLES: usize = 10;
 
 // -----------
 // | Helpers |


### PR DESCRIPTION
### Purpose
This PR adds state transition handler for order book types. This includes:
- Adding new orders to the book
- Attaching validity proofs for an order
- Nullifying orders when their nullifiers are witnessed on-chain

### Testing
- Unit and integration tests pass