### PR TITLE
statev2: replication: raft-node: Implement cluster join logic

### DIFF
--- a/circuits/integration/main.rs
+++ b/circuits/integration/main.rs
@@ -14,7 +14,7 @@ mod zk_gadgets;
 use clap::Parser;
 use mpc_stark::MpcFabric;
 use test_helpers::{integration_test_main, mpc_network::setup_mpc_fabric};
-use tracing::log::LevelFilter;
+use util::logging::LevelFilter;
 
 /// The arguments used for running circuits integration tests
 #[derive(Debug, Clone, Parser)]
@@ -57,7 +57,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 
 /// Setup logging for integration tests
 fn setup_integration_tests(_test_args: &CliArgs) {
-    util::logging::setup_system_logger(LevelFilter::Info);
+    util::logging::setup_system_logger(LevelFilter::INFO);
 }
 
 integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/starknet-client/integration/main.rs
+++ b/starknet-client/integration/main.rs
@@ -16,8 +16,9 @@ use eyre::Result;
 use mpc_stark::algebra::scalar::Scalar;
 use starknet_client::client::{StarknetClient, StarknetClientConfig};
 use test_helpers::integration_test_main;
-use tracing::log::LevelFilter;
-use util::{runtime::block_on_result, starknet::parse_addr_from_deployments_file};
+use util::{
+    logging::LevelFilter, runtime::block_on_result, starknet::parse_addr_from_deployments_file,
+};
 
 use crate::helpers::deploy_new_wallet;
 
@@ -153,7 +154,7 @@ fn setup_pre_allocated_state(client: &StarknetClient) -> Result<PreAllocatedStat
 /// Setup code for the integration tests
 fn setup_integration_tests(_test_args: &CliArgs) {
     // Configure logging
-    util::logging::setup_system_logger(LevelFilter::Info);
+    util::logging::setup_system_logger(LevelFilter::INFO);
 }
 
 integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -57,6 +57,9 @@ mod protos {
 // | Type Definitions + Conversions |
 // ----------------------------------
 
+/// A type alias for peer IDs used in the replication layer
+pub type RaftPeerId = u64;
+
 /// The `StateTransition` type encapsulates all possible state transitions, allowing transitions
 /// to be handled generically before they are applied
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -71,10 +74,16 @@ pub enum StateTransition {
     AddOrderValidityProof(AddOrderValidityProof),
     /// Cancel all orders on a given nullifier
     NullifyOrders(NullifyOrders),
-    /// Add a set of peers to the network topology
+    /// Add a set of peers to the p2p network topology
     AddPeers(AddPeers),
+    /// Add a raft learner to the cluster
+    AddRaftLearner(RaftPeerId),
+    /// Add a raft peer to the local consensus cluster
+    AddRaftPeer(RaftPeerId),
     /// Remove a peer from the network topology
     RemovePeer(RemovePeer),
+    /// Remove a raft peer from the local consensus cluster
+    RemoveRaftPeer(RaftPeerId),
 }
 
 /// PeerId

--- a/statev2/state/Cargo.toml
+++ b/statev2/state/Cargo.toml
@@ -37,7 +37,7 @@ itertools = "0.10"
 mpc-stark = "0.2"
 rand = "0.8"
 serde_json = "1.0"
-slog = "2.2"
+slog = { verison = "2.2", features = ["max_level_trace"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
 uuid = "1.1.2"

--- a/statev2/state/src/applicator/mod.rs
+++ b/statev2/state/src/applicator/mod.rs
@@ -82,6 +82,7 @@ impl StateApplicator {
             StateTransition::NullifyOrders(msg) => self.nullify_orders(msg),
             StateTransition::AddPeers(msg) => self.add_peers(msg),
             StateTransition::RemovePeer(msg) => self.remove_peer(msg),
+            _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
     }
 

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -25,8 +25,7 @@ use test_helpers::integration_test_main;
 use tokio::sync::mpsc::{
     unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
 };
-use tracing::log::LevelFilter;
-use util::starknet::parse_addr_from_deployments_file;
+use util::{logging::LevelFilter, starknet::parse_addr_from_deployments_file};
 
 /// The hostport that the test expects a local devnet node to be running on
 ///
@@ -182,7 +181,7 @@ fn setup_starknet_client_mock(test_args: CliArgs) -> StarknetClient {
 /// Setup code for the integration tests
 fn setup_integration_tests(_test_args: &CliArgs) {
     // Configure logging
-    util::logging::setup_system_logger(LevelFilter::Info);
+    util::logging::setup_system_logger(LevelFilter::INFO);
 }
 
 integration_test_main!(CliArgs, IntegrationTestArgs, setup_integration_tests);

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,3 +17,4 @@ env_logger = "0.9"
 eyre = { workspace = true }
 json = "0.12"
 tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = "0.3"

--- a/util/src/logging.rs
+++ b/util/src/logging.rs
@@ -1,23 +1,12 @@
 //! Defines helpers for logging
 
-use chrono::Local;
-use env_logger::Builder;
-use std::io::Write;
-use tracing::log::LevelFilter;
+pub use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::format::Format;
 
 /// Initialize a logger at the given log level
 pub fn setup_system_logger(level: LevelFilter) {
-    Builder::new()
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "{} [{}] {} - {}",
-                Local::now().format("%Y-%m-%dT%H:%M:%S"),
-                record.level(),
-                record.module_path().unwrap(),
-                record.args()
-            )
-        })
-        .filter(None, level)
+    tracing_subscriber::fmt()
+        .event_format(Format::default().pretty())
+        .with_max_level(level)
         .init();
 }


### PR DESCRIPTION
### Purpose
This PR adds logic to add and remove peers and learners from a raft cluster. As well, this PR fixes a few `LogStore` bugs that popped up during implementation.

Testing coverage will be increased in a future PR.

### Testing
- Unit and integration tests pass
- Tested the case in which a peer joins the cluster and receives replication messages