### PR TITLE
circuits: zk-circuits: valid-commitments: Refactor over `mpc-plonk`

### DIFF
--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -2,7 +2,7 @@
 //! in proving knowledge of witness for throughout the network
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-// pub mod valid_commitments;
+pub mod valid_commitments;
 // pub mod valid_match_mpc;
 // pub mod valid_reblind;
 // pub mod valid_settle;

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -10,27 +10,21 @@
 //! VALID COMMITMENTS is proven once per order in the wallet
 
 use crate::{
-    zk_gadgets::{
-        comparators::EqGadget,
-        gates::{AndGate, ConstrainBinaryGadget, OrGate},
-        select::CondSelectVectorGadget,
-    },
+    zk_gadgets::{comparators::EqGadget, select::CondSelectVectorGadget},
     SingleProverCircuit,
 };
 use circuit_macros::circuit_type;
 use circuit_types::{
-    balance::{BalanceVar, LinkableBalance},
-    fee::{FeeVar, LinkableFee},
-    order::{LinkableOrder, OrderVar},
-    traits::{
-        BaseType, CircuitBaseType, CircuitCommitmentType, CircuitVarType, LinearCombinationLike,
-    },
-    wallet::{LinkableWalletShare, WalletVar},
+    balance::{Balance, BalanceVar},
+    fee::{Fee, FeeVar},
+    order::{Order, OrderVar},
+    traits::{BaseType, CircuitBaseType, CircuitVarType, SecretShareVarType},
+    wallet::{WalletShare, WalletVar},
+    PlonkCircuit,
 };
-use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS};
-use mpc_bulletproof::r1cs::{LinearCombination, R1CSError, RandomizableConstraintSystem, Variable};
-use mpc_stark::algebra::{scalar::Scalar, stark_curve::StarkPoint};
-use rand::{CryptoRng, RngCore};
+use constants::{Scalar, ScalarField, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
+use mpc_plonk::errors::PlonkError;
+use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar, Variable};
 use serde::{Deserialize, Serialize};
 
 // ----------------------
@@ -52,32 +46,42 @@ where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
     /// The circuit constraints for VALID COMMITMENTS
-    pub fn circuit<CS: RandomizableConstraintSystem>(
-        statement: ValidCommitmentsStatementVar<Variable>,
-        witness: ValidCommitmentsWitnessVar<Variable, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
+    pub fn circuit(
+        statement: ValidCommitmentsStatementVar,
+        witness: ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
         // Reconstruct the base and augmented wallets
-        let recovered_blinder =
-            witness.private_secret_shares.blinder + witness.public_secret_shares.blinder;
+        let recovered_blinder = cs.add(
+            witness.private_secret_shares.blinder,
+            witness.public_secret_shares.blinder,
+        )?;
+
         let unblinded_public_shares = witness
             .public_secret_shares
-            .unblind_shares(recovered_blinder.clone());
+            .unblind_shares(recovered_blinder, cs);
         let unblinded_augmented_shares = witness
             .augmented_public_shares
-            .unblind_shares(recovered_blinder);
+            .unblind_shares(recovered_blinder, cs);
 
-        let base_wallet = witness.private_secret_shares.clone() + unblinded_public_shares;
-        let augmented_wallet = witness.private_secret_shares.clone() + unblinded_augmented_shares;
+        let base_wallet = witness
+            .private_secret_shares
+            .add_shares(&unblinded_public_shares, cs);
+        let augmented_wallet = witness
+            .private_secret_shares
+            .add_shares(&unblinded_augmented_shares, cs);
+
+        // The order side should be binary
+        cs.enforce_bool(witness.order.side)?;
+        let side = BoolVar::new_unchecked(witness.order.side);
 
         // The mint that the wallet will receive if the order is matched
-        let mut receive_send_mint =
-            CondSelectVectorGadget::select::<_, _, Variable, LinearCombination, _>(
-                &[witness.order.quote_mint, witness.order.base_mint],
-                &[witness.order.base_mint, witness.order.quote_mint],
-                witness.order.side,
-                cs,
-            );
+        let mut receive_send_mint = CondSelectVectorGadget::select(
+            &[witness.order.quote_mint, witness.order.base_mint],
+            &[witness.order.base_mint, witness.order.quote_mint],
+            side,
+            cs,
+        )?;
         let receive_mint = receive_send_mint.remove(0);
         let send_mint = receive_send_mint.remove(0);
 
@@ -86,110 +90,103 @@ where
         // must come in place of a previous balance that was zero.
         Self::verify_wallets_equal_with_augmentation(
             statement.balance_receive_index,
-            receive_mint.clone(),
+            receive_mint,
             &base_wallet,
             &augmented_wallet,
             cs,
-        );
+        )?;
 
         // Verify that the send balance is at the correct index
         Self::contains_balance_at_index(
             statement.balance_send_index,
-            witness.balance_send.clone(),
+            &witness.balance_send,
             &augmented_wallet,
             cs,
-        );
-        cs.constrain(witness.balance_send.mint - send_mint);
+        )?;
+        cs.enforce_equal(witness.balance_send.mint, send_mint)?;
 
         // Verify that the receive balance is at the correct index
         Self::contains_balance_at_index(
             statement.balance_receive_index,
-            witness.balance_receive.clone(),
+            &witness.balance_receive,
             &augmented_wallet,
             cs,
-        );
-        cs.constrain(witness.balance_receive.mint - receive_mint);
+        )?;
+        cs.enforce_equal(witness.balance_receive.mint, receive_mint)?;
 
         // Verify that the fee balance is in the wallet
         // TODO: Implement fees properly
-        Self::contains_balance(witness.balance_fee.clone(), &augmented_wallet, cs);
-        cs.constrain(witness.balance_fee.mint - witness.fee.gas_addr);
+        Self::contains_balance(&witness.balance_fee, &augmented_wallet, cs)?;
+        cs.enforce_equal(witness.balance_fee.mint, witness.fee.gas_addr)?;
 
         // Verify that the order is at the correct index
-        Self::constrain_valid_order(&witness.order, cs);
-        Self::contains_order_at_index(statement.order_index, witness.order, &augmented_wallet, cs);
+        Self::contains_order_at_index(
+            statement.order_index,
+            &witness.order,
+            &augmented_wallet,
+            cs,
+        )?;
 
         // Verify that the fee is contained in the wallet
-        Self::contains_fee(witness.fee, &augmented_wallet, cs);
-    }
-
-    /// Constrains the order input to the matching engine is valid
-    fn constrain_valid_order<CS: RandomizableConstraintSystem>(
-        order: &OrderVar<Variable>,
-        cs: &mut CS,
-    ) {
-        // The order side should be binary
-        ConstrainBinaryGadget::constrain_binary(order.side, cs);
+        Self::contains_fee(&witness.fee, &augmented_wallet, cs)
     }
 
     /// Verify that two wallets are equal except possibly with a balance
     /// augmentation
-    fn verify_wallets_equal_with_augmentation<CS: RandomizableConstraintSystem>(
+    fn verify_wallets_equal_with_augmentation(
         receive_index: Variable,
-        received_mint: LinearCombination,
-        base_wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        augmented_wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
+        received_mint: Variable,
+        base_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        augmented_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
         // All balances should be the same except possibly the balance at the receive
         // index. We allow This balance to be zero'd in the base wallet, and
         // have the received mint with zero balance in the augmented wallet
-        let mut curr_index: LinearCombination = Variable::Zero().into();
+        let zero_var = cs.zero();
+        let one_var = cs.one();
+        let mut curr_index = zero_var;
+
         for (base_balance, augmented_balance) in base_wallet
             .balances
             .iter()
             .zip(augmented_wallet.balances.iter())
         {
             // Non-augmented case, balances are equal
-            let balances_eq = EqGadget::eq(base_balance.clone(), augmented_balance.clone(), cs);
+            let balances_eq = EqGadget::eq(base_balance, augmented_balance, cs)?;
 
             // Validate a potential augmentation
             let prev_balance_zero = EqGadget::eq(
-                base_balance.clone(),
-                BalanceVar {
-                    mint: Variable::Zero(),
-                    amount: Variable::Zero(),
+                base_balance,
+                &BalanceVar {
+                    mint: zero_var,
+                    amount: zero_var,
                 },
                 cs,
-            );
+            )?;
+
             let augmented_balance = EqGadget::eq(
-                augmented_balance.clone(),
-                BalanceVar {
-                    mint: received_mint.clone(),
-                    amount: Variable::Zero().into(),
+                augmented_balance,
+                &BalanceVar {
+                    mint: received_mint,
+                    amount: zero_var,
                 },
                 cs,
-            );
-            let augmentation_index_mask = EqGadget::eq::<LinearCombination, Variable, _, _, _>(
-                curr_index.clone(),
-                receive_index,
-                cs,
-            );
+            )?;
+
+            let augmentation_index_mask = EqGadget::eq(&curr_index, &receive_index, cs)?;
 
             // Validate that the balance is either unmodified or augmented from (0, 0) to
             // (receive_mint, 0)
-            let augmented_from_zero = AndGate::multi_and(
-                &[
-                    prev_balance_zero,
-                    augmented_balance,
-                    augmentation_index_mask,
-                ],
-                cs,
-            );
-            let valid_balance = OrGate::or(augmented_from_zero, balances_eq, cs);
+            let augmented_from_zero = cs.logic_and_all(&[
+                prev_balance_zero,
+                augmented_balance,
+                augmentation_index_mask,
+            ])?;
+            let valid_balance = cs.logic_or(augmented_from_zero, balances_eq)?;
 
-            cs.constrain(Variable::One() - valid_balance);
-            curr_index += Variable::One();
+            cs.enforce_true(valid_balance)?;
+            curr_index = cs.add(curr_index, one_var)?;
         }
 
         // All orders should be the same
@@ -198,98 +195,100 @@ where
             .iter()
             .zip(augmented_wallet.orders.iter())
         {
-            EqGadget::constrain_eq(base_order.clone(), augmented_order.clone(), cs);
+            EqGadget::constrain_eq(base_order, augmented_order, cs)?;
         }
 
         // All fees should be the same
         for (base_fee, augmented_fee) in base_wallet.fees.iter().zip(augmented_wallet.fees.iter()) {
-            EqGadget::constrain_eq(base_fee.clone(), augmented_fee.clone(), cs);
+            EqGadget::constrain_eq(base_fee, augmented_fee, cs)?;
         }
 
         // Keys should be equal
-        EqGadget::constrain_eq(base_wallet.keys.clone(), augmented_wallet.keys.clone(), cs);
+        EqGadget::constrain_eq(&base_wallet.keys, &augmented_wallet.keys, cs)?;
 
         // Blinders should be equal
-        EqGadget::constrain_eq(
-            base_wallet.blinder.clone(),
-            augmented_wallet.blinder.clone(),
-            cs,
-        );
+        EqGadget::constrain_eq(&base_wallet.blinder, &augmented_wallet.blinder, cs)
     }
 
     /// Verify that the wallet has the given balance at the specified index
-    fn contains_balance_at_index<CS: RandomizableConstraintSystem>(
+    fn contains_balance_at_index(
         index: Variable,
-        target_balance: BalanceVar<Variable>,
-        wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
-        let mut curr_index: LinearCombination = Variable::Zero().into();
-        let mut balance_found: LinearCombination = Variable::Zero().into();
-        for balance in wallet.balances.iter() {
-            let index_mask =
-                EqGadget::eq::<LinearCombination, Variable, _, _, _>(curr_index.clone(), index, cs);
-            let balances_eq = EqGadget::eq(balance.clone(), target_balance.clone(), cs);
+        target_balance: &BalanceVar,
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let mut curr_index = cs.zero();
+        let mut balance_found = cs.false_var();
 
-            let found = AndGate::and(index_mask, balances_eq, cs);
-            balance_found += found;
-            curr_index += Variable::One();
+        for balance in wallet.balances.iter() {
+            let index_mask = EqGadget::eq(&curr_index, &index, cs)?;
+            let balances_eq = EqGadget::eq(balance, target_balance, cs)?;
+
+            let found = cs.logic_and(index_mask, balances_eq)?;
+
+            balance_found = cs.logic_or(balance_found, found)?;
+            curr_index = cs.add(curr_index, cs.one())?;
         }
 
-        cs.constrain(balance_found - Variable::One())
+        cs.enforce_true(balance_found)
     }
 
     /// Verify that the wallet has the given order at the specified index
-    fn contains_order_at_index<CS: RandomizableConstraintSystem>(
+    fn contains_order_at_index(
         index: Variable,
-        target_order: OrderVar<Variable>,
-        wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
-        let mut curr_index: LinearCombination = Variable::Zero().into();
-        let mut order_found: LinearCombination = Variable::Zero().into();
-        for order in wallet.orders.iter() {
-            let index_mask =
-                EqGadget::eq::<LinearCombination, Variable, _, _, _>(curr_index.clone(), index, cs);
-            let orders_eq = EqGadget::eq(order.clone(), target_order.clone(), cs);
+        target_order: &OrderVar,
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let mut curr_index = cs.zero();
+        let mut order_found = cs.false_var();
 
-            let found = AndGate::and(index_mask, orders_eq, cs);
-            order_found += found;
-            curr_index += Variable::One();
+        for order in wallet.orders.iter() {
+            let index_mask = EqGadget::eq(&curr_index, &index, cs)?;
+            let orders_eq = EqGadget::eq(order, target_order, cs)?;
+
+            let found = cs.logic_and(index_mask, orders_eq)?;
+            order_found = cs.logic_or(order_found, found)?;
+            curr_index = cs.add(curr_index, cs.one())?;
         }
 
-        cs.constrain(order_found - Variable::One())
+        cs.enforce_true(order_found)
     }
 
     /// Verify that the wallet contains the given balance at an unspecified
     /// index
-    fn contains_balance<CS: RandomizableConstraintSystem>(
-        target_balance: BalanceVar<Variable>,
-        wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
-        let mut balance_found: LinearCombination = Variable::Zero().into();
+    ///
+    /// Note that this definition implies a balance can exist more than once,
+    /// this is fine from a security perspective
+    fn contains_balance(
+        target_balance: &BalanceVar,
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let mut balance_found = cs.false_var();
         for balance in wallet.balances.iter() {
-            let balances_eq = EqGadget::eq(balance.clone(), target_balance.clone(), cs);
-            balance_found += balances_eq;
+            let balances_eq = EqGadget::eq(balance, target_balance, cs)?;
+
+            balance_found = cs.logic_or(balance_found, balances_eq)?;
         }
 
-        cs.constrain(balance_found - Variable::One());
+        cs.enforce_true(balance_found)
     }
 
     /// Verify that the wallet contains the given fee at an unspecified index
-    fn contains_fee<CS: RandomizableConstraintSystem>(
-        target_fee: FeeVar<Variable>,
-        wallet: &WalletVar<LinearCombination, MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        cs: &mut CS,
-    ) {
-        let mut fee_found: LinearCombination = Variable::Zero().into();
+    fn contains_fee(
+        target_fee: &FeeVar,
+        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let mut fee_found = cs.false_var();
+
         for fee in wallet.fees.iter() {
-            let fees_eq = EqGadget::eq(fee.clone(), target_fee.clone(), cs);
-            fee_found += fees_eq;
+            let fees_eq = EqGadget::eq(fee, target_fee, cs)?;
+            fee_found = cs.logic_or(fee_found, fees_eq)?;
         }
 
-        cs.constrain(fee_found - Variable::One())
+        cs.enforce_true(fee_found)
     }
 }
 
@@ -309,24 +308,24 @@ pub struct ValidCommitmentsWitness<
 {
     /// The private secret shares of the wallet that have been reblinded for
     /// match
-    pub private_secret_shares: LinkableWalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub private_secret_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The public secret shares of the wallet that have been reblinded for
     /// match
-    pub public_secret_shares: LinkableWalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub public_secret_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The modified public secret shares, possibly with a zero'd balance added
     /// for the mint that will be received by this party upon a successful
     /// match
-    pub augmented_public_shares: LinkableWalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+    pub augmented_public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The order that the prover intends to match against with this proof
-    pub order: LinkableOrder,
+    pub order: Order,
     /// The balance that the wallet will send when the order is matched
-    pub balance_send: LinkableBalance,
+    pub balance_send: Balance,
     /// The balance that the wallet will receive into when the order is matched
-    pub balance_receive: LinkableBalance,
+    pub balance_receive: Balance,
     /// The balance that will cover the relayer's fee when matched
-    pub balance_fee: LinkableBalance,
+    pub balance_fee: Balance,
     /// The fee that the relayer will take upon a successful match
-    pub fee: LinkableFee,
+    pub fee: Fee,
 }
 /// A `VALID COMMITMENTS` witness with default const generic sizing parameters
 pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
@@ -357,15 +356,12 @@ where
     type Statement = ValidCommitmentsStatement;
     type Witness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
-    const BP_GENS_CAPACITY: usize = 1024;
-
-    fn apply_constraints<CS: RandomizableConstraintSystem>(
-        witness_var: <Self::Witness as CircuitBaseType>::VarType<Variable>,
-        statement_var: <Self::Statement as CircuitBaseType>::VarType<Variable>,
-        cs: &mut CS,
-    ) -> Result<(), R1CSError> {
-        Self::circuit(statement_var, witness_var, cs);
-        Ok(())
+    fn apply_constraints(
+        witness_var: ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        statement_var: ValidCommitmentsStatementVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Self::circuit(statement_var, witness_var, cs).map_err(PlonkError::CircuitError)
     }
 }
 
@@ -377,7 +373,7 @@ where
 pub mod test_helpers {
     use circuit_types::{
         balance::Balance, native_helpers::create_wallet_shares_from_private, order::OrderSide,
-        traits::LinkableBaseType, wallet::Wallet,
+        wallet::Wallet,
     };
     use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
@@ -411,7 +407,7 @@ pub mod test_helpers {
         let mut rng = thread_rng();
 
         // Split the wallet into secret shares
-        let (private_shares, public_shares) = create_wallet_shares(wallet.clone());
+        let (private_secret_shares, public_secret_shares) = create_wallet_shares(wallet.clone());
 
         // Choose an order and fee to match on
         let ind_order = 0;
@@ -447,18 +443,21 @@ pub mod test_helpers {
 
         // After augmenting, split the augmented wallet into shares, using the same
         // private secret shares as the original (un-augmented) wallet
-        let (_, augmented_public_shares) =
-            create_wallet_shares_from_private(&augmented_wallet, &private_shares, wallet.blinder);
+        let (_, augmented_public_shares) = create_wallet_shares_from_private(
+            &augmented_wallet,
+            &private_secret_shares,
+            wallet.blinder,
+        );
 
         let witness = ValidCommitmentsWitness {
-            private_secret_shares: private_shares.to_linkable(),
-            public_secret_shares: public_shares.to_linkable(),
-            augmented_public_shares: augmented_public_shares.to_linkable(),
-            order: order.to_linkable(),
-            balance_send: balance_send.to_linkable(),
-            balance_receive: balance_receive.to_linkable(),
-            balance_fee: balance_fee.to_linkable(),
-            fee: fee.to_linkable(),
+            private_secret_shares,
+            public_secret_shares,
+            augmented_public_shares,
+            order,
+            balance_send,
+            balance_receive,
+            balance_fee,
+            fee,
         };
 
         let statement = ValidCommitmentsStatement {
@@ -515,20 +514,19 @@ mod test {
         fee::FeeShare,
         fixed_point::FixedPointShare,
         order::{OrderShare, OrderSide},
-        traits::{CircuitBaseType, LinkableBaseType},
     };
+    use constants::Scalar;
     use lazy_static::lazy_static;
-    use merlin::HashChainTranscript as Transcript;
-    use mpc_bulletproof::{r1cs::Prover, PedersenGens};
-    use mpc_stark::algebra::scalar::Scalar;
-    use rand::thread_rng;
 
     use crate::zk_circuits::{
-        test_helpers::{SizedWallet, INITIAL_WALLET},
+        test_helpers::{
+            check_constraint_satisfaction, SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES,
+            MAX_ORDERS,
+        },
         valid_commitments::test_helpers::{create_witness_and_statement, find_balance_or_augment},
     };
 
-    use super::{test_helpers::SizedWitness, ValidCommitments, ValidCommitmentsStatement};
+    use super::ValidCommitments;
 
     // --------------
     // | Dummy Data |
@@ -551,28 +549,8 @@ mod test {
         };
     }
 
-    // -----------
-    // | Helpers |
-    // -----------
-
-    /// Returns true if the given witness and statement satisfy the relation
-    /// defined by `VALID COMMITMENTS`
-    fn constraints_satisfied(witness: SizedWitness, statement: ValidCommitmentsStatement) -> bool {
-        let mut rng = thread_rng();
-
-        // Create a constrain system
-        let pc_gens = PedersenGens::default();
-        let mut transcript = Transcript::new(b"test");
-        let mut prover = Prover::new(&pc_gens, &mut transcript);
-
-        // Commit to the witness and statement
-        let (witness_var, _) = witness.commit_witness(&mut rng, &mut prover);
-        let statement_var = statement.commit_public(&mut prover);
-
-        // Apply the constraints
-        ValidCommitments::circuit(statement_var, witness_var, &mut prover);
-        prover.constraints_satisfied()
-    }
+    /// A type alias for the VALID COMMITMENTS circuit with size parameters
+    pub type SizedCommitments = ValidCommitments<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
     // --------------
     // | Test Cases |
@@ -585,7 +563,9 @@ mod test {
         let wallet = INITIAL_WALLET.clone();
         let (witness, statement) = create_witness_and_statement(&wallet);
 
-        assert!(constraints_satisfied(witness, statement))
+        assert!(check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Tests the case in which an augmented balance must be added
@@ -594,7 +574,9 @@ mod test {
         let wallet = UNAUGMENTED_WALLET.clone();
         let (witness, statement) = create_witness_and_statement(&wallet);
 
-        assert!(constraints_satisfied(witness, statement))
+        assert!(check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Tests the case in which the prover attempts to add a non-zero balance to
@@ -606,12 +588,13 @@ mod test {
 
         // Prover attempt to augment the wallet with a non-zero balance
         let augmented_balance_index = statement.balance_receive_index;
-        witness.augmented_public_shares.balances[augmented_balance_index as usize]
-            .amount
-            .val += Scalar::one();
-        witness.balance_receive.amount.val += Scalar::one();
+        witness.augmented_public_shares.balances[augmented_balance_index as usize].amount +=
+            Scalar::one();
+        witness.balance_receive.amount += 1u64;
 
-        assert!(!constraints_satisfied(witness, statement));
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Tests the case in which the prover clobbers a non-zero balance to
@@ -626,10 +609,11 @@ mod test {
         witness.public_secret_shares.balances[augmentation_index as usize] = BalanceShare {
             amount: Scalar::one(),
             mint: Scalar::one(),
-        }
-        .to_linkable();
+        };
 
-        assert!(!constraints_satisfied(witness, statement))
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Tests the case in which a prover attempts to modify an order in the
@@ -640,9 +624,11 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify an order in the augmented wallet
-        witness.augmented_public_shares.orders[1].amount.val += Scalar::one();
+        witness.augmented_public_shares.orders[1].amount += Scalar::one();
 
-        assert!(!constraints_satisfied(witness, statement));
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which a prover attempts to modify a fee in the
@@ -653,8 +639,10 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify a fee in the wallet
-        witness.augmented_public_shares.fees[0].gas_token_amount.val += Scalar::one();
-        assert!(!constraints_satisfied(witness, statement));
+        witness.augmented_public_shares.fees[0].gas_token_amount += Scalar::one();
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which a prover attempts to modify wallet keys and
@@ -665,8 +653,10 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify a key in the wallet
-        witness.augmented_public_shares.keys.pk_match.key.val += Scalar::one();
-        assert!(!constraints_satisfied(witness, statement));
+        witness.augmented_public_shares.keys.pk_match.key = Scalar::one();
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which a prover attempts to modify the blinder in
@@ -677,8 +667,10 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the wallet blinder
-        witness.augmented_public_shares.blinder.val += Scalar::one();
-        assert!(!constraints_satisfied(witness, statement))
+        witness.augmented_public_shares.blinder += Scalar::one();
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Test the case in which the index of the send balance is incorrect
@@ -690,7 +682,9 @@ mod test {
         // Modify the index of the send balance
         statement.balance_send_index += 1;
 
-        assert!(!constraints_satisfied(witness, statement))
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Test the case in which the index of the receive balance is incorrect
@@ -702,7 +696,9 @@ mod test {
         // Modify the index of the send balance
         statement.balance_receive_index += 1;
 
-        assert!(!constraints_satisfied(witness, statement))
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Test the case in which the index of the matched order is incorrect
@@ -714,7 +710,9 @@ mod test {
         // Modify the index of the order
         statement.order_index += 1;
 
-        assert!(!constraints_satisfied(witness, statement))
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ))
     }
 
     /// Test the case in which a balance is missing from the wallet
@@ -728,9 +726,11 @@ mod test {
             BalanceShare {
                 mint: Scalar::zero(),
                 amount: Scalar::zero(),
-            }
-            .to_linkable();
-        assert!(!constraints_satisfied(witness, statement));
+            };
+
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which the receive balance is missing from the wallet
@@ -744,9 +744,11 @@ mod test {
             BalanceShare {
                 mint: Scalar::zero(),
                 amount: Scalar::zero(),
-            }
-            .to_linkable();
-        assert!(!constraints_satisfied(witness, statement));
+            };
+
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which the fee balance is missing from the wallet
@@ -766,10 +768,11 @@ mod test {
                     mint: Scalar::zero(),
                     amount: Scalar::zero(),
                 }
-                .to_linkable()
             });
 
-        assert!(!constraints_satisfied(witness, statement));
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which the order is missing from the wallet
@@ -788,9 +791,11 @@ mod test {
                 repr: Scalar::zero(),
             },
             timestamp: Scalar::zero(),
-        }
-        .to_linkable();
-        assert!(!constraints_satisfied(witness, statement));
+        };
+
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 
     /// Test the case in which the fee is missing from the wallet
@@ -814,8 +819,10 @@ mod test {
                         repr: Scalar::zero(),
                     },
                 }
-                .to_linkable()
             });
-        assert!(!constraints_satisfied(witness, statement));
+
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(
+            witness, statement
+        ));
     }
 }

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -76,7 +76,7 @@ impl EqZeroGadget {
 pub struct EqGadget {}
 impl EqGadget {
     /// Computes a == b
-    pub fn eq<V>(a: V, b: V, cs: &mut PlonkCircuit) -> Result<BoolVar, CircuitError>
+    pub fn eq<V>(a: &V, b: &V, cs: &mut PlonkCircuit) -> Result<BoolVar, CircuitError>
     where
         V: CircuitVarType,
     {
@@ -87,7 +87,7 @@ impl EqGadget {
     }
 
     /// Constraints a == b
-    pub fn constrain_eq<V, C>(a: V, b: V, cs: &mut C) -> Result<(), CircuitError>
+    pub fn constrain_eq<V, C>(a: &V, b: &V, cs: &mut C) -> Result<(), CircuitError>
     where
         V: CircuitVarType,
         C: Circuit<ScalarField>,
@@ -163,7 +163,7 @@ impl NotEqualGadget {
         b: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<BoolVar, CircuitError> {
-        let eq = EqGadget::eq(a, b, cs)?;
+        let eq = EqGadget::eq(&a, &b, cs)?;
         cs.logic_neg(eq)
     }
 }
@@ -177,7 +177,7 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
         // If we can reconstruct the value without the highest bit, the value is
         // non-negative
         let bit_reconstructed = Self::bit_decompose_reconstruct(x, cs)?;
-        EqGadget::eq(bit_reconstructed, x, cs)
+        EqGadget::eq(&bit_reconstructed, &x, cs)
     }
 
     /// Constrain the value to be greater than zero
@@ -188,7 +188,7 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
         // If we can reconstruct the value without the highest bit, the value is
         // non-negative
         let bit_reconstructed = Self::bit_decompose_reconstruct(x, cs)?;
-        EqGadget::constrain_eq(bit_reconstructed, x, cs)
+        EqGadget::constrain_eq(&bit_reconstructed, &x, cs)
     }
 
     /// A helper function to decompose a scalar into bits and then reconstruct
@@ -436,9 +436,9 @@ mod test {
         let o1_var = o1.create_witness(&mut cs);
         let o2_var = o2.create_witness(&mut cs);
 
-        let eq1 = EqGadget::eq(o1_var.clone(), o2_var.clone(), &mut cs).unwrap(); // o1 == o2
-        let eq2 = EqGadget::eq(o1_var.clone(), o1_var.clone(), &mut cs).unwrap(); // o1 == o1
-        EqGadget::constrain_eq(o1_var.clone(), o1_var, &mut cs).unwrap();
+        let eq1 = EqGadget::eq(&o1_var, &o2_var, &mut cs).unwrap(); // o1 == o2
+        let eq2 = EqGadget::eq(&o1_var, &o1_var, &mut cs).unwrap(); // o1 == o1
+        EqGadget::constrain_eq(&o1_var, &o1_var, &mut cs).unwrap();
 
         cs.enforce_false(eq1).unwrap();
         cs.enforce_true(eq2).unwrap();

--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -37,7 +37,7 @@ impl FixedPointGadget {
         cs: &mut C,
     ) -> Result<(), CircuitError> {
         let fixed_point_repr = Self::integer_to_fixed_point(rhs, cs)?;
-        EqGadget::constrain_eq(lhs, fixed_point_repr, cs)?;
+        EqGadget::constrain_eq(&lhs, &fixed_point_repr, cs)?;
 
         Ok(())
     }
@@ -51,7 +51,7 @@ impl FixedPointGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<BoolVar, CircuitError> {
         let fixed_point_repr = Self::integer_to_fixed_point(rhs, cs)?;
-        EqGadget::eq(lhs, fixed_point_repr, cs)
+        EqGadget::eq(&lhs, &fixed_point_repr, cs)
     }
 
     /// Constrain a fixed point variable to be equal to the given integer


### PR DESCRIPTION
### Purpose
This PR refactors the `VALID COMMITMENTS` circuit over `mpc-plonk`. This circuit is proved once per order and allows a relayer to augment a wallet with balances for received mints in a trade.

### Testing
- Unit tests pass