### PR TITLE
circuits: zk-gadgets: arithmetic, fixed-point, wallet-operations: Refactor and add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4084,6 +4085,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4919,6 +4921,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4950,6 +4953,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -280,7 +280,7 @@ impl<'de> Deserialize<'de> for FixedPoint {
 // ---------------------------------------------
 
 /// A commitment to a fixed-precision variable
-
+impl Copy for FixedPointVar {}
 impl FixedPointVar {
     /// Evaluate the given fixed point variable in the constraint system and
     /// return the underlying value as a floating point

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -1,21 +1,19 @@
 //! Groups ZK gadgets used as arithmetic primitives in more complicated
 //! computations
 
-use ark_ff::Zero;
-use circuit_types::errors::ProverError;
+use ark_ff::{One, Zero};
+use circuit_types::traits::{CircuitBaseType, CircuitVarType};
+use circuit_types::PlonkCircuit;
+use constants::ScalarField;
+use mpc_relation::errors::CircuitError;
+use mpc_relation::traits::Circuit;
+use mpc_relation::Variable;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
 
-use circuit_types::traits::{LinearCombinationLike, MpcLinearCombinationLike};
-use mpc_bulletproof::r1cs::{LinearCombination, RandomizableConstraintSystem, Variable};
-use mpc_bulletproof::r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, R1CSError};
-use mpc_stark::algebra::scalar::Scalar;
-use mpc_stark::MpcFabric;
 use num_bigint::BigUint;
 use num_integer::Integer;
 
-use super::bits::ToBitsGadget;
-use super::comparators::{EqZeroGadget, LessThanGadget};
-use super::select::CondSelectGadget;
+use super::comparators::LessThanGadget;
 
 // -------------------------
 // | Single Prover Gadgets |
@@ -29,322 +27,67 @@ use super::select::CondSelectGadget;
 pub struct DivRemGadget<const D: usize> {}
 impl<const D: usize> DivRemGadget<D> {
     /// Return (q, r) such that a = bq + r and r < b
-    pub fn div_rem<L, CS>(a: L, b: L, cs: &mut CS) -> (Variable, Variable)
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        let a_lc: LinearCombination = a.into();
-        let b_lc: LinearCombination = b.into();
-
-        // Evaluate to bigint
-        let a_bigint = scalar_to_biguint(&cs.eval(&a_lc));
-        let b_bigint = scalar_to_biguint(&cs.eval(&b_lc));
+    pub fn div_rem(
+        a: Variable,
+        b: Variable,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(Variable, Variable), CircuitError> {
+        let a_bigint = scalar_to_biguint(&a.eval(cs));
+        let b_bigint = scalar_to_biguint(&b.eval(cs));
 
         // Compute the divrem outside of the circuit
-        // Verifier evals all wires to zero -- it only knows commitments
-        // Handle this case explicitly
-        let (q, r) = if b_bigint == BigUint::zero() {
-            (BigUint::zero(), b_bigint)
-        } else {
-            a_bigint.div_rem(&b_bigint)
-        };
+        let (q, r) = a_bigint.div_rem(&b_bigint);
 
-        let q_var = cs.allocate(Some(biguint_to_scalar(&q))).unwrap();
-        let r_var = cs.allocate(Some(biguint_to_scalar(&r))).unwrap();
+        let q_var = biguint_to_scalar(&q).create_witness(cs);
+        let r_var = biguint_to_scalar(&r).create_witness(cs);
 
         // Constrain a == bq + r
-        let (_, _, bq) = cs.multiply(b_lc.clone(), q_var.into());
-        cs.constrain(a_lc - bq - r_var);
+        let one_var = cs.one();
+        let one = ScalarField::one();
+        cs.mul_add_gate(&[b, q_var, r_var, one_var, a], &[one, one])?;
 
         // Constraint r < b
-        LessThanGadget::<D>::constrain_less_than(r_var.into(), b_lc, cs);
-        (q_var, r_var)
+        LessThanGadget::<D>::constrain_less_than(r_var, b, cs)?;
+
+        Ok((q_var, r_var))
     }
 }
 
-/// The inputs to the exp gadget
 /// A gadget to compute exponentiation: x^\alpha
 pub struct ExpGadget {}
 impl ExpGadget {
-    /// Computes a linear combination representing the result of taking x^\alpha
-    ///
-    /// Provides a functional interface for composing this gadget into a larger
-    /// circuit.
-    pub fn exp<L, CS>(x: L, alpha: u64, cs: &mut CS) -> LinearCombination
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        if alpha == 0 {
-            LinearCombination::from(Scalar::one())
-        } else if alpha == 1 {
-            x.into()
-        } else if alpha % 2 == 0 {
-            let recursive_result = ExpGadget::exp(x, alpha / 2, cs);
-            let (_, _, out_var) = cs.multiply(recursive_result.clone(), recursive_result);
-            out_var.into()
-        } else {
-            let x_lc = x.into();
-            let recursive_result = ExpGadget::exp(x_lc.clone(), (alpha - 1) / 2, cs);
-            let (_, _, out_var1) = cs.multiply(recursive_result.clone(), recursive_result);
-            let (_, _, out_var2) = cs.multiply(out_var1.into(), x_lc);
-            out_var2.into()
-        }
-    }
-}
-
-/// An exponentiation gadget on a private exponent; compute x^\alpha
-#[derive(Clone, Debug)]
-pub struct PrivateExpGadget<const ALPHA_BITS: usize> {}
-impl<const ALPHA_BITS: usize> PrivateExpGadget<ALPHA_BITS> {
-    /// Compute x^\alpha where `x` is public and alpha is private
-    pub fn exp_private_fixed_base<L, CS>(
-        x: Scalar,
-        alpha: L,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        // Bit decompose the exponent, this removes the need to check `is_odd` at every
-        // iteration
-        let alpha_bits = ToBitsGadget::<ALPHA_BITS>::to_bits(alpha, cs)?;
-        Self::exp_private_fixed_base_impl::<L, CS>(x, &alpha_bits, cs)
-    }
-
-    /// Compute x^\alpha where both x and alpha are private values
-    pub fn exp_private<L, CS>(x: L, alpha: L, cs: &mut CS) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        // Bit decompose the exponent, this removes the need to check `is_odd` at every
-        // iteration
-        let alpha_bits = ToBitsGadget::<ALPHA_BITS>::to_bits(alpha, cs)?;
-
-        let x_lc: LinearCombination = x.into();
-        Self::exp_private_impl(x_lc, &alpha_bits, cs)
-    }
-
-    /// An implementation helper for fixed base exponentiation that assumes a
-    /// bit decomposition of the exponent is passed in
-    fn exp_private_fixed_base_impl<L, CS>(
-        x: Scalar,
-        alpha_bits: &[Variable],
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        if alpha_bits.is_empty() {
-            return Ok(LinearCombination::from(Scalar::one()));
-        }
-
-        // Check whether all bits are zero
-        let alpha_zero = Self::all_bits_zero(alpha_bits, cs);
-        let is_odd = alpha_bits[0];
-
-        // Recursive call
-        let recursive_result = Self::exp_private_fixed_base_impl::<L, CS>(x, &alpha_bits[1..], cs)?;
-        let (_, _, recursive_doubled) = cs.multiply(recursive_result.clone(), recursive_result);
-
-        // If the value is odd multiply by an extra copy of `x`
-        let recursive_plus_one = x * recursive_doubled;
-
-        // Mux between the two results depending on whether the current exponent is odd
-        // or even
-        let odd_bit_selection: LinearCombination =
-            CondSelectGadget::select(recursive_plus_one, recursive_doubled.into(), is_odd, cs);
-
-        // Mask the value of the output if alpha is already zero
-        let zero_mask =
-            CondSelectGadget::select(Variable::One().into(), odd_bit_selection, alpha_zero, cs);
-
-        Ok(zero_mask)
-    }
-
-    /// An implementation helper that assumes a bit decomposition of the
-    /// exponent
-    fn exp_private_impl<L, CS>(
-        x: L,
-        alpha_bits: &[Variable],
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        if alpha_bits.is_empty() {
-            return Ok(LinearCombination::from(Scalar::one()));
-        }
-
-        let x_lc: LinearCombination = x.into();
-
-        // Check whether all bits are zero
-        let alpha_zero = Self::all_bits_zero(alpha_bits, cs);
-        let is_odd = alpha_bits[0];
-
-        // Recursive call
-        let recursive_result = Self::exp_private_impl(x_lc.clone(), &alpha_bits[1..], cs)?;
-        let (_, _, recursive_doubled) = cs.multiply(recursive_result.clone(), recursive_result);
-
-        // If the value is odd multiply by an extra copy of `x`
-        let (_, _, recursive_plus_one) = cs.multiply(x_lc, recursive_doubled.into());
-
-        // Mux between the two results depending on whether the current exponent is odd
-        // or even
-        let odd_bit_selection: LinearCombination =
-            CondSelectGadget::select(recursive_plus_one, recursive_doubled, is_odd, cs);
-
-        // Mask the value of the output if alpha is already zero
-        let zero_mask =
-            CondSelectGadget::select(Variable::One().into(), odd_bit_selection, alpha_zero, cs);
-
-        Ok(zero_mask)
-    }
-
-    /// Returns whether all the given bits are zero, it is assumed that these
-    /// values are constrained to be binary elsewhere in the circuit
-    fn all_bits_zero<L, CS>(bits: &[L], cs: &mut CS) -> Variable
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
-        // Add all the bits
-        let mut bit_sum: LinearCombination = Variable::Zero().into();
-        for bit in bits
-            .iter()
-            .map(|bit| Into::<LinearCombination>::into(bit.clone()))
-        {
-            bit_sum += bit;
-        }
-
-        EqZeroGadget::eq_zero(bit_sum, cs)
-    }
-}
-
-// -----------------------
-// | Multiprover Gadgets |
-// -----------------------
-
-/// A multiprover implementation of the exp gadget
-pub struct MultiproverExpGadget;
-impl MultiproverExpGadget {
-    /// Apply the gadget to the input
-    pub fn exp<L, CS>(
-        x: L,
+    /// Computes a representation of x^\alpha
+    pub fn exp<C: Circuit<ScalarField>>(
+        x: Variable,
         alpha: u64,
-        fabric: &MpcFabric,
-        cs: &mut CS,
-    ) -> Result<MpcLinearCombination, ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         if alpha == 0 {
-            Ok(MpcLinearCombination::from_scalar(
-                Scalar::one(),
-                fabric.clone(),
-            ))
+            Ok(cs.one())
         } else if alpha == 1 {
-            Ok(x.into())
+            Ok(x)
         } else if alpha % 2 == 0 {
-            let recursive_result = MultiproverExpGadget::exp(x, alpha / 2, fabric, cs)?;
-            let (_, _, out_var) = cs
-                .multiply(&recursive_result, &recursive_result)
-                .map_err(ProverError::Collaborative)?;
-            Ok(out_var.into())
+            let recursive_result = ExpGadget::exp(x, alpha / 2, cs)?;
+            cs.mul(recursive_result, recursive_result)
         } else {
-            let x_lc = x.into();
-            let recursive_result =
-                MultiproverExpGadget::exp(x_lc.clone(), (alpha - 1) / 2, fabric, cs)?;
-            let (_, _, out_var1) = cs
-                .multiply(&recursive_result, &recursive_result)
-                .map_err(ProverError::Collaborative)?;
-            let (_, _, out_var2) = cs
-                .multiply(&out_var1.into(), &x_lc)
-                .map_err(ProverError::Collaborative)?;
-            Ok(out_var2.into())
+            let recursive_result = ExpGadget::exp(x, (alpha - 1) / 2, cs)?;
+            let double = cs.mul(recursive_result, recursive_result)?;
+            cs.mul(double, x)
         }
     }
 }
 
 #[cfg(test)]
 mod arithmetic_tests {
-    use circuit_types::traits::CircuitBaseType;
-    use merlin::HashChainTranscript as Transcript;
-    use mpc_bulletproof::{
-        r1cs::{ConstraintSystem, Prover, Variable},
-        PedersenGens,
-    };
-    use mpc_stark::algebra::scalar::Scalar;
+    use circuit_types::{traits::CircuitBaseType, PlonkCircuit};
+    use constants::Scalar;
+    use mpc_relation::traits::Circuit;
     use num_bigint::BigUint;
     use num_integer::Integer;
     use rand::{thread_rng, RngCore};
-    use renegade_crypto::fields::{
-        bigint_to_scalar, biguint_to_scalar, get_scalar_field_modulus, scalar_to_biguint,
-    };
+    use renegade_crypto::fields::biguint_to_scalar;
 
-    use super::{DivRemGadget, ExpGadget, PrivateExpGadget};
-
-    /// Tests the single prover exponentiation gadget
-    #[test]
-    fn test_single_prover_exp() {
-        // Generate a random input
-        let mut rng = thread_rng();
-        let alpha = rng.next_u32(); // Compute x^\alpha
-        let random_value = Scalar::random(&mut rng);
-
-        let random_bigint = scalar_to_biguint(&random_value);
-        let expected_res = random_bigint.modpow(&BigUint::from(alpha), &get_scalar_field_modulus());
-        let expected_scalar = bigint_to_scalar(&expected_res.into());
-
-        // Build a constraint system
-        let mut prover_transcript = Transcript::new("test".as_bytes());
-        let pc_gens = PedersenGens::default();
-        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
-
-        // Create the circuit
-        let base_var = random_bigint.commit_public(&mut prover);
-        let res = ExpGadget::exp(base_var, alpha as u64, &mut prover);
-
-        // Check the result
-        assert_eq!(expected_scalar, prover.eval(&res));
-    }
-
-    /// Tests the single prover exponent gadget on a private exponent
-    #[test]
-    fn test_private_exp_gadget() {
-        let mut rng = thread_rng();
-        let alpha_bytes = 8;
-        let mut random_bytes = vec![0u8; alpha_bytes];
-        rng.fill_bytes(&mut random_bytes);
-
-        let alpha = biguint_to_scalar(&BigUint::from_bytes_le(&random_bytes));
-        let x = Scalar::random(&mut rng);
-
-        // Compute the expected exponentiation result
-        let x_bigint = scalar_to_biguint(&x);
-        let alpha_bigint = scalar_to_biguint(&alpha);
-        let expected = x_bigint.modpow(&alpha_bigint, &get_scalar_field_modulus());
-
-        // Build a constraint system
-        let mut prover_transcript = Transcript::new("test".as_bytes());
-        let pc_gens = PedersenGens::default();
-        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
-
-        let x_var = x_bigint.commit_public(&mut prover);
-        let alpha_var = alpha_bigint.commit_public(&mut prover);
-        let res =
-            PrivateExpGadget::<64 /* ALPHA_BITS */>::exp_private(x_var, alpha_var, &mut prover)
-                .unwrap();
-
-        // Check the result
-        assert_eq!(biguint_to_scalar(&expected), prover.eval(&res));
-    }
+    use super::{DivRemGadget, ExpGadget};
 
     /// Tests the div_rem gadget
     #[test]
@@ -355,21 +98,47 @@ mod arithmetic_tests {
         let random_divisor = BigUint::from(rng.next_u32());
 
         let (expected_q, expected_r) = random_dividend.div_rem(&random_divisor);
+        let expected_q = biguint_to_scalar(&expected_q);
+        let expected_r = biguint_to_scalar(&expected_r);
 
         // Build a constraint system
-        let mut prover_transcript = Transcript::new("test".as_bytes());
-        let pc_gens = PedersenGens::default();
-        let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let expected_q_var = expected_q.create_public_var(&mut cs);
+        let expected_r_var = expected_r.create_public_var(&mut cs);
 
         // Allocate the inputs in the constraint system
-        let dividend_var = prover.commit_public(biguint_to_scalar(&random_dividend));
-        let divisor_var = prover.commit_public(biguint_to_scalar(&random_divisor));
+        let dividend_var = biguint_to_scalar(&random_dividend).create_witness(&mut cs);
+        let divisor_var = biguint_to_scalar(&random_divisor).create_witness(&mut cs);
 
         let (q_res, r_res) =
-            DivRemGadget::<32 /* bitlength */>::div_rem(dividend_var, divisor_var, &mut prover);
-        prover.constrain(q_res - biguint_to_scalar(&expected_q) * Variable::One());
-        prover.constrain(r_res - biguint_to_scalar(&expected_r) * Variable::One());
+            DivRemGadget::<32 /* bitlength */>::div_rem(dividend_var, divisor_var, &mut cs)
+                .unwrap();
 
-        assert!(prover.constraints_satisfied());
+        cs.enforce_equal(expected_q_var, q_res).unwrap();
+        cs.enforce_equal(expected_r_var, r_res).unwrap();
+
+        assert!(cs
+            .check_circuit_satisfiability(&[expected_q.inner(), expected_r.inner()])
+            .is_ok())
+    }
+
+    /// Tests the exp gadget
+    #[test]
+    fn test_exp() {
+        let mut rng = thread_rng();
+        let base = Scalar::random(&mut rng);
+        let exp = rng.next_u64();
+
+        let expected = base.pow(exp);
+
+        // Compute the result in-circuit
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let base_var = base.create_witness(&mut cs);
+        let expected_var = expected.create_public_var(&mut cs);
+
+        let result = ExpGadget::exp(base_var, exp, &mut cs).unwrap();
+        cs.enforce_equal(result, expected_var).unwrap();
+
+        assert!(cs.check_circuit_satisfiability(&[expected.inner()]).is_ok());
     }
 }

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -1,81 +1,84 @@
 //! Defines gadgets on fixed point types
 
-use std::marker::PhantomData;
-
+use ark_ff::One;
 use circuit_types::{
-    errors::ProverError,
-    fixed_point::{
-        AuthenticatedFixedPointVar, FixedPointVar, DEFAULT_FP_PRECISION, TWO_TO_M_SCALAR,
-    },
-    traits::{LinearCombinationLike, MpcLinearCombinationLike},
+    fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION, TWO_TO_M_SCALAR},
+    Fabric, MpcPlonkCircuit, PlonkCircuit,
 };
-use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem, Variable},
-    r1cs_mpc::{MpcLinearCombination, MpcRandomizableConstraintSystem, MpcVariable},
-};
-use mpc_stark::{algebra::scalar::Scalar, MpcFabric};
+use constants::ScalarField;
+use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar, Variable};
 
 use super::{
     arithmetic::DivRemGadget,
-    comparators::{EqGadget, GreaterThanEqGadget, MultiproverGreaterThanEqGadget},
+    comparators::{EqGadget, GreaterThanEqZeroGadget, MultiproverGreaterThanEqZeroGadget},
 };
 
 /// Performs fixed point operations on a single-prover circuit
-pub struct FixedPointGadget<CS: RandomizableConstraintSystem>(PhantomData<CS>);
-impl<CS: RandomizableConstraintSystem> FixedPointGadget<CS> {
+pub struct FixedPointGadget;
+impl FixedPointGadget {
     // === Helpers === //
 
     /// Shifts an integer to the left by the fixed point precision
-    /// and returns the value as an integer
-    fn shift_integer(val: Variable) -> FixedPointVar<LinearCombination> {
-        FixedPointVar {
-            repr: *TWO_TO_M_SCALAR * val,
-        }
+    /// and returns the value as a fixed point value
+    pub fn integer_to_fixed_point<C: Circuit<ScalarField>>(
+        val: Variable,
+        cs: &mut C,
+    ) -> Result<FixedPointVar, CircuitError> {
+        let repr = cs.mul_constant(val, &*TWO_TO_M_SCALAR)?;
+        Ok(FixedPointVar { repr })
     }
 
     // === Equality === //
 
     /// Constrain a fixed point variable to equal an integer
-    pub fn constrain_equal_integer<L: LinearCombinationLike>(
-        lhs: FixedPointVar<L>,
+    pub fn constrain_equal_integer<C: Circuit<ScalarField>>(
+        lhs: FixedPointVar,
         rhs: Variable,
-        cs: &mut CS,
-    ) {
-        let fixed_point_repr = Self::shift_integer(rhs);
-        EqGadget::constrain_eq(lhs, fixed_point_repr, cs);
+        cs: &mut C,
+    ) -> Result<(), CircuitError> {
+        let fixed_point_repr = Self::integer_to_fixed_point(rhs, cs)?;
+        EqGadget::constrain_eq(lhs, fixed_point_repr, cs)?;
+
+        Ok(())
     }
 
     /// Return a boolean indicating whether a fixed point and integer are equal
     ///
     /// 1 represents true, 0 is false
-    pub fn equal_integer<L: LinearCombinationLike>(
-        lhs: FixedPointVar<L>,
+    pub fn equal_integer(
+        lhs: FixedPointVar,
         rhs: Variable,
-        cs: &mut CS,
-    ) -> Variable {
-        let fixed_point_repr = Self::shift_integer(rhs);
+        cs: &mut PlonkCircuit,
+    ) -> Result<BoolVar, CircuitError> {
+        let fixed_point_repr = Self::integer_to_fixed_point(rhs, cs)?;
         EqGadget::eq(lhs, fixed_point_repr, cs)
     }
 
     /// Constrain a fixed point variable to be equal to the given integer
     /// when ignoring the fractional part
-    pub fn constrain_equal_integer_ignore_fraction<L: LinearCombinationLike>(
-        lhs: FixedPointVar<L>,
+    pub fn constrain_equal_integer_ignore_fraction(
+        lhs: FixedPointVar,
         rhs: Variable,
-        cs: &mut CS,
-    ) {
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
         // Shift the integer and take the difference
-        let shifted_rhs = *TWO_TO_M_SCALAR * rhs;
-        let diff = lhs.repr.into() - shifted_rhs;
+        let shifted_rhs = Self::integer_to_fixed_point(rhs, cs)?;
+        let lhs_minus_rhs = cs.sub(lhs.repr, shifted_rhs.repr)?;
 
         // Constrain the difference to be less than the precision on the fixed point,
         // This is effectively the same as constraining the difference to have an
         // integral component of zero
-        GreaterThanEqGadget::<DEFAULT_FP_PRECISION>::constrain_greater_than_eq(
-            LinearCombination::from(*TWO_TO_M_SCALAR - Scalar::one()),
-            diff,
-            cs,
-        );
+
+        let one_var = cs.one();
+        let zero_var = cs.zero();
+        let one = ScalarField::one();
+
+        // 2^m - (lhs - rhs) > 0
+        let diff = cs.lc(
+            &[one_var, lhs_minus_rhs, zero_var, zero_var],
+            &[*TWO_TO_M_SCALAR, -one, one, one],
+        )?;
+        GreaterThanEqZeroGadget::<DEFAULT_FP_PRECISION>::constrain_greater_than_zero(diff, cs)
     }
 
     // === Arithmetic Ops === //
@@ -84,15 +87,12 @@ impl<CS: RandomizableConstraintSystem> FixedPointGadget<CS> {
     /// variable and constraints this value to be correctly computed.
     ///
     /// Returns the integer representation directly
-    pub fn floor<L: LinearCombinationLike>(val: FixedPointVar<L>, cs: &mut CS) -> Variable {
+    pub fn floor(val: FixedPointVar, cs: &mut PlonkCircuit) -> Result<Variable, CircuitError> {
         // Floor div by the scaling factor
-        let (div, _) = DivRemGadget::<DEFAULT_FP_PRECISION>::div_rem(
-            val.repr.into(),
-            *TWO_TO_M_SCALAR * Variable::One(),
-            cs,
-        );
+        let divisor = cs.mul_constant(cs.one(), &*TWO_TO_M_SCALAR).unwrap();
+        let (div, _) = DivRemGadget::<DEFAULT_FP_PRECISION>::div_rem(val.repr, divisor, cs)?;
 
-        div
+        Ok(div)
     }
 }
 
@@ -101,46 +101,147 @@ pub struct MultiproverFixedPointGadget;
 impl MultiproverFixedPointGadget {
     // === Equality === //
 
-    /// Constrain a fixed point variable to equal a native field element
-    pub fn constrain_equal_integer<L, CS>(
-        lhs: &AuthenticatedFixedPointVar<L>,
-        rhs: &MpcVariable,
-        cs: &mut CS,
-    ) where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        // Shift the integer
-        let shifted_rhs = *TWO_TO_M_SCALAR * rhs;
-        cs.constrain(lhs.repr.clone().into() - shifted_rhs);
-    }
-
     /// Constrain a fixed point variable to be equal to the given integer
     /// when ignoring the fractional part
-    pub fn constrain_equal_integer_ignore_fraction<L, CS>(
-        lhs: &AuthenticatedFixedPointVar<L>,
-        rhs: &MpcVariable,
-        fabric: &MpcFabric,
-        cs: &mut CS,
-    ) -> Result<(), ProverError>
-    where
-        L: MpcLinearCombinationLike,
-        CS: MpcRandomizableConstraintSystem,
-    {
-        // Shift the integer and take the difference
-        let shifted_rhs = *TWO_TO_M_SCALAR * rhs;
-        let diff = lhs.repr.clone().into() - shifted_rhs;
+    pub fn constrain_equal_integer_ignore_fraction(
+        lhs: FixedPointVar,
+        rhs: Variable,
+        fabric: &Fabric,
+        cs: &mut MpcPlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        // Shift the rhs and subtract from the lhs
+        let zero_var = cs.zero();
+        let one_var = cs.one();
+        let one = ScalarField::one();
+
+        let lhs_minus_rhs = cs.lc(
+            &[lhs.repr, rhs, zero_var, zero_var],
+            &[one, -*TWO_TO_M_SCALAR, one, one],
+        )?;
 
         // Constrain the difference to be less than the precision on the fixed point,
         // This is effectively the same as constraining the difference to have an
         // integral component of zero
-        let shifted_precision =
-            MpcLinearCombination::from_scalar(*TWO_TO_M_SCALAR - Scalar::one(), fabric.clone());
-        MultiproverGreaterThanEqGadget::<DEFAULT_FP_PRECISION>::constrain_greater_than_eq(
-            shifted_precision,
-            diff,
-            fabric,
-            cs,
+        let diff = cs.lc(
+            &[one_var, lhs_minus_rhs, zero_var, zero_var],
+            &[*TWO_TO_M_SCALAR, -one, one, one],
+        )?;
+
+        MultiproverGreaterThanEqZeroGadget::<DEFAULT_FP_PRECISION>::constrain_greater_than_zero(
+            diff, fabric, cs,
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_mpc::PARTY0;
+    use circuit_types::{
+        fixed_point::FixedPoint,
+        traits::{CircuitBaseType, MpcBaseType, MultiproverCircuitBaseType},
+        MpcPlonkCircuit, PlonkCircuit,
+    };
+    use mpc_relation::traits::Circuit;
+    use rand::{thread_rng, Rng};
+    use test_helpers::mpc_network::execute_mock_mpc;
+
+    use crate::zk_gadgets::fixed_point::MultiproverFixedPointGadget;
+
+    use super::FixedPointGadget;
+
+    /// Test the equality methods
+    #[test]
+    fn test_equality() {
+        let mut rng = thread_rng();
+        let fp1: f64 = rng.gen();
+        let fp_floor = fp1.floor() as u64;
+        let int: u64 = rng.gen();
+
+        // Allocate the values in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let fp_var1 = FixedPoint::from_f64_round_down(fp1).create_witness(&mut cs);
+        let floor_var = fp_floor.create_witness(&mut cs);
+
+        let int_var = int.create_witness(&mut cs);
+        let int_fp = FixedPoint::from_integer(int).create_witness(&mut cs);
+
+        // int_fp == int_var
+        let res1 = FixedPointGadget::equal_integer(int_fp, int_var, &mut cs).unwrap();
+        cs.enforce_true(res1).unwrap();
+
+        // fp1 != floor(fp1)
+        let res2 = FixedPointGadget::equal_integer(fp_var1, floor_var, &mut cs).unwrap();
+        cs.enforce_false(res2).unwrap();
+
+        // fp1 == floor(fp1), when ignoring the fractional part
+        FixedPointGadget::constrain_equal_integer_ignore_fraction(fp_var1, floor_var, &mut cs)
+            .unwrap();
+
+        // Validate constraints
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+    }
+
+    /// Tests the floor method
+    #[test]
+    fn test_floor() {
+        let mut rng = thread_rng();
+        let fp1: f64 = rng.gen();
+        let floor = fp1.floor() as u64;
+
+        // Compute the floor in-circuit
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let fp_var1 = FixedPoint::from_f64_round_down(fp1).create_witness(&mut cs);
+        let floor_var = floor.create_witness(&mut cs);
+
+        let floor_res = FixedPointGadget::floor(fp_var1, &mut cs).unwrap();
+        cs.enforce_equal(floor_res, floor_var).unwrap();
+
+        // Validate constraints
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+    }
+
+    /// Tests the multiprover equality method
+    #[tokio::test]
+    async fn test_multiprover_integer_equality() {
+        let mut rng = thread_rng();
+        let fp1: f64 = rng.gen();
+        let fp_floor = fp1.floor() as u64;
+        let int: u64 = rng.gen();
+
+        let (res, _) = execute_mock_mpc(move |fabric| async move {
+            let mut cs = MpcPlonkCircuit::new(fabric.clone());
+
+            let fp_var = FixedPoint::from_f64_round_down(fp1)
+                .allocate(PARTY0, &fabric)
+                .create_shared_witness(&mut cs)
+                .unwrap();
+            let floor_var = fp_floor
+                .allocate(PARTY0, &fabric)
+                .create_shared_witness(&mut cs)
+                .unwrap();
+            let int_var = int
+                .allocate(PARTY0, &fabric)
+                .create_shared_witness(&mut cs)
+                .unwrap();
+
+            // fp1 == floor(fp1), when ignoring the fractional part
+            MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+                fp_var, floor_var, &fabric, &mut cs,
+            )
+            .unwrap();
+
+            let res = cs.check_circuit_satisfiability(&[]).is_ok();
+
+            // fp1 != int
+            MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+                fp_var, int_var, &fabric, &mut cs,
+            )
+            .unwrap();
+
+            res & cs.check_circuit_satisfiability(&[]).is_err()
+        })
+        .await;
+
+        assert!(res);
     }
 }

--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -1,10 +1,15 @@
 //! Groups gadgets used in zero knowledge circuits
+//!
+//! Some gadgets are implemented in `mpc-jellyfish` so that they can be
+//! implemented generically over provers. Gadgets in this module are built on
+//! top of those low level gadgets defined in `mpc-jellyfish`.
+//!
+//! Some low level gadgets are defined here to provide MPC efficiency
+
 pub mod arithmetic;
 pub mod bits;
 pub mod comparators;
-pub mod elgamal;
 pub mod fixed_point;
-pub mod gates;
 pub mod merkle;
 pub mod poseidon;
 pub mod select;

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -1,16 +1,9 @@
 //! Groups logic for computing wallet commitments and nullifiers inside of a
 //! circuit
 
-use circuit_types::{
-    traits::{CircuitVarType, LinearCombinationLike},
-    wallet::WalletShareVar,
-};
-use itertools::Itertools;
-use mpc_bulletproof::{
-    r1cs::{LinearCombination, RandomizableConstraintSystem},
-    r1cs_mpc::R1CSError,
-};
-use renegade_crypto::hash::default_poseidon_params;
+use circuit_types::{traits::CircuitVarType, wallet::WalletShareVar};
+use constants::ScalarField;
+use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
 use super::poseidon::PoseidonHashGadget;
 
@@ -31,64 +24,42 @@ where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// Compute the commitment to the private wallet shares
-    pub fn compute_private_commitment<
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    >(
-        private_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError> {
-        // Create a new hash gadget
-        let hash_params = default_poseidon_params();
-        let mut hasher = PoseidonHashGadget::new(hash_params);
-
+    pub fn compute_private_commitment<C: Circuit<ScalarField>>(
+        private_wallet_share: WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // Serialize the wallet and hash it into the hasher's state
-        let serialized_wallet: Vec<L> = private_wallet_share.to_vars();
+        let serialized_wallet = private_wallet_share.to_vars();
+
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
         hasher.batch_absorb(&serialized_wallet, cs)?;
 
-        // Squeeze an element out of the state
         hasher.squeeze(cs)
     }
 
     /// Compute the commitment to the full wallet given a commitment to the
     /// private shares
-    pub fn compute_wallet_commitment_from_private<
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    >(
-        blinded_public_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        private_commitment: LinearCombination,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError> {
-        // Create a new hash gadget
-        let hash_params = default_poseidon_params();
-        let mut hasher = PoseidonHashGadget::new(hash_params);
-
+    pub fn compute_wallet_commitment_from_private<C: Circuit<ScalarField>>(
+        blinded_public_wallet_share: WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_commitment: Variable,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // The public shares are added directly to a sponge H(private_commit || public
-        // shares)
-        let mut hash_input = vec![private_commitment];
-        hash_input.append(
-            &mut blinded_public_wallet_share
-                .to_vars()
-                .into_iter()
-                .map(|var| var.into())
-                .collect_vec(),
-        );
+        // shares), giving the full wallet commitment
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.absorb(private_commitment, cs)?;
+        hasher.batch_absorb(&blinded_public_wallet_share.to_vars(), cs)?;
 
-        hasher.batch_absorb(&hash_input, cs)?;
         hasher.squeeze(cs)
     }
 
     /// Compute the full commitment of a wallet's shares given both the public
     /// and private shares
-    pub fn compute_wallet_share_commitment<
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    >(
-        public_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        private_wallet_share: WalletShareVar<L, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError> {
+    pub fn compute_wallet_share_commitment<C: Circuit<ScalarField>>(
+        public_wallet_share: WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_wallet_share: WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // First compute the private half, then absorb in the public
         let private_comm = Self::compute_private_commitment(private_wallet_share, cs)?;
         Self::compute_wallet_commitment_from_private(public_wallet_share, private_comm, cs)
@@ -100,20 +71,127 @@ where
 pub struct NullifierGadget {}
 impl NullifierGadget {
     /// Compute the nullifier of a set of secret shares given their commitment
-    pub fn wallet_shares_nullifier<L, CS>(
-        share_commitment: L,
-        wallet_blinder: L,
-        cs: &mut CS,
-    ) -> Result<LinearCombination, R1CSError>
-    where
-        L: LinearCombinationLike,
-        CS: RandomizableConstraintSystem,
-    {
+    pub fn wallet_shares_nullifier<C: Circuit<ScalarField>>(
+        share_commitment: Variable,
+        wallet_blinder: Variable,
+        cs: &mut C,
+    ) -> Result<Variable, CircuitError> {
         // The nullifier is computed as H(C(w)||r)
-        let hash_params = default_poseidon_params();
-        let mut hasher = PoseidonHashGadget::new(hash_params);
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
 
         hasher.batch_absorb(&[share_commitment, wallet_blinder], cs)?;
         hasher.squeeze(cs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::iter;
+
+    use circuit_types::{
+        native_helpers::{
+            compute_wallet_commitment_from_private, compute_wallet_private_share_commitment,
+            compute_wallet_share_commitment, compute_wallet_share_nullifier,
+        },
+        traits::{BaseType, CircuitBaseType},
+        PlonkCircuit, SizedWalletShare,
+    };
+    use constants::Scalar;
+    use mpc_relation::traits::Circuit;
+    use rand::thread_rng;
+
+    use crate::zk_gadgets::wallet_operations::WalletShareCommitGadget;
+
+    use super::NullifierGadget;
+
+    /// Generate random wallet shares
+    fn random_wallet_shares() -> (SizedWalletShare, SizedWalletShare) {
+        let mut rng = thread_rng();
+        let mut share_iter = iter::from_fn(|| Some(Scalar::random(&mut rng)));
+
+        (
+            SizedWalletShare::from_scalars(&mut share_iter),
+            SizedWalletShare::from_scalars(&mut share_iter),
+        )
+    }
+
+    /// Tests the wallet commitment share gadget
+    #[test]
+    fn test_wallet_share_commitments() {
+        let (private_shares, public_shares) = random_wallet_shares();
+
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let private_share_var = private_shares.create_witness(&mut cs);
+        let public_share_var = public_shares.create_witness(&mut cs);
+
+        // Private share commitment
+        let expected_private = compute_wallet_private_share_commitment(private_shares.clone());
+        let expected_var = expected_private.create_public_var(&mut cs);
+
+        let priv_comm =
+            WalletShareCommitGadget::compute_private_commitment(private_share_var.clone(), &mut cs)
+                .unwrap();
+
+        cs.enforce_equal(priv_comm, expected_var).unwrap();
+
+        // Public share commitment
+        let expected_pub =
+            compute_wallet_commitment_from_private(public_shares.clone(), expected_private);
+        let expected_var = expected_pub.create_public_var(&mut cs);
+
+        let pub_comm = WalletShareCommitGadget::compute_wallet_commitment_from_private(
+            public_share_var.clone(),
+            priv_comm,
+            &mut cs,
+        )
+        .unwrap();
+
+        cs.enforce_equal(pub_comm, expected_var).unwrap();
+
+        // Full wallet commitment
+        let expected_full = compute_wallet_share_commitment(public_shares, private_shares);
+        let expected_var = expected_full.create_public_var(&mut cs);
+
+        let full_comm = WalletShareCommitGadget::compute_wallet_share_commitment(
+            public_share_var,
+            private_share_var,
+            &mut cs,
+        );
+
+        cs.enforce_equal(full_comm.unwrap(), expected_var).unwrap();
+
+        // Verify that all constraints are satisfied
+        assert!(cs
+            .check_circuit_satisfiability(&[
+                expected_private.inner(),
+                expected_pub.inner(),
+                expected_full.inner()
+            ])
+            .is_ok())
+    }
+
+    /// Tests the nullifier gadget
+    #[test]
+    fn test_nullifier_gadget() {
+        let mut rng = thread_rng();
+        let share_commitment = Scalar::random(&mut rng);
+        let wallet_blinder = Scalar::random(&mut rng);
+
+        let expected = compute_wallet_share_nullifier(share_commitment, wallet_blinder);
+
+        // Check against the gadget
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let comm_var = share_commitment.create_witness(&mut cs);
+        let blinder_var = wallet_blinder.create_witness(&mut cs);
+
+        let expected_var = expected.create_public_var(&mut cs);
+
+        let nullifier =
+            NullifierGadget::wallet_shares_nullifier(comm_var, blinder_var, &mut cs).unwrap();
+
+        cs.enforce_equal(nullifier, expected_var).unwrap();
+
+        // Verify that all constraints are satisfied
+        assert!(cs.check_circuit_satisfiability(&[expected.inner()]).is_ok())
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the `arithmetic`, `fixed-point`, and `wallet-operations` modules of the `zk-gadgets` to work over the new `mpc-jellyfish` system. I also added unit tests for all refactored gadgets, some are tested implicitly.

### Testing
- Unit tests pass