### PR TITLE
common: wallet: Add wallet-level lock to prevent concurrent updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "circuits",
  "constants",
  "crossbeam",
+ "derivative",
  "ed25519-dalek 1.0.1",
  "indexmap 1.9.3",
  "itertools 0.10.5",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -30,6 +30,7 @@ util = { path = "../util" }
 # === Misc Dependencies === #
 base64 = { version = "0.13" }
 bimap = "0.6.2"
+derivative = "2.2"
 indexmap = "1.9"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
+    sync::{atomic::AtomicBool, Arc},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -142,6 +143,7 @@ impl From<Wallet> for IndexedWallet {
             blinded_public_shares,
             private_shares,
             merkle_proof: None,
+            update_locked: Arc::new(AtomicBool::default()),
         }
     }
 }

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -6,7 +6,14 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use std::{collections::HashSet, str::FromStr, sync::atomic::AtomicU64};
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, AtomicU64},
+        Arc,
+    },
+};
 
 use circuit_types::{
     balance::Balance as CircuitBalance,
@@ -500,6 +507,7 @@ impl TryFrom<Wallet> for RuntimeWallet {
             private_shares,
             blinded_public_shares,
             merkle_proof,
+            update_locked: Arc::new(AtomicBool::default()),
         })
     }
 }

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -4,6 +4,7 @@
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use async_trait::async_trait;
@@ -261,6 +262,7 @@ impl LookupWalletTask {
             private_shares,
             blinded_public_shares: public_shares,
             merkle_proof: None, // discovered in next step
+            update_locked: Arc::new(AtomicBool::default()),
         };
 
         // Find the authentication path for the wallet

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -136,7 +136,9 @@ impl HandshakeExecutor {
                     self.network_channel.clone(),
                     self.global_state.clone(),
                     self.proof_manager_work_queue.clone(),
-                );
+                )
+                .await
+                .map_err(|_| HandshakeManagerError::TaskError(ERR_TASK_EXECUTION.to_string()))?;
 
                 let (_, join_handle) = self.task_driver.start_task(task).await;
 


### PR DESCRIPTION
### Purpose
Concurrent updates result in confusing state from the client's perspective when one of the updates fails. For now we prevent concurrent updates alltogether. We will introduce a more sophisticated update sequencing and queuing primitive when our state is over a raft.

### Tesing
- All unit and integration tests pass