### PR TITLE
workers: Persist timestamps in global orderbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6676,6 +6676,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
+ "util",
  "uuid 1.4.1",
 ]
 

--- a/common/src/types/network_order.rs
+++ b/common/src/types/network_order.rs
@@ -5,6 +5,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use circuit_types::wallet::Nullifier;
 use serde::{Deserialize, Serialize};
+use util::get_current_time_seconds;
 
 use super::{
     gossip::ClusterId,
@@ -66,6 +67,8 @@ pub struct NetworkOrder {
     /// have `None` in place
     #[serde(skip)]
     pub validity_proof_witnesses: Option<OrderValidityWitnessBundle>,
+    /// The timestamp this order was received at
+    pub timestamp: u64,
 }
 
 impl NetworkOrder {
@@ -84,6 +87,7 @@ impl NetworkOrder {
             state: NetworkOrderState::Received,
             validity_proofs: None,
             validity_proof_witnesses: None,
+            timestamp: get_current_time_seconds(),
         }
     }
 
@@ -177,6 +181,7 @@ mod test {
 
     use mpc_stark::algebra::scalar::Scalar;
     use rand::thread_rng;
+    use util::get_current_time_seconds;
     use uuid::Uuid;
 
     use crate::types::gossip::ClusterId;
@@ -200,6 +205,7 @@ mod test {
             state: NetworkOrderState::Cancelled,
             validity_proofs: None,
             validity_proof_witnesses: None,
+            timestamp: get_current_time_seconds(),
         };
         let mut order2 = order1.clone();
 

--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -4,7 +4,6 @@ use std::{
     collections::HashMap,
     convert::TryInto,
     sync::{atomic::AtomicBool, Arc},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use circuit_types::{
@@ -325,19 +324,13 @@ pub struct NetworkOrder {
 
 impl From<IndexedNetworkOrder> for NetworkOrder {
     fn from(order: IndexedNetworkOrder) -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
         NetworkOrder {
             id: order.id,
             public_share_nullifier: scalar_to_biguint(&order.public_share_nullifier),
             local: order.local,
             cluster: order.cluster.to_string(),
             state: order.state,
-            // TODO: Replace this with the time the order was received
-            timestamp: now,
+            timestamp: order.timestamp,
         }
     }
 }

--- a/state/src/orderbook.rs
+++ b/state/src/orderbook.rs
@@ -30,6 +30,7 @@ use job_types::handshake_manager::HandshakeExecutionJob;
 use std::collections::{HashMap, HashSet};
 use system_bus::SystemBus;
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, RwLockReadGuard, RwLockWriteGuard};
+use util::get_current_time_seconds;
 use uuid::Uuid;
 
 /// The error emitted when enqueueing a job to the handshake manager fails
@@ -286,7 +287,8 @@ impl NetworkOrderBook {
 
     /// Add an order to the book, necessarily this order is in the received
     /// state because we must fetch a validity proof to move it to verified
-    pub async fn add_order(&mut self, order: NetworkOrder) {
+    pub async fn add_order(&mut self, mut order: NetworkOrder) {
+        order.timestamp = get_current_time_seconds();
         // If the order is local, add it to the local order list
         if order.local {
             self.write_local_orders().await.insert(order.id);

--- a/statev2/proto/Cargo.toml
+++ b/statev2/proto/Cargo.toml
@@ -12,6 +12,7 @@ prost = "0.12"
 # === Workspace Dependencies === #
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
+util = { path = "../../util" }
 
 # === Misc Dependencies === #
 eyre = { workspace = true }

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
         Arc,
     },
 };
+use util::get_current_time_seconds;
 
 use circuit_types::{
     balance::Balance as CircuitBalance,
@@ -263,6 +264,7 @@ impl TryFrom<NetworkOrder> for RuntimeNetworkOrder {
             local: false,
             validity_proofs,
             validity_proof_witnesses: None,
+            timestamp: get_current_time_seconds(),
         })
     }
 }


### PR DESCRIPTION
This PR persists timestamps of NetworkOrder objects so that when the global orderbook is fetched, timestamps accurately represent when the order was received.