### PR TITLE
renegade-crypto, constants: Gate `ark-mpc` dependency behind feature flag

### DIFF
--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -3,6 +3,10 @@ name = "constants"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["mpc-types"]
+mpc-types = ["dep:ark-mpc"]
+
 [dependencies]
 ark-bn254 = "0.4"
-ark-mpc = { workspace = true }
+ark-mpc = { workspace = true, optional = true }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(missing_docs)]
 
+#[cfg(feature = "mpc-types")]
 use ark_mpc::algebra::{CurvePoint as GenericCurvePoint, Scalar as GenericScalar};
 
 // -------------------------
@@ -36,9 +37,11 @@ pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 pub type Curve = ark_bn254::G1Projective;
 
 /// The scalar type that the MPC is defined over    
+#[cfg(feature = "mpc-types")]
 pub type Scalar = GenericScalar<Curve>;
 
 /// The curve point type that the MPC is defined over
+#[cfg(feature = "mpc-types")]
 pub type CurvePoint = GenericCurvePoint<Curve>;
 
 // ----------------------

--- a/renegade-crypto/Cargo.toml
+++ b/renegade-crypto/Cargo.toml
@@ -4,32 +4,37 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["inline"]
+default = ["non-wasm"]
+# We define a feature flag that gates all uses of wasm incompatible dependencies
+# specifically for use in stylus contracts
+non-wasm = ["dep:ark-mpc", "dep:rand", "constants/mpc-types", "inline"]
 inline = []
 
 [[bench]]
 name = "elgamal"
 harness = false
+required-features = ["non-wasm"]
 
 [[bench]]
 name = "poseidon"
 harness = false
+required-features = ["non-wasm"]
 
 [dependencies]
 # === Cryptography + Arithmetic === #
 ark-ec = "0.4"
 ark-ff = "0.4"
-ark-mpc = { workspace = true }
+ark-mpc = { workspace = true, optional = true }
 bigdecimal = "0.3"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 
 # === Workspace Dependencies === #
-constants = { path = "../constants" }
+constants = { path = "../constants", default-features = false }
 
 # === Misc Dependencies === #
 itertools = "0.10"
 lazy_static = "1.4"
-rand = { version = "0.8" }
+rand = { version = "0.8", optional = true }
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
 

--- a/renegade-crypto/src/hash.rs
+++ b/renegade-crypto/src/hash.rs
@@ -5,55 +5,69 @@ mod poseidon2;
 pub use constants::*;
 pub use poseidon2::*;
 
-use ::constants::Scalar;
-use itertools::Itertools;
+#[cfg(feature = "non-wasm")]
+pub use mpc_type_interface::*;
 
-/// A hash chain from a seed used to compute CSPRNG values
-pub struct PoseidonCSPRNG {
-    /// The seed of the CSPRNG, this is chained into a hash function
-    /// to give pseudorandom values
-    state: Scalar,
-}
+#[cfg(feature = "non-wasm")]
+mod mpc_type_interface {
+    //! Defines the interface for the Poseidon 2 sponge
+    //!
+    //! We gate this behind a feature flag to avoid importing `ark-mpc` when not
+    //! necessary. This is of particular use in wasm contexts, where
+    //! `ark-mpc` does not build
 
-impl PoseidonCSPRNG {
-    /// Constructor
-    pub fn new(seed: Scalar) -> Self {
-        Self { state: seed }
+    use ::constants::Scalar;
+    use itertools::Itertools;
+
+    use super::Poseidon2Sponge;
+
+    /// A hash chain from a seed used to compute CSPRNG values
+    pub struct PoseidonCSPRNG {
+        /// The seed of the CSPRNG, this is chained into a hash function
+        /// to give pseudorandom values
+        state: Scalar,
     }
-}
 
-impl Iterator for PoseidonCSPRNG {
-    type Item = Scalar;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let hash_res = compute_poseidon_hash(&[self.state]);
-        self.state = hash_res;
-
-        Some(hash_res)
+    impl PoseidonCSPRNG {
+        /// Constructor
+        pub fn new(seed: Scalar) -> Self {
+            Self { state: seed }
+        }
     }
-}
 
-/// Compute the hash of the randomness of a given wallet
-pub fn compute_poseidon_hash(values: &[Scalar]) -> Scalar {
-    let input_seq = values.iter().map(Scalar::inner).collect_vec();
-    let mut hasher = Poseidon2Sponge::new();
-    let res = hasher.hash(&input_seq);
+    impl Iterator for PoseidonCSPRNG {
+        type Item = Scalar;
 
-    Scalar::new(res)
-}
+        fn next(&mut self) -> Option<Self::Item> {
+            let hash_res = compute_poseidon_hash(&[self.state]);
+            self.state = hash_res;
 
-/// Compute a chained Poseidon hash of the given length from the given seed
-pub fn evaluate_hash_chain(seed: Scalar, length: usize) -> Vec<Scalar> {
-    let mut seed = seed.inner();
-    let mut res = Vec::with_capacity(length);
+            Some(hash_res)
+        }
+    }
 
-    for _ in 0..length {
-        // Create a new hasher to reset the internal state
+    /// Compute the hash of the randomness of a given wallet
+    pub fn compute_poseidon_hash(values: &[Scalar]) -> Scalar {
+        let input_seq = values.iter().map(Scalar::inner).collect_vec();
         let mut hasher = Poseidon2Sponge::new();
-        seed = hasher.hash(&[seed]);
+        let res = hasher.hash(&input_seq);
 
-        res.push(Scalar::new(seed));
+        Scalar::new(res)
     }
 
-    res
+    /// Compute a chained Poseidon hash of the given length from the given seed
+    pub fn evaluate_hash_chain(seed: Scalar, length: usize) -> Vec<Scalar> {
+        let mut seed = seed.inner();
+        let mut res = Vec::with_capacity(length);
+
+        for _ in 0..length {
+            // Create a new hasher to reset the internal state
+            let mut hasher = Poseidon2Sponge::new();
+            seed = hasher.hash(&[seed]);
+
+            res.push(Scalar::new(seed));
+        }
+
+        res
+    }
 }

--- a/renegade-crypto/src/hash/poseidon2.rs
+++ b/renegade-crypto/src/hash/poseidon2.rs
@@ -215,6 +215,7 @@ impl Poseidon2Sponge {
 }
 
 #[cfg(test)]
+#[cfg(feature = "non-wasm")]
 mod test {
 
     use ark_ff::BigInt;

--- a/renegade-crypto/src/lib.rs
+++ b/renegade-crypto/src/lib.rs
@@ -5,6 +5,8 @@
 #![allow(incomplete_features)]
 #![feature(inherent_associated_types)]
 
+#[cfg(feature = "non-wasm")]
 pub mod elgamal;
+#[cfg(feature = "non-wasm")]
 pub mod fields;
 pub mod hash;


### PR DESCRIPTION
### Purpose
In WASM contexts (i.e. contracts) we cannot import `ark-mpc`. Aside we only superficially use this crate for its types, so it is unimportant to certain functionalities, i.e. hashing. This PR introduces a feature flag `non-wasm` on by default that allows wasm targets to disable wasm-incompatible features.

### Testing
- Unit tests pass

