### PR TITLE
circuits: zk-circuits: valid-match-mpc: Refactor over `mpc-plonk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "tokio-tungstenite 0.18.0",
  "tracing",
  "tungstenite 0.18.0",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
+checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
 dependencies = [
  "serde",
 ]
@@ -1590,7 +1590,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -1904,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -2408,7 +2408,7 @@ checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.8",
  "digest 0.10.7",
- "elliptic-curve 0.13.7",
+ "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
  "spki 0.7.2",
@@ -2494,12 +2494,12 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.4",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.0",
  "generic-array 0.14.7",
@@ -2816,7 +2816,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "const-hex",
- "elliptic-curve 0.13.7",
+ "elliptic-curve 0.13.8",
  "ethabi 18.0.0",
  "generic-array 0.14.7",
  "k256",
@@ -2925,7 +2925,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "const-hex",
- "elliptic-curve 0.13.7",
+ "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
@@ -2984,7 +2984,7 @@ dependencies = [
  "renegade-crypto",
  "serde",
  "serde_json",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -3400,7 +3400,7 @@ dependencies = [
  "libp2p",
  "serde",
  "serde_json",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -3525,7 +3525,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -4011,7 +4011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.24",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -4112,7 +4112,7 @@ dependencies = [
  "libp2p-core",
  "mpc-stark",
  "tokio",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -4190,7 +4190,7 @@ checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
- "elliptic-curve 0.13.7",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.8",
  "signature 2.2.0",
@@ -5222,7 +5222,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6870,9 +6870,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -7174,9 +7174,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -7201,9 +7201,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7792,7 +7792,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
 dependencies = [
- "crypto-bigint 0.5.4",
+ "crypto-bigint 0.5.5",
  "hex 0.4.3",
  "hmac 0.12.1",
  "num-bigint",
@@ -7834,7 +7834,7 @@ checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
 dependencies = [
  "ark-ff",
  "bigdecimal",
- "crypto-bigint 0.5.4",
+ "crypto-bigint 0.5.5",
  "getrandom 0.2.11",
  "hex 0.4.3",
  "num-bigint",
@@ -7879,7 +7879,7 @@ checksum = "5313524cc79344015ef2a8618947332ab17012b5c50600c7f84c60989bdec980"
 dependencies = [
  "async-trait",
  "auto_impl",
- "crypto-bigint 0.5.4",
+ "crypto-bigint 0.5.5",
  "eth-keystore",
  "rand 0.8.5",
  "starknet-core 0.5.1",
@@ -7919,7 +7919,7 @@ dependencies = [
  "tui",
  "tui-logger",
  "util",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -7940,7 +7940,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -7972,7 +7972,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-slog",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -8228,7 +8228,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -8240,7 +8240,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
- "rustix 0.38.24",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -8965,9 +8965,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.11",
  "serde",
@@ -9324,7 +9324,7 @@ dependencies = [
  "tokio",
  "turn",
  "url",
- "uuid 1.5.0",
+ "uuid 1.6.1",
  "waitgroup",
  "webrtc-mdns",
  "webrtc-util",
@@ -9427,7 +9427,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.24",
+ "rustix 0.38.25",
 ]
 
 [[package]]

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -80,6 +80,17 @@ pub type SizedMerkleOpening = MerkleOpening<MERKLE_HEIGHT>;
 #[derive(Clone, Debug)]
 pub struct AuthenticatedBool(AuthenticatedScalar);
 
+/// This implementation does no validation of the underlying value, to do so
+/// would require leaking privacy or otherwise complicated circuitry
+///
+/// The values here are eventually constrained in a collaborative proof, so
+/// there is no need to validate them here
+impl From<AuthenticatedScalar> for AuthenticatedBool {
+    fn from(value: AuthenticatedScalar) -> Self {
+        Self(value)
+    }
+}
+
 // -----------
 // | Helpers |
 // -----------

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -112,7 +112,7 @@ mod test {
 
             // Allocate the dummy value in the constraint system
             let dummy_allocated = value.allocate(PARTY0, &fabric);
-            let shared_var = dummy_allocated.create_shared_witness(&mut circuit).unwrap();
+            let shared_var = dummy_allocated.create_shared_witness(&mut circuit);
 
             // Evaluate the first variable in the var type
             let eval: AuthenticatedTestType = shared_var.eval_multiprover(&circuit);

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -29,10 +29,10 @@ pub struct MatchResult {
     pub quote_amount: u64,
     /// The amount of the base token exchanged by this match
     pub base_amount: u64,
-    /// The direction of the match, 0 implies that party 1 buys the base and
-    /// sells the quote; 1 implies that party 2 buys the base and sells the
-    /// quote
-    pub direction: u64, // Binary
+    /// The direction of the match, `true` implies that party 1 buys the quote
+    /// and sells the base, `false` implies that party 1 buys the base and
+    /// sells the quote
+    pub direction: bool,
 
     /// The following are supporting variables, derivable from the above, but
     /// useful for shrinking the size of the zero knowledge circuit. As
@@ -46,5 +46,8 @@ pub struct MatchResult {
     pub max_minus_min_amount: u64,
     /// The index of the order (0 or 1) that has the minimum amount, i.e. the
     /// order that is completely filled by this match
-    pub min_amount_order_index: u64,
+    ///
+    /// We serialize this as a `bool` to automatically constrain it to be 0 or 1
+    /// in a circuit. So `false` means 0 and `true` means 1
+    pub min_amount_order_index: bool,
 }

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -3,7 +3,7 @@
 
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
-use mpc_relation::{traits::Circuit, Variable};
+use mpc_relation::{traits::Circuit, BoolVar, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ use crate::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
         MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    Fabric,
+    AuthenticatedBool, Fabric,
 };
 
 /// Represents the base type of an open order, including the asset pair, the
@@ -108,11 +108,11 @@ impl BaseType for OrderSide {
 }
 
 impl CircuitBaseType for OrderSide {
-    type VarType = Variable;
+    type VarType = BoolVar;
 }
 
 impl MpcBaseType for OrderSide {
-    type AllocatedType = AuthenticatedScalar;
+    type AllocatedType = AuthenticatedBool;
 }
 
 impl SecretShareBaseType for OrderSide {

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test_helpers = []
+test_helpers = ["dep:env_logger", "dep:ctor", "dep:util"]
 large_benchmarks = []
 stats = ["ark-mpc/stats"]
 
@@ -58,8 +58,8 @@ ark-crypto-primitives = { version = "0.4", features = [
 ark-ff = "0.4"
 ark-mpc = { workspace = true }
 bigdecimal = "0.3"
-mpc-plonk = { workspace = true, features = ["parallel"] }
-mpc-relation = { workspace = true }
+mpc-plonk = { workspace = true, features = ["parallel", "std"] }
+mpc-relation = { workspace = true, features = ["parallel", "std"] }
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 num-integer = "0.1"
 
@@ -68,9 +68,12 @@ circuit-macros = { path = "../circuit-macros" }
 circuit-types = { path = "../circuit-types" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
+util = { path = "../util", optional = true }
 
 # === Misc Dependencies === #
 bitvec = "1.0"
+ctor = { version = "0.1", optional = true }
+env_logger = { version = "0.9", optional = true }
 futures = "0.3"
 itertools = "0.10"
 lazy_static = "1.4"
@@ -94,7 +97,7 @@ env_logger = "0.9"
 eyre = { workspace = true }
 futures = "0.3"
 inventory = "0.3"
-mpc-plonk = { workspace = true, features = ["test_apis"] }
+mpc-plonk = { workspace = true, features = ["test_apis", "std"] }
 rand = "0.8"
 serde_json = "1.0"
 test-helpers = { path = "../test-helpers" }

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -24,7 +24,7 @@ use circuit_types::{
 };
 use constants::{Scalar, ScalarField, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use mpc_plonk::errors::PlonkError;
-use mpc_relation::{errors::CircuitError, traits::Circuit, BoolVar, Variable};
+use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
 
 // ----------------------
@@ -71,15 +71,11 @@ where
             .private_secret_shares
             .add_shares(&unblinded_augmented_shares, cs);
 
-        // The order side should be binary
-        cs.enforce_bool(witness.order.side)?;
-        let side = BoolVar::new_unchecked(witness.order.side);
-
         // The mint that the wallet will receive if the order is matched
         let mut receive_send_mint = CondSelectVectorGadget::select(
             &[witness.order.quote_mint, witness.order.base_mint],
             &[witness.order.base_mint, witness.order.quote_mint],
-            side,
+            witness.order.side,
             cs,
         )?;
         let receive_mint = receive_send_mint.remove(0);

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -228,7 +228,7 @@ pub mod tests {
     use constants::Scalar;
 
     use crate::{
-        plonk_prove_and_verify,
+        singleprover_prove_and_verify,
         zk_circuits::{
             test_helpers::{
                 check_constraint_satisfaction, INITIAL_BALANCES, INITIAL_ORDERS, MAX_BALANCES,
@@ -254,7 +254,7 @@ pub mod tests {
     #[test]
     fn test_valid_initial_wallet() {
         let (witness, statement) = create_default_witness_statement();
-        plonk_prove_and_verify::<ValidWalletCreate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>>(
+        singleprover_prove_and_verify::<ValidWalletCreate<MAX_BALANCES, MAX_ORDERS, MAX_FEES>>(
             witness, statement,
         )
         .unwrap()

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -312,11 +312,6 @@ where
         new_timestamp: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Ensure all orders have boolean side
-        for order in new_wallet.orders.iter() {
-            cs.enforce_bool(order.side)?;
-        }
-
         // Ensure that all order's asset pairs are unique
         Self::constrain_unique_order_pairs(new_wallet, cs)?;
 
@@ -395,7 +390,7 @@ where
             &OrderVar {
                 quote_mint: zero,
                 base_mint: zero,
-                side: zero,
+                side: cs.false_var(),
                 amount: zero,
                 worst_case_price: FixedPointVar { repr: zero },
                 timestamp: zero,

--- a/circuits/src/zk_gadgets/bits.rs
+++ b/circuits/src/zk_gadgets/bits.rs
@@ -143,7 +143,7 @@ mod bits_test {
             async move {
                 let mut cs = MpcPlonkCircuit::new(fabric.clone());
                 let val = witness.allocate(PARTY0, &fabric);
-                let input_var = val.create_shared_witness(&mut cs).unwrap();
+                let input_var = val.create_shared_witness(&mut cs);
 
                 let res =
                     MultiproverToBitsGadget::<64 /* bits */>::to_bits(input_var, &fabric, &mut cs)

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -318,7 +318,7 @@ impl<const D: usize> MultiproverGreaterThanEqZeroGadget<D> {
         let value_assignment = x.eval_multiprover(cs);
         let bits = to_bits_le::<D>(&value_assignment, fabric)
             .into_iter()
-            .map(|bit| bit.create_shared_witness(cs).unwrap())
+            .map(|bit| bit.create_shared_witness(cs))
             .collect_vec();
 
         // Constrain the bit decomposition to be correct
@@ -506,7 +506,7 @@ mod test {
 
             // a >= 0
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = shared_a.create_shared_witness(&mut cs).unwrap();
+            let a_var = shared_a.create_shared_witness(&mut cs);
 
             MultiproverGreaterThanEqZeroGadget::<BITS>::constrain_greater_than_zero(
                 a_var, &fabric, &mut cs,
@@ -516,7 +516,7 @@ mod test {
 
             // -a >= 0
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = shared_a.create_shared_witness(&mut cs).unwrap();
+            let a_var = shared_a.create_shared_witness(&mut cs);
             let neg_a = cs.mul_constant(a_var, &-ScalarField::one()).unwrap();
 
             MultiproverGreaterThanEqZeroGadget::<BITS>::constrain_greater_than_zero(
@@ -527,8 +527,8 @@ mod test {
 
             // a >= b
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = shared_a.create_shared_witness(&mut cs).unwrap();
-            let b_var = shared_b.create_shared_witness(&mut cs).unwrap();
+            let a_var = shared_a.create_shared_witness(&mut cs);
+            let b_var = shared_b.create_shared_witness(&mut cs);
 
             MultiproverGreaterThanEqGadget::<BITS>::constrain_greater_than_eq(
                 a_var, b_var, &fabric, &mut cs,
@@ -538,8 +538,8 @@ mod test {
 
             // b >= a
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = shared_a.create_shared_witness(&mut cs).unwrap();
-            let b_var = shared_b.create_shared_witness(&mut cs).unwrap();
+            let a_var = shared_a.create_shared_witness(&mut cs);
+            let b_var = shared_b.create_shared_witness(&mut cs);
 
             MultiproverGreaterThanEqGadget::<BITS>::constrain_greater_than_eq(
                 b_var, a_var, &fabric, &mut cs,
@@ -549,7 +549,7 @@ mod test {
 
             // a >= a
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = shared_a.create_shared_witness(&mut cs).unwrap();
+            let a_var = shared_a.create_shared_witness(&mut cs);
 
             MultiproverGreaterThanEqGadget::<BITS>::constrain_greater_than_eq(
                 a_var, a_var, &fabric, &mut cs,

--- a/circuits/src/zk_gadgets/select.rs
+++ b/circuits/src/zk_gadgets/select.rs
@@ -112,19 +112,19 @@ mod cond_select_test {
             let b = b.allocate(PARTY0, &fabric);
 
             let mut cs = MpcPlonkCircuit::new(fabric.clone());
-            let a_var = a.create_shared_public_var(&mut cs).unwrap();
-            let b_var = b.create_shared_public_var(&mut cs).unwrap();
+            let a_var = a.create_shared_public_var(&mut cs);
+            let b_var = b.create_shared_public_var(&mut cs);
 
             // Selector = 1
             let sel = true.allocate(PARTY0, &fabric);
-            let sel = sel.create_shared_witness(&mut cs).unwrap();
+            let sel = sel.create_shared_witness(&mut cs);
 
             let res = CondSelectGadget::select(&a_var, &b_var, sel, &mut cs).unwrap();
             cs.enforce_equal(res, a_var).unwrap();
 
             // Selector = 0
             let sel = false.allocate(PARTY0, &fabric);
-            let sel = sel.create_shared_witness(&mut cs).unwrap();
+            let sel = sel.create_shared_witness(&mut cs);
 
             let res = CondSelectGadget::select(&a_var, &b_var, sel, &mut cs).unwrap();
             cs.enforce_equal(res, b_var).unwrap();

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -74,9 +74,9 @@ pub fn match_orders_with_max_amount(
         quote_mint: o1.quote_mint.clone(),
         base_amount: min_base_amount,
         quote_amount,
-        direction: o1.side.into(),
+        direction: matches!(o1.side, OrderSide::Sell),
         max_minus_min_amount,
-        min_amount_order_index: if max1 <= max2 { 0 } else { 1 },
+        min_amount_order_index: max1 > max2,
     })
 }
 
@@ -177,9 +177,9 @@ mod tests {
             res.quote_amount,
             350 // midpoint_price * base_amount
         );
-        assert_eq!(res.direction, 0);
+        assert_eq!(res.direction as u8, 0);
         assert_eq!(res.max_minus_min_amount, 50);
-        assert_eq!(res.min_amount_order_index, 0);
+        assert_eq!(res.min_amount_order_index as u8, 0);
     }
 
     /// Test a valid match between two order where the buy side is
@@ -208,9 +208,9 @@ mod tests {
         assert_eq!(res.quote_mint, 2u64.into());
         assert_eq!(res.base_amount, 10);
         assert_eq!(res.quote_amount, 70 /* midpoint_price * base_amount */);
-        assert_eq!(res.direction, 0);
+        assert_eq!(res.direction as u8, 0);
         assert_eq!(res.max_minus_min_amount, 90);
-        assert_eq!(res.min_amount_order_index, 0);
+        assert_eq!(res.min_amount_order_index as u8, 0);
     }
 
     /// Test a valid match between two order where the sell side is
@@ -239,9 +239,9 @@ mod tests {
         assert_eq!(res.quote_mint, 2u64.into());
         assert_eq!(res.base_amount, 10);
         assert_eq!(res.quote_amount, 70 /* midpoint_price * base_amount */);
-        assert_eq!(res.direction, 0);
+        assert_eq!(res.direction as u8, 0);
         assert_eq!(res.max_minus_min_amount, 40);
-        assert_eq!(res.min_amount_order_index, 1);
+        assert_eq!(res.min_amount_order_index as u8, 1);
     }
 
     /// Test mismatched base mints


### PR DESCRIPTION
### Purpose
This PR refactors the `VALID MATCH MPC` circuit over the `mpc-plonk` system. This method proves validity of a match that results from an MPC or the internal matching engine.

Note that we intend to combine this circuit with `VALID SETTLE`, this will come in a follow up PR.

Also deferred to a follow up are more extensive unit tests -- this circuit is tested heavily in integration tests, but given the new mocking interface for MPCs, it makes sense to test them in unit as well.

### Testing
- Unit tests pass
- Tested prove/verify 