### PR TITLE
task-driver: helpers: Clean up helpers after refactor

### DIFF
--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -48,7 +48,7 @@ pub struct RelayerState {
     /// The cluster id of the local relayer
     pub local_cluster_id: ClusterId,
     /// Whether to disable fee validation
-    pub disable_fee_validation: bool,
+    pub fees_disabled: bool,
     /// The list of wallets managed by the sending relayer
     wallet_index: AsyncShared<WalletIndex>,
     /// The set of peers known to the sending relayer
@@ -99,7 +99,7 @@ impl RelayerState {
             local_peer_id,
             local_keypair,
             local_cluster_id: args.cluster_id.clone(),
-            disable_fee_validation: args.disable_fee_validation,
+            fees_disabled: args.disable_fee_validation,
             wallet_index: new_async_shared(wallet_index),
             matched_order_pairs: new_async_shared(vec![]),
             peer_index: new_async_shared(peer_index),

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -261,7 +261,7 @@ impl LookupWalletTask {
         let blinder_public_share = curr_blinder - curr_blinder_private_share;
         let blinded_public_shares = self
             .arbitrum_client
-            .fetch_public_shares_from_tx(blinder_public_share)
+            .fetch_public_shares_for_blinder(blinder_public_share)
             .await
             .map_err(|e| LookupWalletTaskError::Arbitrum(e.to_string()))?;
 


### PR DESCRIPTION
### Purpose
This PR refactors the `task-driver` helpers as a cleanup after the task were refactored; i.e. splitting up method, refactoring common patterns into helpers, etc.

### Testing
- Unit tests pass