### PR TITLE
workers: chain-events: Refactor implementation over new arbitrum client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,16 +1374,18 @@ dependencies = [
 name = "chain-events"
 version = "0.1.0"
 dependencies = [
+ "arbitrum-client",
  "circuit-types",
  "common",
  "crossbeam",
+ "ethers",
  "gossip-api",
  "job-types",
  "lazy_static",
  "renegade-crypto",
- "starknet",
  "state",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -6804,6 +6806,7 @@ dependencies = [
  "bigdecimal",
  "constants",
  "criterion",
+ "ethers-core",
  "itertools 0.10.5",
  "lazy_static",
  "num-bigint",

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -1,5 +1,6 @@
 //! Solidity ABI definitions of smart contracts, events, and other on-chain
 //! data structures used by the Arbitrum client.
+#![allow(missing_docs)]
 
 use alloy_sol_types::sol;
 use ethers::contract::abigen;
@@ -17,6 +18,7 @@ abigen!(
 
         event WalletUpdated(bytes indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
+        event NullifierSpent(uint256 nullifier)
     ]"#
 );
 

--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -41,7 +41,7 @@ pub struct ArbitrumClientConfig {
 /// A type alias for the RPC client, which is an ethers middleware stack that
 /// includes a signer derived from a raw private key, and a provider that
 /// connects to the RPC endpoint over HTTP.
-type SignerHttpProvider = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
+pub type SignerHttpProvider = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
 
 impl ArbitrumClientConfig {
     /// Gets the block number at which the darkpool was deployed
@@ -99,7 +99,7 @@ impl ArbitrumClientConfig {
 #[derive(Clone)]
 pub struct ArbitrumClient {
     /// The darkpool contract instance, used to make calls to the darkpool
-    darkpool_contract: DarkpoolContract<SignerHttpProvider>,
+    pub darkpool_contract: DarkpoolContract<SignerHttpProvider>,
     /// The block number at which the darkpool was deployed
     deploy_block: BlockNumber,
 }
@@ -111,5 +111,19 @@ impl ArbitrumClient {
         let deploy_block = config.get_deploy_block();
 
         Ok(Self { darkpool_contract, deploy_block })
+    }
+
+    /// Get a reference to the underlying RPC client
+    fn client(&self) -> Arc<SignerHttpProvider> {
+        self.darkpool_contract.client()
+    }
+
+    /// Get the current Stylus block number
+    pub async fn block_number(&self) -> Result<BlockNumber, ArbitrumClientError> {
+        self.client()
+            .get_block_number()
+            .await
+            .map(BlockNumber::Number)
+            .map_err(|e| ArbitrumClientError::Rpc(e.to_string()))
     }
 }

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -21,6 +21,17 @@ pub enum Chain {
 /// The number of bytes in a Solidity function selector
 pub const SELECTOR_LEN: usize = 4;
 
+// The following are used for cases in which runtime type-based event filtering
+// is not possible. In these cases, we must construct filters manually using ABI
+// signatures
+
+/// The abi signature for the `WalletUpdated` event
+pub const WALLET_UPDATED_EVENT_NAME: &str = "WalletUpdated";
+/// The abi signature for the `NodeChanged` event
+pub const MERKLE_NODE_CHANGED_EVENT_NAME: &str = "NodeChanged";
+/// The abi signature for the `NullifierSpent` event
+pub const NULLIFIER_SPENT_EVENT_NAME: &str = "NullifierSpent";
+
 lazy_static! {
     // ------------------------
     // | Merkle Tree Metadata |

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -17,6 +17,8 @@ pub enum ArbitrumClientError {
     EventQuerying(String),
     /// Error thrown when a commitment can't be found in the Merkle tree
     CommitmentNotFound,
+    /// An error interacting with the lower level rpc client
+    Rpc(String),
     /// Error thrown when getting a transaction fails
     TxQuerying(String),
     /// Error thrown when a transaction can't be found

--- a/arbitrum-client/src/lib.rs
+++ b/arbitrum-client/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-mod abi;
+pub mod abi;
 pub mod client;
 pub mod constants;
 pub mod errors;

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -5,7 +5,7 @@ use std::{
     hash::Hash,
     iter,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -99,6 +99,12 @@ pub struct Wallet {
     /// The authentication paths for the public and private shares of the wallet
     #[serde(default)]
     pub merkle_proof: Option<WalletAuthenticationPath>,
+    /// The staleness of the Merkle proof, i.e. the number of Merkle root
+    /// updates that have occurred since the wallet's Merkle proof was last
+    /// updated
+    #[serde(skip_serializing, skip_deserializing, default)]
+    #[derivative(PartialEq = "ignore")]
+    pub merkle_staleness: Arc<AtomicUsize>,
     /// An update lock, used to protect against concurrent updates to a wallet
     ///
     /// `true` implies that the lock is held elsewhere
@@ -318,7 +324,10 @@ pub struct WalletMetadata {
 pub mod mocks {
     use std::{
         iter,
-        sync::{atomic::AtomicBool, Arc},
+        sync::{
+            atomic::{AtomicBool, AtomicUsize},
+            Arc,
+        },
     };
 
     use circuit_types::{
@@ -366,6 +375,7 @@ pub mod mocks {
             )),
             metadata: WalletMetadata::default(),
             merkle_proof: Some(mock_merkle_path()),
+            merkle_staleness: Arc::new(AtomicUsize::default()),
             update_locked: Arc::new(AtomicBool::default()),
         };
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -58,11 +58,9 @@ struct Cli {
     /// Allow for discovery of nodes on the localhost IP address
     #[clap(long, value_parser, default_value="false")]
     pub allow_local: bool,
-
     /// The address to bind to for gossip, defaults to 0.0.0.0 (all interfaces)
     #[clap(long, value_parser, default_value = "0.0.0.0")]
     pub bind_addr: IpAddr,
-
     /// The known public IP address of the local peer
     #[clap(long, value_parser)] 
     pub public_ip: Option<SocketAddr>,
@@ -83,6 +81,7 @@ struct Cli {
     // ----------------------------
     // | Local Node Configuration |
     // ----------------------------
+
     /// The port to listen on for libp2p
     #[clap(short = 'p', long, value_parser, default_value = "8000")]
     pub p2p_port: u16,
@@ -96,6 +95,10 @@ struct Cli {
     /// A fresh key is generated at startup if this is not present
     #[clap(long, value_parser)]
     pub p2p_key: Option<String>,
+    /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
+    /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
+    #[clap(long, value_parser, default_value = "100")]
+    pub max_merkle_staleness: usize,
     /// Flag to disable the price reporter
     #[clap(long, value_parser)]
     pub disable_price_reporter: bool,
@@ -185,6 +188,10 @@ pub struct RelayerConfig {
     pub websocket_port: u16,
     /// The local peer's base64 encoded p2p key
     pub p2p_key: Option<String>,
+    /// The maximum staleness (number of newer roots observed) to allow on
+    /// Merkle proofs for managed wallets. After this threshold is exceeded,
+    /// the Merkle proof will be updated
+    pub max_merkle_staleness: usize,
     /// Whether to disable the price reporter if e.g. we are streaming from a
     /// dedicated external API gateway node in the cluster
     pub disable_price_reporter: bool,
@@ -235,6 +242,7 @@ impl Clone for RelayerConfig {
             http_port: self.http_port,
             websocket_port: self.websocket_port,
             p2p_key: self.p2p_key.clone(),
+            max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,
             public_ip: self.public_ip,
@@ -328,6 +336,7 @@ fn parse_config_from_args(full_args: Vec<String>) -> Result<RelayerConfig, Strin
         http_port: cli_args.http_port,
         websocket_port: cli_args.websocket_port,
         allow_local: cli_args.allow_local,
+        max_merkle_staleness: cli_args.max_merkle_staleness,
         p2p_key: cli_args.p2p_key,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -242,6 +242,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the on-chain event listener
     let (chain_listener_cancel_sender, chain_listener_cancel_receiver) = watch::channel(());
     let mut chain_listener = OnChainEventListener::new(OnChainEventListenerConfig {
+        max_root_staleness: args.max_merkle_staleness,
         starknet_client: starknet_client.clone(),
         global_state: global_state.clone(),
         handshake_manager_job_queue: handshake_worker_sender,

--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
-    sync::{atomic::AtomicBool, Arc},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -124,7 +123,8 @@ impl From<Wallet> for IndexedWallet {
             blinded_public_shares,
             private_shares,
             merkle_proof: None,
-            update_locked: Arc::new(AtomicBool::default()),
+            merkle_staleness: Default::default(),
+            update_locked: Default::default(),
         }
     }
 }

--- a/renegade-crypto/Cargo.toml
+++ b/renegade-crypto/Cargo.toml
@@ -26,6 +26,7 @@ ark-ec = "0.4"
 ark-ff = "0.4"
 ark-mpc = { workspace = true, optional = true }
 bigdecimal = "0.3"
+ethers-core = "2"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
 
 # === Workspace Dependencies === #

--- a/renegade-crypto/src/fields.rs
+++ b/renegade-crypto/src/fields.rs
@@ -6,11 +6,15 @@ use std::ops::Neg;
 use ark_ff::PrimeField;
 use bigdecimal::BigDecimal;
 use constants::Scalar;
+use ethers_core::types::U256;
 use num_bigint::{BigInt, BigUint, Sign};
 
 // -----------
 // | Helpers |
 // -----------
+
+/// The number of bytes in a U256
+pub const U256_BYTES: usize = 256 / 8;
 
 /// Return the modulus `p` of the `Scalar` ($Z_p$) field as a `BigUint`
 pub fn get_scalar_field_modulus() -> BigUint {
@@ -29,6 +33,12 @@ pub fn scalar_to_bigint(a: &Scalar) -> BigInt {
 /// Convert a scalar to a BigUint
 pub fn scalar_to_biguint(a: &Scalar) -> BigUint {
     a.to_biguint()
+}
+
+/// Convert a scalar to a U256
+pub fn scalar_to_u256(a: &Scalar) -> U256 {
+    // ethers will handle padding
+    U256::from_big_endian(&a.to_bytes_be())
 }
 
 /// Convert a scalar to a BigDecimal
@@ -72,6 +82,12 @@ pub fn biguint_to_scalar(a: &BigUint) -> Scalar {
     Scalar::from(a.clone())
 }
 
+/// Convert a BigUint to a U256
+pub fn biguint_to_u256(a: &BigUint) -> U256 {
+    // ethers will handle padding
+    U256::from_big_endian(&a.to_bytes_be())
+}
+
 /// Convert a bigint to a vector of bits, encoded as scalars
 pub fn bigint_to_scalar_bits<const D: usize>(a: &BigInt) -> Vec<Scalar> {
     let mut res = Vec::with_capacity(D);
@@ -81,6 +97,26 @@ pub fn bigint_to_scalar_bits<const D: usize>(a: &BigInt) -> Vec<Scalar> {
     }
 
     res
+}
+
+// -------------------------
+// | Conversions from U256 |
+// -------------------------
+
+/// Convert a U256 to a scalar
+pub fn u256_to_scalar(a: &U256) -> Scalar {
+    let mut buf = [0u8; 32];
+    a.to_big_endian(&mut buf);
+
+    Scalar::from_be_bytes_mod_order(&buf)
+}
+
+/// Convert a U256 to a BigUint
+pub fn u256_to_biguint(a: &U256) -> BigUint {
+    let mut buf = [0u8; 32];
+    a.to_big_endian(&mut buf);
+
+    BigUint::from_bytes_be(&buf)
 }
 
 // ---------

--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -8,7 +8,7 @@ use common::{
         gossip::{ClusterId, PeerInfo, WrappedPeerId},
         network_order::NetworkOrder,
         proof_bundles::OrderValidityProofBundle,
-        wallet::{OrderIdentifier, Wallet},
+        wallet::{OrderIdentifier, Wallet, WalletIdentifier},
     },
     AsyncShared,
 };
@@ -23,7 +23,10 @@ use libp2p::{
     Multiaddr,
 };
 use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicUsize, Arc},
+};
 use system_bus::SystemBus;
 use tokio::sync::{mpsc::UnboundedSender as TokioSender, RwLockReadGuard, RwLockWriteGuard};
 
@@ -179,6 +182,14 @@ impl RelayerState {
 
         // Get a peer in this cluster
         self.read_peer_index().await.sample_cluster_peer(&managing_cluster).await
+    }
+
+    /// Get a reference to the staleness of a wallet
+    pub async fn get_wallet_merkle_staleness(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Option<Arc<AtomicUsize>> {
+        self.read_wallet_index().await.get_merkle_staleness(wallet_id).await
     }
 
     // ----------------------

--- a/state/src/wallet.rs
+++ b/state/src/wallet.rs
@@ -1,6 +1,9 @@
 //! Groups state primitives for indexing and tracking wallet information
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicUsize, Arc},
+};
 
 use common::types::{
     gossip::WrappedPeerId,
@@ -64,6 +67,14 @@ impl WalletIndex {
     /// Get the wallet with the given ID
     pub async fn get_wallet(&self, wallet_id: &WalletIdentifier) -> Option<Wallet> {
         self.read_wallet(wallet_id).await.map(|locked_val| locked_val.clone())
+    }
+
+    /// Get the merkle proof staleness for a given wallet ID
+    pub async fn get_merkle_staleness(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Option<Arc<AtomicUsize>> {
+        self.read_wallet(wallet_id).await.map(|locked_val| locked_val.merkle_staleness.clone())
     }
 
     /// Get the wallet that an order is allocated in

--- a/statev2/proto/src/lib.rs
+++ b/statev2/proto/src/lib.rs
@@ -6,14 +6,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use std::{
-    collections::HashSet,
-    str::FromStr,
-    sync::{
-        atomic::{AtomicBool, AtomicU64},
-        Arc,
-    },
-};
+use std::{collections::HashSet, str::FromStr, sync::atomic::AtomicU64};
 
 use circuit_types::{
     balance::Balance as CircuitBalance,
@@ -455,7 +448,8 @@ impl TryFrom<Wallet> for RuntimeWallet {
             private_shares,
             blinded_public_shares,
             merkle_proof,
-            update_locked: Arc::new(AtomicBool::default()),
+            merkle_staleness: Default::default(),
+            update_locked: Default::default(),
         })
     }
 }

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -4,7 +4,6 @@
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    sync::{atomic::AtomicBool, Arc},
 };
 
 use arbitrum_client::client::ArbitrumClient;
@@ -209,7 +208,8 @@ impl LookupWalletTask {
             private_shares,
             blinded_public_shares,
             merkle_proof: None, // constructed below
-            update_locked: Arc::new(AtomicBool::default()),
+            merkle_staleness: Default::default(),
+            update_locked: Default::default(),
         };
 
         // Find the authentication path for the wallet

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 # === Concurrency + Runtime === #
 crossbeam = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = "0.1"
 
-# === Networking + Blockchain === #
-starknet = { workspace = true }
+# === Crypto === #
+ethers = "2"
 
 # === Workspace Dependencies === #
+arbitrum-client = { path = "../../arbitrum-client" }
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
 renegade-crypto = { path = "../../renegade-crypto" }

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -1,18 +1,20 @@
 //! Defines error types for the on-chain event listener
 
-use std::fmt::Display;
+use std::{error::Error, fmt::Display};
 
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
 pub enum OnChainEventListenerError {
+    /// An error executing some method in the Arbitrum client
+    Arbitrum(String),
     /// An RPC error with the StarkNet provider
     Rpc(String),
     /// An error sending a message to another worker in the local node
     SendMessage(String),
     /// Error setting up the on-chain event listener
     Setup(String),
-    /// An error executing some method in the Starknet client
-    StarknetClient(String),
+    /// The stream unexpectedly stopped
+    StreamEnded,
 }
 
 impl Display for OnChainEventListenerError {
@@ -20,3 +22,4 @@ impl Display for OnChainEventListenerError {
         write!(f, "{self:?}")
     }
 }
+impl Error for OnChainEventListenerError {}

--- a/workers/chain-events/src/lib.rs
+++ b/workers/chain-events/src/lib.rs
@@ -1,8 +1,20 @@
 //! Defines and implements the worker that listens for on-chain events
+//!
+//! The event listener is responsible for:
+//! - MPC Shootdown: listening for nullifier spent events and sending a
+//!   shootdown event so that all future or in-flight MPCs on a given nullifier
+//!   are halted
+//! - Merkle path updates: As the Merkle tree is updated, wallets' Merkle paths
+//!   should be updated. If these paths are allowed to stale their root reveals
+//!   information about where in the contract history the wallet was last
+//!   updated: potentially down to the exact transaction. So fresh Merkle paths
+//!   give privacy.
 
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -1,47 +1,26 @@
 //! Defines the core implementation of the on-chain event listener
 
 use std::{
-    collections::HashMap,
-    str::FromStr,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Arc,
     },
     thread::JoinHandle,
-    time::Duration,
 };
 
-use circuit_types::wallet::Nullifier;
-
-use common::types::{
-    merkle::{MerkleAuthenticationPath, MerkleTreeCoords},
-    CancelChannel,
+use arbitrum_client::{
+    abi::{DarkpoolContractEvents, NodeChangedFilter, NullifierSpentFilter},
+    client::ArbitrumClient,
+    constants::{MERKLE_NODE_CHANGED_EVENT_NAME, NULLIFIER_SPENT_EVENT_NAME},
 };
+use common::types::{wallet::WalletIdentifier, CancelChannel};
 use crossbeam::channel::Sender as CrossbeamSender;
+use ethers::{prelude::StreamExt, types::Filter};
 use gossip_api::gossip::GossipOutbound;
 use job_types::{handshake_manager::HandshakeExecutionJob, proof_manager::ProofManagerJob};
-use lazy_static::lazy_static;
-use mpc_stark::algebra::scalar::Scalar;
-use renegade_crypto::fields::{
-    starknet_felt_to_biguint, starknet_felt_to_scalar, starknet_felt_to_u64,
-};
-use starknet::{
-    core::{
-        types::{
-            BlockId, BlockTag, EmittedEvent, EventFilter, FieldElement as StarknetFieldElement,
-            StarknetError,
-        },
-        utils::get_selector_from_name,
-    },
-    providers::{
-        jsonrpc::{HttpTransport, JsonRpcClient},
-        MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
-    },
-};
-use starknet_client::client::StarknetClient;
+use renegade_crypto::fields::u256_to_scalar;
 use state::RelayerState;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
-use tokio::time::{sleep_until, Instant};
 use tracing::log;
 
 use super::error::OnChainEventListenerError;
@@ -50,19 +29,11 @@ use super::error::OnChainEventListenerError;
 // | Constants |
 // -------------
 
-/// The chunk size to request paginated events in
-const EVENT_CHUNK_SIZE: u64 = 100;
-/// The interval at which the worker should poll for new contract events
-const EVENTS_POLL_INTERVAL_MS: u64 = 5_000; // 5 seconds
-
-lazy_static! {
-    /// The event selector for a Merkle root update
-    static ref MERKLE_ROOT_CHANGED_EVENT_SELECTOR: StarknetFieldElement = get_selector_from_name("Merkle_root_changed").unwrap();
-    /// The event selector for a Merkle internal node change
-    static ref MERKLE_NODE_CHANGED_EVENT_SELECTOR: StarknetFieldElement = get_selector_from_name("Merkle_internal_node_changed").unwrap();
-    /// The event selector for a nullifier spend
-    static ref NULLIFIER_SPENT_EVENT_SELECTOR: StarknetFieldElement = get_selector_from_name("Nullifier_spent").unwrap();
-}
+/// The "height" coordinate value of the root node's children in the Merkle tree
+///
+/// We do not emit events for the root, so we instead rely on the root's
+/// children to count the staleness of Merkle proofs
+const ROOT_CHILDREN_HEIGHT: u8 = 0;
 
 // ----------
 // | Worker |
@@ -71,8 +42,10 @@ lazy_static! {
 /// The configuration passed to the listener upon startup
 #[derive(Clone)]
 pub struct OnChainEventListenerConfig {
-    /// A client for connecting to Starknet gateway and jsonrpc nodes
-    pub starknet_client: StarknetClient,
+    /// The maximum root staleness to allow in Merkle proofs
+    pub max_root_staleness: usize,
+    /// An arbitrum client for listening to events
+    pub arbitrum_client: ArbitrumClient,
     /// A copy of the relayer global state
     pub global_state: RelayerState,
     /// A sender to the handshake manager's job queue, used to enqueue
@@ -103,12 +76,6 @@ pub struct OnChainEventListener {
 /// The executor that runs in a thread and polls events from on-chain state
 #[derive(Clone)]
 pub struct OnChainEventListenerExecutor {
-    /// The earliest block that the client will poll events from
-    start_block: u64,
-    /// The latest block for which the local node has updated Merkle state
-    merkle_last_consistent_block: Arc<AtomicU64>,
-    /// The event pagination token
-    pagination_token: Arc<AtomicU64>,
     /// A copy of the config that the executor maintains
     config: OnChainEventListenerConfig,
     /// A copy of the relayer-global state
@@ -120,152 +87,63 @@ impl OnChainEventListenerExecutor {
     pub fn new(config: OnChainEventListenerConfig) -> Self {
         let global_state = config.global_state.clone();
 
-        Self {
-            config,
-            start_block: 0,
-            merkle_last_consistent_block: Arc::new(0.into()),
-            pagination_token: Arc::new(0.into()),
-            global_state,
-        }
+        Self { config, global_state }
     }
 
-    /// Shorthand for fetching a reference to the starknet client
-    fn starknet_client(&self) -> &StarknetClient {
-        &self.config.starknet_client
-    }
-
-    /// Helper to fetch the RPC client in the executor's config
-    fn rpc_client(&self) -> &JsonRpcClient<HttpTransport> {
-        self.config.starknet_client.get_jsonrpc_client()
-    }
-
-    /// Helper to get the contract address from the underlying client
-    fn contract_address(&self) -> StarknetFieldElement {
-        self.config.starknet_client.contract_address
+    /// Shorthand for fetching a reference to the arbitrum client
+    fn arbitrum_client(&self) -> &ArbitrumClient {
+        &self.config.arbitrum_client
     }
 
     /// The main execution loop for the executor
-    pub async fn execute(mut self) -> OnChainEventListenerError {
+    pub async fn execute(self) -> Result<(), OnChainEventListenerError> {
         // Get the current block number to start from
         let starting_block_number = self
-            .starknet_client()
-            .get_block_number()
+            .arbitrum_client()
+            .block_number()
             .await
-            .map_err(|err| OnChainEventListenerError::StarknetClient(err.to_string()));
-        if starting_block_number.is_err() {
-            return starting_block_number.err().unwrap();
+            .map_err(|err| OnChainEventListenerError::Arbitrum(err.to_string()))?;
+        log::info!("Starting on-chain event listener from current block {starting_block_number}");
+
+        // Build a filtered stream on events that the chain-events worker listens for
+        let filter = Filter::default()
+            .events(vec![NULLIFIER_SPENT_EVENT_NAME, MERKLE_NODE_CHANGED_EVENT_NAME]);
+        let builder = self
+            .arbitrum_client()
+            .darkpool_contract
+            .event_with_filter::<DarkpoolContractEvents>(filter);
+        let mut event_stream = builder
+            .stream()
+            .await
+            .map_err(|err| OnChainEventListenerError::Arbitrum(err.to_string()))?;
+
+        // Listen for events in a loop
+        while let Some(res) = event_stream.next().await {
+            let event = res.map_err(|err| OnChainEventListenerError::Arbitrum(err.to_string()))?;
+            self.handle_event(event).await?;
         }
 
-        self.start_block = starting_block_number.unwrap();
-        self.merkle_last_consistent_block.store(self.start_block, Ordering::Relaxed);
-        log::info!("Starting on-chain event listener with current block {}", self.start_block);
-
-        // Poll for new events in a loop
-        loop {
-            // Sleep for some time then re-poll events
-            sleep_until(Instant::now() + Duration::from_millis(EVENTS_POLL_INTERVAL_MS)).await;
-            let mut self_clone = self.clone();
-            tokio::spawn(async move {
-                if let Err(e) = self_clone.poll_contract_events().await {
-                    log::error!("error polling events: {e}");
-                };
-            });
-        }
-    }
-
-    /// Poll for new contract events
-    async fn poll_contract_events(&mut self) -> Result<(), OnChainEventListenerError> {
-        log::debug!("polling for events...");
-        loop {
-            let (events, more_pages) = self.fetch_next_events_page().await?;
-            for event in events.into_iter() {
-                self.handle_event(event).await?;
-            }
-
-            if !more_pages {
-                break;
-            }
-        }
-
+        log::error!("on-chain event listener stream ended unexpectedly");
         Ok(())
     }
 
-    /// Fetch the next page of events from the contract
-    ///
-    /// Returns the events in the next page and a boolean indicating whether
-    /// the caller should continue paging
-    async fn fetch_next_events_page(
-        &mut self,
-    ) -> Result<(Vec<EmittedEvent>, bool), OnChainEventListenerError> {
-        let filter = EventFilter {
-            from_block: Some(BlockId::Number(self.start_block)),
-            to_block: Some(BlockId::Tag(BlockTag::Pending)),
-            address: Some(self.contract_address()),
-            keys: Some(vec![vec![
-                *MERKLE_ROOT_CHANGED_EVENT_SELECTOR,
-                *MERKLE_NODE_CHANGED_EVENT_SELECTOR,
-                *NULLIFIER_SPENT_EVENT_SELECTOR,
-            ]]),
-        };
-
-        let pagination_token = self.pagination_token.load(Ordering::Relaxed).to_string();
-        let resp =
-            self.rpc_client().get_events(filter, Some(pagination_token), EVENT_CHUNK_SIZE).await;
-
-        let resp = match resp {
-            Ok(events_page) => Ok(events_page),
-            // If the error is an unknown continuation token, ignore it and stop paging
-            Err(ProviderError::StarknetError(StarknetErrorWithMessage { code, message })) => {
-                if let MaybeUnknownErrorCode::Known(StarknetError::InvalidContinuationToken) = code
-                {
-                    return Ok((Vec::new(), false));
-                };
-
-                Err(OnChainEventListenerError::Rpc(message))
-            },
-
-            // Otherwise propagate the error
-            Err(err) => Err(OnChainEventListenerError::Rpc(err.to_string())),
-        }?;
-
-        // Update the executor held continuation token used across calls to `getEvents`
-        if let Some(pagination_token) = resp.continuation_token.clone() {
-            let parsed_token = u64::from_str(&pagination_token).unwrap();
-            self.pagination_token.store(parsed_token, Ordering::Relaxed);
-        } else {
-            // If no explicit pagination token is given, increment the pagination token by
-            // the number of events received. Ideally the API would do this, but
-            // it simply returns None to indicate no more pages are ready. We
-            // would like to persist this token across polls to getEvents.
-            self.pagination_token.fetch_add(resp.events.len() as u64, Ordering::Relaxed);
-        }
-
-        let continue_paging = resp.continuation_token.is_some();
-        Ok((resp.events, continue_paging))
-    }
-
     /// Handle an event from the contract
-    async fn handle_event(&self, event: EmittedEvent) -> Result<(), OnChainEventListenerError> {
+    async fn handle_event(
+        &self,
+        event: DarkpoolContractEvents,
+    ) -> Result<(), OnChainEventListenerError> {
         // Dispatch based on key
-        let key = event.keys[0];
-        if key == *MERKLE_ROOT_CHANGED_EVENT_SELECTOR {
-            log::info!("Handling merkle root update event");
-
-            // Skip this event if all Merkle events for this block have been consumed
-            let last_consistent_block = self.merkle_last_consistent_block.load(Ordering::Relaxed);
-            if event.block_number <= last_consistent_block {
-                return Ok(());
-            }
-
-            self.handle_root_changed(event.block_number).await?;
-
-            // Update the last consistent block
-            self.merkle_last_consistent_block.store(event.block_number, Ordering::Relaxed);
-        } else if key == *NULLIFIER_SPENT_EVENT_SELECTOR {
-            // Parse the nullifier from the felt
-            log::info!("Handling nullifier spent event");
-            let nullifier = starknet_felt_to_scalar(&event.data[0]);
-            self.handle_nullifier_spent(nullifier).await?;
+        match event {
+            DarkpoolContractEvents::NullifierSpentFilter(event) => {
+                self.handle_nullifier_spent(event).await?;
+            },
+            DarkpoolContractEvents::NodeChangedFilter(event) => {
+                self.handle_internal_node_update(event).await?;
+            },
+            _ => {
+                // Simply log the error and ignore the event
+                log::warn!("chain listener received unexpected event type: {event}");
+            },
         }
 
         Ok(())
@@ -274,9 +152,10 @@ impl OnChainEventListenerExecutor {
     /// Handle a nullifier spent event
     async fn handle_nullifier_spent(
         &self,
-        nullifier: Nullifier,
+        event: NullifierSpentFilter,
     ) -> Result<(), OnChainEventListenerError> {
         // Send an MPC shootdown request to the handshake manager
+        let nullifier = u256_to_scalar(&event.nullifier);
         self.config
             .handshake_manager_job_queue
             .send(HandshakeExecutionJob::MpcShootdown { nullifier })
@@ -288,77 +167,32 @@ impl OnChainEventListenerExecutor {
         Ok(())
     }
 
-    /// Handle a root change event
-    async fn handle_root_changed(
+    /// Handle an internal node update to the contract's Merkle tree
+    async fn handle_internal_node_update(
         &self,
-        block_number: u64,
+        event: NodeChangedFilter,
     ) -> Result<(), OnChainEventListenerError> {
-        // Fetch all the internal node changed events in this block
-        let filter = EventFilter {
-            from_block: Some(BlockId::Number(block_number)),
-            to_block: Some(BlockId::Number(block_number + 1)),
-            address: Some(self.contract_address()),
-            keys: Some(vec![vec![*MERKLE_NODE_CHANGED_EVENT_SELECTOR]]),
-        };
-
-        // Maps updated tree coordinates to their new values
-        let mut node_change_events = HashMap::new();
-        let mut pagination_token = Some("0".to_string());
-
-        while pagination_token.is_some() {
-            // Fetch the next page of events
-            let events_batch = self
-                .rpc_client()
-                .get_events(filter.clone(), pagination_token, 100 /* chunk_size */)
-                .await
-                .map_err(|err| OnChainEventListenerError::Rpc(err.to_string()))?;
-
-            for event in events_batch.events.into_iter() {
-                // Build tree coordinate from event
-                let height: usize = starknet_felt_to_u64(&event.data[0]) as usize;
-                let index = starknet_felt_to_biguint(&event.data[1]);
-                let tree_coordinate = MerkleTreeCoords::new(height, index);
-
-                // Add the value to the list of changes
-                // The events stream comes in transaction order, so the most recent value of
-                // each internal node in the block will overwrite older values
-                // and be the final value stored
-                let new_value = starknet_felt_to_scalar(&event.data[2]);
-                node_change_events.insert(tree_coordinate, new_value);
-            }
-
-            pagination_token = events_batch.continuation_token;
+        // Skip events that are not root children updates
+        if event.height != ROOT_CHILDREN_HEIGHT {
+            return Ok(());
         }
 
-        // Lock the wallet state and apply them one by one to the wallet Merkle paths
-        let locked_wallet_index = self.global_state.read_wallet_index().await;
-        for wallet_id in locked_wallet_index.get_all_wallet_ids() {
-            // Merge in the map of updated nodes into the wallet's merkle proof
-            let mut locked_wallet = locked_wallet_index.write_wallet(&wallet_id).await.unwrap();
-            if locked_wallet.merkle_proof.is_none() {
-                continue;
-            }
+        let wallet_ids = self.global_state.read_wallet_index().await.get_all_wallet_ids();
+        for id in wallet_ids.iter() {
+            // Increment the staleness on the wallet
+            let staleness = self.global_state.get_wallet_merkle_staleness(id).await.unwrap();
 
-            self.update_wallet_merkle_path(
-                locked_wallet.merkle_proof.as_mut().unwrap(),
-                &node_change_events,
-            );
+            let last_val = staleness.fetch_add(1, Ordering::Relaxed);
+            if last_val > self.config.max_root_staleness {
+                self.update_wallet_merkle_path(id, staleness);
+            }
         }
 
         Ok(())
     }
 
-    /// A helper to update the Merkle path of a wallet given the Merkle internal
-    /// nodes that have changed
-    fn update_wallet_merkle_path(
-        &self,
-        merkle_proof: &mut MerkleAuthenticationPath,
-        updated_nodes: &HashMap<MerkleTreeCoords, Scalar>,
-    ) {
-        for (i, coord) in merkle_proof.compute_authentication_path_coords().iter().enumerate() {
-            if let Some(updated_value) = updated_nodes.get(coord) {
-                merkle_proof.path_siblings[i] = *updated_value;
-            }
-        }
+    /// Update the Merkle path of the given wallet to the latest known root
+    fn update_wallet_merkle_path(&self, wallet_id: &WalletIdentifier, staleness: Arc<AtomicUsize>) {
+        todo!()
     }
 }


### PR DESCRIPTION
### Purpose
This PR refactors the `chain-events` worker over the new arbitrum client. This worker has two primary tasks:
- MPC shootdowns: when a nullifier is seen on chain, all in-flight matches on that nullifier should be cancelled.
- Merkle proof updates: as roots in Merkle proofs stale, they leak information about _when_ an obfuscated wallet was last update (or at least a bound on this value), we need to refresh Merkle proofs every so often to avoid this.

This PR does not handle the Merkle refresh logic yet. This will be in a follow up.

### Testing
- Unit tests pass