### PR TITLE
circuits: zk-circuits: valid-reblind: Refactor over `mpc-plonk`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,3 +22,5 @@ jobs:
             -D unsafe_code 
             -D missing_docs
             -D clippy::missing_docs_in_private_items
+            -D clippy::needless_pass_by_value
+            -D clippy::needless_pass_by_ref_mut

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -2,6 +2,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(future_join)]
@@ -175,15 +177,15 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        private_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        public_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
     where
         [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
     {
         let recovered_blinder = private_shares.blinder + public_shares.blinder;
         let unblinded_public_shares = public_shares.unblind_shares(recovered_blinder);
-        private_shares + unblinded_public_shares
+        private_shares.clone() + unblinded_public_shares
     }
 
     /// Compute a commitment to the shares of a wallet
@@ -192,8 +194,8 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        private_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        public_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> WalletShareStateCommitment
     where
         [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
@@ -212,7 +214,7 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        private_share: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_share: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> Scalar
     where
         [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
@@ -227,7 +229,7 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        public_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         private_share_comm: WalletShareStateCommitment,
     ) -> WalletShareStateCommitment
     where
@@ -254,7 +256,7 @@ pub mod native_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        private_secret_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        private_secret_shares: &WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> (
         WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -255,13 +255,13 @@ pub trait SecretShareType: Sized + BaseType {
     /// The base type that this secret share is a representation of
     type Base: BaseType;
     /// Apply an additive blinder to each element of the secret shares
-    fn blind(self, blinder: Scalar) -> Self {
+    fn blind(&self, blinder: Scalar) -> Self {
         let mut res_scalars = self.to_scalars().into_iter().map(|s| s + blinder);
         Self::from_scalars(&mut res_scalars)
     }
 
     /// Remove an additive blind from each element of the secret shares
-    fn unblind(self, blinder: Scalar) -> Self {
+    fn unblind(&self, blinder: Scalar) -> Self {
         let mut res_scalars = self.to_scalars().into_iter().map(|s| s - blinder);
         Self::from_scalars(&mut res_scalars)
     }
@@ -300,7 +300,7 @@ pub trait SecretShareVarType: Sized + CircuitVarType {
     }
 
     /// Remove an additive blind from each element of the secret shares
-    fn unblind(self, blinder: Variable, circuit: &mut PlonkCircuit) -> Self {
+    fn unblind(&self, blinder: Variable, circuit: &mut PlonkCircuit) -> Self {
         let res_vars = self
             .to_vars()
             .into_iter()

--- a/circuit-types/src/wallet.rs
+++ b/circuit-types/src/wallet.rs
@@ -121,7 +121,7 @@ where
 
     /// Unblinds the wallet, but does not unblind the blinder itself
     pub fn unblind_shares(
-        self,
+        &self,
         blinder: Scalar,
     ) -> WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES> {
         let prev_blinder = self.blinder;

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(inherent_associated_types)]

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -4,7 +4,7 @@
 
 pub mod valid_commitments;
 // pub mod valid_match_mpc;
-// pub mod valid_reblind;
+pub mod valid_reblind;
 // pub mod valid_settle;
 pub mod valid_wallet_create;
 pub mod valid_wallet_update;
@@ -111,8 +111,8 @@ pub mod test_helpers {
     /// Check whether a witness and statement satisfy wire assignments for a
     /// circuit
     pub fn check_constraint_satisfaction<C: SingleProverCircuit>(
-        witness: C::Witness,
-        statement: C::Statement,
+        witness: &C::Witness,
+        statement: &C::Statement,
     ) -> bool {
         // Apply the constraints
         let mut cs = PlonkCircuit::new_turbo_plonk();
@@ -136,7 +136,7 @@ pub mod test_helpers {
         const MAX_ORDERS: usize,
         const MAX_FEES: usize,
     >(
-        wallet: Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        wallet: &Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     ) -> (
         WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
@@ -150,7 +150,7 @@ pub mod test_helpers {
 
         let blinder = wallet.blinder;
         create_wallet_shares_with_randomness(
-            &wallet,
+            wallet,
             blinder,
             blinder_share,
             from_fn(|| Some(Scalar::random(&mut rng))),
@@ -325,7 +325,7 @@ pub mod test_helpers {
         // Split into secret shares
         let wallet = INITIAL_WALLET.clone();
         let wallet_blinder = wallet.blinder;
-        let (private_share, public_share) = create_wallet_shares(wallet.clone());
+        let (private_share, public_share) = create_wallet_shares(&wallet);
 
         // Unblind the public shares, recover from shares
         let unblinded_public_shares = public_share.unblind_shares(wallet_blinder);
@@ -341,11 +341,11 @@ pub mod test_helpers {
         use circuit_types::native_helpers::reblind_wallet;
 
         let mut wallet = INITIAL_WALLET.clone();
-        let (private_share, _) = create_wallet_shares(wallet.clone());
+        let (private_share, _) = create_wallet_shares(&wallet);
 
         // Reblind the shares
         let (reblinded_private_shares, reblinded_public_shares) =
-            reblind_wallet(private_share, &wallet);
+            reblind_wallet(&private_share, &wallet);
 
         // Unblind the public shares, recover from shares
         let recovered_blinder = reblinded_public_shares.blinder + reblinded_private_shares.blinder;

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -47,7 +47,7 @@ where
 {
     /// The circuit constraints for VALID COMMITMENTS
     pub fn circuit(
-        statement: ValidCommitmentsStatementVar,
+        statement: &ValidCommitmentsStatementVar,
         witness: ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -361,7 +361,7 @@ where
         statement_var: ValidCommitmentsStatementVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), PlonkError> {
-        Self::circuit(statement_var, witness_var, cs).map_err(PlonkError::CircuitError)
+        Self::circuit(&statement_var, witness_var, cs).map_err(PlonkError::CircuitError)
     }
 }
 
@@ -407,7 +407,7 @@ pub mod test_helpers {
         let mut rng = thread_rng();
 
         // Split the wallet into secret shares
-        let (private_secret_shares, public_secret_shares) = create_wallet_shares(wallet.clone());
+        let (private_secret_shares, public_secret_shares) = create_wallet_shares(wallet);
 
         // Choose an order and fee to match on
         let ind_order = 0;
@@ -564,7 +564,7 @@ mod test {
         let (witness, statement) = create_witness_and_statement(&wallet);
 
         assert!(check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -575,7 +575,7 @@ mod test {
         let (witness, statement) = create_witness_and_statement(&wallet);
 
         assert!(check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -593,7 +593,7 @@ mod test {
         witness.balance_receive.amount += 1u64;
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -612,7 +612,7 @@ mod test {
         };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -627,7 +627,7 @@ mod test {
         witness.augmented_public_shares.orders[1].amount += Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -641,7 +641,7 @@ mod test {
         // Modify a fee in the wallet
         witness.augmented_public_shares.fees[0].gas_token_amount += Scalar::one();
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -655,7 +655,7 @@ mod test {
         // Modify a key in the wallet
         witness.augmented_public_shares.keys.pk_match.key = Scalar::one();
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -669,7 +669,7 @@ mod test {
         // Modify the wallet blinder
         witness.augmented_public_shares.blinder += Scalar::one();
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -683,7 +683,7 @@ mod test {
         statement.balance_send_index += 1;
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -697,7 +697,7 @@ mod test {
         statement.balance_receive_index += 1;
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -711,7 +711,7 @@ mod test {
         statement.order_index += 1;
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ))
     }
 
@@ -729,7 +729,7 @@ mod test {
             };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -747,7 +747,7 @@ mod test {
             };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -771,7 +771,7 @@ mod test {
             });
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -794,7 +794,7 @@ mod test {
         };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 
@@ -822,7 +822,7 @@ mod test {
             });
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(
-            witness, statement
+            &witness, &statement
         ));
     }
 }

--- a/circuits/src/zk_gadgets/merkle.rs
+++ b/circuits/src/zk_gadgets/merkle.rs
@@ -15,12 +15,12 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
     /// Compute the root of the tree given the leaf node and the path of
     /// sister nodes leading to the root
     pub fn compute_root<C: Circuit<ScalarField>>(
-        leaf_node: Vec<Variable>,
-        opening: MerkleOpeningVar<HEIGHT>,
+        leaf_node: &[Variable],
+        opening: &MerkleOpeningVar<HEIGHT>,
         cs: &mut C,
     ) -> Result<Variable, CircuitError> {
         // Hash the leaf_node into a field element
-        let leaf_hash = Self::leaf_hash(&leaf_node, cs)?;
+        let leaf_hash = Self::leaf_hash(leaf_node, cs)?;
         Self::compute_root_prehashed(leaf_hash, opening, cs)
     }
 
@@ -28,7 +28,7 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
     /// buffer first
     pub fn compute_root_prehashed<C: Circuit<ScalarField>>(
         leaf_node: Variable,
-        opening: MerkleOpeningVar<HEIGHT>,
+        opening: &MerkleOpeningVar<HEIGHT>,
         cs: &mut C,
     ) -> Result<Variable, CircuitError> {
         // Hash the leaf_node into a field element
@@ -45,8 +45,8 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
 
     /// Compute the root and constrain it to an expected value
     pub fn compute_and_constrain_root<C: Circuit<ScalarField>>(
-        leaf_node: Vec<Variable>,
-        opening: MerkleOpeningVar<HEIGHT>,
+        leaf_node: &[Variable],
+        opening: &MerkleOpeningVar<HEIGHT>,
         expected_root: Variable,
         cs: &mut C,
     ) -> Result<(), CircuitError> {
@@ -58,7 +58,7 @@ impl<const HEIGHT: usize> PoseidonMerkleHashGadget<HEIGHT> {
     /// value
     pub fn compute_and_constrain_root_prehashed<C: Circuit<ScalarField>>(
         leaf_node: Variable,
-        opening: MerkleOpeningVar<HEIGHT>,
+        opening: &MerkleOpeningVar<HEIGHT>,
         expected_root: Variable,
         cs: &mut C,
     ) -> Result<(), CircuitError> {
@@ -308,8 +308,13 @@ pub(crate) mod merkle_test {
         let root = expected_root.create_public_var(&mut cs);
 
         // Apply the merkle constraints
-        PoseidonMerkleHashGadget::compute_and_constrain_root(leaf_vars, opening_var, root, &mut cs)
-            .unwrap();
+        PoseidonMerkleHashGadget::compute_and_constrain_root(
+            &leaf_vars,
+            &opening_var,
+            root,
+            &mut cs,
+        )
+        .unwrap();
 
         assert!(cs
             .check_circuit_satisfiability(&[expected_root.inner()])
@@ -331,8 +336,13 @@ pub(crate) mod merkle_test {
         let root = expected_root.create_public_var(&mut cs);
 
         // Apply the merkle constraints
-        PoseidonMerkleHashGadget::compute_and_constrain_root(leaf_vars, opening_var, root, &mut cs)
-            .unwrap();
+        PoseidonMerkleHashGadget::compute_and_constrain_root(
+            &leaf_vars,
+            &opening_var,
+            root,
+            &mut cs,
+        )
+        .unwrap();
 
         // Check constraint satisfaction with a different root
         let rand_root = Scalar::random(&mut thread_rng()).inner();


### PR DESCRIPTION
### Purpose
This PR refactors `VALID REBLIND` over the `mpc-plonk` system. This proof samples new shares for the wallet ahead of a match so that it is statistically indistinguishable from a random wallet, even given a previous match. 

This PR also adds a couple lint rules to deny useless pass by value and mutable reference. This comes from an observation that the `circuits` crate did a lot of unnecessary cloning to fit poorly-specified interfaces.

### Testing
- Unit tests pass