### PR TITLE
statev2: proto: Add `Wallet` type conversion methods

### DIFF
--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -10,12 +10,16 @@ derive_builder = "0.12"
 prost = "0.12"
 
 # === Workspace Dependencies === #
+circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
 
 # === Misc Dependencies === #
 eyre = { workspace = true }
+indexmap = "1.9"
+itertools = "0.11"
 multiaddr = "0.17"
 mpc-stark = "0.2"
+num-bigint = "0.4"
 serde_json = "1.0"
 uuid = "1.1.2"
 

--- a/statev2/proto/proto/wallet.proto
+++ b/statev2/proto/proto/wallet.proto
@@ -18,18 +18,20 @@ enum OrderSide {
 
 /// The order type 
 message Order {
+    /// The ID of the order
+    ProtoUuid id = 1;
     /// The mint of the quote token 
-    ProtoBigInt quote_mint = 1;
+    ProtoBigInt quote_mint = 2;
     /// The mint of the base token
-    ProtoBigInt base_mint = 2;
+    ProtoBigInt base_mint = 3;
     /// The side of the order
-    OrderSide side = 3;
+    OrderSide side = 4;
     /// The amount of the order
-    uint64 amount = 4;
+    uint64 amount = 5;
     /// The worst case price that the user is willing to accept on this order
-    double worse_cast_price = 5;
+    double worst_case_price = 6;
     /// A timestamp indicating when the order was placed
-    uint64 timestamp = 6;
+    uint64 timestamp = 7;
 }
 
 /// The balance type 
@@ -59,7 +61,7 @@ message PublicKeyChain {
     /// The serialization of the public root key
     bytes pk_root = 1;
     /// The serialization of the public match key
-    bytes pk_match = 2;
+    ProtoScalar pk_match = 2;
 }
 
 /// The secret keychain, represents the secret keys for wallet operations
@@ -67,7 +69,7 @@ message PrivateKeyChain {
     /// The serialization of the secret root key
     bytes sk_root = 1;
     /// The serialization of the secret match key
-    bytes sk_match = 2;
+    ProtoScalar sk_match = 2;
 }
 
 /// The keychain type, representing both public and secret keys for wallet operations
@@ -121,9 +123,9 @@ message Wallet {
 // -------------
 
 /// Add wallets to the global state
-message AddWallets {
+message AddWallet {
     /// The wallets to add
-    repeated Wallet wallets = 1;
+    Wallet wallets = 1;
 }
 
 /// Update a wallet in the global state

--- a/statev2/state/src/applicator/order_book.rs
+++ b/statev2/state/src/applicator/order_book.rs
@@ -19,7 +19,6 @@ use state_proto::{
     AddOrder as AddOrderMsg, AddOrderValidityProof as AddOrderValidityProofMsg,
     NullifyOrders as NullifyOrdersMsg,
 };
-use uuid::Error as UuidError;
 
 use crate::{
     applicator::{error::StateApplicatorError, ORDERS_TABLE, PRIORITIES_TABLE},
@@ -107,7 +106,7 @@ impl StateApplicator {
             .order_id
             .unwrap_or_default()
             .try_into()
-            .map_err(|e: UuidError| StateApplicatorError::Parse(e.to_string()))?;
+            .map_err(StateApplicatorError::Proto)?;
 
         let bundle: OrderValidityProofBundle = serde_json::from_slice(&msg.proof)
             .map_err(|e| StateApplicatorError::Parse(e.to_string()))?;


### PR DESCRIPTION
### Purpose
This PR adds type conversion methods from wallet types in the proto definition to wallet types in the runtime/state index definition. These type definitions will be used by the `StateApplicator` to process messages


### Testing
- All unit and integration tests pass