### PR TITLE
arbitrum-client: integration: setup pre-allocated state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "circuit-types",
+ "circuits",
  "clap 4.4.8",
  "common",
  "constants",
@@ -365,6 +366,7 @@ dependencies = [
  "serde",
  "serde_with 3.4.0",
  "test-helpers",
+ "tokio",
  "util",
 ]
 
@@ -763,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9d5715c2d329bf1b4da8d60455b99b187f27ba726df2883799af9af60997"
+checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -777,15 +779,14 @@ dependencies = [
  "rustix",
  "slab",
  "tracing",
- "waker-fn",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655b9c7fe787d3b25cc0f804a1a8401790f0c5bc395beb5a64dc77d8de079105"
+checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -1353,7 +1354,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3074,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -3085,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96b852f1345da36d551b9473fa1e2b1eb5c5195585c6c018118bc92a8d91160"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -3475,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -3661,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -4065,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -4168,7 +4169,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4212,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4865,7 +4866,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -5042,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -5074,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#996790a4903bec7a21fefe0863d4ff92093a6cd0"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#dee7e229f42a1395761fdbbb7f4c4a19897ef529"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5769,7 +5770,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6042,16 +6043,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53b6af1f60f36f8c2ac2aad5459d75a5a9b4be1e8cdd40264f315d78193e531"
+checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6241,9 +6242,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -6954,9 +6955,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724fd11728a3804e9944b14cab63825024c40bf42f8af87c8b5d97c4bbacf426"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "proptest",
  "rand 0.8.5",
@@ -9227,12 +9228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
-
-[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9704,7 +9699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9713,7 +9708,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9737,7 +9732,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -9756,6 +9760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9766,6 +9785,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9780,6 +9805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9790,6 +9821,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9804,6 +9841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9814,6 +9857,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9828,6 +9877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9838,6 +9893,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -9,19 +9,22 @@ path = "integration/main.rs"
 harness = false
 
 [dependencies]
-ethers = "2"
+# === Cryptography / Arithmetic === #
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = "0.4.0"
-alloy-primitives = "0.3.1"
-alloy-sol-types = "0.3.1"
 num-bigint = { workspace = true }
 num-traits = "0.2"
-lazy_static = "1.4.0"
+
+# === Networking / Blockchain === #
+ethers = "2"
+alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
 
 # === Workspace Dependencies === #
 constants = { path = "../constants" }
-circuit-types = { path = "../circuit-types" }
+circuit-types = { path = "../circuit-types", features = ["test-helpers"] }
+circuits = { path = "../circuits", features = ["test_helpers"] }
 common = { path = "../common" }
 renegade-crypto = { path = "../renegade-crypto" }
 
@@ -30,9 +33,13 @@ serde = { workspace = true }
 serde_with = "3.4"
 postcard = { version = "1", features = ["alloc"] }
 
+# === Misc === #
+lazy_static = "1.4.0"
+
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
 eyre = { workspace = true }
 test-helpers = { path = "../test-helpers" }
 util = { path = "../util" }
 json = "0.12"
+tokio = { workspace = true }

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -1,11 +1,20 @@
 //! Helper functions for Arbitrum client integration tests
 
+use arbitrum_client::{client::ArbitrumClient, types::ContractValidWalletCreateStatement};
+use circuit_types::{
+    native_helpers::compute_wallet_commitment_from_private, traits::SingleProverCircuit,
+    wallet::WalletShareStateCommitment,
+};
+use circuits::zk_circuits::{
+    test_helpers::SizedWalletShare,
+    valid_wallet_create::{test_helpers::create_default_witness_statement, ValidWalletCreate},
+};
 use eyre::{eyre, Result};
 use std::{fs::File, io::Read};
 
 use crate::constants::DEPLOYMENTS_KEY;
 
-/// Parse a `deployments.json` file to get the address of a deployed contract
+/// Parse the address of the deployed contract from the `deployments.json` file
 pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> Result<String> {
     let mut file_contents = String::new();
     File::open(file_path)?.read_to_string(&mut file_contents)?;
@@ -15,4 +24,30 @@ pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> 
         .as_str()
         .map(|s| s.to_string())
         .ok_or_else(|| eyre!("Could not parse darkpool address from deployments file"))
+}
+
+/// Deploy a new wallet and return the commitment to the wallet and the
+/// public shares of the wallet
+pub async fn deploy_new_wallet(
+    client: &ArbitrumClient,
+) -> Result<(WalletShareStateCommitment, SizedWalletShare)> {
+    let (witness, statement) = create_default_witness_statement();
+    let proof = ValidWalletCreate::prove(witness, statement.clone())?;
+    let contract_statement: ContractValidWalletCreateStatement = statement.clone().into();
+
+    client
+        .new_wallet(
+            statement.public_wallet_shares.blinder,
+            contract_statement,
+            proof,
+        )
+        .await?;
+
+    // The contract will compute the full commitment and insert it into the Merkle
+    // tree; we repeat the same computation here for consistency
+    let full_commitment = compute_wallet_commitment_from_private(
+        &statement.public_wallet_shares,
+        statement.private_shares_commitment,
+    );
+    Ok((full_commitment, statement.public_wallet_shares))
 }

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -122,7 +122,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 
 /// Sets up pre-allocated state used by the integration tests
 fn setup_pre_allocated_state(client: &ArbitrumClient) -> Result<PreAllocatedState> {
-    // Insert two new wallets into the contract
+    // Insert three new wallets into the contract
     let (index0_commitment, index0_shares) = block_on_result(deploy_new_wallet(client))?;
     let (index1_commitment, index1_shares) = block_on_result(deploy_new_wallet(client))?;
     let (index2_commitment, index2_shares) = block_on_result(deploy_new_wallet(client))?;

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -9,8 +9,8 @@ use crate::{
     helpers::{deserialize_calldata, serialize_calldata},
     serde_def_types::SerdeScalarField,
     types::{
-        MatchPayload, Proof, ValidMatchSettleStatement, ValidWalletCreateStatement,
-        ValidWalletUpdateStatement,
+        ContractProof, ContractValidMatchSettleStatement, ContractValidWalletCreateStatement,
+        ContractValidWalletUpdateStatement, MatchPayload,
     },
 };
 
@@ -79,12 +79,12 @@ impl ArbitrumClient {
     pub async fn new_wallet(
         &self,
         wallet_blinder_share: Scalar,
-        valid_wallet_create_statement: ValidWalletCreateStatement,
+        valid_wallet_create_statement: ContractValidWalletCreateStatement,
         proof: PlonkProof,
     ) -> Result<(), ArbitrumClientError> {
         let wallet_blinder_share_calldata =
             serialize_calldata(&SerdeScalarField(wallet_blinder_share.inner()))?;
-        let contract_proof: Proof = proof.try_into()?;
+        let contract_proof: ContractProof = proof.try_into()?;
         let proof_calldata = serialize_calldata(&contract_proof)?;
         let valid_wallet_create_statement_calldata =
             serialize_calldata(&valid_wallet_create_statement)?;
@@ -110,13 +110,13 @@ impl ArbitrumClient {
     pub async fn update_wallet(
         &self,
         wallet_blinder_share: Scalar,
-        valid_wallet_update_statement: ValidWalletUpdateStatement,
+        valid_wallet_update_statement: ContractValidWalletUpdateStatement,
         statement_signature: Vec<u8>,
         proof: PlonkProof,
     ) -> Result<(), ArbitrumClientError> {
         let wallet_blinder_share_calldata =
             serialize_calldata(&SerdeScalarField(wallet_blinder_share.inner()))?;
-        let contract_proof: Proof = proof.try_into()?;
+        let contract_proof: ContractProof = proof.try_into()?;
         let proof_calldata = serialize_calldata(&contract_proof)?;
         let valid_wallet_update_statement_calldata =
             serialize_calldata(&valid_wallet_update_statement)?;
@@ -149,33 +149,35 @@ impl ArbitrumClient {
         party_1_match_payload: MatchPayload,
         party_1_valid_commitments_proof: PlonkProof,
         party_1_valid_reblind_proof: PlonkProof,
-        valid_match_settle_statement: ValidMatchSettleStatement,
+        valid_match_settle_statement: ContractValidMatchSettleStatement,
         valid_match_settle_proof: PlonkProof,
     ) -> Result<(), ArbitrumClientError> {
         let party_0_match_payload_calldata = serialize_calldata(&party_0_match_payload)?;
 
-        let party_0_valid_commitments_proof: Proof = party_0_valid_commitments_proof.try_into()?;
+        let party_0_valid_commitments_proof: ContractProof =
+            party_0_valid_commitments_proof.try_into()?;
         let party_0_valid_commitments_proof_calldata =
             serialize_calldata(&party_0_valid_commitments_proof)?;
 
-        let party_0_valid_reblind_proof: Proof = party_0_valid_reblind_proof.try_into()?;
+        let party_0_valid_reblind_proof: ContractProof = party_0_valid_reblind_proof.try_into()?;
         let party_0_valid_reblind_proof_calldata =
             serialize_calldata(&party_0_valid_reblind_proof)?;
 
         let party_1_match_payload_calldata = serialize_calldata(&party_1_match_payload)?;
 
-        let party_1_valid_commitments_proof: Proof = party_1_valid_commitments_proof.try_into()?;
+        let party_1_valid_commitments_proof: ContractProof =
+            party_1_valid_commitments_proof.try_into()?;
         let party_1_valid_commitments_proof_calldata =
             serialize_calldata(&party_1_valid_commitments_proof)?;
 
-        let party_1_valid_reblind_proof: Proof = party_1_valid_reblind_proof.try_into()?;
+        let party_1_valid_reblind_proof: ContractProof = party_1_valid_reblind_proof.try_into()?;
         let party_1_valid_reblind_proof_calldata =
             serialize_calldata(&party_1_valid_reblind_proof)?;
 
         let valid_match_settle_statement_calldata =
             serialize_calldata(&valid_match_settle_statement)?;
 
-        let valid_match_settle_proof: Proof = valid_match_settle_proof.try_into()?;
+        let valid_match_settle_proof: ContractProof = valid_match_settle_proof.try_into()?;
         let valid_match_settle_proof_calldata = serialize_calldata(&valid_match_settle_proof)?;
 
         self.darkpool_contract

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Various helpers for Arbitrum client execution
 
 use alloy_sol_types::SolCall;
-use circuit_types::{traits::BaseType, SizedWalletShare};
+use circuit_types::{traits::BaseType, wallet::WalletShare};
 use constants::Scalar;
 use ethers::{
     types::{Bytes, H256},
@@ -14,8 +14,8 @@ use crate::{
     errors::ArbitrumClientError,
     serde_def_types::SerdeScalarField,
     types::{
-        MatchPayload, ValidMatchSettleStatement, ValidWalletCreateStatement,
-        ValidWalletUpdateStatement,
+        ContractValidMatchSettleStatement, ContractValidWalletCreateStatement,
+        ContractValidWalletUpdateStatement, MatchPayload,
     },
 };
 
@@ -41,42 +41,63 @@ pub fn keccak_hash_scalar(scalar: Scalar) -> Result<H256, ArbitrumClientError> {
 }
 
 /// Parses wallet shares from the calldata of a `newWallet` call
-pub fn parse_shares_from_new_wallet(
+pub fn parse_shares_from_new_wallet<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
     calldata: &[u8],
-) -> Result<SizedWalletShare, ArbitrumClientError> {
+) -> Result<WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>, ArbitrumClientError>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let call = newWalletCall::decode(calldata, true /* validate */)
         .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
 
-    let statement = deserialize_calldata::<ValidWalletCreateStatement>(
+    let statement = deserialize_calldata::<ContractValidWalletCreateStatement>(
         &call.valid_wallet_create_statement_bytes.into(),
     )?;
 
     let mut shares = statement.public_wallet_shares.into_iter().map(Scalar::new);
 
-    Ok(SizedWalletShare::from_scalars(&mut shares))
+    Ok(WalletShare::from_scalars(&mut shares))
 }
 
 /// Parses wallet shares from the calldata of an `updateWallet` call
-pub fn parse_shares_from_update_wallet(
+pub fn parse_shares_from_update_wallet<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
     calldata: &[u8],
-) -> Result<SizedWalletShare, ArbitrumClientError> {
+) -> Result<WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>, ArbitrumClientError>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let call = updateWalletCall::decode(calldata, true /* validate */)
         .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
 
-    let statement = deserialize_calldata::<ValidWalletUpdateStatement>(
+    let statement = deserialize_calldata::<ContractValidWalletUpdateStatement>(
         &call.valid_wallet_update_statement_bytes.into(),
     )?;
 
     let mut shares = statement.new_public_shares.into_iter().map(Scalar::new);
 
-    Ok(SizedWalletShare::from_scalars(&mut shares))
+    Ok(WalletShare::from_scalars(&mut shares))
 }
 
 /// Parses wallet shares from the calldata of a `processMatchSettle` call
-pub fn parse_shares_from_process_match_settle(
+pub fn parse_shares_from_process_match_settle<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+    const MAX_FEES: usize,
+>(
     calldata: &[u8],
     public_blinder_share: Scalar,
-) -> Result<SizedWalletShare, ArbitrumClientError> {
+) -> Result<WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>, ArbitrumClientError>
+where
+    [(); MAX_BALANCES + MAX_ORDERS + MAX_FEES]: Sized,
+{
     let call = processMatchSettleCall::decode(calldata, true /* validate */)
         .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
 
@@ -85,7 +106,7 @@ pub fn parse_shares_from_process_match_settle(
     let party_1_match_payload =
         deserialize_calldata::<MatchPayload>(&call.party_1_match_payload.into())?;
 
-    let valid_match_settle_statement = deserialize_calldata::<ValidMatchSettleStatement>(
+    let valid_match_settle_statement = deserialize_calldata::<ContractValidMatchSettleStatement>(
         &call.valid_match_settle_statement_bytes.into(),
     )?;
 
@@ -96,14 +117,14 @@ pub fn parse_shares_from_process_match_settle(
             .into_iter()
             .map(Scalar::new);
 
-        Ok(SizedWalletShare::from_scalars(&mut shares))
+        Ok(WalletShare::from_scalars(&mut shares))
     } else if party_1_match_payload.wallet_blinder_share == target_share {
         let mut shares = valid_match_settle_statement
             .party1_modified_shares
             .into_iter()
             .map(Scalar::new);
 
-        Ok(SizedWalletShare::from_scalars(&mut shares))
+        Ok(WalletShare::from_scalars(&mut shares))
     } else {
         Err(ArbitrumClientError::BlinderNotFound)
     }

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -2,11 +2,11 @@
 //! in proving knowledge of witness for throughout the network
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-// pub mod valid_commitments;
-// pub mod valid_match_mpc;
+pub mod valid_commitments;
+pub mod valid_match_settle;
 pub mod valid_reblind;
 pub mod valid_wallet_create;
-// pub mod valid_wallet_update;
+pub mod valid_wallet_update;
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {

--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -6,10 +6,10 @@
 //!
 //! Some low level gadgets are defined here to provide MPC efficiency
 
-// pub mod arithmetic;
+pub mod arithmetic;
 pub mod bits;
-// pub mod comparators;
-// pub mod fixed_point;
+pub mod comparators;
+pub mod fixed_point;
 pub mod merkle;
 pub mod poseidon;
 pub mod select;


### PR DESCRIPTION
This PR introduces the setup of pre-allocated state in the Arbitrum client integration tests, including the necessary helpers to implement this.

It's worth noting that the client in the integration tests will assume that the contracts have had the appropriate verification keys set prior to the test beginning. This will be implemented as another script in the contracts repo which will be invoked within the docker compose stack for the devnet.

At the moment, we use the actual circuitry (on the smaller `(2, 2, 1)` parameter set) in the integration tests for ease of use with existing relayer utilities. If this proves burdensome in terms of proving time in integration tests, or failing proofs (which is out of scope for the client integration tests), I will write dummy circuits that expect the same witnesses but are trivially constrained (and small).