### PR TITLE
arbitrum-client: fetch_public_shares_from_tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
+dependencies = [
+ "dunce",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa7c9a4354b1ff9f1c85adf22802af046e20e4bb55e19b9dc6ca8cbc6f7f4e5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +346,7 @@ name = "arbitrum-client"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -8294,6 +8322,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397f229dc34c7b8231b6ef85502f9ca4e3425b8625e6d403bb74779e6b1917b5"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -9,6 +9,7 @@ ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = "0.4.0"
 alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
 num-bigint = { workspace = true }
 lazy_static = "1.4.0"
 

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -1,6 +1,7 @@
 //! Solidity ABI definitions of smart contracts, events, and other on-chain
 //! data structures used by the Arbitrum client.
 
+use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
 abigen!(
@@ -23,3 +24,9 @@ abigen!(
         event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
     ]"#
 );
+
+sol! {
+    function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
+    function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external;
+    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external;
+}

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -6,7 +6,7 @@ use constants::Scalar;
 
 use crate::{
     errors::ArbitrumClientError,
-    helpers::{deserialize_retdata, serialize_calldata},
+    helpers::{deserialize_calldata, serialize_calldata},
     serde_def_types::SerdeScalarField,
     types::{
         MatchPayload, Proof, ValidMatchSettleStatement, ValidWalletCreateStatement,
@@ -33,7 +33,7 @@ impl ArbitrumClient {
             .await
             .map_err(|e| ArbitrumClientError::ContractInteraction(e.to_string()))?;
 
-        let merkle_root = deserialize_retdata::<SerdeScalarField>(&merkle_root_bytes)?.0;
+        let merkle_root = deserialize_calldata::<SerdeScalarField>(&merkle_root_bytes)?.0;
 
         Ok(Scalar::new(merkle_root))
     }

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -33,6 +33,9 @@ pub const EMPTY_LEAF_VALUE: Scalar = Scalar(Fp(
     PhantomData,
 ));
 
+/// The number of bytes in a Solidity function selector
+pub const SELECTOR_LEN: usize = 4;
+
 lazy_static! {
     // ------------------------
     // | Merkle Tree Metadata |

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -17,6 +17,15 @@ pub enum ArbitrumClientError {
     EventQuerying(String),
     /// Error thrown when a commitment can't be found in the Merkle tree
     CommitmentNotFound,
+    /// Error thrown when a transaction can't be found
+    TxNotFound(String),
+    /// Error thrown when a transaction's selector doesn't match
+    /// one of the supported ones
+    /// (`newWallet`, `updateWallet`, `processMatchSettle`)
+    InvalidSelector,
+    /// Error thrown when a target public blinder share was not found
+    /// in a given transaction
+    BlinderNotFound,
 }
 
 impl Display for ArbitrumClientError {

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -1,5 +1,7 @@
 //! Various helpers for Arbitrum client execution
 
+use alloy_sol_types::SolCall;
+use circuit_types::{traits::BaseType, SizedWalletShare};
 use constants::Scalar;
 use ethers::{
     types::{Bytes, H256},
@@ -7,7 +9,15 @@ use ethers::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{errors::ArbitrumClientError, serde_def_types::SerdeScalarField};
+use crate::{
+    abi::{newWalletCall, processMatchSettleCall, updateWalletCall},
+    errors::ArbitrumClientError,
+    serde_def_types::SerdeScalarField,
+    types::{
+        MatchPayload, ValidMatchSettleStatement, ValidWalletCreateStatement,
+        ValidWalletUpdateStatement,
+    },
+};
 
 /// Serializes a calldata element for a contract call
 pub fn serialize_calldata<T: Serialize>(data: &T) -> Result<Bytes, ArbitrumClientError> {
@@ -17,10 +27,10 @@ pub fn serialize_calldata<T: Serialize>(data: &T) -> Result<Bytes, ArbitrumClien
 }
 
 /// Deserializes a return value from a contract call
-pub fn deserialize_retdata<'de, T: Deserialize<'de>>(
-    retdata: &'de Bytes,
+pub fn deserialize_calldata<'de, T: Deserialize<'de>>(
+    calldata: &'de Bytes,
 ) -> Result<T, ArbitrumClientError> {
-    postcard::from_bytes(retdata).map_err(|e| ArbitrumClientError::Serde(e.to_string()))
+    postcard::from_bytes(calldata).map_err(|e| ArbitrumClientError::Serde(e.to_string()))
 }
 
 /// Computes the Keccak-256 hash of the serialization of a scalar,
@@ -28,4 +38,63 @@ pub fn deserialize_retdata<'de, T: Deserialize<'de>>(
 pub fn keccak_hash_scalar(scalar: Scalar) -> Result<H256, ArbitrumClientError> {
     let scalar_bytes = serialize_calldata(&SerdeScalarField(scalar.inner()))?;
     Ok(keccak256(scalar_bytes).into())
+}
+
+pub fn parse_shares_from_new_wallet(
+    calldata: &[u8],
+) -> Result<SizedWalletShare, ArbitrumClientError> {
+    let call = newWalletCall::decode(&calldata, true /* validate */)
+        .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
+
+    let mut statement = deserialize_calldata::<ValidWalletCreateStatement>(
+        &call.valid_wallet_create_statement_bytes.into(),
+    )?;
+
+    Ok(SizedWalletShare::from_scalars(
+        &mut statement.public_wallet_shares,
+    ))
+}
+
+pub fn parse_shares_from_update_wallet(
+    calldata: &[u8],
+) -> Result<SizedWalletShare, ArbitrumClientError> {
+    let call = updateWalletCall::decode(&calldata, true /* validate */)
+        .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
+
+    let mut statement = deserialize_calldata::<ValidWalletUpdateStatement>(
+        &call.valid_wallet_update_statement_bytes.into(),
+    )?;
+
+    Ok(SizedWalletShare::from_scalars(
+        &mut statement.new_public_shares,
+    ))
+}
+
+pub fn parse_shares_from_process_match_settle(
+    calldata: &[u8],
+) -> Result<SizedWalletShare, ArbitrumClientError> {
+    let call = processMatchSettleCall::decode(&calldata, true /* validate */)
+        .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
+
+    let party_0_match_payload =
+        deserialize_calldata::<MatchPayload>(&call.party_0_match_payload.into())?;
+    let party_1_match_payload =
+        deserialize_calldata::<MatchPayload>(&call.party_1_match_payload.into())?;
+
+    let mut valid_match_settle_statement = deserialize_calldata::<ValidMatchSettleStatement>(
+        &call.valid_match_settle_statement_bytes.into(),
+    )?;
+
+    let target_share = public_blinder_share.inner();
+    if party_0_match_payload.wallet_blinder_share == target_share {
+        Ok(SizedWalletShare::from_scalars(
+            &mut valid_match_settle_statement.party0_modified_shares,
+        ))
+    } else if party_1_match_payload.wallet_blinder_share == target_share {
+        Ok(SizedWalletShare::from_scalars(
+            &mut valid_match_settle_statement.party1_modified_shares,
+        ))
+    } else {
+        Err(ArbitrumClientError::BlinderNotFound)
+    }
 }


### PR DESCRIPTION
This PR adds the `fetch_public_shares_from_tx` method to the Arbitrum client, allowing it to read a wallet's public secret shares from calldata.

Currently, this method only expects to parse shares from calldata where the {`new_wallet`, `update_wallet`, `process_match_settle`} call was a top-level call issued by an EOA, for simplicity. I've added a todo for parsing shares from calldata where the Darkpool function was called by another contract, I felt it was not worth trying to implement before having an integration testing stack.

This marks the end of the core functionality required by the client, the next PRs will focus on integration testing of the client, after which I'll focus on deprecating the Starknet client throughout the relayer in favor of the Arbitrum client.