### PR TITLE
arbitrum-client: give contract deployment service generous timeout

### DIFF
--- a/arbitrum-client/docker-compose.yml
+++ b/arbitrum-client/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 10s
       retries: 3
-      start_period: 2m
+      start_period: 10m
 
   relayer:
     image: arbitrum-client-integration-test:latest


### PR DESCRIPTION
This PR bumps the healthcheck timeout for the contract deployment docker compose service to ensure that the integration tests can run on an initial clone of the repo (of course, one must clone with `--recurse-submodules`). This is necessary because in an initial clone, the nitro stack must also pull and build all of its images, which, although concurrent with the building of our own integration stack, takes long enough that the healthcheck fails.