### PR TITLE
network-manager, task-driver: create-new-wallet Refactor over `mpc-plonk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,6 +5371,7 @@ dependencies = [
 name = "network-manager"
 version = "0.1.0"
 dependencies = [
+ "ark-mpc",
  "async-trait",
  "common",
  "ed25519-dalek 1.0.1",
@@ -5383,8 +5384,6 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "libp2p-swarm-derive",
- "mpc-stark",
- "portpicker",
  "serde_json",
  "state",
  "system-bus",
@@ -8460,6 +8459,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "task-driver"
 version = "0.1.0"
 dependencies = [
+ "arbitrum-client",
  "ark-mpc",
  "async-trait",
  "circuit-types",

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -321,7 +321,7 @@ pub mod mocks {
             fees: vec![],
             key_chain: KeyChain {
                 public_keys: PublicKeyChain {
-                    pk_root: PublicSigningKey::from(&BigUint::from(0u8)),
+                    pk_root: PublicSigningKey::default(),
                     pk_match: PublicIdentificationKey::from(Scalar::zero()),
                 },
                 secret_keys: PrivateKeyChain {

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -23,15 +23,18 @@ ark-mpc = { workspace = true }
 num-bigint = { workspace = true }
 
 # === Workspace Dependencies === #
+arbitrum-client = { path = "../arbitrum-client" }
 circuits = { path = "../circuits" }
 circuit-types = { path = "../circuit-types" }
 common = { path = "../common" }
+constants = { path = "../constants" }
 external-api = { path = "../external-api" }
 gossip-api = { path = "../gossip-api" }
 job-types = { path = "../workers/job-types" }
 renegade-crypto = { path = "../renegade-crypto" }
 state = { path = "../state" }
 system-bus = { path = "../system-bus" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 itertools = "0.11"

--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -19,11 +19,7 @@ use tokio::{
 use tracing::log;
 use uuid::Uuid;
 
-use super::{
-    create_new_wallet::NewWalletTaskState, initialize_state::InitializeStateTaskState,
-    lookup_wallet::LookupWalletTaskState, settle_match::SettleMatchTaskState,
-    settle_match_internal::SettleMatchInternalTaskState, update_wallet::UpdateWalletTaskState,
-};
+use super::create_new_wallet::NewWalletTaskState;
 
 /// The amount to increase the backoff delay by every retry
 const BACKOFF_AMPLIFICATION_FACTOR: u32 = 2;
@@ -110,33 +106,33 @@ pub trait Task: Send {
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "task_type", content = "state")]
 pub enum StateWrapper {
-    /// The state object for the relayer state initialization task
-    InitializeState(InitializeStateTaskState),
-    /// The state object for the deposit balance task
-    UpdateWallet(UpdateWalletTaskState),
-    /// The state object for the lookup wallet task
-    LookupWallet(LookupWalletTaskState),
+    // /// The state object for the relayer state initialization task
+    // InitializeState(InitializeStateTaskState),
+    // /// The state object for the deposit balance task
+    // UpdateWallet(UpdateWalletTaskState),
+    // /// The state object for the lookup wallet task
+    // LookupWallet(LookupWalletTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
-    /// The state object for the settle match task
-    SettleMatch(SettleMatchTaskState),
-    /// The state object for the settle match internal task
-    SettleMatchInternal(SettleMatchInternalTaskState),
+    // /// The state object for the settle match task
+    // SettleMatch(SettleMatchTaskState),
+    // /// The state object for the settle match internal task
+    // SettleMatchInternal(SettleMatchInternalTaskState),
 }
 
-impl Display for StateWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let out = match self {
-            StateWrapper::InitializeState(state) => state.to_string(),
-            StateWrapper::UpdateWallet(state) => state.to_string(),
-            StateWrapper::LookupWallet(state) => state.to_string(),
-            StateWrapper::NewWallet(state) => state.to_string(),
-            StateWrapper::SettleMatch(state) => state.to_string(),
-            StateWrapper::SettleMatchInternal(state) => state.to_string(),
-        };
-        write!(f, "{out}")
-    }
-}
+// impl Display for StateWrapper {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         let out = match self {
+//             StateWrapper::InitializeState(state) => state.to_string(),
+//             StateWrapper::UpdateWallet(state) => state.to_string(),
+//             StateWrapper::LookupWallet(state) => state.to_string(),
+//             StateWrapper::NewWallet(state) => state.to_string(),
+//             StateWrapper::SettleMatch(state) => state.to_string(),
+//             StateWrapper::SettleMatchInternal(state) => state.to_string(),
+//         };
+//         write!(f, "{out}")
+//     }
+// }
 
 // ---------------
 // | Task Driver |

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -5,9 +5,11 @@
 //! transaction success, and then prove `VALID COMMITMENTS`
 
 #![allow(incomplete_features)]
+#![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(clippy::missing_docs_in_private_items)]
-#![deny(missing_docs)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![feature(let_chains)]
 #![feature(generic_const_exprs)]
 #![feature(iter_advance_by)]
@@ -15,8 +17,8 @@
 pub mod create_new_wallet;
 pub mod driver;
 mod helpers;
-pub mod initialize_state;
-pub mod lookup_wallet;
-pub mod settle_match;
-pub mod settle_match_internal;
-pub mod update_wallet;
+// pub mod initialize_state;
+// pub mod lookup_wallet;
+// pub mod settle_match;
+// pub mod settle_match_internal;
+// pub mod update_wallet;

--- a/workers/network-manager/Cargo.toml
+++ b/workers/network-manager/Cargo.toml
@@ -11,19 +11,19 @@ async-trait = "0.1.60"
 futures = "0.3"
 libp2p = { workspace = true, features = [
     "gossipsub",
-    "identify", 
+    "identify",
     "kad",
     "tokio",
     "quic",
-]}
+] }
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-swarm-derive = { workspace = true }
 tokio = { workspace = true }
 
 # === Cryptography === #
+ark-mpc = { workspace = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
-mpc-stark =  { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
@@ -36,7 +36,6 @@ util = { path = "../../util" }
 
 # === Misc Dependencies === #
 itertools = "0.11"
-portpicker = "0.1"
 serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = "1.1.2"

--- a/workers/network-manager/src/composed_protocol.rs
+++ b/workers/network-manager/src/composed_protocol.rs
@@ -64,7 +64,7 @@ impl ComposedNetworkBehavior {
     pub fn new(
         peer_id: PeerId,
         protocol_version: ProtocolVersion,
-        keypair: Keypair,
+        keypair: &Keypair,
     ) -> Result<Self, NetworkManagerError> {
         // Construct the point-to-point request response protocol
         let request_response = RequestResponse::new(

--- a/workers/network-manager/src/lib.rs
+++ b/workers/network-manager/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 

--- a/workers/network-manager/src/manager/control_directives.rs
+++ b/workers/network-manager/src/manager/control_directives.rs
@@ -3,13 +3,13 @@
 
 use std::net::SocketAddr;
 
+use ark_mpc::network::QuicTwoPartyNet;
 use common::types::handshake::ConnectionRole;
 use gossip_api::gossip::ManagerControlDirective;
 use itertools::Itertools;
 use job_types::handshake_manager::HandshakeExecutionJob;
 use libp2p_core::{Endpoint, Multiaddr};
 use libp2p_swarm::{ConnectionId, NetworkBehaviour};
-use mpc_stark::network::QuicTwoPartyNet;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
 use tracing::log;
 use util::networking::{is_dialable_addr, is_dialable_multiaddr, multiaddr_to_socketaddr};

--- a/workers/network-manager/src/worker.rs
+++ b/workers/network-manager/src/worker.rs
@@ -137,7 +137,7 @@ impl Worker for NetworkManager {
         let mut behavior = ComposedNetworkBehavior::new(
             *self.local_peer_id,
             ProtocolVersion::Version0,
-            self.local_keypair.clone(),
+            &self.local_keypair,
         )?;
 
         // Add any bootstrap addresses to the peer info table


### PR DESCRIPTION
### Purpose
This PR refactors:
- A small bit of the `network-manager` to work with the new `mpc-plonk` system
- The `create-new-wallet` task in the `task-driver` to work with the new `mpc-plonk` system and the `arbitrum-client`

### Testing
- Unit tests pass