### PR TITLE
circuit-types: traits: Refactor traits over plonk proof system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,11 +281,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ark-bls12-377"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-bw6-761"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
+dependencies = [
+ "ark-bls12-377",
  "ark-ec",
  "ark-ff",
  "ark-std",
@@ -336,6 +371,42 @@ dependencies = [
  "num-traits",
  "rayon",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-377"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
+dependencies = [
+ "ark-bls12-377",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6d678bb98a7e4f825bd4e332e93ac4f5a114ce2e3340dee4d7dc1c7ab5b323"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ed-on-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -423,6 +494,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "ark-pallas"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760ecac12a00211188c9101b63bd284b80da5abcc5d97d9d2b3803bca1f63a52"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -698,6 +780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.10"
+source = "git+https://github.com/EspressoSystems/blst.git?branch=no-std#faefc7fcb21864aaf4f6f443636ce8924108fcbd"
+dependencies = [
+ "cc",
+ "glob",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,15 +1098,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead 0.4.3",
- "chacha20",
+ "chacha20 0.8.2",
  "cipher 0.3.0",
- "poly1305",
+ "poly1305 0.7.2",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -1099,6 +1221,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1107,7 +1230,7 @@ version = "0.1.0"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
- "merlin",
+ "merlin 2.0.0",
  "mpc-bulletproof",
  "proc-macro2",
  "quote",
@@ -1120,18 +1243,19 @@ dependencies = [
 name = "circuit-types"
 version = "0.1.0"
 dependencies = [
+ "ark-ec",
  "ark-ff",
+ "ark-mpc",
  "async-trait",
  "bigdecimal",
  "circuit-macros",
  "constants",
- "ed25519-dalek 1.0.1",
  "futures",
  "itertools 0.10.5",
  "lazy_static",
- "merlin",
- "mpc-bulletproof",
- "mpc-stark",
+ "merlin 2.0.0",
+ "mpc-plonk",
+ "mpc-relation",
  "num-bigint",
  "rand 0.8.5",
  "renegade-crypto",
@@ -1168,7 +1292,7 @@ dependencies = [
  "inventory",
  "itertools 0.10.5",
  "lazy_static",
- "merlin",
+ "merlin 2.0.0",
  "mpc-bulletproof",
  "mpc-stark",
  "num-bigint",
@@ -1365,6 +1489,7 @@ name = "constants"
 version = "0.1.0"
 dependencies = [
  "ark-bn254",
+ "ark-ec",
  "ark-mpc",
 ]
 
@@ -1416,6 +1541,12 @@ checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
+
+[[package]]
+name = "crc-any"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
 
 [[package]]
 name = "crc-catalog"
@@ -1636,6 +1767,18 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.7",
  "subtle",
+]
+
+[[package]]
+name = "crypto_kx"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704722d1d929489c8528bb1882805700f1ba20f54325704973e786352320b1ed"
+dependencies = [
+ "blake2",
+ "curve25519-dalek 4.1.1",
+ "rand_core 0.6.4",
+ "serdect",
 ]
 
 [[package]]
@@ -2022,10 +2165,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
@@ -2100,7 +2261,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
@@ -2178,6 +2339,11 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "espresso-systems-common"
+version = "0.4.0"
+source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4.0#5abd890f79014a86db31286e1f3a529f161e69de"
 
 [[package]]
 name = "eth-keystore"
@@ -2340,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
+checksum = "f69037fe1b785e84986b4f2cbcf647381876a00671d25ceef715d7812dd7e1dd"
 
 [[package]]
 name = "fixed-hash"
@@ -2602,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3297,6 +3463,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jf-primitives"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+dependencies = [
+ "anyhow",
+ "ark-bls12-377",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-bw6-761",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ed-on-bls12-377",
+ "ark-ed-on-bls12-381",
+ "ark-ed-on-bn254",
+ "ark-ff",
+ "ark-pallas",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "blst",
+ "chacha20poly1305 0.10.1",
+ "crypto_kx",
+ "derivative",
+ "digest 0.10.7",
+ "displaydoc",
+ "espresso-systems-common",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "jf-utils",
+ "merlin 3.0.0",
+ "mpc-relation",
+ "num-bigint",
+ "num-traits",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "tagged-base64",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "jf-utils"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "digest 0.10.7",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "tagged-base64",
+]
+
+[[package]]
 name = "job-types"
 version = "0.1.0"
 dependencies = [
@@ -3437,7 +3663,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -3842,9 +4068,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -3981,6 +4207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,7 +4263,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools 0.10.5",
- "merlin",
+ "merlin 2.0.0",
  "mpc-stark",
  "num-bigint",
  "rand 0.8.5",
@@ -4037,6 +4275,64 @@ dependencies = [
  "thiserror",
  "tokio",
  "unzip-n",
+]
+
+[[package]]
+name = "mpc-plonk"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-mpc",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "async-trait",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "espresso-systems-common",
+ "futures",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "jf-primitives",
+ "jf-utils",
+ "merlin 3.0.0",
+ "mpc-relation",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha3 0.10.8",
+ "tagged-base64",
+]
+
+[[package]]
+name = "mpc-relation"
+version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c3cef9ef8a09ba1aa9b96e8e1d627d6a025aa443"
+dependencies = [
+ "ark-bls12-377",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-bw6-761",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "jf-utils",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
 ]
 
 [[package]]
@@ -4860,6 +5156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
 name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,7 +5354,7 @@ dependencies = [
  "constants",
  "crossbeam",
  "job-types",
- "merlin",
+ "merlin 2.0.0",
  "mpc-bulletproof",
  "mpc-stark",
  "rand 0.8.5",
@@ -5329,7 +5636,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -5426,7 +5733,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "libredox",
  "thiserror",
 ]
@@ -5605,7 +5912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
  "cc",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5721,7 +6028,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.10",
+ "linux-raw-sys 0.4.11",
  "windows-sys 0.48.0",
 ]
 
@@ -5908,7 +6215,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array 0.14.7",
  "pkcs8 0.9.0",
@@ -6061,6 +6368,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -6304,6 +6621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "backtrace",
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "snow"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6311,7 +6651,7 @@ checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
 dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
- "chacha20poly1305",
+ "chacha20poly1305 0.9.1",
  "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
  "ring 0.16.20",
@@ -6548,7 +6888,7 @@ dependencies = [
  "ark-ff",
  "bigdecimal",
  "crypto-bigint 0.5.3",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "hex 0.4.3",
  "num-bigint",
  "serde",
@@ -6812,6 +7152,32 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tagged-base64"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50189d4e81e3a3850799299cc908f28fb15740adccf8bd620f855be396e6e730"
+dependencies = [
+ "ark-serialize",
+ "ark-std",
+ "base64 0.13.1",
+ "crc-any",
+ "serde",
+ "snafu",
+ "tagged-base64-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tagged-base64-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71636a96f40b6ea3d969182ce22ad8042d5a38839ce448fff3cef4dec80f7589"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7501,7 +7867,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -7511,7 +7877,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -7592,6 +7958,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ lto = true
 # === Arithmetic + Cryptography === #
 ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc" }
 merlin = { git = "https://github.com/renegade-fi/merlin" }
+mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
+mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 mpc-stark = "0.2"
 num-bigint = { version = "0.4.3" }

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2021"
 [dependencies]
 # === Crytography === #
 ark-ff = "0.4"
-ed25519-dalek = "1.0.1"
-mpc-stark = { workspace = true }
-mpc-bulletproof = { workspace = true }
+ark-ec = "0.4"
+ark-mpc = { workspace = true }
+mpc-plonk = { workspace = true }
+mpc-relation = { workspace = true }
 
 # === Arithmetic === #
 bigdecimal = "0.3"

--- a/circuit-types/src/errors.rs
+++ b/circuit-types/src/errors.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{Display, Formatter, Result},
 };
 
-use mpc_bulletproof::r1cs_mpc::{MultiproverError, R1CSError};
+use mpc_plonk::errors::PlonkError;
 
 /// Represents an error during the course of an MPC circuit execution
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -30,15 +30,13 @@ impl Display for MpcError {
 impl Error for MpcError {}
 
 /// Represents an error during the course of proving a statement
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum ProverError {
     /// An error during the course of a multi-prover execution that results
     /// from the MPC network itself
     Mpc(MpcError),
-    /// An error that occurs from the execution of a collaborative proof
-    Collaborative(MultiproverError),
-    /// An error that occurs from an R1CS error directly
-    R1CS(R1CSError),
+    /// An error executing the Plonk prover
+    Plonk(PlonkError),
 }
 
 impl Display for ProverError {
@@ -49,10 +47,10 @@ impl Display for ProverError {
 impl Error for ProverError {}
 
 /// Represents an error during proof verification
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum VerifierError {
-    /// An error that occurs as a result of R1CS non-satisfaction
-    R1CS(R1CSError),
+    /// An error in plonk verification
+    Plonk(PlonkError),
 }
 
 impl Display for VerifierError {

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -13,53 +13,45 @@
 //!       values
 //!     - Single-prover variable types: base types allocated in a single-prover
 //!       constraint system
-//!     - Single-prover commitment types: commitments to base types in a
-//!       single-prover system
 //!     - MPC types: base types that have been allocated in an MPC fabric
-//!     - Multi-prover variable types: base types allocated in a multi-prover
-//!       constraint system
-//!     - Multi-prover commitment types: commitments to base types in a
-//!       multi-prover system
-//!     - Linkable types: Types that may be commitment linked across proofs
 //!     - Secret share types: Additive sharings of a base type
 
+use ark_mpc::{algebra::AuthenticatedScalarResult, network::PartyId};
 use async_trait::async_trait;
+use constants::{AuthenticatedScalar, Scalar, ScalarField, SystemCurve, SystemCurveGroup};
 use futures::future::join_all;
 use itertools::Itertools;
-use mpc_bulletproof::{
-    r1cs::{
-        LinearCombination, Prover, R1CSProof, RandomizableConstraintSystem, Variable, Verifier,
+use mpc_plonk::{
+    errors::PlonkError,
+    multiprover::proof_system::{
+        CollaborativeProof, MpcCircuit, MpcPlonkCircuit as GenericMpcPlonkCircuit,
+        MultiproverPlonkKzgSnark,
     },
-    r1cs_mpc::{
-        MpcLinearCombination, MpcProver, MpcRandomizableConstraintSystem, MpcVariable,
-        PartiallySharedR1CSProof, R1CSError,
+    proof_system::{
+        structs::{Proof, ProvingKey, VerifyingKey},
+        PlonkKzgSnark, UniversalSNARK,
     },
-    BulletproofGens,
+    transcript::SolidityTranscript,
 };
-use mpc_stark::{
-    algebra::{
-        authenticated_scalar::AuthenticatedScalarResult,
-        authenticated_stark_point::AuthenticatedStarkPointOpenResult, scalar::Scalar,
-        stark_curve::StarkPoint,
-    },
-    network::PartyId,
-    MpcFabric,
-};
+use mpc_relation::{constraint_system::Circuit, PlonkCircuit as GenericPlonkCircuit, Variable};
 use num_bigint::BigUint;
-use rand::{thread_rng, CryptoRng, RngCore};
+use rand::thread_rng;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint, scalar_to_u64};
 
 use crate::{
     errors::{MpcError, ProverError, VerifierError},
-    AuthenticatedLinkableCommitment, LinkableCommitment,
+    Fabric,
 };
 
 /// The error message emitted when too few scalars are given
 const ERR_TOO_FEW_SCALARS: &str = "from_scalars: Invalid number of scalars";
 /// The error message emitted when too few variables are given
 const ERR_TOO_FEW_VARS: &str = "from_vars: Invalid number of variables";
-/// The error message emitted when too few commitments are given
-const ERR_TOO_FEW_COMMITMENTS: &str = "from_commitments: Invalid number of commitments";
+
+/// A circuit type with curve generic attached
+type PlonkCircuit = GenericPlonkCircuit<ScalarField>;
+/// A circuit type with curve generic attached in a multiprover context
+type MpcPlonkCircuit = GenericMpcPlonkCircuit<SystemCurveGroup>;
 
 // ---------------
 // | Type Traits |
@@ -68,21 +60,13 @@ const ERR_TOO_FEW_COMMITMENTS: &str = "from_commitments: Invalid number of commi
 /// Implementing types are base (application level) types that define
 /// serialization to/from `Scalars`
 ///
-/// Commitment, variable, MPC, etc types are implemented automatically from
-/// serialization and deserialization
+/// Variable, MPC, etc types are implemented automatically from serialization
+/// and deserialization
 #[async_trait]
 pub trait BaseType: Clone {
     /// Convert the base type to its serialized scalar representation in the
     /// circuit
     fn to_scalars(&self) -> Vec<Scalar>;
-    /// Convert the base type to its serialized scalar representation including
-    /// commitment linking information
-    ///
-    /// The default implementation does nothing beyond what `to_scalars` does,
-    /// but commitment linked types should override this method
-    fn to_scalars_with_linking(&self) -> Vec<Scalar> {
-        self.to_scalars()
-    }
     /// Convert from a serialized scalar representation to the base type
     fn from_scalars<I: Iterator<Item = Scalar>>(i: &mut I) -> Self;
 
@@ -91,8 +75,8 @@ pub trait BaseType: Clone {
     /// This method is added to the `BaseType` trait for maximum flexibility, so
     /// that types may be shared without requiring them to implement the
     /// full `MpcBaseType` trait
-    async fn share_public(&self, owning_party: PartyId, fabric: MpcFabric) -> Self {
-        let self_scalars = self.clone().to_scalars_with_linking();
+    async fn share_public(&self, owning_party: PartyId, fabric: Fabric) -> Self {
+        let self_scalars = self.to_scalars();
         let res_scalars = fabric
             .batch_share_plaintext(self_scalars, owning_party)
             .await;
@@ -103,100 +87,40 @@ pub trait BaseType: Clone {
 
 // --- Singleprover Circuit Traits --- //
 
-/// A marker trait used to generalize over the atomic `Variable`
-/// and `LinearCombination` types
-pub trait LinearCombinationLike:
-    Into<LinearCombination> + Clone + CircuitVarType<Self> + From<Variable>
-{
-}
-impl LinearCombinationLike for Variable {}
-impl LinearCombinationLike for LinearCombination {}
-
 /// The base type that may be allocated in a single-prover circuit
 pub trait CircuitBaseType: BaseType {
     /// The variable type for this base type
-    type VarType<L: LinearCombinationLike>: CircuitVarType<L>;
-    /// The commitment type for this base type
-    type CommitmentType: CircuitCommitmentType<VarType = Self::VarType<Variable>>;
+    type VarType: CircuitVarType;
 
-    /// Commit to the base type as a witness variable
-    fn commit_witness<R: RngCore + CryptoRng>(
-        &self,
-        rng: &mut R,
-        prover: &mut Prover,
-    ) -> (Self::VarType<Variable>, Self::CommitmentType) {
+    /// Allocate the base type in the proof system and return the variable type
+    /// associate with the base type
+    fn create_witness(&self, circuit: &mut PlonkCircuit) -> Self::VarType {
         let scalars: Vec<Scalar> = self.clone().to_scalars();
-        let randomness = self.commitment_randomness(rng);
-        let (comms, vars): (Vec<StarkPoint>, Vec<Variable>) = scalars
+        let mut vars = scalars
             .into_iter()
-            .zip(randomness)
-            .map(|(s, r)| prover.commit(s, r))
-            .unzip();
+            .map(|s| circuit.create_variable(s.inner()).unwrap());
 
-        (
-            Self::VarType::from_vars(&mut vars.into_iter()),
-            Self::CommitmentType::from_commitments(&mut comms.into_iter()),
-        )
-    }
-
-    /// Commit to the base type as a public variable
-    fn commit_public<CS: RandomizableConstraintSystem>(
-        &self,
-        cs: &mut CS,
-    ) -> Self::VarType<Variable> {
-        let scalars: Vec<Scalar> = self.clone().to_scalars();
-        let mut vars = scalars.into_iter().map(|s| cs.commit_public(s));
         Self::VarType::from_vars(&mut vars)
     }
 
-    /// Get the randomness used to commit to this value
-    ///
-    /// We make this method generically defined so that linkable types may store
-    /// and re-use their commitment randomness between proofs
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<Scalar>;
+    /// Allocate the base type as a public variable in a constraint system
+    fn create_public_var(&self, circuit: &mut PlonkCircuit) -> Self::VarType {
+        let scalars: Vec<Scalar> = self.clone().to_scalars();
+        let mut vars = scalars
+            .into_iter()
+            .map(|s| circuit.create_public_variable(s.inner()).unwrap());
+
+        Self::VarType::from_vars(&mut vars)
+    }
 }
 
 /// Implementing types are variable types that may appear in constraints in
 /// a constraint system
-pub trait CircuitVarType<L: LinearCombinationLike>: Clone {
-    /// The type created by converting all base types to `LinearCombination`
-    type LinearCombinationType: CircuitVarType<LinearCombination>;
+pub trait CircuitVarType: Clone {
     /// Convert to a collection of serialized variables for the type
-    fn to_vars(&self) -> Vec<L>;
+    fn to_vars(&self) -> Vec<Variable>;
     /// Convert from an iterable of variables representing the serialized type
-    fn from_vars<I: Iterator<Item = L>>(i: &mut I) -> Self;
-    /// Convert the base type to a `LinearCombination` type
-    fn to_lc(&self) -> Self::LinearCombinationType {
-        let mut vars = self
-            .to_vars()
-            .into_iter()
-            .map(|v| Into::<LinearCombination>::into(v));
-        Self::LinearCombinationType::from_vars(&mut vars)
-    }
-}
-
-/// Implementing types are commitments to base types that have an analogous
-/// variable type allocated with them
-pub trait CircuitCommitmentType: Clone {
-    /// The variable type that this type is a commitment to
-    type VarType: CircuitVarType<Variable>;
-    /// Convert from an iterable of Stark curve points, each representing
-    /// a commitment to an underlying variable
-    fn from_commitments<I: Iterator<Item = StarkPoint>>(i: &mut I) -> Self;
-    /// Convert to a vector of Stark curve points
-    fn to_commitments(&self) -> Vec<StarkPoint>;
-
-    /// Commit to a hidden value in the Verifier
-    fn commit_verifier(&self, verifier: &mut Verifier) -> Self::VarType {
-        let vars = self
-            .clone()
-            .to_commitments()
-            .into_iter()
-            .map(|c| verifier.commit(c))
-            .collect_vec();
-
-        Self::VarType::from_vars(&mut vars.into_iter())
-    }
+    fn from_vars<I: Iterator<Item = Variable>>(i: &mut I) -> Self;
 }
 
 // --- MPC Circuit Traits --- //
@@ -207,8 +131,8 @@ pub trait MpcBaseType: BaseType {
     type AllocatedType: MpcType;
 
     /// Allocates the base type in the network as a shared value
-    fn allocate(&self, sender: PartyId, fabric: &MpcFabric) -> Self::AllocatedType {
-        let self_scalars = self.clone().to_scalars_with_linking();
+    fn allocate(&self, sender: PartyId, fabric: &Fabric) -> Self::AllocatedType {
+        let self_scalars = self.to_scalars();
         let values = fabric.batch_share_scalar(self_scalars, sender);
 
         Self::AllocatedType::from_authenticated_scalars(&mut values.into_iter())
@@ -222,26 +146,16 @@ pub trait MpcType: Clone {
     /// The native type when the value is opened out of a circuit
     type NativeType: BaseType;
     /// Get a reference to the underlying MPC fabric
-    fn fabric(&self) -> &MpcFabric;
+    fn fabric(&self) -> &Fabric;
     /// Convert from an iterable of authenticated scalars: scalars that have
     /// been allocated in an MPC fabric
-    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalarResult>>(i: &mut I)
-        -> Self;
+    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalar>>(i: &mut I) -> Self;
     /// Convert to a vector of authenticated scalars
-    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalarResult>;
-    /// Convert to a vector of authenticated scalars with proof linking
-    /// information included
-    ///
-    /// By default this method does nothing beyond what
-    /// `to_authenticated_scalars` does, but commitment linked types should
-    /// override this method to include commitment randomness
-    fn to_authenticated_scalars_with_linking(&self) -> Vec<AuthenticatedScalarResult> {
-        self.to_authenticated_scalars()
-    }
+    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalar>;
 
     /// Opens the shared type without authenticating
     async fn open(self) -> Result<Self::NativeType, MpcError> {
-        let self_scalars = self.to_authenticated_scalars_with_linking();
+        let self_scalars = self.to_authenticated_scalars();
         let opened_scalars = join_all(AuthenticatedScalarResult::open_batch(&self_scalars)).await;
 
         Ok(Self::NativeType::from_scalars(
@@ -251,7 +165,7 @@ pub trait MpcType: Clone {
 
     /// Opens the shared type and authenticates the result
     async fn open_and_authenticate(self) -> Result<Self::NativeType, MpcError> {
-        let self_scalars = self.to_authenticated_scalars_with_linking();
+        let self_scalars = self.to_authenticated_scalars();
         let opened_scalars = join_all(AuthenticatedScalarResult::open_authenticated_batch(
             &self_scalars,
         ))
@@ -268,119 +182,26 @@ pub trait MpcType: Clone {
 
 // --- Multiprover Circuit Traits --- //
 
-/// A marker trait used to generalize over the atomic `MpcVariable`
-/// and `MpcLinearCombination` types
-pub trait MpcLinearCombinationLike:
-    MultiproverCircuitVariableType<Self> + Sized + Into<MpcLinearCombination> + Clone
-{
-}
-impl MpcLinearCombinationLike for MpcVariable {}
-impl MpcLinearCombinationLike for MpcLinearCombination {}
-
 /// A base type for allocating within a multiprover constraint system
 pub trait MultiproverCircuitBaseType: MpcType {
     /// The base type of the multiprover circuit type
     type BaseType: CircuitBaseType;
-    /// The multiprover constraint system variable type that results when
-    /// committing to the base type in a multiprover constraint system
-    type MultiproverVarType<L: MpcLinearCombinationLike>: MultiproverCircuitVariableType<L>;
-    /// The shared commitment type that results when committing to the base type
-    /// in a multiprover constraint system
-    type MultiproverCommType: MultiproverCircuitCommitmentType;
+    /// The constraint system variable type that results when
+    /// allocating the base type in a multiprover constraint system
+    type VarType: CircuitVarType;
 
     /// Commit to the value in a multiprover constraint system
     #[allow(clippy::type_complexity)]
-    fn commit_shared<R: RngCore + CryptoRng>(
+    fn create_shared_witness(
         &self,
-        rng: &mut R,
-        prover: &mut MpcProver,
-    ) -> Result<
-        (
-            Self::MultiproverVarType<MpcVariable>,
-            Self::MultiproverCommType,
-        ),
-        MpcError,
-    > {
+        circuit: &mut MpcPlonkCircuit,
+    ) -> Result<Self::VarType, MpcError> {
         let self_scalars = self.clone().to_authenticated_scalars();
-        let randomness = self.commitment_randomness(rng);
-
-        let (comms, vars) = prover
-            .batch_commit_preshared(&self_scalars, &randomness)
-            .map_err(|err| MpcError::SharingError(err.to_string()))?;
-
-        Ok((
-            Self::MultiproverVarType::from_mpc_vars(&mut vars.into_iter()),
-            Self::MultiproverCommType::from_mpc_commitments(&mut comms.into_iter()),
-        ))
-    }
-
-    /// Get the randomness needed to commit to a given value
-    fn commitment_randomness<R: RngCore + CryptoRng>(
-        &self,
-        rng: &mut R,
-    ) -> Vec<AuthenticatedScalarResult>;
-}
-
-/// A multiprover circuit variable type
-pub trait MultiproverCircuitVariableType<L: MpcLinearCombinationLike>: Clone {
-    /// Serialization to a vector of MPC allocated variables
-    fn to_mpc_vars(&self) -> Vec<L>;
-    /// Deserialization from an iterator over MPC allocated variables
-    fn from_mpc_vars<I: Iterator<Item = L>>(i: &mut I) -> Self;
-}
-
-/// A multiprover circuit commitment type
-#[async_trait]
-pub trait MultiproverCircuitCommitmentType: Clone + Sync {
-    /// The base commitment type that this commitment opens to
-    type BaseCommitType: CircuitCommitmentType;
-    /// Deserialization form an iterator over MPC allocated commitments
-    ///
-    /// The transcript opens each commitment as it is generated so that the
-    /// transcript may be evaluated in plaintext (outside of the MPC
-    /// circuit). For this reason, the primitive type of a multiprover
-    /// commitment type is the result of this opening, which may resolve to
-    /// an error if either party cheats
-    fn from_mpc_commitments<I: Iterator<Item = AuthenticatedStarkPointOpenResult>>(
-        i: &mut I,
-    ) -> Self;
-    /// Serialization to a vector of MPC allocated commitments
-    fn to_mpc_commitments(&self) -> Vec<AuthenticatedStarkPointOpenResult>;
-
-    /// Opens the shared type and authenticates the result
-    async fn open_and_authenticate(self) -> Result<Self::BaseCommitType, MpcError> {
-        let opened_commitments = join_all(self.to_mpc_commitments())
-            .await
+        let mut vars = self_scalars
             .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| MpcError::OpeningError(err.to_string()))?;
+            .map(|s| circuit.create_variable(s).unwrap());
 
-        Ok(Self::BaseCommitType::from_commitments(
-            &mut opened_commitments.into_iter(),
-        ))
-    }
-}
-
-// --- Proof Linkable Types --- //
-
-/// Implementing types have an analogous linkable type that may be shared
-/// between proofs
-pub trait LinkableBaseType: BaseType {
-    /// The linkable type that re-uses commitment randomness between commitments
-    type Linkable: LinkableType;
-    /// Convert from the base type to the linkable type
-    fn to_linkable(&self) -> Self::Linkable;
-}
-
-/// Implementing types are proof-linkable analogs of a base type, which hold
-/// onto their commitment randomness and re-use it between proofs
-pub trait LinkableType: Clone + BaseType {
-    /// The base type this type is a linkable commitment for
-    type BaseType: LinkableBaseType;
-    /// Convert to the base type, removing the proof-linkable information
-    fn to_base_type(&self) -> Self::BaseType {
-        let self_scalars = self.to_scalars();
-        Self::BaseType::from_scalars(&mut self_scalars.into_iter())
+        Ok(Self::VarType::from_vars(&mut vars))
     }
 }
 
@@ -427,30 +248,28 @@ pub trait SecretShareType: Sized + BaseType {
 }
 
 /// Implementing types represent a secret share allocated in a constraint system
-pub trait SecretShareVarType<L: LinearCombinationLike>: Sized + CircuitVarType<L> {
+pub trait SecretShareVarType: Sized + CircuitVarType {
     /// The base type that this secret share is a representation of
-    type Base: CircuitVarType<LinearCombination>;
-    /// The type that results from blinding or unblinding the share
-    type BlindType: CircuitVarType<LinearCombination>;
+    type Base: CircuitVarType;
 
     /// Apply an additive blinder to each element of the secret shares
-    fn blind<L1: LinearCombinationLike>(self, blinder: L1) -> Self::BlindType {
-        let mut res_lcs = self
+    fn blind(self, blinder: Variable, circuit: &mut PlonkCircuit) -> Self {
+        let mut res_vars = self
             .to_vars()
             .into_iter()
-            .map(|v| v.into() + blinder.clone().into());
+            .map(|v| circuit.add(v, blinder).unwrap());
 
-        Self::BlindType::from_vars(&mut res_lcs)
+        Self::from_vars(&mut res_vars)
     }
 
     /// Remove an additive blind from each element of the secret shares
-    fn unblind<L1: LinearCombinationLike>(self, blinder: L1) -> Self::BlindType {
-        let mut res_lcs = self
+    fn unblind(self, blinder: Variable, circuit: &mut PlonkCircuit) -> Self {
+        let mut res_vars = self
             .to_vars()
             .into_iter()
-            .map(|v| v.into() - blinder.clone().into());
+            .map(|v| circuit.sub(v, blinder).unwrap());
 
-        Self::BlindType::from_vars(&mut res_lcs)
+        Self::from_vars(&mut res_vars)
     }
 
     /// Add two sets of shares to recover the base type
@@ -459,18 +278,17 @@ pub trait SecretShareVarType<L: LinearCombinationLike>: Sized + CircuitVarType<L
     /// implement traits on generics types (e.g. `[T]` where `T:
     /// SecretShareType`). Requiring an additional trait bound on `T` would
     /// prevent this.
-    fn add_shares<L1, R>(self, rhs: R) -> Self::Base
+    fn add_shares<R>(self, rhs: R, circuit: &mut PlonkCircuit) -> Self::Base
     where
-        L1: LinearCombinationLike,
-        R: SecretShareVarType<L1>,
+        R: SecretShareVarType,
     {
-        let mut res_lcs = self
+        let mut res_vars = self
             .to_vars()
             .into_iter()
             .zip(rhs.to_vars())
-            .map(|(v1, v2)| v1.into() + v2.into());
+            .map(|(v1, v2)| circuit.add(v1, v2).unwrap());
 
-        Self::Base::from_vars(&mut res_lcs)
+        Self::Base::from_vars(&mut res_vars)
     }
 }
 
@@ -487,24 +305,6 @@ impl BaseType for Scalar {
 
     fn from_scalars<I: Iterator<Item = Scalar>>(i: &mut I) -> Self {
         i.next().unwrap()
-    }
-}
-
-impl BaseType for LinkableCommitment {
-    fn to_scalars(&self) -> Vec<Scalar> {
-        vec![self.val]
-    }
-
-    fn to_scalars_with_linking(&self) -> Vec<Scalar> {
-        vec![self.val, self.randomness]
-    }
-
-    fn from_scalars<I: Iterator<Item = Scalar>>(i: &mut I) -> Self {
-        // Choose a random commitment
-        Self {
-            val: i.next().unwrap(),
-            randomness: i.next().unwrap(),
-        }
     }
 }
 
@@ -541,12 +341,6 @@ impl<const N: usize, T: BaseType> BaseType for [T; N] {
         self.iter().flat_map(|x| x.to_scalars()).collect()
     }
 
-    fn to_scalars_with_linking(&self) -> Vec<Scalar> {
-        self.iter()
-            .flat_map(|x| x.to_scalars_with_linking())
-            .collect()
-    }
-
     fn from_scalars<I: Iterator<Item = Scalar>>(i: &mut I) -> Self {
         (0..N)
             .map(|_| T::from_scalars(i))
@@ -560,64 +354,26 @@ impl<const N: usize, T: BaseType> BaseType for [T; N] {
 // --- Singleprover Circuit Trait Impls --- //
 
 impl CircuitBaseType for Scalar {
-    type VarType<L: LinearCombinationLike> = L;
-    type CommitmentType = StarkPoint;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<Scalar> {
-        vec![Scalar::random(rng)]
-    }
-}
-
-impl CircuitBaseType for LinkableCommitment {
-    type VarType<L: LinearCombinationLike> = L;
-    type CommitmentType = StarkPoint;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, _rng: &mut R) -> Vec<Scalar> {
-        vec![self.randomness]
-    }
+    type VarType = Variable;
 }
 
 impl CircuitBaseType for u64 {
-    type VarType<L: LinearCombinationLike> = L;
-    type CommitmentType = StarkPoint;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<Scalar> {
-        vec![Scalar::random(rng)]
-    }
+    type VarType = Variable;
 }
 
 impl CircuitBaseType for BigUint {
-    type VarType<L: LinearCombinationLike> = L;
-    type CommitmentType = StarkPoint;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<Scalar> {
-        vec![Scalar::random(rng)]
-    }
+    type VarType = Variable;
 }
 
 impl CircuitBaseType for () {
-    type VarType<L: LinearCombinationLike> = ();
-    type CommitmentType = ();
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, _rng: &mut R) -> Vec<Scalar> {
-        vec![]
-    }
+    type VarType = ();
 }
 
 impl<const N: usize, T: CircuitBaseType> CircuitBaseType for [T; N] {
-    type VarType<L: LinearCombinationLike> = [T::VarType<L>; N];
-    type CommitmentType = [T::CommitmentType; N];
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<Scalar> {
-        self.iter()
-            .flat_map(|x| x.commitment_randomness(rng))
-            .collect()
-    }
+    type VarType = [T::VarType; N];
 }
 
-impl CircuitVarType<Variable> for Variable {
-    type LinearCombinationType = LinearCombination;
-
+impl CircuitVarType for Variable {
     fn to_vars(&self) -> Vec<Variable> {
         vec![*self]
     }
@@ -627,36 +383,20 @@ impl CircuitVarType<Variable> for Variable {
     }
 }
 
-impl CircuitVarType<LinearCombination> for LinearCombination {
-    type LinearCombinationType = LinearCombination;
+impl CircuitVarType for () {
+    fn from_vars<I: Iterator<Item = Variable>>(_: &mut I) -> Self {}
 
-    fn to_vars(&self) -> Vec<LinearCombination> {
-        vec![self.clone()]
-    }
-
-    fn from_vars<I: Iterator<Item = LinearCombination>>(i: &mut I) -> Self {
-        i.next().unwrap()
-    }
-}
-
-impl<L: LinearCombinationLike> CircuitVarType<L> for () {
-    type LinearCombinationType = ();
-
-    fn from_vars<I: Iterator<Item = L>>(_: &mut I) -> Self {}
-
-    fn to_vars(&self) -> Vec<L> {
+    fn to_vars(&self) -> Vec<Variable> {
         vec![]
     }
 }
 
-impl<const N: usize, L: LinearCombinationLike, T: CircuitVarType<L>> CircuitVarType<L> for [T; N] {
-    type LinearCombinationType = [T::LinearCombinationType; N];
-
-    fn to_vars(&self) -> Vec<L> {
+impl<const N: usize, T: CircuitVarType> CircuitVarType for [T; N] {
+    fn to_vars(&self) -> Vec<Variable> {
         self.iter().flat_map(|x| x.to_vars()).collect()
     }
 
-    fn from_vars<I: Iterator<Item = L>>(i: &mut I) -> Self {
+    fn from_vars<I: Iterator<Item = Variable>>(i: &mut I) -> Self {
         (0..N)
             .map(|_| T::from_vars(i))
             .collect_vec()
@@ -666,60 +406,18 @@ impl<const N: usize, L: LinearCombinationLike, T: CircuitVarType<L>> CircuitVarT
     }
 }
 
-impl CircuitCommitmentType for StarkPoint {
-    type VarType = Variable;
-
-    fn from_commitments<I: Iterator<Item = StarkPoint>>(i: &mut I) -> Self {
-        i.next().unwrap()
-    }
-
-    fn to_commitments(&self) -> Vec<StarkPoint> {
-        vec![*self]
-    }
-}
-
-impl CircuitCommitmentType for () {
-    type VarType = ();
-    fn from_commitments<I: Iterator<Item = StarkPoint>>(_: &mut I) -> Self {}
-
-    fn to_commitments(&self) -> Vec<StarkPoint> {
-        vec![]
-    }
-}
-
-impl<const N: usize, T: CircuitCommitmentType> CircuitCommitmentType for [T; N] {
-    type VarType = [T::VarType; N];
-
-    fn from_commitments<I: Iterator<Item = StarkPoint>>(i: &mut I) -> Self {
-        (0..N)
-            .map(|_| T::from_commitments(i))
-            .collect_vec()
-            .try_into()
-            .map_err(|_| ERR_TOO_FEW_COMMITMENTS)
-            .unwrap()
-    }
-
-    fn to_commitments(&self) -> Vec<StarkPoint> {
-        self.iter().flat_map(|x| x.to_commitments()).collect_vec()
-    }
-}
-
 // --- MPC Circuit Trait Impls --- //
 
 impl MpcBaseType for Scalar {
-    type AllocatedType = AuthenticatedScalarResult;
+    type AllocatedType = AuthenticatedScalar;
 }
 
 impl MpcBaseType for u64 {
-    type AllocatedType = AuthenticatedScalarResult;
+    type AllocatedType = AuthenticatedScalar;
 }
 
 impl MpcBaseType for BigUint {
-    type AllocatedType = AuthenticatedScalarResult;
-}
-
-impl MpcBaseType for LinkableCommitment {
-    type AllocatedType = AuthenticatedLinkableCommitment;
+    type AllocatedType = AuthenticatedScalar;
 }
 
 impl MpcBaseType for () {
@@ -730,61 +428,32 @@ impl<const L: usize, T: MpcBaseType> MpcBaseType for [T; L] {
     type AllocatedType = [T::AllocatedType; L];
 }
 
-impl MpcType for AuthenticatedScalarResult {
+impl MpcType for AuthenticatedScalar {
     type NativeType = Scalar;
 
-    fn fabric(&self) -> &MpcFabric {
+    fn fabric(&self) -> &Fabric {
         self.fabric()
     }
 
-    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalarResult>>(
-        i: &mut I,
-    ) -> Self {
+    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalar>>(i: &mut I) -> Self {
         i.next().unwrap()
     }
 
-    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalarResult> {
+    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalar> {
         vec![self.clone()]
-    }
-}
-
-impl MpcType for AuthenticatedLinkableCommitment {
-    type NativeType = LinkableCommitment;
-
-    fn fabric(&self) -> &MpcFabric {
-        self.val.fabric()
-    }
-
-    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalarResult>>(
-        i: &mut I,
-    ) -> Self {
-        let val = i.next().unwrap();
-        let randomness = i.next().unwrap();
-        AuthenticatedLinkableCommitment { val, randomness }
-    }
-
-    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalarResult> {
-        vec![self.val.clone()]
-    }
-
-    fn to_authenticated_scalars_with_linking(&self) -> Vec<AuthenticatedScalarResult> {
-        vec![self.val.clone(), self.randomness.clone()]
     }
 }
 
 impl MpcType for () {
     type NativeType = ();
 
-    fn fabric(&self) -> &MpcFabric {
+    fn fabric(&self) -> &Fabric {
         unimplemented!()
     }
 
-    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalarResult>>(
-        _: &mut I,
-    ) -> Self {
-    }
+    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalar>>(_: &mut I) -> Self {}
 
-    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalarResult> {
+    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalar> {
         vec![]
     }
 }
@@ -792,13 +461,11 @@ impl MpcType for () {
 impl<const L: usize, T: MpcType> MpcType for [T; L] {
     type NativeType = [T::NativeType; L];
 
-    fn fabric(&self) -> &MpcFabric {
+    fn fabric(&self) -> &Fabric {
         self[0].fabric()
     }
 
-    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalarResult>>(
-        i: &mut I,
-    ) -> Self {
+    fn from_authenticated_scalars<I: Iterator<Item = AuthenticatedScalar>>(i: &mut I) -> Self {
         (0..L)
             .map(|_| T::from_authenticated_scalars(i))
             .collect_vec()
@@ -807,210 +474,28 @@ impl<const L: usize, T: MpcType> MpcType for [T; L] {
             .unwrap()
     }
 
-    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalarResult> {
+    fn to_authenticated_scalars(&self) -> Vec<AuthenticatedScalar> {
         self.iter()
             .flat_map(|x| x.to_authenticated_scalars())
-            .collect_vec()
-    }
-
-    fn to_authenticated_scalars_with_linking(&self) -> Vec<AuthenticatedScalarResult> {
-        self.iter()
-            .flat_map(|x| x.to_authenticated_scalars_with_linking())
             .collect_vec()
     }
 }
 
 // --- Multiprover Circuit Trait Impls --- //
 
-impl MultiproverCircuitBaseType for AuthenticatedScalarResult {
+impl MultiproverCircuitBaseType for AuthenticatedScalar {
     type BaseType = Scalar;
-    type MultiproverVarType<L: MpcLinearCombinationLike> = L;
-    type MultiproverCommType = AuthenticatedStarkPointOpenResult;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(
-        &self,
-        _rng: &mut R,
-    ) -> Vec<AuthenticatedScalarResult> {
-        self.fabric().random_shared_scalars_authenticated(1 /* n */)
-    }
-}
-
-impl MultiproverCircuitBaseType for AuthenticatedLinkableCommitment {
-    type BaseType = LinkableCommitment;
-    type MultiproverVarType<L: MpcLinearCombinationLike> = L;
-    type MultiproverCommType = AuthenticatedStarkPointOpenResult;
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(
-        &self,
-        _rng: &mut R,
-    ) -> Vec<AuthenticatedScalarResult> {
-        vec![self.randomness.clone()]
-    }
+    type VarType = Variable;
 }
 
 impl MultiproverCircuitBaseType for () {
     type BaseType = ();
-    type MultiproverVarType<L: MpcLinearCombinationLike> = ();
-    type MultiproverCommType = ();
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(
-        &self,
-        _rng: &mut R,
-    ) -> Vec<AuthenticatedScalarResult> {
-        vec![]
-    }
+    type VarType = ();
 }
 
 impl<const L: usize, T: MultiproverCircuitBaseType> MultiproverCircuitBaseType for [T; L] {
     type BaseType = [T::BaseType; L];
-    type MultiproverVarType<M: MpcLinearCombinationLike> = [T::MultiproverVarType<M>; L];
-    type MultiproverCommType = [T::MultiproverCommType; L];
-
-    fn commitment_randomness<R: RngCore + CryptoRng>(
-        &self,
-        rng: &mut R,
-    ) -> Vec<AuthenticatedScalarResult> {
-        self.iter()
-            .flat_map(|x| x.commitment_randomness(rng))
-            .collect_vec()
-    }
-}
-
-impl MultiproverCircuitVariableType<MpcVariable> for MpcVariable {
-    fn to_mpc_vars(&self) -> Vec<MpcVariable> {
-        vec![self.clone()]
-    }
-
-    fn from_mpc_vars<I: Iterator<Item = MpcVariable>>(i: &mut I) -> Self {
-        i.next().unwrap()
-    }
-}
-
-impl MultiproverCircuitVariableType<MpcLinearCombination> for MpcLinearCombination {
-    fn to_mpc_vars(&self) -> Vec<MpcLinearCombination> {
-        vec![self.clone()]
-    }
-
-    fn from_mpc_vars<I: Iterator<Item = MpcLinearCombination>>(i: &mut I) -> Self {
-        i.next().unwrap()
-    }
-}
-
-impl<L: MpcLinearCombinationLike> MultiproverCircuitVariableType<L> for () {
-    fn to_mpc_vars(&self) -> Vec<L> {
-        vec![]
-    }
-
-    fn from_mpc_vars<I: Iterator<Item = L>>(_: &mut I) -> Self {}
-}
-
-impl<const U: usize, L: MpcLinearCombinationLike, T: MultiproverCircuitVariableType<L>>
-    MultiproverCircuitVariableType<L> for [T; U]
-{
-    fn to_mpc_vars(&self) -> Vec<L> {
-        self.iter().flat_map(|x| x.to_mpc_vars()).collect()
-    }
-
-    fn from_mpc_vars<I: Iterator<Item = L>>(i: &mut I) -> Self {
-        (0..U)
-            .map(|_| T::from_mpc_vars(i))
-            .collect_vec()
-            .try_into()
-            .map_err(|_| ERR_TOO_FEW_VARS)
-            .unwrap()
-    }
-}
-
-impl MultiproverCircuitCommitmentType for AuthenticatedStarkPointOpenResult {
-    type BaseCommitType = StarkPoint;
-    fn from_mpc_commitments<I: Iterator<Item = AuthenticatedStarkPointOpenResult>>(
-        i: &mut I,
-    ) -> Self {
-        i.next().unwrap()
-    }
-
-    fn to_mpc_commitments(&self) -> Vec<AuthenticatedStarkPointOpenResult> {
-        vec![self.clone()]
-    }
-}
-
-impl MultiproverCircuitCommitmentType for () {
-    type BaseCommitType = ();
-    fn from_mpc_commitments<I: Iterator<Item = AuthenticatedStarkPointOpenResult>>(
-        _: &mut I,
-    ) -> Self {
-    }
-
-    fn to_mpc_commitments(&self) -> Vec<AuthenticatedStarkPointOpenResult> {
-        vec![]
-    }
-}
-
-impl<const U: usize, T: MultiproverCircuitCommitmentType> MultiproverCircuitCommitmentType
-    for [T; U]
-{
-    type BaseCommitType = [T::BaseCommitType; U];
-    fn from_mpc_commitments<I: Iterator<Item = AuthenticatedStarkPointOpenResult>>(
-        i: &mut I,
-    ) -> Self {
-        (0..U)
-            .map(|_| T::from_mpc_commitments(i))
-            .collect_vec()
-            .try_into()
-            .map_err(|_| "from_mpc_commitments: Invalid number of commitments")
-            .unwrap()
-    }
-
-    fn to_mpc_commitments(&self) -> Vec<AuthenticatedStarkPointOpenResult> {
-        self.iter().flat_map(|x| x.to_mpc_commitments()).collect()
-    }
-}
-
-// --- Linkable Type Trait Impls --- //
-
-impl LinkableBaseType for Scalar {
-    type Linkable = LinkableCommitment;
-
-    fn to_linkable(&self) -> Self::Linkable {
-        LinkableCommitment::from(*self)
-    }
-}
-
-impl LinkableBaseType for u64 {
-    type Linkable = LinkableCommitment;
-
-    fn to_linkable(&self) -> Self::Linkable {
-        LinkableCommitment::from(Scalar::from(*self))
-    }
-}
-
-impl LinkableBaseType for BigUint {
-    type Linkable = LinkableCommitment;
-
-    fn to_linkable(&self) -> Self::Linkable {
-        LinkableCommitment::from(biguint_to_scalar(self))
-    }
-}
-
-impl<const N: usize, T: LinkableBaseType> LinkableBaseType for [T; N] {
-    type Linkable = [T::Linkable; N];
-
-    fn to_linkable(&self) -> Self::Linkable {
-        self.iter()
-            .map(|x| x.to_linkable())
-            .collect_vec()
-            .try_into()
-            .map_err(|_| ERR_TOO_FEW_SCALARS)
-            .unwrap()
-    }
-}
-
-impl LinkableType for LinkableCommitment {
-    type BaseType = Scalar;
-}
-
-impl<const N: usize, T: LinkableType> LinkableType for [T; N] {
-    type BaseType = [T::BaseType; N];
+    type VarType = [T::VarType; L];
 }
 
 // --- Secret Share Impls --- //
@@ -1039,28 +524,19 @@ impl<const N: usize, T: SecretShareType> SecretShareType for [T; N] {
     type Base = [T::Base; N];
 }
 
-impl SecretShareVarType<Variable> for Variable {
-    type Base = LinearCombination;
-    type BlindType = LinearCombination;
+impl SecretShareVarType for Variable {
+    type Base = Variable;
 }
 
-impl SecretShareVarType<LinearCombination> for LinearCombination {
-    type Base = LinearCombination;
-    type BlindType = LinearCombination;
-}
-
-impl<const N: usize, L: LinearCombinationLike, T: SecretShareVarType<L>> SecretShareVarType<L>
-    for [T; N]
-{
+impl<const N: usize, T: SecretShareVarType> SecretShareVarType for [T; N] {
     type Base = [T::Base; N];
-    type BlindType = [T::BlindType; N];
 }
 
 // ------------------
 // | Circuit Traits |
 // ------------------
 
-/// Defines the abstraction of a Circuit.
+/// Defines the abstraction of a Circuit
 ///
 /// A circuit represents a provable unit, a complete NP statement that takes as
 /// input a series of values, commits to them, and applies constraints
@@ -1069,7 +545,7 @@ impl<const N: usize, L: LinearCombinationLike, T: SecretShareVarType<L>> SecretS
 /// The witness type represents the secret witness that the prover has access to
 /// but that the verifier does not. The statement is the set of public inputs
 /// and any other circuit meta-parameters that both prover and verifier have
-/// access to.
+/// access to
 pub trait SingleProverCircuit {
     /// The witness type, given only to the prover, which generates a blinding
     /// commitment that can be given to the verifier
@@ -1078,19 +554,12 @@ pub trait SingleProverCircuit {
     /// the underlying NP statement being proven
     type Statement: CircuitBaseType;
 
-    /// The size of the bulletproof generators that must be allocated
-    /// to fully compute a proof or verification of the statement
-    ///
-    /// This is a function of circuit depth, one generator is needed per
-    /// multiplication gate (roughly)
-    const BP_GENS_CAPACITY: usize;
-
     /// Apply the constraints of the circuit to a given constraint system
-    fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: <Self::Witness as CircuitBaseType>::VarType<Variable>,
-        statement_var: <Self::Statement as CircuitBaseType>::VarType<Variable>,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>;
+    fn apply_constraints(
+        witness_var: <Self::Witness as CircuitBaseType>::VarType,
+        statement_var: <Self::Statement as CircuitBaseType>::VarType,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError>;
 
     /// Generate a proof of the statement represented by the circuit
     ///
@@ -1098,53 +567,48 @@ pub trait SingleProverCircuit {
     fn prove(
         witness: Self::Witness,
         statement: Self::Statement,
-        bp_gens: &BulletproofGens,
-        mut prover: Prover,
-    ) -> Result<
-        (
-            <Self::Witness as CircuitBaseType>::CommitmentType,
-            R1CSProof,
-        ),
-        ProverError,
-    > {
-        // Commit to the witness and statement
-        let mut rng = thread_rng();
-        let (witness_var, witness_comm) = witness.commit_witness(&mut rng, &mut prover);
-        let statement_var = statement.commit_public(&mut prover);
+        pk: &ProvingKey<SystemCurve>,
+        mut circuit: PlonkCircuit,
+    ) -> Result<Proof<SystemCurve>, ProverError> {
+        // Allocate the witness and statement in the constraint system
+        let witness_var = witness.create_witness(&mut circuit);
+        let statement_var = statement.create_public_var(&mut circuit);
 
         // Apply the constraints
-        Self::apply_constraints(witness_var, statement_var, &mut prover)
-            .map_err(ProverError::R1CS)?;
+        Self::apply_constraints(witness_var, statement_var, &mut circuit)
+            .map_err(ProverError::Plonk)?;
 
         // Generate the proof
-        let proof = prover.prove(bp_gens).map_err(ProverError::R1CS)?;
-
-        Ok((witness_comm, proof))
+        let mut rng = thread_rng();
+        PlonkKzgSnark::prove::<_, _, SolidityTranscript>(
+            &mut rng, &circuit, pk, None, // extra_init_msg
+        )
+        .map_err(ProverError::Plonk)
     }
 
     /// Verify a proof of the statement represented by the circuit
     ///
-    /// The verifier has access to the statement variables, but only hiding (and
-    /// binding) commitments to the witness variables
+    /// The verifier has access to the statement variables, but not the witness
     fn verify(
-        witness_commitment: <Self::Witness as CircuitBaseType>::CommitmentType,
         statement: Self::Statement,
-        proof: R1CSProof,
-        bp_gens: &BulletproofGens,
-        mut verifier: Verifier,
+        proof: Proof<SystemCurve>,
+        vk: &VerifyingKey<SystemCurve>,
     ) -> Result<(), VerifierError> {
-        // Commit to the witness and statement
-        let witness_var = witness_commitment.commit_verifier(&mut verifier);
-        let statement_var = statement.commit_public(&mut verifier);
-
-        // Apply the constraints
-        Self::apply_constraints(witness_var, statement_var, &mut verifier)
-            .map_err(VerifierError::R1CS)?;
+        // Allocate the statement in the constraint system
+        let statement_vals = statement
+            .to_scalars()
+            .iter()
+            .map(Scalar::inner)
+            .collect_vec();
 
         // Verify the proof
-        verifier
-            .verify(&proof, bp_gens)
-            .map_err(VerifierError::R1CS)
+        PlonkKzgSnark::verify::<SolidityTranscript>(
+            vk,
+            &statement_vals,
+            &proof,
+            None, // extra_init_msg
+        )
+        .map_err(VerifierError::Plonk)
     }
 }
 
@@ -1152,13 +616,13 @@ pub trait SingleProverCircuit {
 /// setting
 ///
 /// A circuit represents a provable unit, a complete NP statement that takes as
-/// input a series of values, commits to them, and applies constraints.
+/// input a series of values, commits to them, and applies constraints
 ///
 /// The input types are broken out into the witness type and the statement type.
 /// The witness type represents the secret witness that the prover has access to
 /// but that the verifier does not. The statement is the set of public inputs
 /// and any other circuit meta-parameters that both prover and verifier have
-/// access to.
+/// access to
 pub trait MultiProverCircuit {
     /// The witness type, given only to the prover, which generates a blinding
     /// commitment that can be given to the verifier
@@ -1167,33 +631,20 @@ pub trait MultiProverCircuit {
     /// the underlying NP statement being proven
     type Statement: Clone + MultiproverCircuitBaseType + MpcType;
 
-    /// The size of the bulletproof generators that must be allocated
-    /// to fully compute a proof or verification of the statement
-    ///
-    /// This is a function of circuit depth, one generator is needed per
-    /// multiplication gate (roughly)
-    const BP_GENS_CAPACITY: usize;
+    /// The single-prover circuit analog that this multiprover circuit is
+    /// derived from, used for verification
+    type BaseCircuit: SingleProverCircuit<
+        Witness = <Self::Witness as MultiproverCircuitBaseType>::BaseType,
+        Statement = <Self::Statement as MultiproverCircuitBaseType>::BaseType,
+    >;
 
     /// Apply the constraints of the circuit to a multiprover constraint system
-    fn apply_constraints_multiprover<CS: MpcRandomizableConstraintSystem>(
-        witness: <Self::Witness as MultiproverCircuitBaseType>::MultiproverVarType<MpcVariable>,
-        statement: <Self::Statement as MultiproverCircuitBaseType>::MultiproverVarType<MpcVariable>,
-        fabric: MpcFabric,
-        cs: &mut CS,
+    fn apply_constraints_multiprover(
+        witness: <Self::Witness as MultiproverCircuitBaseType>::VarType,
+        statement: <Self::Statement as MultiproverCircuitBaseType>::VarType,
+        fabric: &Fabric,
+        circuit: &mut MpcPlonkCircuit,
     ) -> Result<(), ProverError>;
-
-    /// Apply the constraints of the circuit to a singleprover constraint system
-    #[allow(clippy::type_complexity)]
-    fn apply_constraints_singleprover<CS: RandomizableConstraintSystem>(
-        witness:
-            <<<Self::Witness as MultiproverCircuitBaseType>::MultiproverCommType
-                as MultiproverCircuitCommitmentType>::BaseCommitType
-                as CircuitCommitmentType>::VarType,
-        statement:
-            <<Self::Statement as MultiproverCircuitBaseType>::BaseType
-                as CircuitBaseType>::VarType<Variable>,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>;
 
     /// Generate a proof of the statement represented by the circuit
     ///
@@ -1202,32 +653,23 @@ pub trait MultiProverCircuit {
     fn prove(
         witness: Self::Witness,
         statement: Self::Statement,
-        bp_gens: &BulletproofGens,
-        fabric: MpcFabric,
-        mut prover: MpcProver,
-    ) -> Result<
-        (
-            <Self::Witness as MultiproverCircuitBaseType>::MultiproverCommType,
-            PartiallySharedR1CSProof,
-        ),
-        ProverError,
-    > {
-        // Commit to the witness and statement
-        let mut rng = thread_rng();
-        let (witness_var, witness_comm) = witness
-            .commit_shared(&mut rng, &mut prover)
+        pk: &ProvingKey<SystemCurve>,
+        fabric: Fabric,
+        circuit: &mut MpcPlonkCircuit,
+    ) -> Result<CollaborativeProof<SystemCurve>, ProverError> {
+        // Allocate the witness and statement in the constraint system
+        let witness_var = witness
+            .create_shared_witness(circuit)
             .map_err(ProverError::Mpc)?;
-        let (statement_var, _) = statement
-            .commit_shared(&mut rng, &mut prover)
+        let statement_var = statement
+            .create_shared_witness(circuit)
             .map_err(ProverError::Mpc)?;
 
         // Apply the constraints
-        Self::apply_constraints_multiprover(witness_var, statement_var, fabric, &mut prover)?;
+        Self::apply_constraints_multiprover(witness_var, statement_var, &fabric, circuit)?;
 
         // Generate the proof
-        let proof = prover.prove(bp_gens).map_err(ProverError::Collaborative)?;
-
-        Ok((witness_comm, proof))
+        MultiproverPlonkKzgSnark::prove(circuit, pk, fabric).map_err(ProverError::Plonk)
     }
 
     /// Verify a proof of the statement represented by the circuit
@@ -1241,26 +683,10 @@ pub trait MultiProverCircuit {
     /// from their shares. Then the opened proof and commitments can be
     /// passed to the verifier.
     fn verify(
-        witness_commitments:
-            <<Self::Witness as MultiproverCircuitBaseType>::MultiproverCommType
-                as MultiproverCircuitCommitmentType>::BaseCommitType,
         statement: <Self::Statement as MultiproverCircuitBaseType>::BaseType,
-        proof: R1CSProof,
-        bp_gens: &BulletproofGens,
-        mut verifier: Verifier,
-    ) -> Result<(), VerifierError>
-where {
-        // Commit to the witness and statement
-        let witness_var = witness_commitments.commit_verifier(&mut verifier);
-        let statement_var = statement.commit_public(&mut verifier);
-
-        // Apply the circuit constraints
-        Self::apply_constraints_singleprover(witness_var, statement_var, &mut verifier)
-            .map_err(VerifierError::R1CS)?;
-
-        // Verify the proof
-        verifier
-            .verify(&proof, bp_gens)
-            .map_err(VerifierError::R1CS)
+        proof: Proof<SystemCurve>,
+        vk: &VerifyingKey<SystemCurve>,
+    ) -> Result<(), VerifierError> {
+        Self::BaseCircuit::verify(statement, proof, vk)
     }
 }

--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -10,3 +10,4 @@ mpc-types = ["dep:ark-mpc"]
 [dependencies]
 ark-bn254 = "0.4"
 ark-mpc = { workspace = true, optional = true }
+ark-ec = "0.4"

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -4,8 +4,11 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(missing_docs)]
 
+use ark_ec::Group;
 #[cfg(feature = "mpc-types")]
-use ark_mpc::algebra::{CurvePoint as GenericCurvePoint, Scalar as GenericScalar};
+use ark_mpc::algebra::{
+    AuthenticatedScalarResult, CurvePoint as GenericCurvePoint, Scalar as GenericScalar,
+};
 
 // -------------------------
 // | System-Wide Constants |
@@ -34,7 +37,13 @@ pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 // ------------------------------------
 
 /// The curve that our proof system operates over
-pub type Curve = ark_bn254::G1Projective;
+pub type SystemCurve = ark_bn254::Bn254;
+
+/// The curve group that our proof system operates over
+pub type SystemCurveGroup = ark_bn254::G1Projective;
+
+/// The scalar field the curve is defined over
+pub type ScalarField = <ark_bn254::G1Projective as Group>::ScalarField;
 
 /// The scalar type that the MPC is defined over    
 #[cfg(feature = "mpc-types")]
@@ -43,6 +52,10 @@ pub type Scalar = GenericScalar<Curve>;
 /// The curve point type that the MPC is defined over
 #[cfg(feature = "mpc-types")]
 pub type CurvePoint = GenericCurvePoint<Curve>;
+
+/// The authenticated scalar type that the MPC is defined over
+#[cfg(feature = "mpc-types")]
+pub type AuthenticatedScalar = AuthenticatedScalarResult<SystemCurveGroup>;
 
 // ----------------------
 // | Starknet Constants |

--- a/renegade-crypto/src/hash/constants.rs
+++ b/renegade-crypto/src/hash/constants.rs
@@ -6,7 +6,7 @@
 
 use ark_ec::Group;
 use ark_ff::BigInt;
-use constants::Curve;
+use constants::SystemCurveGroup as Curve;
 
 /// The scalar field type that the hash function operates over
 pub type ScalarField = <Curve as Group>::ScalarField;


### PR DESCRIPTION
### Purpose
This PR refactors the `traits` module in the `circuit-types` crates to reflect the new plonkish arithmetization and multiprover paradigm. Of notable difference:
- The plonk arithmetization requires one gate per addition, so we do not have the `Variable` and `LinearCombination` distinction that Dalek gave. This simplifies the associated types on Variable types. As well, it allow us to reuse variable types between single and multi prover
- We no longer have a need for proof linkable types, the proof linking scheme will come later
- Commitment types are removed, Plonk commits to its witness using KZG, which is unstructured wrt runtime types

### Testing
- CI passes for the crate