### PR TITLE
external-api: (De)serialize all keys from/to hex strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,12 +2834,14 @@ version = "0.1.0"
 dependencies = [
  "circuit-types",
  "common",
+ "constants",
+ "hex 0.4.3",
  "itertools 0.10.5",
  "num-bigint",
- "num-traits",
  "renegade-crypto",
  "serde",
  "serde_json",
+ "util",
  "uuid 1.6.1",
 ]
 
@@ -8228,10 +8230,12 @@ dependencies = [
  "env_logger 0.9.3",
  "eyre",
  "futures",
+ "hex 0.4.3",
  "json",
  "lazy_static",
  "libp2p",
  "num-bigint",
+ "num-traits",
  "rand 0.8.5",
  "renegade-crypto",
  "tokio",

--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -6,15 +6,17 @@ edition = "2021"
 [dependencies]
 # === Arithmetic === #
 num-bigint = { workspace = true }
-num-traits = "0.2"
 
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }
 common = { path = "../common" }
+constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 itertools = { workspace = true }
+hex = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -10,7 +10,7 @@ use common::types::{
 };
 use serde::Serialize;
 
-use crate::types::Wallet;
+use crate::types::ApiWallet;
 
 // ----------------------------
 // | System Bus Message Types |
@@ -107,7 +107,7 @@ pub enum SystemBusMessage {
     /// A message indicating that a wallet has been updated
     WalletUpdate {
         /// The new wallet after update
-        wallet: Box<Wallet>,
+        wallet: Box<ApiWallet>,
     },
 
     /// A message indicating an internal (gossip metadata) update has been

--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -2,18 +2,18 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::NetworkOrder;
+use crate::types::ApiNetworkOrder;
 
 /// The response type to fetch all the known orders in the network
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkOrdersResponse {
     /// The orders known to the local peer
-    pub orders: Vec<NetworkOrder>,
+    pub orders: Vec<ApiNetworkOrder>,
 }
 
 /// The response type to fetch a given network order by its ID
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkOrderByIdResponse {
     /// The requested network order
-    pub order: NetworkOrder,
+    pub order: ApiNetworkOrder,
 }

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    biguint_from_hex_string, biguint_to_hex_string,
-    types::{Balance, Fee, Order, Wallet},
+    deserialize_biguint_from_hex_string, serialize_biguint_to_hex_string,
+    types::{ApiBalance, ApiFee, ApiOrder, ApiWallet},
 };
 
 // --------------------
@@ -21,14 +21,14 @@ use crate::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetWalletResponse {
     /// The wallet requested by the client
-    pub wallet: Wallet,
+    pub wallet: ApiWallet,
 }
 
 /// The request type to create a new wallet
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateWalletRequest {
     /// The wallet info to be created
-    pub wallet: Wallet,
+    pub wallet: ApiWallet,
 }
 
 /// The response type to a request to create a new wallet
@@ -71,20 +71,20 @@ pub struct FindWalletResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetOrdersResponse {
     /// The orders within a given wallet
-    pub orders: Vec<Order>,
+    pub orders: Vec<ApiOrder>,
 }
 /// The response type to get a single order by ID
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetOrderByIdResponse {
     /// The order requested
-    pub order: Order,
+    pub order: ApiOrder,
 }
 
 /// The request type to add a new order to a given wallet
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateOrderRequest {
     /// The order to be created
-    pub order: Order,
+    pub order: ApiOrder,
     /// A signature of the circuit statement used in the proof of
     /// VALID WALLET UPDATE by `sk_root`. This allows the contract
     /// to guarantee that the wallet updates are properly authorized
@@ -104,7 +104,7 @@ pub struct CreateOrderResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UpdateOrderRequest {
     /// The order to be updated
-    pub order: Order,
+    pub order: ApiOrder,
     /// A signature of the circuit statement used in the proof of
     /// VALID WALLET UPDATE by `sk_root`. This allows the contract
     /// to guarantee that the wallet updates are properly authorized
@@ -133,7 +133,7 @@ pub struct CancelOrderResponse {
     /// The ID of the task allocated for this request
     pub task_id: TaskIdentifier,
     /// The order information of the now-cancelled order
-    pub order: Order,
+    pub order: ApiOrder,
 }
 
 // -----------------------------
@@ -144,14 +144,14 @@ pub struct CancelOrderResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetBalancesResponse {
     /// The balances in the given wallet
-    pub balances: Vec<Balance>,
+    pub balances: Vec<ApiBalance>,
 }
 
 /// The response type to get a single balance by mint
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetBalanceByMintResponse {
     /// The requested balance
-    pub balance: Balance,
+    pub balance: ApiBalance,
 }
 
 /// The request type to deposit a balance into the darkpool
@@ -159,14 +159,14 @@ pub struct GetBalanceByMintResponse {
 pub struct DepositBalanceRequest {
     /// The arbitrum account contract address to send the balance from
     #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
+        serialize_with = "serialize_biguint_to_hex_string",
+        deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub from_addr: BigUint,
     /// The mint (ERC-20 contract address) of the token to deposit
     #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
+        serialize_with = "serialize_biguint_to_hex_string",
+        deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub mint: BigUint,
     /// The amount of the token to deposit
@@ -193,8 +193,8 @@ pub struct DepositBalanceResponse {
 pub struct WithdrawBalanceRequest {
     /// The destination address to withdraw the balance to
     #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
+        serialize_with = "serialize_biguint_to_hex_string",
+        deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub destination_addr: BigUint,
     /// The amount of the token to withdraw
@@ -227,8 +227,8 @@ pub struct InternalTransferRequest {
     pub statement_sig: Vec<u8>,
     /// The recipient's settle key
     #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
+        serialize_with = "serialize_biguint_to_hex_string",
+        deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub recipient_key: BigUint,
     /// The amount to transfer
@@ -250,14 +250,14 @@ pub struct InternalTransferResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetFeesResponse {
     /// The fees in a given wallet
-    pub fees: Vec<Fee>,
+    pub fees: Vec<ApiFee>,
 }
 
 /// The request type to add a fee to a wallet
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddFeeRequest {
     /// The fee to add to the wallet
-    pub fee: Fee,
+    pub fee: ApiFee,
     /// A signature of the circuit statement used in the proof of
     /// VALID WALLET UPDATE by `sk_root`. This allows the contract
     /// to guarantee that the wallet updates are properly authorized
@@ -292,5 +292,5 @@ pub struct RemoveFeeResponse {
     /// The ID of the task allocated for this request
     pub task_id: TaskIdentifier,
     /// The fee that was removed
-    pub fee: Fee,
+    pub fee: ApiFee,
 }

--- a/task-driver/integration/helpers.rs
+++ b/task-driver/integration/helpers.rs
@@ -16,10 +16,9 @@ use common::types::{
 };
 use constants::Scalar;
 use ethers::types::{Address, U256};
-use external_api::types::Wallet as ApiWallet;
+use external_api::types::ApiWallet;
 use eyre::{eyre, Result};
 use num_bigint::BigUint;
-use num_traits::Num;
 use rand::thread_rng;
 use renegade_crypto::hash::{evaluate_hash_chain, PoseidonCSPRNG};
 use system_bus::SystemBus;
@@ -31,12 +30,6 @@ use test_helpers::{assert_eq_result, assert_true_result};
 use uuid::Uuid;
 
 use crate::IntegrationTestArgs;
-
-/// Parse a biguint from a hex string
-pub fn biguint_from_hex_string(s: &str) -> BigUint {
-    let stripped = s.strip_prefix("0x").unwrap_or(s);
-    BigUint::from_str_radix(stripped, 16 /* radix */).unwrap()
-}
 
 /// Parse a biguint from an H160 address
 pub fn biguint_from_address(val: Address) -> BigUint {

--- a/task-driver/integration/tests/lookup_wallet.rs
+++ b/task-driver/integration/tests/lookup_wallet.rs
@@ -24,7 +24,7 @@ async fn test_lookup_wallet__invalid_wallet(test_args: IntegrationTestArgs) -> R
         Uuid::new_v4(),
         Scalar::zero(), // blinder_stream_seed
         Scalar::zero(), // secret_share_stream_seed
-        wallet.key_chain,
+        wallet.key_chain.try_into().unwrap(),
         test_args.arbitrum_client.clone(),
         test_args.network_sender.clone(),
         test_args.global_state.clone(),

--- a/task-driver/integration/tests/settle_match.rs
+++ b/task-driver/integration/tests/settle_match.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     helpers::{
-        biguint_from_address, biguint_from_hex_string, increase_erc20_allowance,
-        lookup_wallet_and_check_result, new_wallet_in_darkpool,
+        biguint_from_address, increase_erc20_allowance, lookup_wallet_and_check_result,
+        new_wallet_in_darkpool,
     },
     IntegrationTestArgs,
 };
@@ -32,7 +32,7 @@ use test_helpers::{
     arbitrum::PREDEPLOYED_WETH_ADDR, assert_eq_result, assert_true_result, integration_test_async,
 };
 use tokio::sync::{mpsc::unbounded_channel, oneshot::channel};
-use util::matching_engine::settle_match_into_wallets;
+use util::{hex::biguint_from_hex_string, matching_engine::settle_match_into_wallets};
 use uuid::Uuid;
 
 use super::update_wallet::execute_wallet_update;
@@ -52,8 +52,8 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
     };
 
     Order {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr),
-        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR),
+        quote_mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(),
+        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(),
         side,
         amount: 10,
         worst_case_price: FixedPoint::from_integer(worst_cast_price),
@@ -65,10 +65,10 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
 fn dummy_balance(side: OrderSide, test_args: &IntegrationTestArgs) -> Balance {
     match side {
         OrderSide::Buy => {
-            Balance { mint: biguint_from_hex_string(&test_args.erc20_addr), amount: 500 }
+            Balance { mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(), amount: 500 }
         },
         OrderSide::Sell => {
-            Balance { mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR), amount: 200 }
+            Balance { mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(), amount: 200 }
         },
     }
 }
@@ -162,8 +162,8 @@ async fn setup_match_result(
     let direction = wallet1.orders.first().unwrap().1.side.is_sell();
 
     let match_ = MatchResult {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr),
-        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR),
+        quote_mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(),
+        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(),
         quote_amount: scalar_to_u64(&quote_amount.floor()),
         base_amount,
         direction,

--- a/task-driver/integration/tests/update_wallet.rs
+++ b/task-driver/integration/tests/update_wallet.rs
@@ -15,14 +15,13 @@ use num_bigint::BigUint;
 use rand::thread_rng;
 use task_driver::update_wallet::UpdateWalletTask;
 use test_helpers::{assert_true_result, integration_test_async};
-use util::get_current_time_seconds;
+use util::{get_current_time_seconds, hex::biguint_from_hex_string};
 use uuid::Uuid;
 
 use crate::{
     helpers::{
-        allocate_wallet_in_darkpool, biguint_from_address, biguint_from_hex_string,
-        empty_wallet_from_seed, increase_erc20_allowance, lookup_wallet_and_check_result,
-        new_wallet_in_darkpool,
+        allocate_wallet_in_darkpool, biguint_from_address, empty_wallet_from_seed,
+        increase_erc20_allowance, lookup_wallet_and_check_result, new_wallet_in_darkpool,
     },
     IntegrationTestArgs,
 };
@@ -251,7 +250,7 @@ async fn test_update_wallet__deposit_and_withdraw(test_args: IntegrationTestArgs
     // Update the wallet by depositing into the pool
     let old_wallet = wallet.clone();
 
-    let mint = biguint_from_hex_string(&test_args.erc20_addr);
+    let mint = biguint_from_hex_string(&test_args.erc20_addr).unwrap();
     let amount = 10u64;
 
     wallet.balances.insert(mint.clone(), Balance { mint: mint.clone(), amount });

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Arithmetic === #
+num-bigint = "0.4"
+num-traits = "0.2"
+
 # === Networking === #
 libp2p = { workspace = true }
 
@@ -20,11 +24,11 @@ renegade-crypto = { path = "../renegade-crypto" }
 chrono = "0.4"
 env_logger = "0.9"
 eyre = { workspace = true }
+hex = "0.4"
 json = "0.12"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 
 [dev-dependencies]
 lazy_static = "1.4"
-num-bigint = "0.4"
 rand = "0.8"

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -1,0 +1,63 @@
+//! Helpers for converting values to and from hex strings
+use circuit_types::keychain::{NonNativeScalar, PublicSigningKey};
+use constants::Scalar;
+use num_bigint::BigUint;
+use num_traits::Num;
+use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
+
+/// A helper to serialize a BigUint to a hex string
+pub fn biguint_to_hex_string(val: &BigUint) -> String {
+    format!("0x{}", val.to_str_radix(16 /* radix */))
+}
+
+/// A helper to deserialize a BigUint from a hex string
+pub fn biguint_from_hex_string(hex: &str) -> Result<BigUint, String> {
+    // Deserialize as a string and remove "0x" if present
+    let stripped = hex.strip_prefix("0x").unwrap_or(hex);
+    BigUint::from_str_radix(stripped, 16 /* radix */)
+        .map_err(|e| format!("error deserializing BigUint from hex string: {e}"))
+}
+
+/// A helper to serialize a scalar to a hex string
+pub fn scalar_to_hex_string(val: &Scalar) -> String {
+    let biguint = scalar_to_biguint(val);
+    biguint_to_hex_string(&biguint)
+}
+
+/// A helper to deserialize a scalar from a hex string
+pub fn scalar_from_hex_string(hex: &str) -> Result<Scalar, String> {
+    let biguint = biguint_from_hex_string(hex)?;
+    Ok(biguint_to_scalar(&biguint))
+}
+
+/// A helper to serialize a nonnative scalar to a hex string
+pub fn nonnative_scalar_to_hex_string<const NUM_WORDS: usize>(
+    val: &NonNativeScalar<NUM_WORDS>,
+) -> String {
+    biguint_to_hex_string(&val.into())
+}
+
+/// A helper method to deserialize a nonnative scalar from a hex string
+pub fn nonnative_scalar_from_hex_string<const NUM_WORDS: usize>(
+    hex: &str,
+) -> Result<NonNativeScalar<NUM_WORDS>, String> {
+    let biguint = biguint_from_hex_string(hex)?;
+    Ok(NonNativeScalar::from(&biguint))
+}
+
+/// A helper to serialize a signing key to a hex string
+pub fn public_sign_key_to_hex_string(val: &PublicSigningKey) -> String {
+    let bytes = val.to_compressed_bytes();
+    format!("0x{}", hex::encode(bytes))
+}
+
+/// A helper to deserialize a signing key from a hex string
+pub fn public_sign_key_from_hex_string(hex: &str) -> Result<PublicSigningKey, String> {
+    // Deserialize as a string and remove "0x" if present
+    let stripped = hex.strip_prefix("0x").unwrap_or(hex);
+    let bytes = hex::decode(stripped)
+        .map_err(|e| format!("error deserializing bytes from hex string: {e}"))?;
+
+    PublicSigningKey::from_bytes(&bytes)
+        .map_err(|e| format!("error deserializing signing key from bytes: {e}"))
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -9,6 +9,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub mod arbitrum;
+pub mod hex;
 pub mod logging;
 pub mod matching_engine;
 pub mod networking;

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 use external_api::{
     http::order_book::{GetNetworkOrderByIdResponse, GetNetworkOrdersResponse},
-    types::NetworkOrder,
+    types::ApiNetworkOrder,
     EmptyRequestResponse,
 };
 use hyper::HeaderMap;
@@ -66,7 +66,7 @@ impl TypedHandler for GetNetworkOrdersHandler {
         _req: Self::Request,
         _params: UrlParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let orders: Vec<NetworkOrder> = self
+        let orders: Vec<ApiNetworkOrder> = self
             .global_state
             .read_order_book()
             .await

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -21,7 +21,7 @@ use external_api::{
         GetWalletResponse, RemoveFeeRequest, RemoveFeeResponse, UpdateOrderRequest,
         UpdateOrderResponse, WithdrawBalanceRequest, WithdrawBalanceResponse,
     },
-    types::{Balance as ApiBalance, Fee as ApiFee, Order as ApiOrder},
+    types::{ApiBalance, ApiFee, ApiOrder},
     EmptyRequestResponse,
 };
 use gossip_api::gossip::GossipOutbound;


### PR DESCRIPTION
### Purpose
This PR changes all key types to be serialized and deserialized to/from hex strings at the API layer. 

### Testing
- Unit and integration tests pass
- Tested with `POST /v0/wallet/`