### PR TITLE
task-driver: update-merkle-proof: Define task to update wallet merkle proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,8 +1384,8 @@ dependencies = [
  "lazy_static",
  "renegade-crypto",
  "state",
+ "task-driver",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 

--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use crate::{
     create_new_wallet::NewWalletTaskState, lookup_wallet::LookupWalletTaskState,
     settle_match::SettleMatchTaskState, settle_match_internal::SettleMatchInternalTaskState,
-    update_wallet::UpdateWalletTaskState,
+    update_merkle_proof::UpdateMerkleProofTaskState, update_wallet::UpdateWalletTaskState,
 };
 
 /// The amount to increase the backoff delay by every retry
@@ -110,8 +110,6 @@ pub trait Task: Send {
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "task_type", content = "state")]
 pub enum StateWrapper {
-    /// The state object for the deposit balance task
-    UpdateWallet(UpdateWalletTaskState),
     /// The state object for the lookup wallet task
     LookupWallet(LookupWalletTaskState),
     /// The state object for the new wallet task
@@ -120,16 +118,21 @@ pub enum StateWrapper {
     SettleMatch(SettleMatchTaskState),
     /// The state object for the settle match internal task
     SettleMatchInternal(SettleMatchInternalTaskState),
+    /// The state object for the update Merkle proof task
+    UpdateMerkleProof(UpdateMerkleProofTaskState),
+    /// The state object for the update wallet task
+    UpdateWallet(UpdateWalletTaskState),
 }
 
 impl Display for StateWrapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
-            StateWrapper::UpdateWallet(state) => state.to_string(),
             StateWrapper::LookupWallet(state) => state.to_string(),
             StateWrapper::NewWallet(state) => state.to_string(),
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
+            StateWrapper::UpdateWallet(state) => state.to_string(),
+            StateWrapper::UpdateMerkleProof(state) => state.to_string(),
         };
         write!(f, "{out}")
     }

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -20,4 +20,5 @@ mod helpers;
 pub mod lookup_wallet;
 pub mod settle_match;
 pub mod settle_match_internal;
+pub mod update_merkle_proof;
 pub mod update_wallet;

--- a/task-driver/src/update_merkle_proof.rs
+++ b/task-driver/src/update_merkle_proof.rs
@@ -1,0 +1,211 @@
+//! The `update_merkle_proof` task updates the Merkle opening for a wallet to
+//! the most recent known root
+
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    sync::atomic::Ordering,
+};
+
+use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
+use common::types::wallet::Wallet;
+use crossbeam::channel::Sender as CrossbeamSender;
+use gossip_api::gossip::GossipOutbound;
+use job_types::proof_manager::ProofManagerJob;
+use serde::Serialize;
+use state::RelayerState;
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
+
+use crate::{
+    driver::{StateWrapper, Task},
+    helpers::update_wallet_validity_proofs,
+};
+
+/// The human-readable name of the the task
+const UPDATE_MERKLE_PROOF_TASK_NAME: &str = "update-merkle-proof";
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Defines the long running flow for updating the Merkle opening for a wallet
+pub struct UpdateMerkleProofTask {
+    /// The wallet to update
+    pub wallet: Wallet,
+    /// The arbitrum client to use for submitting transactions
+    pub arbitrum_client: ArbitrumClient,
+    /// A copy of the relayer-global state
+    pub global_state: RelayerState,
+    /// The work queue to add proof management jobs to
+    pub proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+    /// A sender to the network manager's work queue
+    pub network_sender: TokioSender<GossipOutbound>,
+    /// The state of the task
+    pub task_state: UpdateMerkleProofTaskState,
+}
+
+/// The error type for the update merkle proof task
+#[derive(Clone, Debug)]
+pub enum UpdateMerkleProofTaskError {
+    /// An error occurred interacting with Arbitrum
+    Arbitrum(String),
+    /// An error while updating validity proofs for a wallet
+    UpdatingValidityProofs(String),
+    /// Wallet is already locked, cannot update
+    WalletLocked,
+}
+
+impl Display for UpdateMerkleProofTaskError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+impl Error for UpdateMerkleProofTaskError {}
+
+/// Defines the state of the deposit balance task
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum UpdateMerkleProofTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is finding a new Merkle opening for the wallet
+    FindingOpening,
+    /// The task is updating the validity proofs for all orders in the
+    /// wallet
+    UpdatingValidityProofs,
+    /// The task has finished
+    Completed,
+}
+
+impl Display for UpdateMerkleProofTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Pending => write!(f, "Pending"),
+            Self::FindingOpening => write!(f, "FindingOpening"),
+            Self::UpdatingValidityProofs => write!(f, "UpdatingValidityProofs"),
+            Self::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl Serialize for UpdateMerkleProofTaskState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl From<UpdateMerkleProofTaskState> for StateWrapper {
+    fn from(state: UpdateMerkleProofTaskState) -> Self {
+        StateWrapper::UpdateMerkleProof(state)
+    }
+}
+
+#[async_trait]
+impl Task for UpdateMerkleProofTask {
+    type Error = UpdateMerkleProofTaskError;
+    type State = UpdateMerkleProofTaskState;
+
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        // Dispatch based on the current transaction step
+        match self.state() {
+            UpdateMerkleProofTaskState::Pending => {
+                self.task_state = UpdateMerkleProofTaskState::FindingOpening
+            },
+            UpdateMerkleProofTaskState::FindingOpening => {
+                self.find_opening().await?;
+                self.task_state = UpdateMerkleProofTaskState::UpdatingValidityProofs
+            },
+            UpdateMerkleProofTaskState::UpdatingValidityProofs => {
+                self.update_validity_proofs().await?;
+                self.task_state = UpdateMerkleProofTaskState::Completed
+            },
+            UpdateMerkleProofTaskState::Completed => {
+                panic!("step() called in state Completed")
+            },
+        }
+
+        Ok(())
+    }
+
+    // Unlock the update lock if the task fails
+    async fn cleanup(&mut self) -> Result<(), UpdateMerkleProofTaskError> {
+        self.wallet.unlock_wallet();
+        Ok(())
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self.state(), Self::State::Completed)
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    fn name(&self) -> String {
+        UPDATE_MERKLE_PROOF_TASK_NAME.to_string()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl UpdateMerkleProofTask {
+    /// Constructor
+    pub async fn new(
+        wallet: Wallet,
+        arbitrum_client: ArbitrumClient,
+        global_state: RelayerState,
+        proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
+        network_sender: TokioSender<GossipOutbound>,
+    ) -> Result<Self, UpdateMerkleProofTaskError> {
+        if !wallet.try_lock_wallet() {
+            return Err(UpdateMerkleProofTaskError::WalletLocked);
+        }
+
+        Ok(Self {
+            wallet,
+            arbitrum_client,
+            global_state,
+            proof_manager_work_queue,
+            network_sender,
+            task_state: UpdateMerkleProofTaskState::Pending,
+        })
+    }
+
+    // --------------
+    // | Task Steps |
+    // --------------
+
+    /// Find the opening of the wallet to the newest known Merkle root
+    pub async fn find_opening(&mut self) -> Result<(), UpdateMerkleProofTaskError> {
+        let wallet_commitment = self.wallet.get_wallet_share_commitment();
+        let new_opening = self
+            .arbitrum_client
+            .find_merkle_authentication_path(wallet_commitment)
+            .await
+            .map_err(|err| UpdateMerkleProofTaskError::Arbitrum(err.to_string()))?;
+        self.wallet.merkle_proof = Some(new_opening);
+        self.wallet.merkle_staleness.store(0, Ordering::Relaxed);
+
+        // Update the global state
+        self.global_state.update_wallet(self.wallet.clone()).await;
+        Ok(())
+    }
+
+    /// Update the validity proofs for all orders in the wallet
+    pub async fn update_validity_proofs(&self) -> Result<(), UpdateMerkleProofTaskError> {
+        update_wallet_validity_proofs(
+            &self.wallet,
+            self.proof_manager_work_queue.clone(),
+            self.global_state.clone(),
+            self.network_sender.clone(),
+        )
+        .await
+        .map_err(|e| UpdateMerkleProofTaskError::UpdatingValidityProofs(e.to_string()))
+    }
+}

--- a/task-driver/src/update_wallet.rs
+++ b/task-driver/src/update_wallet.rs
@@ -41,7 +41,7 @@ const ERR_NO_MERKLE_PROOF: &str = "merkle proof for wallet not found";
 // | Task Definition |
 // -------------------
 
-/// Defines the long running flow for adding a balance to a wallet
+/// Defines the long running flow for updating a wallet
 pub struct UpdateWalletTask {
     /// The timestamp at which the task was initiated, used to timestamp orders
     pub timestamp_received: u64,
@@ -68,7 +68,7 @@ pub struct UpdateWalletTask {
     pub task_state: UpdateWalletTaskState,
 }
 
-/// The error type for the deposit balance task
+/// The error type for the update wallet task
 #[derive(Clone, Debug)]
 pub enum UpdateWalletTaskError {
     /// A wallet was submitted with an invalid secret shares
@@ -93,7 +93,7 @@ impl Display for UpdateWalletTaskError {
 
 impl Error for UpdateWalletTaskError {}
 
-/// Defines the state of the deposit balance task
+/// Defines the state of the deposit update wallet task
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum UpdateWalletTaskState {
@@ -248,8 +248,7 @@ impl UpdateWalletTask {
     // | Task Steps |
     // --------------
 
-    /// Generate a proof of `VALID WALLET UPDATE` for the wallet with added
-    /// balance
+    /// Generate a proof of `VALID WALLET UPDATE` for the wallet
     async fn generate_proof(&mut self) -> Result<(), UpdateWalletTaskError> {
         let (witness, statement) = self.get_witness_statement()?;
 

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 # === Concurrency + Runtime === #
 crossbeam = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = "0.1"
 
 # === Crypto === #
 ethers = "2"
@@ -20,6 +19,7 @@ renegade-crypto = { path = "../../renegade-crypto" }
 gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
 state = { path = "../../state" }
+task-driver = { path = "../../task-driver" }
 
 # === Misc Dependencies === #
 lazy_static = "1.4"

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -15,6 +15,8 @@ pub enum OnChainEventListenerError {
     Setup(String),
     /// The stream unexpectedly stopped
     StreamEnded,
+    /// An error starting up a task
+    TaskStartup(String),
 }
 
 impl Display for OnChainEventListenerError {


### PR DESCRIPTION
### Purpose
This PR adds a task `update-merkle-proofs` to update the Merkle proof of a given wallet to reference the latest known root. This task is used by the event listener to update stale proofs for privacy.

### Testing
- Unit tests pass