### PR TITLE
config: Add `disabled-exchanges` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ name = "config"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
- "clap 3.2.25",
+ "clap 4.4.2",
  "common",
  "ed25519-dalek 1.0.1",
  "libp2p",

--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -1,6 +1,9 @@
 //! Defines exchanges used for price information
 
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +39,21 @@ impl Display for Exchange {
             Exchange::UniswapV3 => String::from("uniswapv3"),
         };
         write!(f, "{}", fmt_str)
+    }
+}
+
+impl FromStr for Exchange {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "binance" => Ok(Exchange::Binance),
+            "coinbase" => Ok(Exchange::Coinbase),
+            "kraken" => Ok(Exchange::Kraken),
+            "okx" => Ok(Exchange::Okx),
+            "uniswapv3" | "uniswap" => Ok(Exchange::UniswapV3),
+            _ => Err(format!("Unknown exchange: {s}")),
+        }
     }
 }
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,7 +13,7 @@ util = { path = "../util" }
 
 # === Misc Dependencies === #
 base64 = "0.13"
-clap = { version = "3.2.8", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 rand_core = "0.5"
 serde = { workspace = true }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -234,7 +234,7 @@ async fn main() -> Result<(), CoordinatorError> {
         coinbase_api_secret: args.coinbase_api_secret,
         eth_websocket_addr: args.eth_websocket_addr,
         disabled: args.disable_price_reporter,
-        disable_binance: args.disable_binance,
+        disabled_exchanges: args.disabled_exchanges,
     })
     .expect("failed to build price reporter manager");
     price_reporter_manager

--- a/workers/price-reporter/src/worker.rs
+++ b/workers/price-reporter/src/worker.rs
@@ -34,10 +34,8 @@ pub struct PriceReporterManagerConfig {
     pub eth_websocket_addr: Option<String>,
     /// Whether or not the worker is disabled
     pub disabled: bool,
-    /// Whether or not to disable binance streaming
-    ///
-    /// Used in locations that Binance has IP blocked
-    pub disable_binance: bool,
+    /// Exchanges that are explicitly disabled for price reporting
+    pub disabled_exchanges: Vec<Exchange>,
     /// The channel on which the coordinator may mandate that the price reporter
     /// manager cancel its execution
     pub cancel_channel: CancelChannel,
@@ -50,13 +48,16 @@ impl PriceReporterManagerConfig {
     /// For example; we do not connect to Coinbase if a Coinbase API key
     /// and secret is not provided
     pub(crate) fn exchange_configured(&self, exchange: Exchange) -> bool {
-        match exchange {
+        let disabled = self.disabled_exchanges.contains(&exchange);
+        let configured = match exchange {
             Exchange::Coinbase => {
                 self.coinbase_api_key.is_some() && self.coinbase_api_secret.is_some()
             },
             Exchange::UniswapV3 => self.eth_websocket_addr.is_some(),
             _ => true,
-        }
+        };
+
+        !disabled && configured
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a `--disabled-exchanges` flag which allows the CLI to specify which exchanges to disable. This replaces the ad-hoc `--disable-binance` flag.

### Testing
- Disabled binance and uniswap using the flag, verified that price reports excluded them