### PR TITLE
circuits: zk-gadgets: poseidon: Refactor and add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,9 +1052,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
 dependencies = [
  "libc",
 ]
@@ -1261,6 +1261,8 @@ dependencies = [
  "inventory",
  "itertools 0.10.5",
  "lazy_static",
+ "mpc-plonk",
+ "mpc-relation",
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
@@ -1705,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array 0.14.7",
  "subtle",
@@ -2183,7 +2185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
- "signature 2.1.0",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3071,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95b9abcae896730d42b78e09c155ed4ddf82c07b4de772c64aee5b2d8b7c150"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -3401,7 +3403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.21",
+ "rustix 0.38.22",
  "windows-sys 0.48.0",
 ]
 
@@ -3432,7 +3434,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c8a7b2ec774cb79bc4d141edf54ba381ad356853"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0f017c5a202cdab639684846bbce890374ab3fb6"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3476,7 +3478,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c8a7b2ec774cb79bc4d141edf54ba381ad356853"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0f017c5a202cdab639684846bbce890374ab3fb6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4247,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c8a7b2ec774cb79bc4d141edf54ba381ad356853"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0f017c5a202cdab639684846bbce890374ab3fb6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4279,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#c8a7b2ec774cb79bc4d141edf54ba381ad356853"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#0f017c5a202cdab639684846bbce890374ab3fb6"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5977,9 +5979,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "80109a168d9bc0c7f483083244543a6eb0dba02295d33ca268145e6190d6df0c"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -6476,9 +6478,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simba"
@@ -6801,7 +6806,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
 dependencies = [
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.4",
  "hex 0.4.3",
  "hmac 0.12.1",
  "num-bigint",
@@ -6843,7 +6848,7 @@ checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
 dependencies = [
  "ark-ff",
  "bigdecimal",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.4",
  "getrandom 0.2.11",
  "hex 0.4.3",
  "num-bigint",
@@ -6888,7 +6893,7 @@ checksum = "5313524cc79344015ef2a8618947332ab17012b5c50600c7f84c60989bdec980"
 dependencies = [
  "async-trait",
  "auto_impl",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.4",
  "eth-keystore",
  "rand 0.8.5",
  "starknet-core 0.5.1",
@@ -7194,7 +7199,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
- "rustix 0.38.21",
+ "rustix 0.38.22",
  "windows-sys 0.48.0",
 ]
 
@@ -7497,9 +7502,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -7528,9 +7533,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -7808,7 +7813,7 @@ dependencies = [
  "renegade-crypto",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.17",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -8285,7 +8290,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.21",
+ "rustix 0.38.22",
 ]
 
 [[package]]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -58,6 +58,8 @@ ark-crypto-primitives = { version = "0.4", features = [
 ark-ff = "0.4"
 ark-mpc = { workspace = true }
 bigdecimal = "0.3"
+mpc-plonk = { workspace = true }
+mpc-relation = { workspace = true }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
 

--- a/circuits/src/zk_gadgets/poseidon.rs
+++ b/circuits/src/zk_gadgets/poseidon.rs
@@ -1,19 +1,14 @@
 //! Groups logic for adding Poseidon hash function constraints to a Bulletproof
 //! constraint system
 
-use circuit_types::{
-    errors::ProverError,
-    traits::{LinearCombinationLike, MpcLinearCombinationLike},
-};
+use ark_ff::One;
+use constants::ScalarField;
 use itertools::Itertools;
-use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem},
-    r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, MpcVariable, R1CSError},
+use mpc_plonk::errors::PlonkError;
+use mpc_relation::{constants::GATE_WIDTH, ConstraintSystem, Variable};
+use renegade_crypto::hash::{
+    CAPACITY, FULL_ROUND_CONSTANTS, PARTIAL_ROUND_CONSTANTS, RATE, R_F, R_P, WIDTH as SPONGE_WIDTH,
 };
-use mpc_stark::{algebra::scalar::Scalar, MpcFabric};
-use renegade_crypto::hash::PoseidonParams;
-
-use super::arithmetic::{ExpGadget, MultiproverExpGadget};
 
 // -----------------------
 // | Singleprover Gadget |
@@ -25,10 +20,8 @@ use super::arithmetic::{ExpGadget, MultiproverExpGadget};
 /// This version of the gadget is used for the single-prover case, i.e. no MPC
 #[derive(Debug)]
 pub struct PoseidonHashGadget {
-    /// The parameterization of the hash function
-    params: PoseidonParams,
     /// The hash state
-    state: Vec<LinearCombination>,
+    state: Vec<Variable>,
     /// The next index in the state to being absorbing inputs at
     next_index: usize,
     /// Whether the sponge is in squeezing mode. For simplicity, we disallow
@@ -38,13 +31,11 @@ pub struct PoseidonHashGadget {
 
 impl PoseidonHashGadget {
     /// Construct a new hash gadget with the given parameterization
-    pub fn new(params: PoseidonParams) -> Self {
+    pub fn new(zero_var: Variable) -> Self {
         // Initialize the state as all zeros
-        let state = (0..params.capacity + params.rate)
-            .map(|_| LinearCombination::from(Scalar::zero()))
-            .collect::<Vec<_>>();
+        let state = (0..CAPACITY + RATE).map(|_| zero_var).collect_vec();
+
         Self {
-            params,
             state,
             next_index: 0,
             in_squeeze_state: false, // Start in absorb state
@@ -52,86 +43,80 @@ impl PoseidonHashGadget {
     }
 
     /// Reset the internal state of the hasher
-    pub fn reset_state(&mut self) {
-        self.state = (0..self.params.capacity + self.params.rate)
-            .map(|_| LinearCombination::from(Scalar::zero()))
-            .collect::<Vec<_>>();
+    pub fn reset_state<C: ConstraintSystem<ScalarField>>(&mut self, cs: &C) {
+        let zero = cs.zero();
+        self.state = (0..CAPACITY + RATE).map(|_| zero).collect_vec();
         self.in_squeeze_state = false;
     }
 
     /// Hashes the given input and constraints the result to equal the expected
     /// output
-    pub fn hash<L, CS>(
+    pub fn hash<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        hash_input: &[L],
-        expected_output: L,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+        hash_input: &[Variable],
+        expected_output: Variable,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
         self.batch_absorb(hash_input, cs)?;
-        self.constrained_squeeze(expected_output.into(), cs)
+        self.constrained_squeeze(expected_output, cs)
     }
 
     /// Absorb an input into the hasher state
-    pub fn absorb<L, CS>(&mut self, a: L, cs: &mut CS) -> Result<(), R1CSError>
-    where
-        L: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn absorb<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        a: Variable,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
         assert!(
             !self.in_squeeze_state,
             "Cannot absorb from a sponge that has already been squeezed"
         );
 
         // Permute the digest state if we have filled up the rate sized buffer
-        if self.next_index == self.params.rate {
+        if self.next_index == RATE {
             self.permute(cs)?;
             self.next_index = 0;
         }
 
-        let access_index = self.next_index + self.params.capacity;
-        self.state[access_index] = self.state[access_index].clone() + a;
+        let access_index = self.next_index + CAPACITY;
+        self.state[access_index] = cs.add(a, self.state[access_index])?;
         self.next_index += 1;
         Ok(())
     }
 
     /// Absorb a batch of inputs into the hasher state
-    pub fn batch_absorb<L, CS>(&mut self, a: &[L], cs: &mut CS) -> Result<(), R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        a.iter()
-            .try_for_each(|val| self.absorb(Into::<LinearCombination>::into(val.clone()), cs))
+    pub fn batch_absorb<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        a: &[Variable],
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        a.iter().try_for_each(|val| self.absorb(*val, cs))
     }
 
     /// Squeeze an element from the sponge and return its representation in the
     /// constraint system
-    pub fn squeeze<CS: RandomizableConstraintSystem>(
+    pub fn squeeze<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError> {
+        cs: &mut C,
+    ) -> Result<Variable, PlonkError> {
         // Once we exit the absorb state, ensure that the digest state is permuted
         // before squeezing
-        if !self.in_squeeze_state || self.next_index == self.params.rate {
+        if !self.in_squeeze_state || self.next_index == RATE {
             self.permute(cs)?;
             self.next_index = 0;
             self.in_squeeze_state = true;
         }
 
-        Ok(self.state[self.params.capacity + self.next_index].clone())
+        Ok(self.state[CAPACITY + self.next_index])
     }
 
     /// Squeeze a batch of elements from the sponge and return their
     /// representation in the constraint system
-    pub fn batch_squeeze<CS: RandomizableConstraintSystem>(
+    pub fn batch_squeeze<C: ConstraintSystem<ScalarField>>(
         &mut self,
         num_elements: usize,
-        cs: &mut CS,
-    ) -> Result<Vec<LinearCombination>, R1CSError> {
+        cs: &mut C,
+    ) -> Result<Vec<Variable>, PlonkError> {
         let mut res = Vec::with_capacity(num_elements);
         for _ in 0..num_elements {
             res.push(self.squeeze(cs)?)
@@ -142,451 +127,217 @@ impl PoseidonHashGadget {
 
     /// Squeeze an output from the hasher, and constraint its value to equal the
     /// provided statement variable.
-    pub fn constrained_squeeze<L, CS>(&mut self, expected: L, cs: &mut CS) -> Result<(), R1CSError>
-    where
-        L: Into<LinearCombination>,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn constrained_squeeze<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        expected: Variable,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
         let squeezed_elem = self.squeeze(cs)?;
-        cs.constrain(squeezed_elem - expected);
+        cs.enforce_equal(expected, squeezed_elem)?;
         Ok(())
     }
 
     /// Squeeze a set of elements from the hasher, and constraint the elements
     /// to be equal to the provided statement variables
-    pub fn batch_constrained_squeeze<L, CS>(
+    pub fn batch_constrained_squeeze<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        expected: &[L],
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+        expected: &[Variable],
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
         expected
             .iter()
-            .try_for_each(|val| self.constrained_squeeze(val.clone(), cs))
+            .try_for_each(|val| self.constrained_squeeze(*val, cs))
     }
 
-    /// Permute the digest by applying the Poseidon round function
-    fn permute<CS: RandomizableConstraintSystem>(&mut self, cs: &mut CS) -> Result<(), R1CSError> {
-        // Compute full_rounds / 2 rounds in which the sbox is applied to all elements
-        for round in 0..self.params.full_rounds / 2 {
-            self.add_round_constants(round);
-            self.apply_sbox(true /* full_round */, cs)?;
-            self.apply_mds()?;
+    /// Permute the state using the Poseidon 2 permutation
+    #[allow(clippy::missing_docs_in_private_items)]
+    fn permute<C: ConstraintSystem<ScalarField>>(&mut self, cs: &mut C) -> Result<(), PlonkError> {
+        // Multiply by the external round matrix
+        self.external_mds(cs)?;
+
+        // Compute full_rounds / 2 rounds of the permutation
+        const HALF: usize = R_F / 2;
+        #[allow(clippy::never_loop)]
+        for round in 0..HALF {
+            self.external_round(round, cs)?;
         }
 
-        // Compute partial_rounds rounds in which the sbox is applied to only the last
-        // element
-        let partial_rounds_start = self.params.full_rounds / 2;
-        let partial_rounds_end = partial_rounds_start + self.params.partial_rounds;
-        for round in partial_rounds_start..partial_rounds_end {
-            self.add_round_constants(round);
-            self.apply_sbox(false /* full_round */, cs)?;
-            self.apply_mds()?;
+        // Compute the partial rounds of the permutation
+        for round in 0..R_P {
+            self.internal_round(round, cs)?;
         }
 
-        // Compute another full_rounds / 2 rounds in which we apply the sbox to all
-        // elements
-        let final_full_rounds_start = partial_rounds_end;
-        let final_full_rounds_end = self.params.partial_rounds + self.params.full_rounds;
-        for round in final_full_rounds_start..final_full_rounds_end {
-            self.add_round_constants(round);
-            self.apply_sbox(true /* full_round */, cs)?;
-            self.apply_mds()?;
+        // Compute another full_rounds / 2 rounds of the permutation
+        for round in HALF..R_F {
+            self.external_round(round, cs)?;
         }
 
         Ok(())
     }
 
-    /// Add the round constants for the given round to the state
-    ///
-    /// This is the first step in any round of the Poseidon permutation
-    fn add_round_constants(&mut self, round_number: usize) {
-        for (elem, round_constant) in self.state.iter_mut().zip(
-            self.params.ark[round_number]
-                .iter()
-                .copied()
-                .map(Scalar::from),
-        ) {
-            *elem += LinearCombination::from(round_constant)
-        }
+    /// Run an external round on the state
+    fn external_round<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        round_number: usize,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        self.external_add_rc(round_number, cs)?;
+        self.external_sbox(cs)?;
+        self.external_mds(cs)
     }
 
-    /// Apply the Poseidon s-box (i.e. x^\alpha \mod L) for given parameter
-    /// \alpha
-    ///
-    /// This permutation is applied to every element of the state for a full
-    /// round, and only to the last element of the state for a partial round
-    ///
-    /// This step is applied in the Poseidon permutation after the round
-    /// constants are added to the state.
-    fn apply_sbox<CS: RandomizableConstraintSystem>(
+    /// Add round constants in an external round
+    fn external_add_rc<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        full_round: bool,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError> {
-        // If this is a full round, apply the sbox to each elem
-        if full_round {
-            self.state = self
-                .state
-                .iter()
-                .map(|val| ExpGadget::exp(val.clone(), self.params.alpha, cs))
-                .collect_vec();
-        } else {
-            self.state[0] = ExpGadget::exp(self.state[0].clone(), self.params.alpha, cs)
+        round_number: usize,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        let rc = &FULL_ROUND_CONSTANTS[round_number];
+        for (state_elem, rc) in self.state.iter_mut().zip(rc.iter()) {
+            *state_elem = cs.add_constant(*state_elem, rc)?;
         }
 
         Ok(())
     }
 
-    /// Multiply the state by the MDS (Maximum Distance Separable) matrix
-    ///
-    /// This step is applied after the sbox is applied to the state
-    fn apply_mds(&mut self) -> Result<(), R1CSError> {
-        let mut new_state: Vec<LinearCombination> =
-            vec![LinearCombination::default(); self.state.len()];
-        for (i, row) in self.params.mds.iter().enumerate() {
-            for (a, b) in row
-                .iter()
-                .copied()
-                .map(Scalar::from)
-                .zip(self.state.iter_mut())
-            {
-                new_state[i] += a * b.clone()
-            }
-        }
-
-        self.state = new_state;
-
-        Ok(())
-    }
-}
-
-// ----------------------
-// | Multiprover Gadget |
-// ----------------------
-
-/// A hash gadget that applies a Poseidon hash function to the given constraint
-/// system
-///
-/// This version of the gadget is used for the multi-prover case, i.e in an MPC
-/// execution
-#[derive(Debug)]
-pub struct MultiproverPoseidonHashGadget {
-    /// The parameterization of the hash function
-    params: PoseidonParams,
-    /// The hash state
-    state: Vec<MpcLinearCombination>,
-    /// The next index in the state to being absorbing inputs at
-    next_index: usize,
-    /// Whether the sponge is in squeezing mode. For simplicity, we disallow
-    /// the case in which a caller wishes to squeeze values and the absorb more.
-    in_squeeze_state: bool,
-    /// A reference to the shared MPC fabric that the computation variables are
-    /// allocated in
-    fabric: MpcFabric,
-}
-
-impl MultiproverPoseidonHashGadget {
-    /// Construct a new hash gadget with the given parameterization
-    pub fn new(params: PoseidonParams, fabric: MpcFabric) -> Self {
-        // Initialize the state as all zeros
-        let state = (0..params.capacity + params.rate)
-            .map(|_| MpcLinearCombination::from_scalar(Scalar::zero(), fabric.clone()))
-            .collect::<Vec<_>>();
-        Self {
-            params,
-            state,
-            next_index: 0,
-            in_squeeze_state: false, // Start in absorb state
-            fabric,
-        }
-    }
-
-    /// Hashes the payload and then constrains the squeezed output to be the
-    /// provided expected output.
-    pub fn hash<L, CS>(
+    /// Apply the sbox to the state in an external round
+    fn external_sbox<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        hash_input: &[L],
-        expected_output: &L,
-        cs: &mut CS,
-    ) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        self.batch_absorb(hash_input, cs)?;
-        self.constrained_squeeze(expected_output.clone(), cs)
-    }
-
-    /// Absorb an input into the hasher state
-    pub fn absorb<L, CS>(&mut self, a: L, cs: &mut CS) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        assert!(
-            !self.in_squeeze_state,
-            "Cannot absorb from a sponge that has already been squeezed"
-        );
-
-        // Permute the digest state if we have filled up the rate sized buffer
-        if self.next_index == self.params.rate {
-            self.permute(cs)?;
-            self.next_index = 0;
-        }
-
-        let access_index = self.next_index + self.params.capacity;
-        self.state[access_index] = &self.state[access_index] + a.into();
-        self.next_index += 1;
-        Ok(())
-    }
-
-    /// Absorb a batch of inputs into the hasher state
-    pub fn batch_absorb<L, CS>(&mut self, a: &[L], cs: &mut CS) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        a.iter().try_for_each(|val| self.absorb(val.clone(), cs))
-    }
-
-    /// Squeeze an output from the hasher and return to the caller
-    pub fn squeeze<CS>(&mut self, cs: &mut CS) -> Result<MpcLinearCombination, ProverError>
-    where
-        CS: MpcRandomizableConstraintSystem,
-    {
-        // Once we exit the absorb state, ensure that the digest state is permuted
-        // before squeezing
-        if !self.in_squeeze_state || self.next_index == self.params.rate {
-            self.permute(cs)?;
-            self.next_index = 0;
-            self.in_squeeze_state = true;
-        }
-
-        Ok(self.state[self.params.capacity + self.next_index].clone())
-    }
-
-    /// Squeeze an output from the hasher, and constraint its value to equal the
-    /// provided statement variable.
-    pub fn constrained_squeeze<L, CS>(
-        &mut self,
-        expected: L,
-        cs: &mut CS,
-    ) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        let squeezed = self.squeeze(cs)?;
-        cs.constrain(squeezed - expected.into());
-        Ok(())
-    }
-
-    /// Squeeze a batch of elements from the hasher
-    pub fn batch_squeeze<CS>(
-        &mut self,
-        num_elems: usize,
-        cs: &mut CS,
-    ) -> Result<Vec<MpcLinearCombination>, ProverError>
-    where
-        CS: MpcRandomizableConstraintSystem,
-    {
-        (0..num_elems)
-            .map(|_| self.squeeze(cs))
-            .collect::<Result<Vec<_>, ProverError>>()
-    }
-
-    /// Squeeze a set of elements from the hasher, and constraint the elements
-    /// to be equal to the provided statement variables
-    pub fn batch_constrained_squeeze<L, CS>(
-        &mut self,
-        expected: &[MpcVariable],
-        cs: &mut CS,
-    ) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        expected
-            .iter()
-            .try_for_each(|val| self.constrained_squeeze(val.clone(), cs))
-    }
-
-    /// Permute the digest by applying the Poseidon round function
-    fn permute<CS: MpcRandomizableConstraintSystem>(
-        &mut self,
-        cs: &mut CS,
-    ) -> Result<(), ProverError> {
-        // Compute full_rounds / 2 rounds in which the sbox is applied to all elements
-        for round in 0..self.params.full_rounds / 2 {
-            self.add_round_constants(round);
-            self.apply_sbox(true /* full_round */, cs)?;
-            self.apply_mds();
-        }
-
-        // Compute partial_rounds rounds in which the sbox is applied to only the last
-        // element
-        let partial_rounds_start = self.params.full_rounds / 2;
-        let partial_rounds_end = partial_rounds_start + self.params.partial_rounds;
-        for round in partial_rounds_start..partial_rounds_end {
-            self.add_round_constants(round);
-            self.apply_sbox(false /* full_round */, cs)?;
-            self.apply_mds();
-        }
-
-        // Compute another full_rounds / 2 rounds in which we apply the sbox to all
-        // elements
-        let final_full_rounds_start = partial_rounds_end;
-        let final_full_rounds_end = self.params.partial_rounds + self.params.full_rounds;
-        for round in final_full_rounds_start..final_full_rounds_end {
-            self.add_round_constants(round);
-            self.apply_sbox(true /* full_round */, cs)?;
-            self.apply_mds();
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        for state_elem in self.state.iter_mut() {
+            *state_elem = cs.pow5(*state_elem)?;
         }
 
         Ok(())
     }
 
-    /// Add the round constants for the given round to the state
+    /// Apply the external MDS matrix to the state
     ///
-    /// This is the first step in any round of the Poseidon permutation
-    fn add_round_constants(&mut self, round_number: usize) {
-        for (elem, round_constant) in self.state.iter_mut().zip(
-            self.params.ark[round_number]
-                .iter()
-                .copied()
-                .map(Scalar::from),
-        ) {
-            *elem += MpcLinearCombination::from_scalar(round_constant, self.fabric.clone())
-        }
-    }
-
-    /// Apply the Poseidon s-box (i.e. x^\alpha \mod L) for given parameter
-    /// \alpha
+    /// For t = 3, this is the circulant matrix `circ(2, 1, 1)`
     ///
-    /// This permutation is applied to every element of the state for a full
-    /// round, and only to the last element of the state for a partial round
-    ///
-    /// This step is applied in the Poseidon permutation after the round
-    /// constants are added to the state.
-    fn apply_sbox<CS: MpcRandomizableConstraintSystem>(
+    /// This is equivalent to doubling each element then adding the other two to
+    /// it, or more efficiently: adding the sum of the elements to each
+    /// individual element. This efficient structure is borrowed from:
+    ///     https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2.rs#L129-L137
+    fn external_mds<C: ConstraintSystem<ScalarField>>(
         &mut self,
-        full_round: bool,
-        cs: &mut CS,
-    ) -> Result<(), ProverError> {
-        // If this is a full round, apply the sbox to each elem
-        if full_round {
-            self.state = self
-                .state
-                .iter()
-                .map(|val| {
-                    MultiproverExpGadget::exp(val.clone(), self.params.alpha, &self.fabric, cs)
-                })
-                .collect::<Result<Vec<_>, ProverError>>()?;
-        } else {
-            self.state[0] = MultiproverExpGadget::exp(
-                self.state[0].clone(),
-                self.params.alpha,
-                &self.fabric,
-                cs,
-            )?
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        let coeffs = [ScalarField::one(); GATE_WIDTH];
+        let in_wires = self.state.clone();
+        for state_elem in self.state.iter_mut() {
+            let lc_wires = [*state_elem, in_wires[0], in_wires[1], in_wires[2]];
+            *state_elem = cs.lc(&lc_wires, &coeffs)?;
         }
 
         Ok(())
     }
 
-    /// Multiply the state by the MDS (Maximum Distance Separable) matrix
+    /// Run an internal round on the state
+    fn internal_round<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        round_number: usize,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        self.internal_add_rc(round_number, cs)?;
+        self.internal_sbox(cs)?;
+        self.internal_mds(cs)
+    }
+
+    /// Add round constants in an internal round
+    fn internal_add_rc<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        round_number: usize,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        let rc = &PARTIAL_ROUND_CONSTANTS[round_number];
+        self.state[0] = cs.add_constant(self.state[0], rc)?;
+
+        Ok(())
+    }
+
+    /// Apply the sbox to the state in an internal round
+    fn internal_sbox<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        self.state[0] = cs.pow5(self.state[0])?;
+        Ok(())
+    }
+
+    /// Apply the internal MDS matrix M_I to the state
     ///
-    /// This step is applied after the sbox is applied to the state
-    fn apply_mds(&mut self) {
-        let mut new_state = vec![MpcLinearCombination::default(); self.state.len()];
-        for (i, row) in self.params.mds.iter().enumerate() {
-            for (a, b) in row.iter().copied().map(Scalar::from).zip(self.state.iter()) {
-                new_state[i] += a * b
-            }
+    /// For t = 3, this is the matrix:
+    ///     [2, 1, 1]
+    ///     [1, 2, 1]
+    ///     [1, 1, 3]
+    ///
+    /// This can be done efficiently by adding the sum to each element as in the
+    /// external MDS case but adding an additional copy of the final state
+    /// element
+    fn internal_mds<C: ConstraintSystem<ScalarField>>(
+        &mut self,
+        cs: &mut C,
+    ) -> Result<(), PlonkError> {
+        let mut coeffs = [ScalarField::one(); GATE_WIDTH];
+        let in_wires = self.state.clone();
+
+        // The first two elements of the state
+        for state_elem in self.state[..SPONGE_WIDTH - 1].iter_mut() {
+            let lc_wires = [*state_elem, in_wires[0], in_wires[1], in_wires[2]];
+            *state_elem = cs.lc(&lc_wires, &coeffs)?;
         }
 
-        self.state = new_state;
+        // The last element of the state requires an additional copy of itself
+        coeffs[0] = ScalarField::from(2u8);
+        let lc_wires = [
+            self.state[SPONGE_WIDTH - 1],
+            in_wires[0],
+            in_wires[1],
+            in_wires[2],
+        ];
+        self.state[SPONGE_WIDTH - 1] = cs.lc(&lc_wires, &coeffs)?;
+
+        Ok(())
     }
 }
 
 #[cfg(test)]
-mod single_prover_test {
-    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
-    use circuit_types::traits::CircuitBaseType;
+mod test {
+    use circuit_types::{traits::CircuitBaseType, PlonkCircuit};
+    use constants::Scalar;
     use itertools::Itertools;
-    use merlin::HashChainTranscript as Transcript;
-    use mpc_bulletproof::{r1cs::Prover, PedersenGens};
-    use mpc_stark::algebra::scalar::Scalar;
-    use rand::{rngs::OsRng, RngCore};
-    use renegade_crypto::hash::default_poseidon_params;
+    use mpc_relation::{Circuit, ConstraintSystem};
+    use rand::thread_rng;
+    use renegade_crypto::hash::compute_poseidon_hash;
 
-    use super::PoseidonHashGadget;
+    use crate::zk_gadgets::poseidon::PoseidonHashGadget;
 
+    /// Tests absorbing a series of elements into the hasher and comparing to
+    /// the hasher in `renegade-crypto`
     #[test]
-    fn test_single_prover_hash() {
-        // Sample random values to hash
-        let mut rng = OsRng {};
-        let n = 15;
-        let random_elems = (0..n).map(|_| rng.next_u64()).collect_vec();
+    fn test_sponge() {
+        const N: usize = 100;
+        let mut rng = thread_rng();
+        let values = (0..N).map(|_| Scalar::random(&mut rng)).collect_vec();
 
-        // Compute the hash via Arkworks for expected result
-        let arkworks_params = default_poseidon_params();
-        let mut arkworks_hasher = PoseidonSponge::new(&arkworks_params);
+        let expected = compute_poseidon_hash(&values);
 
-        for elem in random_elems.iter() {
-            arkworks_hasher.absorb(&Scalar::Field::from(*elem as i128));
-        }
+        // Constrain the gadget result
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let mut gadget = PoseidonHashGadget::new(cs.zero());
 
-        let expected_result: Scalar::Field =
-            arkworks_hasher.squeeze_field_elements(1 /* num_elements */)[0];
-
-        // Build a constraint system
-        let pc_gens = PedersenGens::default();
-        let mut transcript = Transcript::new(b"test");
-        let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-        let preimage_vars = random_elems
-            .into_iter()
-            .map(|elem| elem.commit_public(&mut prover))
+        // Allocate the values in the constraint system
+        let input_vars = values
+            .iter()
+            .map(|v| v.create_witness(&mut cs))
             .collect_vec();
-        let expected_out_var = Scalar::from(expected_result).commit_public(&mut prover);
+        let output_var = expected.create_public_var(&mut cs);
 
-        let mut hasher = PoseidonHashGadget::new(default_poseidon_params());
-        hasher
-            .hash(&preimage_vars, expected_out_var, &mut prover)
-            .unwrap();
+        gadget.hash(&input_vars, output_var, &mut cs).unwrap();
 
-        assert!(prover.constraints_satisfied());
-    }
-
-    /// Tests the case in which the pre-image is not correct
-    #[test]
-    fn test_single_prover_hash_failure() {
-        let mut rng = OsRng {};
-        let n = 15;
-        let random_elems = (0..n).map(|_| Scalar::random(&mut rng)).collect_vec();
-        let random_expected = Scalar::random(&mut rng);
-
-        // Build a constraint system
-        let pc_gens = PedersenGens::default();
-        let mut transcript = Transcript::new(b"test");
-        let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-        let preimage_vars = random_elems
-            .into_iter()
-            .map(|elem| elem.commit_public(&mut prover))
-            .collect_vec();
-        let expected_out_var = random_expected.commit_public(&mut prover);
-
-        let mut hasher = PoseidonHashGadget::new(default_poseidon_params());
-        hasher
-            .hash(&preimage_vars, expected_out_var, &mut prover)
-            .unwrap();
-
-        assert!(!prover.constraints_satisfied());
+        // Check that the constraints are satisfied
+        assert!(cs.check_circuit_satisfiability(&[expected.inner()]).is_ok());
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the Poseidon gadget to work over the new `mpc-plonk` system. This gadget also works for both single and multiprovers. I added a test for coherence with the sponge defined in `renegade-crypto`.

### Testing
- Unit tests pass