### PR TITLE
circuits: zk-circuits: valid-match-settle: Merge match and settle circuits

### DIFF
--- a/circuit-macros/src/circuit_type.rs
+++ b/circuit-macros/src/circuit_type.rs
@@ -133,7 +133,8 @@ pub(crate) fn circuit_type_impl(target_struct: ItemStruct, macro_args: MacroArgs
 
     // Build secret share types
     if macro_args.build_secret_share_types {
-        let secret_share_type_tokens = build_secret_share_types(&target_struct, macro_args.serde);
+        let secret_share_type_tokens =
+            build_secret_share_types(&target_struct, macro_args.build_mpc_types, macro_args.serde);
         out_tokens.extend(secret_share_type_tokens);
     }
 

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -841,7 +841,7 @@ pub trait MultiProverCircuit {
         // Allocate the witness and statement in the constraint system
         let mut circuit = MpcPlonkCircuit::new(fabric.clone());
         let witness_var = witness.create_shared_witness(&mut circuit);
-        let statement_var = statement.create_shared_witness(&mut circuit);
+        let statement_var = statement.create_shared_public_var(&mut circuit);
 
         // Apply the constraints
         Self::apply_constraints_multiprover(witness_var, statement_var, &fabric, &mut circuit)?;

--- a/circuit-types/src/wallet.rs
+++ b/circuit-types/src/wallet.rs
@@ -5,7 +5,7 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::{Scalar, ScalarField};
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use itertools::Itertools;
 use mpc_relation::{traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
@@ -13,10 +13,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     scalar_from_hex_string, scalar_to_hex_string,
     traits::{
-        BaseType, CircuitBaseType, CircuitVarType, SecretShareBaseType, SecretShareType,
-        SecretShareVarType,
+        BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
+        MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    PlonkCircuit,
+    Fabric, PlonkCircuit,
 };
 
 use super::{
@@ -38,7 +38,7 @@ pub type Nullifier = Scalar;
 
 /// Represents the base type of a wallet holding orders, balances, fees, keys
 /// and cryptographic randomness
-#[circuit_type(serde, singleprover_circuit, secret_share)]
+#[circuit_type(serde, singleprover_circuit, secret_share, mpc, multiprover_circuit)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Wallet<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
 where

--- a/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
@@ -20,11 +20,15 @@ use crate::zk_gadgets::{
 
 // --- Matching Engine --- //
 
-impl ValidMatchSettle {
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidMatchSettle<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     /// The order crossing check, verifies that the matches result is valid
     /// given the orders and balances of the two parties
     pub(crate) fn validate_matching_engine(
-        witness: &ValidMatchSettleWitnessVar,
+        witness: &ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         fabric: &Fabric,
         cs: &mut MpcPlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -230,12 +234,16 @@ impl ValidMatchSettle {
 
 // --- Settlement --- //
 
-impl ValidMatchSettle {
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidMatchSettle<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     /// Validate settlement of a match result into the wallets of the two
     /// parties
     #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn validate_settlement(
-        witness: &ValidMatchSettleWitnessVar,
+        witness: &ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement: (),
         fabric: &Fabric,
         cs: &mut MpcPlonkCircuit,

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -21,12 +21,16 @@ use super::{ValidMatchSettle, ValidMatchSettleWitnessVar};
 
 // --- Matching Engine --- //
 
-impl ValidMatchSettle {
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidMatchSettle<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     /// The order crossing check, for a single prover
     ///
     /// Used to apply constraints to the verifier
     pub(crate) fn validate_matching_engine_singleprover(
-        witness: &ValidMatchSettleWitnessVar,
+        witness: &ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
         let zero = ScalarField::zero();
@@ -223,12 +227,16 @@ impl ValidMatchSettle {
 
 // --- Settlement --- //
 
-impl ValidMatchSettle {
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
+    ValidMatchSettle<MAX_BALANCES, MAX_ORDERS, MAX_FEES>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     /// Validate settlement of a match result into the wallets of the two
     /// parties
     #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn validate_settlement_singleprover(
-        witness: &ValidMatchSettleWitnessVar,
+        witness: &ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement: (),
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -6,18 +6,22 @@ use circuit_types::{
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
     r#match::MatchResultVar,
+    wallet::WalletShareVar,
     PlonkCircuit, AMOUNT_BITS, PRICE_BITS,
 };
 use constants::ScalarField;
-use mpc_relation::{errors::CircuitError, traits::Circuit};
+use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
-use crate::zk_gadgets::{
-    comparators::{EqGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget},
-    fixed_point::FixedPointGadget,
-    select::{CondSelectGadget, CondSelectVectorGadget},
+use crate::{
+    zk_circuits::valid_commitments::OrderSettlementIndicesVar,
+    zk_gadgets::{
+        comparators::{EqGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget},
+        fixed_point::FixedPointGadget,
+        select::{CondSelectGadget, CondSelectVectorGadget},
+    },
 };
 
-use super::{ValidMatchSettle, ValidMatchSettleWitnessVar};
+use super::{ValidMatchSettle, ValidMatchSettleStatementVar, ValidMatchSettleWitnessVar};
 
 // --- Matching Engine --- //
 
@@ -232,14 +236,168 @@ impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize, const MAX_FEES: usize>
 where
     [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
 {
-    /// Validate settlement of a match result into the wallets of the two
-    /// parties
-    #[allow(clippy::needless_pass_by_ref_mut)]
-    pub(crate) fn validate_settlement_singleprover(
+    /// The circuit representing `VALID SETTLE`
+    pub fn validate_settlement_singleprover(
+        statement: &ValidMatchSettleStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         witness: &ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
-        statement: (),
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
+        // Select the balances received by each party
+        let (base_amt, quote_amt) = (
+            witness.match_res.base_amount,
+            witness.match_res.quote_amount,
+        );
+        let party0_party1_received = CondSelectGadget::select(
+            &[quote_amt, base_amt],
+            &[base_amt, quote_amt],
+            witness.match_res.direction,
+            cs,
+        )?;
+
+        let party0_received_amount = party0_party1_received[0];
+        let party1_received_amount = party0_party1_received[1];
+
+        // Constrain the wallet updates to party0's shares
+        Self::validate_balance_updates_singleprover(
+            party1_received_amount,
+            party0_received_amount,
+            &statement.party0_indices,
+            &witness.party0_public_shares,
+            &statement.party0_modified_shares,
+            cs,
+        )?;
+
+        Self::validate_order_updates_singleprover(
+            witness.match_res.base_amount,
+            &statement.party0_indices,
+            &witness.party0_public_shares,
+            &statement.party0_modified_shares,
+            cs,
+        )?;
+
+        Self::validate_fees_keys_blinder_updates_singleprover(
+            &witness.party0_public_shares,
+            &statement.party0_modified_shares,
+            cs,
+        )?;
+
+        // Constrain the wallet update to party1's shares
+        Self::validate_balance_updates_singleprover(
+            party0_received_amount,
+            party1_received_amount,
+            &statement.party1_indices,
+            &witness.party1_public_shares,
+            &statement.party1_modified_shares,
+            cs,
+        )?;
+
+        Self::validate_order_updates_singleprover(
+            witness.match_res.base_amount,
+            &statement.party1_indices,
+            &witness.party1_public_shares,
+            &statement.party1_modified_shares,
+            cs,
+        )?;
+
+        Self::validate_fees_keys_blinder_updates_singleprover(
+            &witness.party1_public_shares,
+            &statement.party1_modified_shares,
+            cs,
+        )
+    }
+
+    /// Verify that the balance updates to a wallet are valid
+    ///
+    /// That is, all balances in the settled wallet are the same as in the
+    /// pre-settle wallet except for the balance sent and the balance
+    /// received, which have the correct amounts applied from the match
+    fn validate_balance_updates_singleprover(
+        send_amount: Variable,
+        received_amount: Variable,
+        indices: &OrderSettlementIndicesVar,
+        pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let one = ScalarField::one();
+
+        let mut curr_index = cs.zero();
+        for (pre_update_balance, post_update_balance) in pre_update_shares
+            .balances
+            .clone()
+            .into_iter()
+            .zip(post_update_shares.balances.clone().into_iter())
+        {
+            // Mask the send term
+            let send_term_index_mask = EqGadget::eq(&indices.balance_send, &curr_index, cs)?;
+            let masked_send = cs.mul_with_coeff(send_term_index_mask.into(), send_amount, &-one)?;
+
+            // Mask the receive term
+            let receive_term_index_mask = EqGadget::eq(&indices.balance_receive, &curr_index, cs)?;
+            let masked_receive = cs.mul(receive_term_index_mask.into(), received_amount)?;
+
+            // Add the terms together to get the expected update
+            let expected_balance_amount =
+                cs.sum(&[pre_update_balance.amount, masked_send, masked_receive])?;
+            let mut expected_balance_shares = pre_update_balance.clone();
+            expected_balance_shares.amount = expected_balance_amount;
+
+            EqGadget::constrain_eq(&expected_balance_shares, &post_update_balance, cs)?;
+
+            // Increment the index
+            curr_index = cs.add(curr_index, cs.one())?;
+        }
+
         Ok(())
+    }
+
+    /// Verify that order updates to a wallet are valid
+    ///
+    /// The orders should all be equal except that the amount of the matched
+    /// order should be decremented by the amount of the base token swapped
+    fn validate_order_updates_singleprover(
+        base_amount_swapped: Variable,
+        indices: &OrderSettlementIndicesVar,
+        pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let one = ScalarField::one();
+
+        let mut curr_index = cs.zero();
+        for (pre_update_order, post_update_order) in pre_update_shares
+            .orders
+            .clone()
+            .into_iter()
+            .zip(post_update_shares.orders.clone().into_iter())
+        {
+            // Mask with the index
+            let index_mask = EqGadget::eq(&indices.order, &curr_index, cs)?;
+            let delta_term = cs.mul_with_coeff(index_mask.into(), base_amount_swapped, &-one)?;
+
+            // Constrain the order update to be correct
+            let expected_volume = cs.add(pre_update_order.amount, delta_term)?;
+            let mut expected_order_shares = pre_update_order.clone();
+            expected_order_shares.amount = expected_volume;
+
+            EqGadget::constrain_eq(&expected_order_shares, &post_update_order, cs)?;
+
+            // Increment the index
+            curr_index = cs.add(curr_index, cs.one())?;
+        }
+
+        Ok(())
+    }
+
+    /// Validate that fees, keys, and blinders remain the same in the pre and
+    /// post wallet shares
+    fn validate_fees_keys_blinder_updates_singleprover(
+        pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        EqGadget::constrain_eq(&pre_update_shares.fees, &post_update_shares.fees, cs)?;
+        EqGadget::constrain_eq(&pre_update_shares.keys, &post_update_shares.keys, cs)?;
+        EqGadget::constrain_eq(&pre_update_shares.blinder, &post_update_shares.blinder, cs)
     }
 }


### PR DESCRIPTION
### Purpose
This PR merges the match and settle circuits into one. This is necessary to enable proof linking across all proofs. This PR also refactors the circuits over the `mpc-plonk` system.

This circuit now validates the execution of the matching engine as well as the execution of the settlement logic into the two parties' wallets.

Along the way it was necessary to build a multiprover `==` gadget, this exposes an interface to test equality on only public values -- i.e. those that have been opened. We use this only on statement types (indices) so this is safe.

### Testing
- Unit tests pass