### PR TITLE
workers: Persist timestamps in global orderbook

### DIFF
--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -336,7 +336,6 @@ impl From<IndexedNetworkOrder> for NetworkOrder {
             local: order.local,
             cluster: order.cluster.to_string(),
             state: order.state,
-            // TODO: Replace this with the time the order was received
             timestamp: now,
         }
     }

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -59,14 +59,14 @@ impl GetNetworkOrdersHandler {
 }
 
 /// Asynchronously retrieves the timestamp of an order by its identifier from the global state.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `order_id` - The identifier of the order
 /// * `global_state` - The global state containing the order
-/// 
+///
 /// # Returns
-/// 
+///
 /// An optional `u64` representing the timestamp of the order, or `None` if the order is not found.
 async fn get_timestamp_by_order_id(
     order_id: &OrderIdentifier,


### PR DESCRIPTION
This PR persists timestamps of NetworkOrder objects so that when the global orderbook is fetched, timestamps accurately represent when the order was received.