### PR TITLE
circuit-types: Add boolean type and `BoolVar`, `AuthenticatedBool` analogs

### DIFF
--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -4,8 +4,8 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar};
-use mpc_relation::Variable;
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 

--- a/circuit-types/src/fee.rs
+++ b/circuit-types/src/fee.rs
@@ -4,8 +4,8 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar};
-use mpc_relation::Variable;
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 

--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -4,9 +4,9 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar};
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use ed25519_dalek::PublicKey as DalekKey;
-use mpc_relation::Variable;
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::get_scalar_field_modulus;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -23,7 +23,8 @@ use ark_ff::BigInt;
 use ark_mpc::MpcFabric;
 use bigdecimal::Num;
 use constants::{
-    Scalar, ScalarField, SystemCurveGroup, MAX_BALANCES, MAX_FEES, MAX_ORDERS, MERKLE_HEIGHT,
+    AuthenticatedScalar, Scalar, ScalarField, SystemCurveGroup, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
+    MERKLE_HEIGHT,
 };
 use fixed_point::DEFAULT_FP_PRECISION;
 use merkle::MerkleOpening;
@@ -68,6 +69,14 @@ pub type SizedWalletShare = WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 /// A type alias for the Merkle opening with system-wide default generics
 /// attached
 pub type SizedMerkleOpening = MerkleOpening<MERKLE_HEIGHT>;
+
+// --------------------
+// | Type Definitions |
+// --------------------
+
+/// A boolean allocated in an MPC network
+#[derive(Clone, Debug)]
+pub struct AuthenticatedBool(AuthenticatedScalar);
 
 // -----------
 // | Helpers |

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -8,7 +8,7 @@
 mod test {
     use ark_mpc::PARTY0;
     use circuit_macros::circuit_type;
-    use constants::{AuthenticatedScalar, Scalar};
+    use constants::{AuthenticatedScalar, Scalar, ScalarField};
     use mpc_plonk::multiprover::proof_system::MpcPlonkCircuit;
     use mpc_relation::{ConstraintSystem, PlonkCircuit, Variable};
     use std::ops::Add;

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -2,8 +2,8 @@
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar};
-use mpc_relation::Variable;
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 
 use crate::{

--- a/circuit-types/src/merkle.rs
+++ b/circuit-types/src/merkle.rs
@@ -3,8 +3,8 @@
 #![allow(missing_docs)]
 
 use circuit_macros::circuit_type;
-use constants::Scalar;
-use mpc_relation::Variable;
+use constants::{Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -2,8 +2,8 @@
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar};
-use mpc_relation::Variable;
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/transfers.rs
+++ b/circuit-types/src/transfers.rs
@@ -6,8 +6,8 @@
 // ----------------------
 
 use circuit_macros::circuit_type;
-use constants::Scalar;
-use mpc_relation::Variable;
+use constants::{Scalar, ScalarField};
+use mpc_relation::{ConstraintSystem, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/wallet.rs
+++ b/circuit-types/src/wallet.rs
@@ -5,9 +5,9 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::Scalar;
+use constants::{Scalar, ScalarField};
 use itertools::Itertools;
-use mpc_relation::Variable;
+use mpc_relation::{ConstraintSystem, Variable};
 use serde::{Deserialize, Serialize};
 
 use crate::{


### PR DESCRIPTION
### Purpose
This PR introduces a boolean type to MPC and ZK circuits. This necessitates that variable types have a reference to the underlying constraint system when they are deserialized, so that they may apply constraints on their underlying variables. For the boolean type this adds a constraint that the value is boolean (i.e. $x(1 -x) \stackrel{?}{=} 0$)

### Testing
- Unit tests pass