### PR TITLE
circuits: mpc-gadgets: arithmetic, bits: Refactor implementations and add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,18 +1087,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "zeroize",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
@@ -1110,27 +1098,14 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
-dependencies = [
- "aead 0.4.3",
- "chacha20 0.8.2",
- "cipher 0.3.0",
- "poly1305 0.7.2",
- "zeroize",
-]
-
-[[package]]
-name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead 0.5.2",
- "chacha20 0.9.1",
+ "chacha20",
  "cipher 0.4.4",
- "poly1305 0.8.0",
+ "poly1305",
  "zeroize",
 ]
 
@@ -1255,11 +1230,9 @@ dependencies = [
  "rand 0.8.5",
  "renegade-crypto",
  "serde",
- "serde_arrays",
  "serde_json",
  "test-helpers",
  "tokio",
- "util",
 ]
 
 [[package]]
@@ -1270,6 +1243,7 @@ dependencies = [
  "ark-ec",
  "ark-ed25519",
  "ark-ff",
+ "ark-mpc",
  "bigdecimal",
  "bitvec 1.0.1",
  "chrono",
@@ -1287,9 +1261,6 @@ dependencies = [
  "inventory",
  "itertools 0.10.5",
  "lazy_static",
- "merlin 2.0.0",
- "mpc-bulletproof",
- "mpc-stark",
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
@@ -3478,7 +3449,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "blst",
- "chacha20poly1305 0.10.1",
+ "chacha20poly1305",
  "crypto_kx",
  "derivative",
  "digest 0.10.7",
@@ -5141,17 +5112,6 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
-dependencies = [
- "cpufeatures",
- "opaque-debug 0.3.0",
- "universal-hash 0.4.1",
-]
-
-[[package]]
-name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
@@ -6640,16 +6600,16 @@ dependencies = [
 
 [[package]]
 name = "snow"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
+checksum = "58021967fd0a5eeeb23b08df6cc244a4d4a5b4aec1d27c9e02fad1a58b4cd74e"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm 0.10.3",
  "blake2",
- "chacha20poly1305 0.9.1",
+ "chacha20poly1305",
  "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
- "ring 0.16.20",
+ "ring 0.17.5",
  "rustc_version",
  "sha2 0.10.8",
  "subtle",

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -27,13 +27,11 @@ futures = "0.3"
 circuit-macros = { path = "../circuit-macros" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
-util = { path = "../util" }
 
 # === Misc === #
 itertools = "0.10"
 lazy_static = "1.4"
 serde = { version = "1.0.139", features = ["serde_derive"] }
-serde_arrays = "0.1"
 serde_json = "1.0"
 
 

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 test_helpers = []
 large_benchmarks = []
-stats = ["mpc-stark/stats"]
+stats = ["ark-mpc/stats"]
 
 [[test]]
 name = "integration"
@@ -56,10 +56,8 @@ ark-crypto-primitives = { version = "0.4", features = [
     "sponge",
 ] }
 ark-ff = "0.4"
+ark-mpc = { workspace = true }
 bigdecimal = "0.3"
-merlin = { workspace = true }
-mpc-stark = { workspace = true }
-mpc-bulletproof = { workspace = true }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
 

--- a/circuits/src/mpc_gadgets/arithmetic.rs
+++ b/circuits/src/mpc_gadgets/arithmetic.rs
@@ -1,10 +1,11 @@
 //! Groups MPC gadgets centered around arithmetic operations
 
-use mpc_stark::{algebra::authenticated_scalar::AuthenticatedScalarResult, MpcFabric};
+use circuit_types::Fabric;
+use constants::AuthenticatedScalar;
 
 /// Computes the product of all elements in constant number of rounds
 ///     Result = a_0 * ... * a_n
-pub fn product(a: &[AuthenticatedScalarResult], fabric: &MpcFabric) -> AuthenticatedScalarResult {
+pub fn product(a: &[AuthenticatedScalar], fabric: &Fabric) -> AuthenticatedScalar {
     prefix_product_impl(a, &[a.len() - 1], fabric)[0].clone()
 }
 
@@ -13,10 +14,7 @@ pub fn product(a: &[AuthenticatedScalarResult], fabric: &MpcFabric) -> Authentic
 ///
 /// This implementation is done in a constant number of rounds according to:
 /// https://iacr.org/archive/tcc2006/38760286/38760286.pdf
-pub fn prefix_mul(
-    a: &[AuthenticatedScalarResult],
-    fabric: &MpcFabric,
-) -> Vec<AuthenticatedScalarResult> {
+pub fn prefix_mul(a: &[AuthenticatedScalar], fabric: &Fabric) -> Vec<AuthenticatedScalar> {
     prefix_product_impl(
         a,
         &(0usize..a.len()).collect::<Vec<_>>(), // Select all prefix products
@@ -34,10 +32,10 @@ pub fn prefix_mul(
 /// Note that each additional prefix incurs more bandwidth (although constant
 /// round)
 fn prefix_product_impl(
-    a: &[AuthenticatedScalarResult],
+    a: &[AuthenticatedScalar],
     pre: &[usize],
-    fabric: &MpcFabric,
-) -> Vec<AuthenticatedScalarResult> {
+    fabric: &Fabric,
+) -> Vec<AuthenticatedScalar> {
     let n = a.len();
     assert!(
         pre.iter().all(|x| x < &n),
@@ -50,11 +48,11 @@ fn prefix_product_impl(
     // Using the inverse pairs (b_i, b_i^-1), compute d_i = b_{i-1} * a_i * b_i^-1
     // We will open these values and use them to form telescoping partial products
     // wherein the only non-cancelled terms are a b_{k-1} * b_k^-1
-    let d_partial = AuthenticatedScalarResult::batch_mul(&b_values[..n], a);
-    let d_values = AuthenticatedScalarResult::batch_mul(&d_partial, &b_inv_values[1..]);
+    let d_partial = AuthenticatedScalar::batch_mul(&b_values[..n], a);
+    let d_values = AuthenticatedScalar::batch_mul(&d_partial, &b_inv_values[1..]);
 
     // TODO: Can we just call `batch_open` here and simply authenticate at the end?
-    let d_values_open = AuthenticatedScalarResult::open_batch(&d_values);
+    let d_values_open = AuthenticatedScalar::open_batch(&d_values);
 
     // The partial products are formed by creating a series of telescoping products
     // and then cancelling them out with the correct b_i values
@@ -70,7 +68,7 @@ fn prefix_product_impl(
     // So it must be multiplied by b_{i-1}^-1 * b_i to create a secret sharing
     // of a_0 * ... * a_i.
     // To do so, we first batch multiply b_0^-1 * b_i for i > 0
-    let cancellation_factors = AuthenticatedScalarResult::batch_mul(
+    let cancellation_factors = AuthenticatedScalar::batch_mul(
         &vec![b_inv_values[0].clone(); pre.len()], // Each prefix product starts at 0
         &pre.iter()
             .map(|index| b_values[*index].clone())
@@ -85,12 +83,12 @@ fn prefix_product_impl(
     // No communication is required here, the partial_products are public and the
     // cancellation_factors are shared, so computation can be done locally.
     // Unwrap is therefore safe
-    AuthenticatedScalarResult::batch_mul(&selected_partial_products, &cancellation_factors)
+    AuthenticatedScalar::batch_mul(&selected_partial_products, &cancellation_factors)
 }
 
 /// Computes a^n using a recursive squaring approach for a public parameter
 /// exponent
-pub fn pow(a: &AuthenticatedScalarResult, n: u64, fabric: &MpcFabric) -> AuthenticatedScalarResult {
+pub fn pow(a: &AuthenticatedScalar, n: u64, fabric: &Fabric) -> AuthenticatedScalar {
     if n == 0 {
         fabric.one_authenticated()
     } else if n == 1 {
@@ -101,5 +99,68 @@ pub fn pow(a: &AuthenticatedScalarResult, n: u64, fabric: &MpcFabric) -> Authent
     } else {
         let recursive_res = pow(a, (n - 1) / 2, fabric);
         &recursive_res * &recursive_res * a
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_mpc::PARTY0;
+    use constants::Scalar;
+    use itertools::Itertools;
+    use rand::{thread_rng, Rng};
+    use test_helpers::mpc_network::execute_mock_mpc;
+
+    use crate::{
+        mpc_gadgets::arithmetic::{pow, prefix_mul},
+        test_helpers::joint_open,
+    };
+
+    /// Tests the prefix product implementation
+    #[tokio::test]
+    async fn test_prefix_prod() {
+        const N: usize = 10;
+
+        let mut rng = thread_rng();
+        let values = (0..N).map(|_| Scalar::random(&mut rng)).collect_vec();
+
+        let expected = values
+            .iter()
+            .scan(Scalar::one(), |acc, x| {
+                *acc = *acc * x;
+                Some(*acc)
+            })
+            .collect_vec();
+
+        let (res, _) = execute_mock_mpc(move |fabric| {
+            let values = values.clone();
+            async move {
+                let shared_values = fabric.batch_share_scalar(values, PARTY0);
+                let res = prefix_mul(&shared_values, &fabric);
+
+                joint_open(res).await
+            }
+        })
+        .await;
+
+        assert_eq!(res.unwrap(), expected);
+    }
+
+    /// Tests the `pow` implementation
+    #[tokio::test]
+    async fn test_pow() {
+        let mut rng = thread_rng();
+        let base = Scalar::random(&mut rng);
+        let exp = rng.gen();
+
+        let expected = base.pow(exp);
+        let (res, _) = execute_mock_mpc(move |fabric| async move {
+            let shared_base = fabric.share_scalar(base, PARTY0);
+            let res = pow(&shared_base, exp, &fabric);
+
+            res.open_authenticated().await
+        })
+        .await;
+
+        assert_eq!(res.unwrap(), expected);
     }
 }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -8,6 +8,7 @@ use ark_ec::Group;
 #[cfg(feature = "mpc-types")]
 use ark_mpc::algebra::{
     AuthenticatedScalarResult, CurvePoint as GenericCurvePoint, Scalar as GenericScalar,
+    ScalarResult as GenericScalarResult,
 };
 
 // -------------------------
@@ -48,6 +49,10 @@ pub type ScalarField = <ark_bn254::G1Projective as Group>::ScalarField;
 /// The scalar type that the MPC is defined over    
 #[cfg(feature = "mpc-types")]
 pub type Scalar = GenericScalar<SystemCurveGroup>;
+
+/// The scalar result type that the MPC is defined over
+#[cfg(feature = "mpc-types")]
+pub type ScalarResult = GenericScalarResult<SystemCurveGroup>;
 
 /// The curve point type that the MPC is defined over
 #[cfg(feature = "mpc-types")]


### PR DESCRIPTION
### Purpose
This PR refactors the arithmetic and bitwise MPC gadgets over the new `ark_mpc` library and adds unit tests for important gadgets that were previously only tested in integration tests. Some gadgets don't have tests as they are implicitly tested elsewhere.

### Testing
- Unit tests pass