### PR TITLE
arbitrum-client: clear & re-initialize preallocated state

### DIFF
--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
-    helpers::{deploy_new_wallet, random_wallet_shares},
+    helpers::{clear_merkle, deploy_new_wallet, random_wallet_shares},
     IntegrationTestArgs,
 };
 
@@ -24,7 +24,9 @@ async fn test_new_wallet(test_args: IntegrationTestArgs) -> Result<()> {
         client.fetch_public_shares_for_blinder(public_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(public_shares, recovered_public_shares)
+    assert_eq_result!(public_shares, recovered_public_shares)?;
+
+    clear_merkle(client).await
 }
 integration_test_async!(test_new_wallet);
 
@@ -50,7 +52,9 @@ async fn test_update_wallet(test_args: IntegrationTestArgs) -> Result<()> {
         client.fetch_public_shares_for_blinder(new_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(new_shares, recovered_public_shares)
+    assert_eq_result!(new_shares, recovered_public_shares)?;
+
+    clear_merkle(client).await
 }
 integration_test_async!(test_update_wallet);
 
@@ -90,6 +94,8 @@ async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()>
         client.fetch_public_shares_for_blinder(party_1_new_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(party_1_new_shares, recovered_party_1_shares)
+    assert_eq_result!(party_1_new_shares, recovered_party_1_shares)?;
+
+    clear_merkle(client).await
 }
 integration_test_async!(test_process_match_settle);

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -24,8 +24,7 @@ use arbitrum_client::{
 use circuit_types::SizedWalletShare;
 use clap::Parser;
 use constants::DARKPOOL_PROXY_CONTRACT_KEY;
-use eyre::Result;
-use helpers::{deploy_new_wallet, parse_addr_from_deployments_file};
+use helpers::parse_addr_from_deployments_file;
 use test_helpers::integration_test_main;
 use util::{logging::LevelFilter, runtime::block_on_result};
 
@@ -66,8 +65,6 @@ struct CliArgs {
 struct IntegrationTestArgs {
     /// The Arbitrum client that resolves to a locally running devnet node
     client: ArbitrumClient,
-    /// The pre-allocated state elements in the contract
-    pre_allocated_state: PreAllocatedState,
 }
 
 /// The set of pre-allocated state elements in the contract
@@ -76,22 +73,22 @@ struct IntegrationTestArgs {
 /// wallets in each other's first-level Merkle authentication paths, and one
 /// with a default value in its first-level Merkle authentication path
 #[derive(Clone)]
-struct PreAllocatedState {
+pub struct PreAllocatedState {
     /// The commitment inserted at index 0 in the Merkle tree when integration
     /// tests begin
-    index0_commitment: Scalar,
+    pub index0_commitment: Scalar,
     /// The commitment inserted at index 1 in the Merkle tree when integration
     /// tests begin
-    index1_commitment: Scalar,
+    pub index1_commitment: Scalar,
     /// The commitment inserted at index 2 in the Merkle tree when integration
     /// tests begin
-    index2_commitment: Scalar,
+    pub index2_commitment: Scalar,
     /// The public wallet shares of the first wallet added to the tree
-    index0_public_wallet_shares: SizedWalletShare,
+    pub index0_public_wallet_shares: SizedWalletShare,
     /// The public wallet shares of the second wallet added to the tree
-    index1_public_wallet_shares: SizedWalletShare,
+    pub index1_public_wallet_shares: SizedWalletShare,
     /// The public wallet shares of the third wallet added to the tree
-    index2_public_wallet_shares: SizedWalletShare,
+    pub index2_public_wallet_shares: SizedWalletShare,
 }
 
 impl From<CliArgs> for IntegrationTestArgs {
@@ -117,27 +114,8 @@ impl From<CliArgs> for IntegrationTestArgs {
         }))
         .unwrap();
 
-        let pre_allocated_state = setup_pre_allocated_state(&client).unwrap();
-
-        Self { client, pre_allocated_state }
+        Self { client }
     }
-}
-
-/// Sets up pre-allocated state used by the integration tests
-fn setup_pre_allocated_state(client: &ArbitrumClient) -> Result<PreAllocatedState> {
-    // Insert three new wallets into the contract
-    let (index0_commitment, index0_shares) = block_on_result(deploy_new_wallet(client))?;
-    let (index1_commitment, index1_shares) = block_on_result(deploy_new_wallet(client))?;
-    let (index2_commitment, index2_shares) = block_on_result(deploy_new_wallet(client))?;
-
-    Ok(PreAllocatedState {
-        index0_commitment,
-        index1_commitment,
-        index2_commitment,
-        index0_public_wallet_shares: index0_shares,
-        index1_public_wallet_shares: index1_shares,
-        index2_public_wallet_shares: index2_shares,
-    })
 }
 
 /// Setup code for the integration tests

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -5,6 +5,7 @@
 use alloy_sol_types::sol;
 use ethers::contract::abigen;
 
+#[cfg(not(feature = "integration"))]
 abigen!(
     DarkpoolContract,
     r#"[
@@ -19,6 +20,30 @@ abigen!(
         event WalletUpdated(bytes indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
         event NullifierSpent(uint256 nullifier)
+    ]"#
+);
+
+/// This ABI represents the Darkpool testing contract,
+/// which contains all the same methods as the Darkpool (from which it
+/// inherits), but also exposes some additional methods for testing purposes.
+#[cfg(feature = "integration")]
+abigen!(
+    DarkpoolContract,
+    r#"[
+        function isNullifierSpent(bytes memory nullifier) external view returns (bool)
+        function getRoot() external view returns (bytes)
+        function rootInHistory(bytes memory root) external view returns (bool)
+
+        function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
+
+        event WalletUpdated(bytes indexed wallet_blinder_share)
+        event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
+        event NullifierSpent(uint256 nullifier)
+
+
+        function clearMerkle() external
     ]"#
 );
 

--- a/arbitrum-client/src/lib.rs
+++ b/arbitrum-client/src/lib.rs
@@ -15,6 +15,6 @@ pub mod abi;
 pub mod client;
 pub mod constants;
 pub mod errors;
-mod helpers;
+pub mod helpers;
 mod serde_def_types;
 pub mod types;

--- a/docker/contracts/deploy_contracts.sh
+++ b/docker/contracts/deploy_contracts.sh
@@ -47,7 +47,7 @@ cargo run \
     -r $DEVNET_RPC_URL \
     -d $DEPLOYMENTS_PATH \
     deploy-stylus \
-    --contract darkpool \
+    --contract darkpool-test-contract \
     $(no_verify)
 
 # Deploy the proxy contract


### PR DESCRIPTION
This PR changes the Arbitrum client integration tests to clear and re-allocate Merkle state at the beginning/end of all relevant tests. This allows the tests to run in any order, without relying on e.g. the Merkle paths remaining unchanged.