### PR TITLE
task-driver: integration: Refactor tests over `mpc-plonk` + `arbitrum-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8191,6 +8191,7 @@ dependencies = [
  "common",
  "constants",
  "crossbeam",
+ "ethers",
  "external-api",
  "eyre",
  "futures",

--- a/arbitrum-client/integration/constants.rs
+++ b/arbitrum-client/integration/constants.rs
@@ -1,14 +1,1 @@
 //! Constants used in the Arbitrum client integration tests
-
-/// The default hostport that the Nitro devnet L2 node runs on
-pub(crate) const DEFAULT_DEVNET_HOSTPORT: &str = "http://localhost:8547";
-
-/// The default private key that the Nitro devnet is seeded with
-pub(crate) const DEFAULT_DEVNET_PKEY: &str =
-    "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659";
-
-/// The deployments key in the `deployments.json` file
-pub(crate) const DEPLOYMENTS_KEY: &str = "deployments";
-
-/// The darkpool proxy contract key in the `deployments.json` file
-pub(crate) const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -9,21 +9,9 @@ use common::types::proof_bundles::mocks::dummy_valid_wallet_create_bundle;
 use constants::Scalar;
 use eyre::{eyre, Result};
 use rand::thread_rng;
-use std::{fs::File, io::Read, iter};
+use std::iter;
 
-use crate::{constants::DEPLOYMENTS_KEY, PreAllocatedState};
-
-/// Parse the address of the deployed contract from the `deployments.json` file
-pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> Result<String> {
-    let mut file_contents = String::new();
-    File::open(file_path)?.read_to_string(&mut file_contents)?;
-
-    let parsed_json = json::parse(&file_contents)?;
-    parsed_json[DEPLOYMENTS_KEY][contract_key]
-        .as_str()
-        .map(|s| s.to_string())
-        .ok_or_else(|| eyre!("Could not parse darkpool address from deployments file"))
-}
+use crate::PreAllocatedState;
 
 /// Create a set of random wallet shares
 pub fn random_wallet_shares() -> SizedWalletShare {

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -23,12 +23,15 @@ use arbitrum_client::{
 };
 use circuit_types::SizedWalletShare;
 use clap::Parser;
-use constants::DARKPOOL_PROXY_CONTRACT_KEY;
-use helpers::parse_addr_from_deployments_file;
-use test_helpers::integration_test_main;
-use util::{logging::LevelFilter, runtime::block_on_result};
-
-use crate::constants::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY};
+use test_helpers::{
+    arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
+    integration_test_main,
+};
+use util::{
+    arbitrum::{parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY},
+    logging::LevelFilter,
+    runtime::block_on_result,
+};
 
 /// The arguments used to run the integration tests
 #[derive(Debug, Clone, Parser)]

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -1,6 +1,7 @@
 //! Solidity ABI definitions of smart contracts, events, and other on-chain
 //! data structures used by the Arbitrum client.
 #![allow(missing_docs)]
+#![allow(unused_doc_comments)]
 
 use alloy_sol_types::sol;
 use ethers::contract::abigen;
@@ -44,6 +45,22 @@ abigen!(
 
 
         function clearMerkle() external
+    ]"#
+);
+
+/// Represents an ERC20 contract's abi used in integration tests for
+/// deposit/withdrawal mechanics
+#[cfg(feature = "integration")]
+abigen!(
+    ERC20Contract,
+    r#"[
+        function totalSupply() external view returns (uint256)
+        function balanceOf(address account) external view returns (uint256)
+        function mint(address memory _address, uint256 memory value) external
+        function transfer(address to, uint256 value) external returns (bool)
+        function allowance(address owner, address spender) external view returns (uint256)
+        function approve(address spender, uint256 value) external returns (bool)
+        function transferFrom(address from, address to, uint256 value) external returns (bool)
     ]"#
 );
 

--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -114,8 +114,13 @@ impl ArbitrumClient {
     }
 
     /// Get a reference to the underlying RPC client
-    fn client(&self) -> Arc<SignerHttpProvider> {
+    pub fn client(&self) -> Arc<SignerHttpProvider> {
         self.darkpool_contract.client()
+    }
+
+    /// Get the address of the wallet used for signing transactions
+    pub fn wallet_address(&self) -> Address {
+        self.client().address()
     }
 
     /// Get the current Stylus block number

--- a/arbitrum-client/src/types.rs
+++ b/arbitrum-client/src/types.rs
@@ -249,7 +249,7 @@ impl From<ValidReblindStatement> for ContractValidReblindStatement {
     }
 }
 
-/// Statememt for the `VALID_COMMITMENTS` circuit
+/// Statement for the `VALID_COMMITMENTS` circuit
 #[derive(Serialize, Deserialize)]
 pub struct ContractValidCommitmentsStatement {
     /// The index of the balance sent by the party if a successful match occurs

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -85,6 +85,16 @@ pub enum OrderSide {
 }
 
 impl OrderSide {
+    /// Return whether the order is a sell side order, this is equivalent to the
+    /// conversion that makes the `OrderSide` a bool type when allocated in
+    /// the circuit
+    pub fn is_sell(&self) -> bool {
+        match self {
+            OrderSide::Buy => false,
+            OrderSide::Sell => true,
+        }
+    }
+
     /// Return the opposite direction to self
     pub fn opposite(&self) -> OrderSide {
         match self {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 use toml::{value::Map, Value};
-use util::arbitrum::parse_addr_from_deployments_file;
+use util::arbitrum::{parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY};
 
 /// The default version of the node
 const DEFAULT_VERSION: &str = "0.1.0";
@@ -451,7 +451,8 @@ fn toml_value_to_string(val: &Value) -> Result<String, String> {
 fn set_contract_from_file(config: &mut RelayerConfig, file: Option<String>) -> Result<(), String> {
     // Do not override if the file is not specified
     if let Some(path) = file {
-        let darkpool_addr = parse_addr_from_deployments_file(path).map_err(|e| e.to_string())?;
+        let darkpool_addr = parse_addr_from_deployments_file(&path, DARKPOOL_PROXY_CONTRACT_KEY)
+            .map_err(|e| e.to_string())?;
         config.contract_address = darkpool_addr;
     }
 

--- a/task-driver/Cargo.toml
+++ b/task-driver/Cargo.toml
@@ -44,6 +44,8 @@ tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
+ethers = "2"
+
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
 eyre = { workspace = true }

--- a/task-driver/integration/tests/create_new_wallet.rs
+++ b/task-driver/integration/tests/create_new_wallet.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `NewWalletTask`
 
+use constants::Scalar;
 use eyre::{eyre, Result};
-use mpc_stark::algebra::scalar::Scalar;
 use rand::thread_rng;
 use task_driver::create_new_wallet::NewWalletTask;
 use test_helpers::integration_test_async;
@@ -18,7 +18,7 @@ async fn create_new_wallet(test_args: IntegrationTestArgs) -> Result<()> {
     let task = NewWalletTask::new(
         wallet.id,
         wallet,
-        test_args.starknet_client.clone(),
+        test_args.arbitrum_client.clone(),
         test_args.global_state.clone(),
         test_args.proof_job_queue.clone(),
     )?;
@@ -44,7 +44,7 @@ async fn create_new_wallet__invalid_shares(test_args: IntegrationTestArgs) -> Re
     let task = NewWalletTask::new(
         wallet.id,
         wallet,
-        test_args.starknet_client.clone(),
+        test_args.arbitrum_client.clone(),
         test_args.global_state.clone(),
         test_args.proof_job_queue.clone(),
     );

--- a/task-driver/integration/tests/lookup_wallet.rs
+++ b/task-driver/integration/tests/lookup_wallet.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `LookupWalletTask`
 
+use constants::Scalar;
 use eyre::Result;
-use mpc_stark::algebra::scalar::Scalar;
 use rand::{distributions::uniform::SampleRange, thread_rng};
 use task_driver::lookup_wallet::LookupWalletTask;
 use test_helpers::{assert_true_result, integration_test_async};
@@ -25,7 +25,7 @@ async fn test_lookup_wallet__invalid_wallet(test_args: IntegrationTestArgs) -> R
         Scalar::zero(), // blinder_stream_seed
         Scalar::zero(), // secret_share_stream_seed
         wallet.key_chain,
-        test_args.starknet_client.clone(),
+        test_args.arbitrum_client.clone(),
         test_args.network_sender.clone(),
         test_args.global_state.clone(),
         test_args.proof_job_queue.clone(),
@@ -43,7 +43,7 @@ integration_test_async!(test_lookup_wallet__invalid_wallet);
 async fn test_lookup_wallet__valid_wallet(test_args: IntegrationTestArgs) -> Result<()> {
     // Create a wallet from a blinder seed
     let mut rng = thread_rng();
-    let client = &test_args.starknet_client;
+    let client = &test_args.arbitrum_client;
 
     let blinder_seed = Scalar::random(&mut rng);
     let share_seed = Scalar::random(&mut rng);

--- a/task-driver/integration/tests/mod.rs
+++ b/task-driver/integration/tests/mod.rs
@@ -4,7 +4,3 @@ pub mod create_new_wallet;
 pub mod lookup_wallet;
 pub mod settle_match;
 pub mod update_wallet;
-
-/// The deployed address of the WETH ERC20 contract
-pub(crate) const WETH_ADDR: &str =
-    "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";

--- a/test-helpers/src/arbitrum.rs
+++ b/test-helpers/src/arbitrum.rs
@@ -1,0 +1,9 @@
+//! Helpers related to interfacing with an Arbitrum devnet node
+
+/// The deployed address of the WETH ERC20 contract on a devnet node
+pub const PREDEPLOYED_WETH_ADDR: &str = "0x408Da76E87511429485C32E4Ad647DD14823Fdc4";
+/// The default hostport that the Nitro devnet L2 node runs on
+pub const DEFAULT_DEVNET_HOSTPORT: &str = "http://localhost:8547";
+/// The default private key that the Nitro devnet is seeded with
+pub const DEFAULT_DEVNET_PKEY: &str =
+    "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659";

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(unsafe_code)]
 
+pub mod arbitrum;
 pub mod assertions;
 pub mod macros;
 pub mod mpc_network;

--- a/util/src/arbitrum.rs
+++ b/util/src/arbitrum.rs
@@ -8,14 +8,16 @@ use eyre::{eyre, Result};
 pub const DEPLOYMENTS_KEY: &str = "deployments";
 /// The darkpool key in the `deployments.json` file
 pub const DARKPOOL_KEY: &str = "darkpool";
+/// The darkpool proxy contract key in the `deployments.json` file
+pub const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";
 
-/// Parse a `deployments.json` file to get the address of the darkpool contract
-pub fn parse_addr_from_deployments_file(file_path: String) -> Result<String> {
+/// Parse the address of the deployed contract from the `deployments.json` file
+pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> Result<String> {
     let mut file_contents = String::new();
     File::open(file_path)?.read_to_string(&mut file_contents)?;
 
     let parsed_json = json::parse(&file_contents)?;
-    parsed_json[DEPLOYMENTS_KEY][DARKPOOL_KEY]
+    parsed_json[DEPLOYMENTS_KEY][contract_key]
         .as_str()
         .map(|s| s.to_string())
         .ok_or_else(|| eyre!("Could not parse darkpool address from deployments file"))


### PR DESCRIPTION
### Purpose
This PR refactors the `task-driver` integration tests over the `mpc-plonk` and `arbitrum-client` implementations. These tests are not passing, waiting for our integration testing stack to stabilize.

Some helpers were generalized out of `arbitrum-client/integration` into `utils`

### Testing
- Unit tests pass