### PR TITLE
circuits: zk-circuits: valid-wallet-create: Refactor over `mpc-plonk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,7 @@ dependencies = [
  "ed25519-dalek 1.0.1",
  "futures",
  "itertools 0.10.5",
+ "jf-primitives",
  "lazy_static",
  "mpc-plonk",
  "mpc-relation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc" }
 merlin = { git = "https://github.com/renegade-fi/merlin" }
 mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
+jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 mpc-bulletproof = { git = "https://github.com/renegade-fi/mpc-bulletproof" }
 mpc-stark = "0.2"
 num-bigint = { version = "0.4.3" }

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -3,7 +3,8 @@ name = "circuit-types"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+test-helpers = ["mpc-plonk/test-srs", "dep:jf-primitives"]
 
 [dependencies]
 # === Crytography === #
@@ -11,6 +12,7 @@ ark-ff = "0.4"
 ark-ec = "0.4"
 ark-mpc = { workspace = true }
 ed25519-dalek = "1.0.1"
+jf-primitives = { workspace = true, optional = true }
 mpc-plonk = { workspace = true }
 mpc-relation = { workspace = true }
 

--- a/circuit-types/src/errors.rs
+++ b/circuit-types/src/errors.rs
@@ -40,6 +40,8 @@ pub enum ProverError {
     Mpc(MpcError),
     /// An error executing the Plonk prover
     Plonk(PlonkError),
+    /// An error verifying a proof in a prove-then-verify setup
+    Verification(VerifierError),
 }
 
 impl Display for ProverError {

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -355,3 +355,26 @@ pub mod native_helpers {
         (private_shares, blinded_public_shares)
     }
 }
+
+/// Helpers for tests
+#[cfg(feature = "test-helpers")]
+pub mod test_helpers {
+    use constants::SystemCurve;
+    use jf_primitives::pcs::prelude::UnivariateUniversalParams;
+    use lazy_static::lazy_static;
+    use mpc_plonk::proof_system::{PlonkKzgSnark, UniversalSNARK};
+    use rand::thread_rng;
+
+    /// The maximum degree SRS to allocate for testing circuits
+    const MAX_DEGREE_TESTING: usize = 32768;
+
+    lazy_static! {
+        /// A universal SRS for testing circuits that is generated once and used
+        /// across circuits
+        pub static ref TESTING_SRS: UnivariateUniversalParams<SystemCurve> = {
+            let mut rng = thread_rng();
+            PlonkKzgSnark::<SystemCurve>::universal_setup_for_testing(MAX_DEGREE_TESTING, &mut rng)
+                .unwrap()
+        };
+    }
+}

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -58,7 +58,7 @@ ark-crypto-primitives = { version = "0.4", features = [
 ark-ff = "0.4"
 ark-mpc = { workspace = true }
 bigdecimal = "0.3"
-mpc-plonk = { workspace = true }
+mpc-plonk = { workspace = true, features = ["parallel"] }
 mpc-relation = { workspace = true }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
@@ -83,6 +83,7 @@ tracing = { version = "0.1", features = ["log"] }
 [dev-dependencies]
 ark-ec = "0.4"
 ark-ed25519 = "0.4"
+circuit-types = { path = "../circuit-types", features = ["test-helpers"] }
 chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(generic_const_exprs)]
 #![feature(inherent_associated_types)]
 
+use circuit_types::{errors::ProverError, traits::SingleProverCircuit};
 use constants::Scalar;
 
 pub mod mpc_circuits;
@@ -89,6 +90,15 @@ pub fn scalar_2_to_m(m: u64) -> Scalar {
     );
 
     Scalar::from(2u8).pow(m)
+}
+
+/// Generate a proof of a circuit and verify it
+pub fn plonk_prove_and_verify<C: SingleProverCircuit>(
+    witness: C::Witness,
+    statement: C::Statement,
+) -> Result<(), ProverError> {
+    let proof = C::prove(witness, statement.clone())?;
+    C::verify(statement, &proof).map_err(ProverError::Verification)
 }
 
 // ----------------


### PR DESCRIPTION
### Purpose
This PR makes the changes necessary to support full ZK prove/verify flows and uses this to refactor the `VALID WALLET CREATE` circuit. This includes structuring how the proving and verifying keys fit into the `SingleProverCircuit` and `MultiProverCircuit` traits.

### Testing
- Unit tests pass