### PR TITLE
test-helpers: Refactor over new `ark-mpc` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,14 +7266,14 @@ dependencies = [
 name = "test-helpers"
 version = "0.1.0"
 dependencies = [
+ "ark-ec",
+ "ark-mpc",
  "async-trait",
  "constants",
  "dns-lookup",
  "eyre",
  "futures",
- "inventory",
  "itertools 0.10.5",
- "mpc-stark",
  "num-bigint",
  "rand 0.8.5",
  "renegade-crypto",
@@ -7282,7 +7282,6 @@ dependencies = [
  "serde_json",
  "starknet",
  "tokio",
- "tokio-condvar",
  "tracing",
 ]
 
@@ -7404,15 +7403,6 @@ dependencies = [
  "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-condvar"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7233b09174540ef9bf9fc8326bcad6ccebc631e7c9a1e2e48d956a133056f9d"
-dependencies = [
- "tokio",
 ]
 
 [[package]]

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -10,14 +10,14 @@ async-trait = "0.1"
 dns-lookup = "1.0"
 futures = "0.3"
 tokio = { workspace = true }
-tokio-condvar = "0.1"
 
 # === Node Interaction === #
 starknet = { workspace = true }
 reqwest = "0.11.13"
 
 # === Cryptography + Arithmetic === #
-mpc-stark = { workspace = true }
+ark-mpc = { workspace = true }
+ark-ec = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 
 # === Workspace Dependencies === # 
@@ -25,7 +25,6 @@ constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 
 # === Misc Dependencies === #
-inventory = "0.3"
 itertools = "0.10.5"
 eyre = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
### Purpose
This PR refactors the `test-helpers` crate over the new `ark-mpc` implementation. This largely involves attaching generics that represent the curve group now that the MPC implementation is curve-generic.

### Testing
- Unit tests pass