### PR TITLE
circuit-types: fixed-point: Refactor fixed point arithmetic over new circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,6 @@ dependencies = [
  "futures",
  "itertools 0.10.5",
  "lazy_static",
- "merlin 2.0.0",
  "mpc-plonk",
  "mpc-relation",
  "num-bigint",

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -37,6 +37,5 @@ serde_json = "1.0"
 
 
 [dev-dependencies]
-merlin = { workspace = true }
 test-helpers = { path = "../test-helpers" }
 tokio = { workspace = true }

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -10,7 +10,7 @@ mod test {
     use circuit_macros::circuit_type;
     use constants::{AuthenticatedScalar, Scalar};
     use mpc_plonk::multiprover::proof_system::MpcPlonkCircuit;
-    use mpc_relation::{Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{ConstraintSystem, PlonkCircuit, Variable};
     use std::ops::Add;
     use test_helpers::mpc_network::execute_mock_mpc;
 
@@ -182,13 +182,16 @@ mod test {
         // Test blind and unblind
         let blinded = var1.blind(circuit.one(), &mut circuit);
         assert_eq!(
-            TestType {
+            TestTypeShare {
                 val: Scalar::from(2u8)
             },
-            blinded.val.eval(&circuit)
+            blinded.eval(&circuit)
         );
 
         let unblinded = blinded.unblind(circuit.one(), &mut circuit);
-        assert_eq!(TestType { val: Scalar::one() }, unblinded.eval(&circuit));
+        assert_eq!(
+            TestTypeShare { val: Scalar::one() },
+            unblinded.eval(&circuit)
+        );
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the fixed point arithmetic implementation over the new `mpc-jellyfish` circuits. This includes types for native FP arithmetic, in-circuit arithmetic, and mpc fixed point arithmetic.]

### Testing
- All unit tests pass
- Tested arithmetic operations of all forms of fixed point