### PR TITLE
external-api: Add update_locked field to Wallet type to expose field to API

### DIFF
--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -3,7 +3,10 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
-    sync::{atomic::AtomicBool, Arc},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use circuit_types::{
@@ -56,6 +59,9 @@ pub struct Wallet {
     pub private_shares: Vec<BigUint>,
     /// The wallet blinder, used to blind wallet secret shares
     pub blinder: BigUint,
+    /// The state of update lock of the wallet, used to protect against
+    /// concurrent updates to the wallet
+    pub update_locked: bool,
 }
 
 /// Conversion from a wallet that has been indexed in the global state to the
@@ -105,6 +111,7 @@ impl From<IndexedWallet> for Wallet {
             blinded_public_shares,
             private_shares,
             blinder: scalar_to_biguint(&wallet.blinder),
+            update_locked: wallet.update_locked.load(Ordering::Relaxed),
         }
     }
 }


### PR DESCRIPTION
This PR adds the `update_locked` field to the Wallet type so that the field is present when the type conversion happens within `GetWalletHandler`. For use in the frontend to disable functionality when the wallet is undergoing any wallet update operations.