### PR TITLE
util: matching-engine: Centralize settlement logic into util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8842,6 +8842,8 @@ dependencies = [
  "json",
  "lazy_static",
  "libp2p",
+ "num-bigint",
+ "rand 0.8.5",
  "renegade-crypto",
  "tokio",
  "tracing",

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -5,6 +5,7 @@ use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     traits::{
@@ -50,4 +51,19 @@ pub struct MatchResult {
     /// We serialize this as a `bool` to automatically constrain it to be 0 or 1
     /// in a circuit. So `false` means 0 and `true` means 1
     pub min_amount_order_index: bool,
+}
+
+/// The indices that specify where settlement logic should modify the wallet
+/// shares
+#[circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct OrderSettlementIndices {
+    /// The index of the balance that holds the mint that the wallet will
+    /// send if a successful match occurs
+    pub balance_send: u64,
+    /// The index of the balance that holds the mint that the wallet will
+    /// receive if a successful match occurs
+    pub balance_receive: u64,
+    /// The index of the order that is to be matched
+    pub order: u64,
 }

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -137,3 +137,9 @@ impl From<u64> for OrderSide {
         }
     }
 }
+
+impl From<bool> for OrderSide {
+    fn from(value: bool) -> Self {
+        Self::from(value as u64)
+    }
+}

--- a/circuits/integration/mpc_circuits/match_settle.rs
+++ b/circuits/integration/mpc_circuits/match_settle.rs
@@ -7,6 +7,7 @@ use circuit_types::{
     balance::Balance,
     fixed_point::FixedPoint,
     order::OrderSide,
+    r#match::OrderSettlementIndices,
     traits::{BaseType, MpcBaseType, MpcType, MultiProverCircuit, MultiproverCircuitBaseType},
     Fabric, MpcPlonkCircuit,
 };
@@ -15,7 +16,6 @@ use circuits::{
     test_helpers::{random_indices, random_orders_and_match},
     zk_circuits::{
         test_helpers::{SizedWallet, MAX_BALANCES, MAX_FEES, MAX_ORDERS},
-        valid_commitments::OrderSettlementIndices,
         valid_match_settle::{
             AuthenticatedValidMatchSettleStatement, AuthenticatedValidMatchSettleWitness,
             ValidMatchSettle,

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -158,7 +158,7 @@ pub mod test_helpers {
     use circuit_types::{
         fixed_point::FixedPoint,
         order::{Order, OrderSide},
-        r#match::MatchResult,
+        r#match::{MatchResult, OrderSettlementIndices},
         traits::BaseType,
         wallet::WalletShare,
     };
@@ -171,10 +171,7 @@ pub mod test_helpers {
     use tracing::log::LevelFilter;
     use util::matching_engine::match_orders_with_max_amount;
 
-    use crate::zk_circuits::{
-        test_helpers::{MAX_BALANCES, MAX_ORDERS},
-        valid_commitments::OrderSettlementIndices,
-    };
+    use crate::zk_circuits::test_helpers::{MAX_BALANCES, MAX_ORDERS};
 
     // -----------
     // | Helpers |

--- a/circuits/src/mpc_circuits/settle.rs
+++ b/circuits/src/mpc_circuits/settle.rs
@@ -1,11 +1,11 @@
 //! Settles a match into secret shared wallets
 
-use circuit_types::{r#match::AuthenticatedMatchResult, wallet::AuthenticatedWalletShare};
-
-use crate::{
-    mpc_gadgets::comparators::cond_select_vec,
-    zk_circuits::valid_commitments::OrderSettlementIndices,
+use circuit_types::{
+    r#match::{AuthenticatedMatchResult, OrderSettlementIndices},
+    wallet::AuthenticatedWalletShare,
 };
+
+use crate::mpc_gadgets::comparators::cond_select_vec;
 
 /// Settles a match into two wallets and returns the updated wallet shares
 ///
@@ -70,7 +70,7 @@ mod test {
     use ark_mpc::{PARTY0, PARTY1};
     use circuit_types::{
         order::OrderSide,
-        r#match::MatchResult,
+        r#match::{MatchResult, OrderSettlementIndices},
         traits::{BaseType, MpcBaseType, MpcType},
         SizedWalletShare,
     };
@@ -78,15 +78,9 @@ mod test {
     use rand::{thread_rng, Rng};
     use renegade_crypto::fields::scalar_to_biguint;
     use test_helpers::mpc_network::execute_mock_mpc;
+    use util::matching_engine::apply_match_to_shares;
 
-    use crate::{
-        mpc_circuits::settle::settle_match,
-        test_helpers::random_indices,
-        zk_circuits::{
-            valid_commitments::OrderSettlementIndices,
-            valid_match_settle::test_helpers::apply_match_to_shares,
-        },
-    };
+    use crate::{mpc_circuits::settle::settle_match, test_helpers::random_indices};
 
     /// The parameterization of a test
     #[derive(Clone)]
@@ -126,14 +120,14 @@ mod test {
         let party0_pre_shares = random_shares();
         let party0_indices = random_indices();
         let party0_side = OrderSide::from(match_res.direction as u64);
-        let party0_post_shares =
-            apply_match_to_shares(&party0_pre_shares, &party0_indices, &match_res, party0_side);
+        let mut party0_post_shares = party0_pre_shares.clone();
+        apply_match_to_shares(&mut party0_post_shares, &party0_indices, &match_res, party0_side);
 
         let party1_pre_shares = random_shares();
         let party1_indices = random_indices();
         let party1_side = party0_side.opposite();
-        let party1_post_shares =
-            apply_match_to_shares(&party1_pre_shares, &party1_indices, &match_res, party1_side);
+        let mut party1_post_shares = party1_pre_shares.clone();
+        apply_match_to_shares(&mut party1_post_shares, &party1_indices, &match_res, party1_side);
 
         SettlementTest {
             match_res,

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -18,14 +18,12 @@ use circuit_types::{
     balance::{Balance, BalanceVar},
     fee::{Fee, FeeVar},
     order::{Order, OrderVar},
-    traits::{
-        BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
-        MultiproverCircuitBaseType, SecretShareVarType,
-    },
+    r#match::OrderSettlementIndices,
+    traits::{BaseType, CircuitBaseType, CircuitVarType, SecretShareVarType},
     wallet::{WalletShare, WalletVar},
-    Fabric, PlonkCircuit,
+    PlonkCircuit,
 };
-use constants::{AuthenticatedScalar, Scalar, ScalarField, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
+use constants::{Scalar, ScalarField, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use mpc_plonk::errors::PlonkError;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
@@ -312,21 +310,6 @@ pub type SizedValidCommitmentsWitness = ValidCommitmentsWitness<MAX_BALANCES, MA
 pub struct ValidCommitmentsStatement {
     /// The indices used in settling this order once matched
     pub indices: OrderSettlementIndices,
-}
-
-/// The indices that specify where settlement logic should modify the wallet
-/// shares
-#[circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)]
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-pub struct OrderSettlementIndices {
-    /// The index of the balance that holds the mint that the wallet will
-    /// send if a successful match occurs
-    pub balance_send: u64,
-    /// The index of the balance that holds the mint that the wallet will
-    /// receive if a successful match occurs
-    pub balance_receive: u64,
-    /// The index of the order that is to be matched
-    pub order: u64,
 }
 
 // ---------------------

--- a/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
@@ -5,7 +5,7 @@ use circuit_types::{
     balance::BalanceVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::MatchResultVar,
+    r#match::{MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     Fabric, MpcPlonkCircuit, AMOUNT_BITS, PRICE_BITS,
 };
@@ -13,16 +13,13 @@ use constants::ScalarField;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
 use super::{ValidMatchSettle, ValidMatchSettleStatementVar, ValidMatchSettleWitnessVar};
-use crate::{
-    zk_circuits::valid_commitments::OrderSettlementIndicesVar,
-    zk_gadgets::{
-        comparators::{
-            EqGadget, MultiproverEqGadget, MultiproverGreaterThanEqGadget,
-            MultiproverGreaterThanEqZeroGadget,
-        },
-        fixed_point::MultiproverFixedPointGadget,
-        select::{CondSelectGadget, CondSelectVectorGadget},
+use crate::zk_gadgets::{
+    comparators::{
+        EqGadget, MultiproverEqGadget, MultiproverGreaterThanEqGadget,
+        MultiproverGreaterThanEqZeroGadget,
     },
+    fixed_point::MultiproverFixedPointGadget,
+    select::{CondSelectGadget, CondSelectVectorGadget},
 };
 
 // --- Matching Engine --- //

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -5,20 +5,17 @@ use circuit_types::{
     balance::BalanceVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::MatchResultVar,
+    r#match::{MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     PlonkCircuit, AMOUNT_BITS, PRICE_BITS,
 };
 use constants::ScalarField;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
-use crate::{
-    zk_circuits::valid_commitments::OrderSettlementIndicesVar,
-    zk_gadgets::{
-        comparators::{EqGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget},
-        fixed_point::FixedPointGadget,
-        select::{CondSelectGadget, CondSelectVectorGadget},
-    },
+use crate::zk_gadgets::{
+    comparators::{EqGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget},
+    fixed_point::FixedPointGadget,
+    select::{CondSelectGadget, CondSelectVectorGadget},
 };
 
 use super::{ValidMatchSettle, ValidMatchSettleStatementVar, ValidMatchSettleWitnessVar};

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -26,3 +26,5 @@ tracing-subscriber = "0.3"
 
 [dev-dependencies]
 lazy_static = "1.4"
+num-bigint = "0.4"
+rand = "0.8"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![allow(incomplete_features)]
 #![feature(ip)]
+#![feature(generic_const_exprs)]
 
 use std::time::{SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
### Purpose
This PR refactors the settlement logic to live in the `util` crate, matching the paradigm established with the matching engine. This allows all downstream crates to use the same settlement logic.

### Testing
- Unit and integration tests pass