### PR TITLE
statev2: applicator, replication: Accept inbound proposals, and apply state transitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,13 @@ libp2p-identity = { version = "0.1" }
 libp2p-swarm = { version = "0.42" }
 libp2p-swarm-derive = { version = "0.32" }
 
+# === Concurrency + Messaging === #
+crossbeam = "0.8"
+tokio = { version = "1" }
+
 # === Misc === #
 eyre = "0.6"
 itertools = "0.10"
 serde = { version = "1.0.139" }
 serde_json = "1.0.64"
-tokio = { version = "1" }
 tracing = "0.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ mpc-stark = { workspace = true }
 num-bigint = { workspace = true }
 
 # === Runtime + Networking === #
-crossbeam = "0.8"
+crossbeam = { workspace = true }
 libp2p = { workspace = true }
 libp2p-identity = { workspace = true }
 tokio = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ debug-tui = []
 
 [dependencies]
 # === Runtime + Async === #
-crossbeam = "0.8"
+crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Workspace Dependencies === #

--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -20,6 +20,7 @@ itertools = "0.11"
 multiaddr = "0.17"
 mpc-stark = "0.2"
 num-bigint = "0.4"
+serde = { workspace = true }
 serde_json = "1.0"
 uuid = "1.1.2"
 

--- a/statev2/proto/build.rs
+++ b/statev2/proto/build.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
     let builder_pattern_targets = ".";
     builder_config.message_attribute(
         builder_pattern_targets,
-        "#[derive(derive_builder::Builder)]",
+        "#[derive(derive_builder::Builder, serde::Serialize, serde::Deserialize)]",
     );
     builder_config.message_attribute(builder_pattern_targets, "#[builder(pattern = \"owned\")]");
     builder_config.message_attribute(builder_pattern_targets, "#[builder(default)]");

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -37,6 +37,7 @@ use itertools::Itertools;
 use mpc_stark::algebra::scalar::Scalar;
 use multiaddr::Multiaddr;
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub use protos::*;
@@ -55,6 +56,26 @@ mod protos {
 // ----------------------------------
 // | Type Definitions + Conversions |
 // ----------------------------------
+
+/// The `StateTransition` type encapsulates all possible state transitions and allows
+/// in an adjacently tagged enum representation
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum StateTransition {
+    /// Add a wallet to the managed state
+    AddWallet(AddWallet),
+    /// Update a wallet in the managed state
+    UpdateWallet(UpdateWallet),
+    /// Add an order to the network order book
+    AddOrder(AddOrder),
+    /// Add a validity proof to an existing order in the book
+    AddOrderValidityProof(AddOrderValidityProof),
+    /// Cancel all orders on a given nullifier
+    NullifyOrders(NullifyOrders),
+    /// Add a set of peers to the network topology
+    AddPeers(AddPeers),
+    /// Remove a peer from the network topology
+    RemovePeer(RemovePeer),
+}
 
 /// PeerId
 impl From<String> for PeerId {

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -57,8 +57,8 @@ mod protos {
 // | Type Definitions + Conversions |
 // ----------------------------------
 
-/// The `StateTransition` type encapsulates all possible state transitions and allows
-/// in an adjacently tagged enum representation
+/// The `StateTransition` type encapsulates all possible state transitions, allowing transitions
+/// to be handled generically before they are applied
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StateTransition {
     /// Add a wallet to the managed state

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -19,6 +19,7 @@ protobuf = "2.0"
 serde = { workspace = true, features = ["derive"] }
 
 # === Messaging + Concurrency === #
+crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Workspace Dependencies === #
@@ -42,7 +43,6 @@ tracing-slog = "0.2"
 uuid = "1.1.2"
 
 [dev-dependencies]
-crossbeam = "0.8"
 multiaddr = "0.17"
 num-bigint = "0.4"
 tempfile = "3.8"

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true }
 # === Workspace Dependencies === #
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
+config = { path = "../../config" }
 constants = { path = "../../constants" }
 external-api = { path = "../../external-api" }
 job-types = { path = "../../workers/job-types" }
@@ -33,6 +34,7 @@ system-bus = { path = "../../system-bus" }
 # === Misc === #
 itertools = "0.10"
 mpc-stark = "0.2"
+rand = "0.8"
 serde_json = "1.0"
 slog = "2.2"
 tracing = { workspace = true, features = ["log"] }

--- a/statev2/state/src/applicator/mod.rs
+++ b/statev2/state/src/applicator/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use common::types::gossip::ClusterId;
 use external_api::bus_message::SystemBusMessage;
+use state_proto::StateTransition;
 use system_bus::SystemBus;
 
 use crate::storage::db::DB;
@@ -69,6 +70,19 @@ impl StateApplicator {
         Self::create_db_tables(&config.db)?;
 
         Ok(Self { config })
+    }
+
+    /// Handle a state transition
+    pub fn handle_state_transition(&self, transition: StateTransition) -> Result<()> {
+        match transition {
+            StateTransition::AddWallet(msg) => self.add_wallet(msg),
+            StateTransition::UpdateWallet(msg) => self.update_wallet(msg),
+            StateTransition::AddOrder(msg) => self.new_order(msg),
+            StateTransition::AddOrderValidityProof(msg) => self.add_order_validity_proof(msg),
+            StateTransition::NullifyOrders(msg) => self.nullify_orders(msg),
+            StateTransition::AddPeers(msg) => self.add_peers(msg),
+            StateTransition::RemovePeer(msg) => self.remove_peer(msg),
+        }
     }
 
     /// Create tables in the DB if not already created

--- a/statev2/state/src/applicator/wallet_index.rs
+++ b/statev2/state/src/applicator/wallet_index.rs
@@ -142,8 +142,7 @@ impl StateApplicator {
 }
 
 #[cfg(all(test, feature = "all-tests"))]
-mod test {
-
+pub(crate) mod test {
     use common::types::{wallet::Wallet, wallet_mocks::mock_empty_wallet};
     use constants::MERKLE_HEIGHT;
     use mpc_stark::algebra::scalar::Scalar;
@@ -229,7 +228,7 @@ mod test {
     }
 
     /// Create a dummy `AddWallet` message
-    fn dummy_add_wallet() -> AddWallet {
+    pub(crate) fn dummy_add_wallet() -> AddWallet {
         let wallet = dummy_proto_wallet();
         AddWalletBuilder::default().wallet(wallet).build().unwrap()
     }

--- a/statev2/state/src/replication/error.rs
+++ b/statev2/state/src/replication/error.rs
@@ -16,12 +16,16 @@ pub enum ReplicationError {
     EntryNotFound,
     /// Error parsing a stored value
     ParseValue(String),
+    /// An error reading from the proposal queue
+    ProposalQueue(String),
     /// An error from the raft library
     Raft(RaftError),
     /// An error receiving a message
     RecvMessage(IOError),
     /// An error sending a message
     SendMessage(IOError),
+    /// An error serializing a value
+    SerializeValue(String),
     /// An error interacting with storage
     Storage(StorageError),
 }
@@ -37,7 +41,9 @@ impl Error for ReplicationError {}
 impl From<ReplicationError> for RaftError {
     fn from(value: ReplicationError) -> Self {
         match value {
-            ReplicationError::Applicator(_) => RaftError::ProposalDropped,
+            ReplicationError::Applicator(_)
+            | ReplicationError::ProposalQueue(_)
+            | ReplicationError::SerializeValue(_) => RaftError::ProposalDropped,
             ReplicationError::EntryNotFound => RaftError::Store(RaftStorageError::Unavailable),
             ReplicationError::Raft(e) => e,
             ReplicationError::Storage(e) => e.into(),

--- a/statev2/state/src/replication/network.rs
+++ b/statev2/state/src/replication/network.rs
@@ -30,7 +30,7 @@ pub trait RaftNetwork {
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use crossbeam::channel::{
-        Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,
+        unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,
     };
     use raft::prelude::Message as RaftMessage;
     use std::io::{Error as IOError, ErrorKind};
@@ -54,6 +54,14 @@ pub(crate) mod test_helpers {
             receiver: CrossbeamReceiver<RaftMessage>,
         ) -> Self {
             Self { sender, receiver }
+        }
+
+        /// Create a double sided mock connection
+        pub fn new_duplex_conn() -> (Self, Self) {
+            let (s1, r1) = unbounded();
+            let (s2, r2) = unbounded();
+
+            (Self::new(s1, r2), Self::new(s2, r1))
         }
     }
 

--- a/statev2/state/src/replication/raft_node.rs
+++ b/statev2/state/src/replication/raft_node.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use config::RelayerConfig;
+use crossbeam::channel::{Receiver as CrossbeamReceiver, TryRecvError};
 use external_api::bus_message::SystemBusMessage;
 use protobuf::Message;
 use raft::{
@@ -31,16 +32,21 @@ use super::{error::ReplicationError, log_store::LogStore, network::RaftNetwork};
 // | Raft Node |
 // -------------
 
-/// The interval at which to tick the raft node
-const RAFT_TICK_INTERVAL_MS: u64 = 100; // 100 ms
 /// The interval at which to poll for new inbound messages
 const RAFT_POLL_INTERVAL_MS: u64 = 10; // 10 ms
+
+/// Error message emitted when the proposal queue is disconnected
+const PROPOSAL_QUEUE_DISCONNECTED: &str = "Proposal queue disconnected";
 
 /// The config for the local replication node
 #[derive(Clone)]
 pub struct ReplicationNodeConfig<N: RaftNetwork> {
+    /// The period (in milliseconds) on which to tick the raft node
+    tick_period_ms: u64,
     /// A copy of the relayer's config
     relayer_config: RelayerConfig,
+    /// A reference to the channel on which the replication node may receive proposals
+    proposal_queue: CrossbeamReceiver<StateTransition>,
     /// A reference to the networking layer that backs the raft node
     network: N,
     /// A handle on the persistent storage layer underlying the raft node
@@ -51,8 +57,12 @@ pub struct ReplicationNodeConfig<N: RaftNetwork> {
 
 /// A raft node that replicates the relayer's state machine
 pub struct ReplicationNode<N: RaftNetwork> {
+    /// The frequency on which to tick the raft node
+    tick_period_ms: u64,
     /// The inner raft node
     inner: RawNode<LogStore>,
+    /// The queue on which state transition proposals may be received
+    proposal_queue: CrossbeamReceiver<StateTransition>,
     /// A handle to the state applicator: the module responsible for applying state
     /// transitions to the state machine when they are committed
     applicator: StateApplicator,
@@ -63,8 +73,26 @@ pub struct ReplicationNode<N: RaftNetwork> {
 impl<N: RaftNetwork> ReplicationNode<N> {
     /// Creates a new replication node
     pub fn new(config: ReplicationNodeConfig<N>) -> Result<Self, ReplicationError> {
+        // TODO: Replace random node ID with the first 8 bytes of the local peer ID
+        let my_id = thread_rng().next_u64();
+
+        Self::new_with_config(
+            config,
+            RaftConfig {
+                id: my_id,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Creates a new replication node with a given raft config
+    pub fn new_with_config(
+        config: ReplicationNodeConfig<N>,
+        raft_config: RaftConfig,
+    ) -> Result<Self, ReplicationError> {
         // Build the log store on top of the DB
         let store = LogStore::new(config.db.clone())?;
+        Self::setup_storage_as_leader(raft_config.id, &store)?;
 
         // Build a state applicator to handle state transitions
         let applicator = StateApplicator::new(StateApplicatorConfig {
@@ -80,25 +108,42 @@ impl<N: RaftNetwork> ReplicationNode<N> {
         let logger = Logger::root(tracing_drain, slog::o!());
 
         // Build raft node
-        // TODO: Replace random node ID with the first 8 bytes of the local peer ID
-        let raft_config = RaftConfig {
-            id: thread_rng().next_u64(),
-            ..Default::default()
-        };
-
         let node = RawNode::new(&raft_config, store, &logger).map_err(ReplicationError::Raft)?;
 
         Ok(Self {
+            tick_period_ms: config.tick_period_ms,
             inner: node,
             applicator,
+            proposal_queue: config.proposal_queue,
             network: config.network,
         })
     }
 
+    /// Set defaults in the storage module that imply the local peer is the leader
+    /// and the only member of the cluster.
+    ///
+    /// This may change as the local peer bootstraps into the network and discovers cluster
+    /// peers, at which point it will step down as begin syncing with the cluster
+    fn setup_storage_as_leader(my_id: u64, storage: &LogStore) -> Result<(), ReplicationError> {
+        // Store a default snapshot under the assumption that the raft was just initialized
+        // from the local node. This is effectively a raft wherein the first term has just begun,
+        // and the log is empty at the first index. We also register the local peer as the only
+        // voter known to the cluster. This ensures that the local peer will elect itself leader
+        let mut snap = Snapshot::new();
+        let md = snap.mut_metadata();
+
+        md.index = 1;
+        md.term = 1;
+        md.mut_conf_state().voters = vec![my_id];
+
+        // Store the snapshot
+        storage.apply_snapshot(&snap)
+    }
+
     /// The main loop of the raft consensus engine, we tick the state machine every
-    /// `RAFT_TICK_INTERVAL_MS` milliseconds
+    /// `tick_period_ms` milliseconds
     pub fn run(mut self) -> Result<(), ReplicationError> {
-        let tick_interval = Duration::from_millis(RAFT_TICK_INTERVAL_MS);
+        let tick_interval = Duration::from_millis(self.tick_period_ms);
         let poll_interval = Duration::from_millis(RAFT_POLL_INTERVAL_MS);
 
         let mut last_tick = Instant::now();
@@ -106,7 +151,22 @@ impl<N: RaftNetwork> ReplicationNode<N> {
         loop {
             thread::sleep(poll_interval);
 
-            // Check for new messages
+            // Check for new proposals
+            while let Some(msg) = self
+                .proposal_queue
+                .try_recv()
+                .map(Some)
+                .or_else(|e| match e {
+                    TryRecvError::Empty => Ok(None),
+                    TryRecvError::Disconnected => Err(ReplicationError::ProposalQueue(
+                        PROPOSAL_QUEUE_DISCONNECTED.to_string(),
+                    )),
+                })?
+            {
+                self.process_proposal(msg)?;
+            }
+
+            // Check for new messages from raft peers
             while let Some(msg) = self.network.try_recv().map_err(Into::into)? {
                 self.inner.step(msg).map_err(ReplicationError::Raft)?;
             }
@@ -119,6 +179,16 @@ impl<N: RaftNetwork> ReplicationNode<N> {
                 last_tick = Instant::now();
             }
         }
+    }
+
+    /// Process a state transition proposal
+    fn process_proposal(&mut self, proposal: StateTransition) -> Result<(), ReplicationError> {
+        let payload = serde_json::to_vec(&proposal)
+            .map_err(|e| ReplicationError::SerializeValue(e.to_string()))?;
+
+        self.inner
+            .propose(vec![] /* context */, payload)
+            .map_err(ReplicationError::Raft)
     }
 
     /// Process the ready state of the node
@@ -144,7 +214,7 @@ impl<N: RaftNetwork> ReplicationNode<N> {
 
         // Apply snapshot
         if !ready.snapshot().is_empty() {
-            self.apply_snapshot(ready.snapshot());
+            self.apply_snapshot(ready.snapshot())?;
         }
 
         // Commit entries
@@ -184,8 +254,8 @@ impl<N: RaftNetwork> ReplicationNode<N> {
     }
 
     /// Apply a raft snapshot from the ready state
-    fn apply_snapshot(&mut self, snapshot: &Snapshot) {
-        self.inner.mut_store().apply_snapshot(snapshot);
+    fn apply_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), ReplicationError> {
+        self.inner.mut_store().apply_snapshot(snapshot)
     }
 
     /// Commit entries from the ready state and apply them to the state machine
@@ -248,30 +318,113 @@ impl<N: RaftNetwork> ReplicationNode<N> {
 // ---------
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test_helpers {
     use std::sync::Arc;
 
-    use crate::{replication::network::test_helpers::MockNetwork, test_helpers::mock_db};
+    use crossbeam::channel::Receiver as CrossbeamReceiver;
+    use raft::prelude::Config as RaftConfig;
+    use rand::{thread_rng, RngCore};
+    use state_proto::StateTransition;
+    use system_bus::SystemBus;
+
+    use crate::{replication::network::test_helpers::MockNetwork, storage::db::DB};
 
     use super::{ReplicationNode, ReplicationNodeConfig};
+
+    /// Create a mock node
+    pub fn mock_replication_node(
+        db: Arc<DB>,
+        proposal_queue: CrossbeamReceiver<StateTransition>,
+        network: MockNetwork,
+    ) -> ReplicationNode<MockNetwork> {
+        // Build a raft node that has high tick frequency and low leader timeout intervals to
+        // speed up tests. In unit tests there is no practical latency issue, so we can set the
+        // timeouts to the minimum values they may validly take
+        ReplicationNode::new_with_config(
+            ReplicationNodeConfig {
+                tick_period_ms: 10,
+                relayer_config: Default::default(),
+                proposal_queue,
+                network,
+                db,
+                system_bus: SystemBus::new(),
+            },
+            RaftConfig {
+                id: thread_rng().next_u64(),
+                election_tick: 2,
+                min_election_tick: 2,
+                max_election_tick: 3,
+                heartbeat_tick: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+}
+
+#[cfg(all(test, feature = "all-tests"))]
+mod test {
+    use std::{sync::Arc, thread, time::Duration};
+
+    use common::types::wallet::Wallet;
+    use crossbeam::channel::unbounded;
+    use state_proto::StateTransition;
+
+    use crate::{
+        applicator::{wallet_index::test::dummy_add_wallet, WALLETS_TABLE},
+        replication::network::test_helpers::MockNetwork,
+        test_helpers::mock_db,
+    };
+
+    use super::{test_helpers::mock_replication_node, ReplicationNode, ReplicationNodeConfig};
 
     /// Tests that the constructor works properly, largely this means testing that the `LogStore`
     /// initialization is compatible with the `raft` setup
     #[test]
     fn test_constructor() {
         let db = Arc::new(mock_db());
+        let (net, _) = MockNetwork::new_duplex_conn();
 
-        // Setup a dummy network, for this test it is okay if both ends resolve
-        // to the same channel
-        let (network_out, network_in) = crossbeam::channel::unbounded();
-        let net = MockNetwork::new(network_out, network_in);
-
+        let (_, proposal_receiver) = unbounded();
         let node_config = ReplicationNodeConfig {
+            tick_period_ms: 10,
             relayer_config: Default::default(),
+            proposal_queue: proposal_receiver,
             network: net,
             db: db.clone(),
             system_bus: Default::default(),
         };
         let _node = ReplicationNode::new(node_config).unwrap();
+    }
+
+    /// Tests handling a proposal to add a wallet
+    #[test]
+    fn test_proposal_add_wallet() {
+        let db = Arc::new(mock_db());
+        let (net, _net2) = MockNetwork::new_duplex_conn();
+        let (proposal_send, proposal_recv) = unbounded();
+
+        let node = mock_replication_node(db.clone(), proposal_recv, net);
+        let handle = thread::spawn(|| node.run());
+
+        // Give the raft time to timeout and elect a leader
+        thread::sleep(Duration::from_millis(300));
+
+        // Send a proposal to add a wallet
+        let add_wallet_msg = dummy_add_wallet();
+        let transition = StateTransition::AddWallet(add_wallet_msg.clone());
+
+        proposal_send.send(transition).unwrap();
+
+        // Wait a bit for the proposal to be processed
+        thread::sleep(Duration::from_millis(100));
+
+        // Check that the wallet was added to the index
+        let expected_wallet: Wallet = add_wallet_msg.wallet.unwrap().try_into().unwrap();
+        let wallet_id = expected_wallet.wallet_id;
+        let wallet: Wallet = db.read(WALLETS_TABLE, &wallet_id).unwrap().unwrap();
+
+        assert!(!handle.is_finished());
+        assert_eq!(wallet, expected_wallet);
     }
 }

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["integration"]
 [dependencies]
 # === Async + Runtime === #
 async-trait = "0.1.60"
-crossbeam = "0.8"
+crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Cryptography === #

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -17,7 +17,7 @@ tokio-tungstenite = { version = "0.18", features = ["native-tls"] }
 tungstenite = "0.18"
 
 # === Runtime + Concurrency === #
-crossbeam = "0.8"
+crossbeam = { workspace = true }
 futures = "0.3"
 futures-util = "0.3"
 tokio = { workspace = true }

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 mpc-stark = { workspace = true }
 
 # === Concurrency + Runtime === #
-crossbeam = "0.8.1"
+crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Networking + Blockchain === #

--- a/workers/handshake-manager/Cargo.toml
+++ b/workers/handshake-manager/Cargo.toml
@@ -9,7 +9,7 @@ mpc-bulletproof = { workspace = true }
 mpc-stark = { workspace = true }
 
 # === Concurrency + Networking === #
-crossbeam = "0.8.1"
+crossbeam = { workspace = true }
 futures = "0.3"
 libp2p = { workspace = true }
 tokio = { workspace = true }

--- a/workers/proof-manager/Cargo.toml
+++ b/workers/proof-manager/Cargo.toml
@@ -13,7 +13,7 @@ mpc-bulletproof = { workspace = true }
 mpc-stark = { workspace = true, optional = true }
 
 # === Runtime + Threading === #
-crossbeam = { version = "0.8.1" }
+crossbeam = { workspace = true }
 rayon = { version = "1.5.3" }
 tokio = { workspace = true }
 


### PR DESCRIPTION
### Purpose
This PR takes the first step in pulling together the replication, storage, and applicator layers by accepting state transition proposals from outside the state management module. The flow is:
1. An inbound proposal reaches the raft event loop via the `proposals_queue` channel
2. The raft node proposes the state transition to the cluster
3. The raft group appends the state transition to the log, forms consensus over the entry, then commits the log entry
4. The raft nodes individually forward the now-committed state transition to the `StateApplicator` to apply the state transition

### Testing
- Unit and integration tests pass
- Tested state application of a new wallet to test the communication flow