### PR TITLE
circuit-types, circuit-macros: Remove `ConstraintSystem` use

### DIFF
--- a/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
+++ b/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
@@ -170,7 +170,7 @@ fn build_from_vars(self_struct: &ItemStruct) -> TokenStream2 {
     }
 
     parse_quote! {
-        fn #method_name<I: Iterator<Item = #from_type>, C: ConstraintSystem<ScalarField>>(i: &mut I, cs: &mut C) -> Self {
+        fn #method_name<I: Iterator<Item = #from_type>, C: Circuit<ScalarField>>(i: &mut I, cs: &mut C) -> Self {
             Self {
                 #fields_expr
             }

--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -5,7 +5,7 @@ use std::ops::Add;
 
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 

--- a/circuit-types/src/fee.rs
+++ b/circuit-types/src/fee.rs
@@ -5,7 +5,7 @@ use std::ops::Add;
 
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 

--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -6,7 +6,7 @@ use std::ops::Add;
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use ed25519_dalek::PublicKey as DalekKey;
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::get_scalar_field_modulus;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -159,9 +159,6 @@ where
 
 /// Groups helpers that operate on native types; which correspond to circuitry
 /// defined in this library
-///
-/// For example; when computing witnesses, wallet commitments, note commitments,
-/// nullifiers, etc are all useful helpers
 pub mod native_helpers {
     use constants::Scalar;
     use itertools::Itertools;

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -10,7 +10,7 @@ mod test {
     use circuit_macros::circuit_type;
     use constants::{AuthenticatedScalar, Scalar, ScalarField};
     use mpc_plonk::multiprover::proof_system::MpcPlonkCircuit;
-    use mpc_relation::{ConstraintSystem, PlonkCircuit, Variable};
+    use mpc_relation::{traits::Circuit, PlonkCircuit, Variable};
     use std::ops::Add;
     use test_helpers::mpc_network::execute_mock_mpc;
 

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -3,7 +3,7 @@
 
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 
 use crate::{

--- a/circuit-types/src/merkle.rs
+++ b/circuit-types/src/merkle.rs
@@ -4,7 +4,7 @@
 
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -3,7 +3,7 @@
 
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -23,14 +23,14 @@ use futures::future::join_all;
 use itertools::Itertools;
 use mpc_plonk::{
     errors::PlonkError,
-    multiprover::proof_system::{CollaborativeProof, MpcCircuit, MultiproverPlonkKzgSnark},
+    multiprover::proof_system::{CollaborativeProof, MultiproverPlonkKzgSnark},
     proof_system::{
         structs::{Proof, ProvingKey, VerifyingKey},
         PlonkKzgSnark, UniversalSNARK,
     },
     transcript::SolidityTranscript,
 };
-use mpc_relation::{constraint_system::Circuit, BoolVar, ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, BoolVar, Variable};
 use num_bigint::BigUint;
 use rand::thread_rng;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint, scalar_to_u64};
@@ -117,7 +117,7 @@ pub trait CircuitVarType: Clone {
     /// Convert to a collection of serialized variables for the type
     fn to_vars(&self) -> Vec<Variable>;
     /// Convert from an iterable of variables representing the serialized type
-    fn from_vars<I: Iterator<Item = Variable>, C: ConstraintSystem<ScalarField>>(
+    fn from_vars<I: Iterator<Item = Variable>, C: Circuit<ScalarField>>(
         i: &mut I,
         cs: &mut C,
     ) -> Self;
@@ -444,7 +444,7 @@ impl CircuitVarType for Variable {
         vec![*self]
     }
 
-    fn from_vars<I: Iterator<Item = Variable>, C: ConstraintSystem<ScalarField>>(
+    fn from_vars<I: Iterator<Item = Variable>, C: Circuit<ScalarField>>(
         i: &mut I,
         _cs: &mut C,
     ) -> Self {
@@ -459,7 +459,7 @@ impl CircuitVarType for BoolVar {
         vec![(*self).into()]
     }
 
-    fn from_vars<I: Iterator<Item = Variable>, C: ConstraintSystem<ScalarField>>(
+    fn from_vars<I: Iterator<Item = Variable>, C: Circuit<ScalarField>>(
         i: &mut I,
         cs: &mut C,
     ) -> Self {
@@ -473,7 +473,7 @@ impl CircuitVarType for BoolVar {
 impl CircuitVarType for () {
     type BaseType = ();
 
-    fn from_vars<I: Iterator<Item = Variable>, C: ConstraintSystem<ScalarField>>(
+    fn from_vars<I: Iterator<Item = Variable>, C: Circuit<ScalarField>>(
         _: &mut I,
         _cs: &mut C,
     ) -> Self {
@@ -491,7 +491,7 @@ impl<const N: usize, T: CircuitVarType> CircuitVarType for [T; N] {
         self.iter().flat_map(|x| x.to_vars()).collect()
     }
 
-    fn from_vars<I: Iterator<Item = Variable>, C: ConstraintSystem<ScalarField>>(
+    fn from_vars<I: Iterator<Item = Variable>, C: Circuit<ScalarField>>(
         i: &mut I,
         cs: &mut C,
     ) -> Self {

--- a/circuit-types/src/transfers.rs
+++ b/circuit-types/src/transfers.rs
@@ -7,7 +7,7 @@
 
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};

--- a/circuit-types/src/wallet.rs
+++ b/circuit-types/src/wallet.rs
@@ -7,7 +7,7 @@ use std::ops::Add;
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
 use itertools::Itertools;
-use mpc_relation::{ConstraintSystem, Variable};
+use mpc_relation::{traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -11,8 +11,7 @@ use bitvec::{order::Lsb0, slice::BitSlice};
 use circuit_types::{traits::CircuitVarType, Fabric, MpcPlonkCircuit, PlonkCircuit};
 use constants::{Scalar, ScalarField};
 use itertools::Itertools;
-use mpc_plonk::multiprover::proof_system::MpcCircuit;
-use mpc_relation::{errors::CircuitError, BoolVar, ConstraintSystem, Variable};
+use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar, Variable};
 
 use crate::mpc_gadgets::bits::to_bits_le;
 
@@ -86,8 +85,7 @@ mod bits_test {
         MpcPlonkCircuit, PlonkCircuit,
     };
     use constants::Scalar;
-    use mpc_plonk::multiprover::proof_system::MpcCircuit;
-    use mpc_relation::{Circuit, ConstraintSystem};
+    use mpc_relation::traits::Circuit;
     use rand::{thread_rng, RngCore};
     use renegade_crypto::fields::{bigint_to_scalar_bits, scalar_to_bigint};
     use test_helpers::mpc_network::execute_mock_mpc;
@@ -148,7 +146,7 @@ mod bits_test {
                     cs.enforce_constant(bit, expected.inner()).unwrap();
                 }
 
-                cs.check_circuit_satisfiability(&[]).await
+                cs.check_circuit_satisfiability(&[])
             }
         })
         .await;

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -2,7 +2,7 @@
 
 use circuit_types::traits::CircuitVarType;
 use constants::ScalarField;
-use mpc_relation::{errors::CircuitError, BoolVar, ConstraintSystem};
+use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar};
 
 /// Implements the control flow gate if selector { a } else { b }
 pub struct CondSelectGadget;
@@ -11,7 +11,7 @@ impl CondSelectGadget {
     pub fn select<V, C>(a: V, b: V, selector: BoolVar, cs: &mut C) -> Result<V, CircuitError>
     where
         V: CircuitVarType,
-        C: ConstraintSystem<ScalarField>,
+        C: Circuit<ScalarField>,
     {
         let a_vars = a.to_vars();
         let b_vars = b.to_vars();
@@ -44,7 +44,7 @@ impl CondSelectVectorGadget {
     ) -> Result<Vec<V>, CircuitError>
     where
         V: CircuitVarType,
-        C: ConstraintSystem<ScalarField>,
+        C: Circuit<ScalarField>,
     {
         assert_eq!(a.len(), b.len(), "a and b must be of equal length");
 
@@ -70,8 +70,7 @@ mod cond_select_test {
         MpcPlonkCircuit, PlonkCircuit,
     };
     use constants::Scalar;
-    use mpc_plonk::multiprover::proof_system::MpcCircuit;
-    use mpc_relation::{Circuit, ConstraintSystem};
+    use mpc_relation::traits::Circuit;
     use rand::{rngs::OsRng, thread_rng};
     use test_helpers::mpc_network::execute_mock_mpc;
 
@@ -135,7 +134,7 @@ mod cond_select_test {
             let res = CondSelectGadget::select(a_var, b_var, sel, &mut cs).unwrap();
             cs.enforce_equal(res, b_var).unwrap();
 
-            cs.check_circuit_satisfiability(&[a, b]).await
+            cs.check_circuit_satisfiability(&[a, b])
         })
         .await;
 


### PR DESCRIPTION
### Purpose
This PR removes the use of `ConstraintSystem` in the `circuit-types` and `circuit-macros` crates following changes to the upstream to merge `ConstraintSystem` and `Circuit`.

### Testing
- All tests pass