### PR TITLE
arbitrum-client: remove merkle event source field & add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "serde_with 3.4.0",
  "test-helpers",
  "tokio",
+ "tracing",
  "util",
 ]
 

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -36,6 +36,7 @@ postcard = { version = "1", features = ["alloc"] }
 
 # === Misc === #
 lazy_static = "1.4.0"
+tracing = { workspace = true }
 
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }

--- a/arbitrum-client/integration/constants.rs
+++ b/arbitrum-client/integration/constants.rs
@@ -10,8 +10,5 @@ pub(crate) const DEFAULT_DEVNET_PKEY: &str =
 /// The deployments key in the `deployments.json` file
 pub(crate) const DEPLOYMENTS_KEY: &str = "deployments";
 
-/// The Merkle contract key in the `deployments.json` file
-pub(crate) const MERKLE_CONTRACT_KEY: &str = "merkle_contract";
-
 /// The darkpool proxy contract key in the `deployments.json` file
 pub(crate) const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -22,7 +22,7 @@ use arbitrum_client::{
 };
 use circuit_types::SizedWalletShare;
 use clap::Parser;
-use constants::{DARKPOOL_PROXY_CONTRACT_KEY, MERKLE_CONTRACT_KEY};
+use constants::DARKPOOL_PROXY_CONTRACT_KEY;
 use eyre::Result;
 use helpers::{deploy_new_wallet, parse_addr_from_deployments_file};
 use test_helpers::integration_test_main;
@@ -103,9 +103,6 @@ impl From<CliArgs> for IntegrationTestArgs {
             DARKPOOL_PROXY_CONTRACT_KEY,
         )
         .unwrap();
-        let merkle_event_source =
-            parse_addr_from_deployments_file(&test_args.deployments_path, MERKLE_CONTRACT_KEY)
-                .unwrap();
 
         // Build a client that references the darkpool
         // We block on the client creation so that we can match the (synchronous)
@@ -114,7 +111,6 @@ impl From<CliArgs> for IntegrationTestArgs {
         let client = block_on_result(ArbitrumClient::new(ArbitrumClientConfig {
             chain: Chain::Devnet,
             darkpool_addr,
-            merkle_event_source,
             arb_priv_key: test_args.private_key,
             rpc_url: test_args.rpc_url,
         }))

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -76,7 +76,7 @@ impl ArbitrumClient {
             let events = self
                 .darkpool_contract
                 .event::<NodeChangedFilter>()
-                .address(self.merkle_event_source.into())
+                .address(self.darkpool_contract.address().into())
                 .topic1(height)
                 .topic2(index)
                 .from_block(self.deploy_block)
@@ -107,7 +107,7 @@ impl ArbitrumClient {
         let events = self
             .darkpool_contract
             .event::<NodeChangedFilter>()
-            .address(self.merkle_event_source.into())
+            .address(self.darkpool_contract.address().into())
             .topic3(commitment_hash)
             .from_block(self.deploy_block)
             .query()

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -21,6 +21,8 @@ pub enum ArbitrumClientError {
     TxQuerying(String),
     /// Error thrown when a transaction can't be found
     TxNotFound(String),
+    /// Error thrown when a transaction is dropped from the mempool
+    TxDropped,
     /// Error thrown when a transaction's selector doesn't match
     /// one of the supported ones
     /// (`newWallet`, `updateWallet`, `processMatchSettle`)


### PR DESCRIPTION
This PR removes the `merkle_event_source` field from the Arbitrum client now that the delegatecall implementation is fixed contract-side. Additionally, we add logging of the transaction hash for successful transactions.

Event indexing integration tests pass.