### PR TITLE
circuits: zk-gadgets: merkle: Refactor and add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,7 +4041,6 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4085,7 +4084,6 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4921,7 +4919,6 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4953,7 +4950,6 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/circuit-types/src/merkle.rs
+++ b/circuit-types/src/merkle.rs
@@ -26,21 +26,22 @@ pub struct MerkleOpening<const HEIGHT: usize> {
         deserialize_with = "deserialize_array"
     )]
     pub elems: [Scalar; HEIGHT],
-    /// The opening indices from the leaf node to the root, each value is zero
-    /// or one: 0 indicating that the node in the opening at index i is a
-    /// left hand child of its parent, 1 indicating it's a right hand child
+    /// The opening indices from the leaf node to the root, each value is a bool
+    /// representing whether the current node is a left child
+    ///
+    /// I.e. `true` means that it is a right child, `false` a left
     #[serde(
         serialize_with = "serialize_array",
         deserialize_with = "deserialize_array"
     )]
-    pub indices: [Scalar; HEIGHT],
+    pub indices: [bool; HEIGHT],
 }
 
 impl<const HEIGHT: usize> Default for MerkleOpening<HEIGHT> {
     fn default() -> Self {
         Self {
             elems: [Scalar::zero(); HEIGHT],
-            indices: [Scalar::zero(); HEIGHT],
+            indices: [false; HEIGHT],
         }
     }
 }

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -1,14 +1,10 @@
 //! Groups gadgets around computing Merkle entries and proving Merkle openings
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-use circuit_types::{merkle::MerkleOpeningVar, traits::LinearCombinationLike};
-use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem},
-    r1cs_mpc::R1CSError,
-};
-use mpc_stark::algebra::scalar::Scalar;
-use renegade_crypto::hash::default_poseidon_params;
-use std::ops::Neg;
+use ark_ff::One;
+use circuit_types::merkle::MerkleOpeningVar;
+use constants::ScalarField;
+use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar, Variable};
 
 use super::poseidon::PoseidonHashGadget;
 
@@ -18,85 +14,56 @@ pub struct PoseidonMerkleHashGadget<const HEIGHT: usize> {}
 impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
     /// Compute the root of the tree given the leaf node and the path of
     /// sister nodes leading to the root
-    pub fn compute_root<L1, L2, CS>(
-        leaf_node: Vec<L1>,
-        opening: MerkleOpeningVar<L2, HEIGHT>,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L1: LinearCombinationLike,
-        L2: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn compute_root<C: Circuit<ScalarField>>(
+        leaf_node: Vec<Variable>,
+        opening: MerkleOpeningVar<HEIGHT>,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // Hash the leaf_node into a field element
-        let leaf_hash: LinearCombination = Self::leaf_hash(&leaf_node, cs)?;
+        let leaf_hash = Self::leaf_hash(&leaf_node, cs)?;
         Self::compute_root_prehashed(leaf_hash, opening, cs)
     }
 
     /// Compute the root given an already hashed leaf, i.e. do not hash a leaf
     /// buffer first
-    pub fn compute_root_prehashed<L1, L2, CS>(
-        leaf_node: L1,
-        opening: MerkleOpeningVar<L2, HEIGHT>,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L1: LinearCombinationLike,
-        L2: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn compute_root_prehashed<C: Circuit<ScalarField>>(
+        leaf_node: Variable,
+        opening: MerkleOpeningVar<HEIGHT>,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // Hash the leaf_node into a field element
-        let mut current_hash: LinearCombination = leaf_node.into();
+        let mut current_hash = leaf_node;
         for (path_elem, lr_select) in opening.elems.into_iter().zip(opening.indices.into_iter()) {
             // Select the left and right hand sides based on whether this node in the
             // opening represents the left or right hand child of its parent
-            let (lhs, rhs) = Self::select_left_right(
-                current_hash.clone(),
-                path_elem.into(),
-                lr_select.into(),
-                cs,
-            );
-            current_hash = Self::hash_internal_nodes(&lhs, &rhs, cs)?;
+            let (lhs, rhs) = Self::select_left_right(current_hash, path_elem, lr_select, cs)?;
+            current_hash = Self::hash_internal_nodes(lhs, rhs, cs)?;
         }
 
         Ok(current_hash)
     }
 
     /// Compute the root and constrain it to an expected value
-    pub fn compute_and_constrain_root<L1, L2, CS>(
-        leaf_node: Vec<L1>,
-        opening: MerkleOpeningVar<L2, HEIGHT>,
-        expected_root: L1,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>
-    where
-        L1: LinearCombinationLike,
-        L2: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn compute_and_constrain_root<C: Circuit<ScalarField>>(
+        leaf_node: Vec<Variable>,
+        opening: MerkleOpeningVar<HEIGHT>,
+        expected_root: Variable,
+        cs: &mut C,
+    ) -> Result<(), CircuitError> {
         let root = Self::compute_root(leaf_node, opening, cs)?;
-        cs.constrain(expected_root.into() - root);
-
-        Ok(())
+        cs.enforce_equal(expected_root, root)
     }
 
     /// Compute the root from a prehashed leaf and constrain it to an expected
     /// value
-    pub fn compute_and_constrain_root_prehashed<L1, L2, CS>(
-        leaf_node: L1,
-        opening: MerkleOpeningVar<L2, HEIGHT>,
-        expected_root: L1,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError>
-    where
-        L1: LinearCombinationLike,
-        L2: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn compute_and_constrain_root_prehashed<C: Circuit<ScalarField>>(
+        leaf_node: Variable,
+        opening: MerkleOpeningVar<HEIGHT>,
+        expected_root: Variable,
+        cs: &mut C,
+    ) -> Result<(), CircuitError> {
         let root = Self::compute_root_prehashed(leaf_node, opening, cs)?;
-        cs.constrain(expected_root.into() - root);
-
-        Ok(())
+        cs.enforce_equal(expected_root, root)
     }
 
     /// Selects whether to place the current hash on the left or right hand
@@ -104,47 +71,35 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
     ///
     /// This is based on whether the current hash represents the left or right
     /// child of its parent to be computed
-    fn select_left_right<L, CS>(
-        current_hash: L,
-        sister_node: L,
-        lr_select: L,
-        cs: &mut CS,
-    ) -> (LinearCombination, LinearCombination)
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        let current_hash_lc = current_hash.into();
-        let sister_node_lc = sister_node.into();
-        let lr_select_lc = lr_select.into();
+    fn select_left_right<C: Circuit<ScalarField>>(
+        current_hash: Variable,
+        sister_node: Variable,
+        lr_select: BoolVar,
+        cs: &mut C,
+    ) -> Result<(Variable, Variable), CircuitError> {
+        // lr_select is `true` if the current hash is the right child of its parent
+        let left_child = cs.mux(lr_select, sister_node, current_hash)?;
 
-        // If lr_select == 0 { current_hash } else { sister_node }
-        //      ==> current_hash * (1 - lr_select) + sister_node * lr_select
-        let (_, _, left_child_term1) = cs.multiply(
-            current_hash_lc.clone(),
-            lr_select_lc.clone().neg() + Scalar::one(),
-        );
-        let (_, _, left_child_term2) = cs.multiply(sister_node_lc.clone(), lr_select_lc);
+        // right_child = current_hash + sister_node - left_child
+        let one = ScalarField::one();
+        let neg_one = -one;
+        let zero_var = cs.zero();
 
-        let left_child = left_child_term1 + left_child_term2;
+        let right_child = cs.lc(
+            &[current_hash, sister_node, left_child, zero_var],
+            &[one, one, neg_one, one],
+        )?;
 
-        // If lr_select == 0 { sister_node } else { current_hash }
-        // We can avoid an extra multiplication here, because we know the lhs term, the
-        // rhs term is equal to the other term, which can be computed by
-        // addition alone      rhs = a + b - lhs
-        let right_child = current_hash_lc + sister_node_lc - left_child.clone();
-        (left_child, right_child)
+        Ok((left_child, right_child))
     }
 
     /// Hash the value at the leaf into a bulletproof constraint value
-    fn leaf_hash<L, CS>(values: &[L], cs: &mut CS) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    fn leaf_hash<C: Circuit<ScalarField>>(
+        values: &[Variable],
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // Build a sponge hasher
-        let hasher_params = default_poseidon_params();
-        let mut hasher = PoseidonHashGadget::new(hasher_params);
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
         hasher.batch_absorb(values, cs)?;
 
         hasher.squeeze(cs)
@@ -152,14 +107,13 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
 
     /// Hash two internal nodes in the (binary) Merkle tree, giving the tree
     /// value at the parent node
-    fn hash_internal_nodes<CS: RandomizableConstraintSystem>(
-        left: &LinearCombination,
-        right: &LinearCombination,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError> {
-        let hasher_params = default_poseidon_params();
-        let mut hasher = PoseidonHashGadget::new(hasher_params);
-        hasher.batch_absorb(&[left.clone(), right.clone()], cs)?;
+    fn hash_internal_nodes<C: Circuit<ScalarField>>(
+        left: Variable,
+        right: Variable,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.batch_absorb(&[left, right], cs)?;
 
         hasher.squeeze(cs)
     }
@@ -167,38 +121,102 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
 
 #[cfg(test)]
 pub(crate) mod merkle_test {
+    use std::{borrow::Borrow, iter};
+
     use ark_crypto_primitives::{
-        crh::{
-            poseidon::{TwoToOneCRH, CRH},
-            CRHScheme,
-        },
+        crh::{CRHScheme, TwoToOneCRHScheme},
         merkle_tree::{Config, IdentityDigestConverter, MerkleTree},
     };
-    use circuit_types::{merkle::MerkleOpening, traits::CircuitBaseType};
+    use circuit_types::{merkle::MerkleOpening, scalar, traits::CircuitBaseType, PlonkCircuit};
+    use constants::{Scalar, ScalarField};
     use itertools::Itertools;
-    use merlin::HashChainTranscript as Transcript;
-    use mpc_bulletproof::{r1cs::Prover, PedersenGens};
-    use mpc_stark::algebra::scalar::Scalar;
-    use rand::{thread_rng, Rng};
-    use renegade_crypto::hash::default_poseidon_params;
+    use mpc_relation::traits::Circuit;
+    use rand::{distributions::uniform::SampleRange, thread_rng, Rng};
+    use renegade_crypto::hash::compute_poseidon_hash;
 
-    use crate::zk_gadgets::merkle::PoseidonMerkleHashGadget;
+    use crate::{
+        test_helpers::random_field_elements, zk_gadgets::merkle::PoseidonMerkleHashGadget,
+    };
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// The height of the tree to test against
+    const TREE_HEIGHT: usize = 10;
+    /// The number of scalars in a leaf value
+    const LEAF_SIZE: usize = 6;
+
+    /// A dummy hasher to build an arkworks Merkle tree on top of
+    struct Poseidon2Hasher;
+    impl CRHScheme for Poseidon2Hasher {
+        type Input = Vec<ScalarField>;
+        type Output = ScalarField;
+        type Parameters = ();
+
+        fn setup<R: Rng>(_: &mut R) -> Result<Self::Parameters, ark_crypto_primitives::Error> {
+            Ok(())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            _parameters: &Self::Parameters,
+            input: T,
+        ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+            let scalars = input.borrow().iter().map(|s| scalar!(*s)).collect_vec();
+            let res = compute_poseidon_hash(&scalars);
+
+            Ok(res.inner())
+        }
+    }
+
+    impl TwoToOneCRHScheme for Poseidon2Hasher {
+        type Input = ScalarField;
+        type Output = ScalarField;
+        type Parameters = ();
+
+        fn setup<R: Rng>(_: &mut R) -> Result<Self::Parameters, ark_crypto_primitives::Error> {
+            Ok(())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            _parameters: &Self::Parameters,
+            left_input: T,
+            right_input: T,
+        ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+            let res = compute_poseidon_hash(&[
+                scalar!(*left_input.borrow()),
+                scalar!(*right_input.borrow()),
+            ]);
+
+            Ok(res.inner())
+        }
+
+        fn compress<T: Borrow<Self::Output>>(
+            parameters: &Self::Parameters,
+            left_input: T,
+            right_input: T,
+        ) -> Result<Self::Output, ark_crypto_primitives::Error> {
+            <Self as TwoToOneCRHScheme>::evaluate(parameters, left_input, right_input)
+        }
+    }
 
     struct MerkleConfig {}
     impl Config for MerkleConfig {
-        type Leaf = [Scalar::Field];
-        type LeafDigest = Scalar::Field;
-        type InnerDigest = Scalar::Field;
+        type Leaf = Vec<ScalarField>;
+        type LeafDigest = ScalarField;
+        type InnerDigest = ScalarField;
 
-        type LeafHash = CRH<Scalar::Field>;
-        type TwoToOneHash = TwoToOneCRH<Scalar::Field>;
+        type LeafHash = Poseidon2Hasher;
+        type TwoToOneHash = Poseidon2Hasher;
         type LeafInnerDigestConverter = IdentityDigestConverter<Scalar::Field>;
     }
 
-    /// Create a random sequence of field elements
-    fn random_field_elements(n: usize) -> Vec<Scalar> {
-        let mut rng = thread_rng();
-        (0..n).map(|_| Scalar::random(&mut rng)).collect_vec()
+    /// Generate random leaf data
+    fn random_leaf_data() -> Vec<ScalarField> {
+        random_field_elements(LEAF_SIZE)
+            .iter()
+            .map(Scalar::inner)
+            .collect_vec()
     }
 
     /// Get the opening indices from the index, this can be done by
@@ -207,169 +225,117 @@ pub(crate) mod merkle_test {
     ///
     /// The tree indices from leaf to root are exactly the LSB decomposition of
     /// the scalar
-    pub(crate) fn get_opening_indices<const HEIGHT: usize>(
-        mut leaf_index: usize,
-    ) -> [Scalar; HEIGHT]
+    pub(crate) fn get_opening_indices<const HEIGHT: usize>(mut leaf_index: usize) -> [bool; HEIGHT]
     where
         [(); HEIGHT]: Sized,
     {
         let mut res = Vec::with_capacity(HEIGHT);
         for _ in 0..HEIGHT {
-            res.push(match leaf_index % 2 {
-                val @ 0..=1 => Scalar::from(val as u64),
-                _ => unreachable!("impossible evaluation mod 2"),
-            });
-
+            res.push(leaf_index % 2 == 1);
             leaf_index >>= 1;
         }
 
         res.try_into().unwrap()
     }
 
-    #[test]
+    /// Fill an arkworks tree, sample a random index, and generate a proof of
+    /// opening for the given index
+    ///
+    /// Returns:
+    ///     - The leaf data hashed into the tree
+    ///     - The expected root of the tree
+    ///     - The opening for the sampled index
     #[allow(non_upper_case_globals)]
-    fn test_against_arkworks() {
-        // A random input at the leaf
-        const leaf_size: usize = 6;
-        let num_leaves = 32;
-        const TREE_HEIGHT: usize = 10;
+    fn build_random_opening() -> (Vec<Scalar>, Scalar, MerkleOpening<TREE_HEIGHT>) {
+        // Fill the tree with a random number of leaves
+        let mut rng = thread_rng();
+        let num_leaves = (0..2usize.pow(TREE_HEIGHT as u32)).sample_single(&mut rng);
 
-        // Build a random Merkle tree via arkworks
-        let arkworks_params = default_poseidon_params();
-
-        let mut merkle_tree =
-            MerkleTree::<MerkleConfig>::blank(&arkworks_params, &arkworks_params, TREE_HEIGHT)
-                .unwrap();
-
-        let mut ark_leaf_data = Vec::with_capacity(num_leaves);
+        let mut ark_tree = MerkleTree::<MerkleConfig>::blank(&(), &(), TREE_HEIGHT + 1).unwrap();
         for i in 0..num_leaves {
-            let leaf_data: [Scalar::Field; leaf_size] = (*random_field_elements(leaf_size))
-                .iter()
-                .map(|s| s.inner())
-                .collect_vec()
-                .try_into()
-                .unwrap();
-
-            merkle_tree.update(i, &leaf_data).unwrap();
-            ark_leaf_data.push(leaf_data);
+            let leaf_data = random_leaf_data();
+            ark_tree.update(i, &leaf_data).unwrap();
         }
 
-        // Generate a proof for a random index and prove it in the native gadget
+        // Select an index at which to modify the opening, and generate fresh leaf data
         let random_index = thread_rng().gen_range(0..num_leaves);
-        let expected_root = merkle_tree.root();
-        let opening = merkle_tree.generate_proof(random_index).unwrap();
-        let mut opening_scalars: Vec<Scalar::Field> = opening
+        let new_leaf = random_leaf_data();
+        ark_tree.update(random_index, &new_leaf).unwrap();
+
+        // Generate a proof for a random index and prove it in the native
+        let expected_root = scalar!(ark_tree.root());
+        let opening = ark_tree.generate_proof(random_index).unwrap();
+
+        // Reverse the opening (bottom to top) and prepend the leaf sibling's hash
+        let opening_scalars = opening
             .auth_path
             .into_iter()
-            .rev() // Path comes in reverse
-            .collect_vec();
-
-        // Hash the sister leaf of the given scalar
-        let sister_leaf_data = if random_index % 2 == 0 {
-            ark_leaf_data[random_index + 1]
-        } else {
-            ark_leaf_data[random_index - 1]
-        };
-        let sister_leaf_hash: Scalar::Field =
-            CRH::evaluate(&arkworks_params, sister_leaf_data).unwrap();
-
-        opening_scalars.insert(0, sister_leaf_hash);
-
-        // Convert the leaf data for the given leaf to scalars
-        let leaf_data = ark_leaf_data[random_index];
-
-        // Build a constraint system
-        let pc_gens = PedersenGens::default();
-        let mut transcript = Transcript::new(b"test");
-        let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-        let leaf_vars = leaf_data
-            .into_iter()
-            .map(Scalar::from)
-            .map(|x| x.commit_public(&mut prover))
-            .collect_vec();
-
-        let opening_var = MerkleOpening {
-            elems: opening_scalars
-                .into_iter()
-                .map(Scalar::from)
-                .collect_vec()
-                .try_into()
-                .unwrap(),
-            indices: get_opening_indices::<{ TREE_HEIGHT - 1 }>(random_index),
-        }
-        .commit_public(&mut prover);
-        let expected_root_var = Scalar::from(expected_root).commit_public(&mut prover);
-
-        // Apply the constraints
-        PoseidonMerkleHashGadget::compute_and_constrain_root(
-            leaf_vars,
-            opening_var,
-            expected_root_var,
-            &mut prover,
-        )
-        .unwrap();
-        assert!(prover.constraints_satisfied());
-    }
-
-    #[test]
-    #[allow(non_upper_case_globals)]
-    fn test_invalid_witness() {
-        // A random input at the leaf
-        let mut rng = thread_rng();
-        const leaf_size: usize = 6;
-        const TREE_HEIGHT: usize = 10;
-
-        let leaf_data: [Scalar::Field; leaf_size] = (0..leaf_size)
-            .map(|_| Scalar::random(&mut rng))
-            .map(|s| s.inner())
+            .chain(iter::once(opening.leaf_sibling_hash))
+            .map(Scalar::new)
+            .rev()
             .collect_vec()
             .try_into()
             .unwrap();
 
-        // Compute the correct root via Arkworks
-        let arkworks_params = default_poseidon_params();
-        let mut merkle_tree =
-            MerkleTree::<MerkleConfig>::blank(&arkworks_params, &arkworks_params, TREE_HEIGHT)
-                .unwrap();
-        merkle_tree.update(0 /* index */, &leaf_data).unwrap();
+        (
+            new_leaf.into_iter().map(Scalar::new).collect(),
+            expected_root,
+            MerkleOpening {
+                elems: opening_scalars,
+                indices: get_opening_indices::<{ TREE_HEIGHT }>(random_index),
+            },
+        )
+    }
 
-        // Random (incorrect) root
-        let expected_root = Scalar::random(&mut rng);
-        let opening = merkle_tree.generate_proof(0 /* index */).unwrap();
-        let mut opening_scalars: Vec<Scalar::Field> =
-            opening.auth_path.into_iter().rev().collect_vec();
+    // ---------
+    // | Tests |
+    // ---------
 
-        // Add a zero to the opening scalar for the next leaf
-        opening_scalars.insert(0, Scalar::zero().inner());
+    /// Tests our Merkle tree's constraint satisfaction against an Arkworks
+    /// generated opening
+    #[test]
+    fn test_against_arkworks() {
+        // Build a random opening
+        let (leaf_data, expected_root, opening) = build_random_opening();
 
-        // Build a constraint system
-        let pc_gens = PedersenGens::default();
-        let mut transcript = Transcript::new(b"test");
-        let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-        // Apply the constraints
+        // Allocate the leaf data and opening in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
         let leaf_vars = leaf_data
             .into_iter()
-            .map(Scalar::from)
-            .map(|x| x.commit_public(&mut prover))
+            .map(|x| x.create_witness(&mut cs))
             .collect_vec();
-        let opening_scalars = opening_scalars.into_iter().map(Scalar::from).collect_vec();
+        let opening_var = opening.create_witness(&mut cs);
+        let root = expected_root.create_public_var(&mut cs);
 
-        let opening_var = MerkleOpening {
-            elems: opening_scalars.try_into().unwrap(),
-            indices: get_opening_indices::<{ TREE_HEIGHT - 1 }>(0 /* leaf_index */),
-        }
-        .commit_public(&mut prover);
-        let expected_root_var = expected_root.commit_public(&mut prover);
+        // Apply the merkle constraints
+        PoseidonMerkleHashGadget::compute_and_constrain_root(leaf_vars, opening_var, root, &mut cs)
+            .unwrap();
 
-        PoseidonMerkleHashGadget::compute_and_constrain_root(
-            leaf_vars,
-            opening_var,
-            expected_root_var,
-            &mut prover,
-        )
-        .unwrap();
-        assert!(!prover.constraints_satisfied());
+        assert!(cs
+            .check_circuit_satisfiability(&[expected_root.inner()])
+            .is_ok())
+    }
+
+    #[test]
+    fn test_invalid_witness() {
+        // Build a random opening
+        let (leaf_data, expected_root, opening) = build_random_opening();
+
+        // Allocate the leaf data and opening in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let leaf_vars = leaf_data
+            .into_iter()
+            .map(|x| x.create_witness(&mut cs))
+            .collect_vec();
+        let opening_var = opening.create_witness(&mut cs);
+        let root = expected_root.create_public_var(&mut cs);
+
+        // Apply the merkle constraints
+        PoseidonMerkleHashGadget::compute_and_constrain_root(leaf_vars, opening_var, root, &mut cs)
+            .unwrap();
+
+        // Check constraint satisfaction with a different root
+        let rand_root = Scalar::random(&mut thread_rng()).inner();
+        assert!(cs.check_circuit_satisfiability(&[rand_root]).is_err())
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the Merkle tree gadget implementation and adds unit tests for valid and invalid witness cases.

### Testing
- Unit tests pass