### PR TITLE
arbitrum-client, docker: adapt to new contract interface

### DIFF
--- a/arbitrum-client/integration/constants.rs
+++ b/arbitrum-client/integration/constants.rs
@@ -1,1 +1,0 @@
-//! Constants used in the Arbitrum client integration tests

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -11,7 +11,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-mod constants;
 mod contract_interaction;
 mod event_indexing;
 mod helpers;

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -10,16 +10,16 @@ use ethers::contract::abigen;
 abigen!(
     DarkpoolContract,
     r#"[
-        function isNullifierSpent(bytes memory nullifier) external view returns (bool)
-        function getRoot() external view returns (bytes)
-        function rootInHistory(bytes memory root) external view returns (bool)
+        function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
+        function getRoot() external view returns (uint256)
+        function rootInHistory(uint256 memory root) external view returns (bool)
 
-        function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
 
-        event WalletUpdated(bytes indexed wallet_blinder_share)
-        event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
+        event WalletUpdated(uint256 indexed wallet_blinder_share)
+        event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
         event NullifierSpent(uint256 nullifier)
     ]"#
 );
@@ -31,16 +31,16 @@ abigen!(
 abigen!(
     DarkpoolContract,
     r#"[
-        function isNullifierSpent(bytes memory nullifier) external view returns (bool)
-        function getRoot() external view returns (bytes)
-        function rootInHistory(bytes memory root) external view returns (bool)
+        function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
+        function getRoot() external view returns (uint256)
+        function rootInHistory(uint256 memory root) external view returns (bool)
 
-        function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
 
-        event WalletUpdated(bytes indexed wallet_blinder_share)
-        event NodeChanged(uint8 indexed height, uint128 indexed index, bytes indexed new_value_hash, bytes new_value)
+        event WalletUpdated(uint256 indexed wallet_blinder_share)
+        event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
         event NullifierSpent(uint256 nullifier)
 
 
@@ -65,7 +65,7 @@ abigen!(
 );
 
 sol! {
-    function newWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
-    function updateWallet(bytes memory wallet_blinder_share, bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external;
+    function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
+    function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external;
 }

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -6,8 +6,7 @@ use constants::Scalar;
 use ethers::{
     abi::Detokenize,
     contract::ContractCall,
-    types::{Bytes, TransactionReceipt, H256},
-    utils::keccak256,
+    types::{Bytes, TransactionReceipt},
 };
 use serde::{Deserialize, Serialize};
 
@@ -15,10 +14,9 @@ use crate::{
     abi::{newWalletCall, processMatchSettleCall, updateWalletCall},
     client::SignerHttpProvider,
     errors::ArbitrumClientError,
-    serde_def_types::SerdeScalarField,
     types::{
         ContractValidMatchSettleStatement, ContractValidWalletCreateStatement,
-        ContractValidWalletUpdateStatement, MatchPayload,
+        ContractValidWalletUpdateStatement,
     },
 };
 
@@ -34,13 +32,6 @@ pub fn deserialize_calldata<'de, T: Deserialize<'de>>(
     calldata: &'de Bytes,
 ) -> Result<T, ArbitrumClientError> {
     postcard::from_bytes(calldata).map_err(|e| ArbitrumClientError::Serde(e.to_string()))
-}
-
-/// Computes the Keccak-256 hash of the serialization of a scalar,
-/// used for filtering events that have indexed scalar topics
-pub fn keccak_hash_scalar(scalar: Scalar) -> Result<H256, ArbitrumClientError> {
-    let scalar_bytes = serialize_calldata(&SerdeScalarField(scalar.inner()))?;
-    Ok(keccak256(scalar_bytes).into())
 }
 
 /// Sends a transaction, awaiting its confirmation and returning the receipt
@@ -95,22 +86,25 @@ pub fn parse_shares_from_process_match_settle(
     let call = processMatchSettleCall::decode(calldata, true /* validate */)
         .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
 
-    let party_0_match_payload =
-        deserialize_calldata::<MatchPayload>(&call.party_0_match_payload.into())?;
-    let party_1_match_payload =
-        deserialize_calldata::<MatchPayload>(&call.party_1_match_payload.into())?;
-
     let valid_match_settle_statement = deserialize_calldata::<ContractValidMatchSettleStatement>(
         &call.valid_match_settle_statement_bytes.into(),
     )?;
 
+    // The blinder is expected to be the last public wallet share
+    let party_0_public_blinder_share =
+        valid_match_settle_statement.party0_modified_shares.last().unwrap();
+
+    // The blinder is expected to be the last public wallet share
+    let party_1_public_blinder_share =
+        valid_match_settle_statement.party1_modified_shares.last().unwrap();
+
     let target_share = public_blinder_share.inner();
-    if party_0_match_payload.wallet_blinder_share == target_share {
+    if party_0_public_blinder_share == &target_share {
         let mut shares =
             valid_match_settle_statement.party0_modified_shares.into_iter().map(Scalar::new);
 
         Ok(SizedWalletShare::from_scalars(&mut shares))
-    } else if party_1_match_payload.wallet_blinder_share == target_share {
+    } else if party_1_public_blinder_share == &target_share {
         let mut shares =
             valid_match_settle_statement.party1_modified_shares.into_iter().map(Scalar::new);
 

--- a/arbitrum-client/src/types.rs
+++ b/arbitrum-client/src/types.rs
@@ -317,9 +317,6 @@ impl From<SizedValidMatchSettleStatement> for ContractValidMatchSettleStatement 
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct MatchPayload {
-    /// The public secret share of the party's wallet-level blinder
-    #[serde_as(as = "ScalarFieldDef")]
-    pub wallet_blinder_share: ScalarField,
     /// The statement for the party's `VALID_COMMITMENTS` proof
     pub valid_commitments_statement: ContractValidCommitmentsStatement,
     /// The statement for the party's `VALID_REBLIND` proof

--- a/docker/contracts/deploy_contracts.sh
+++ b/docker/contracts/deploy_contracts.sh
@@ -30,97 +30,50 @@ no_verify() {
 
 # Deploy verifier contract
 cargo run \
-    -p scripts -- \
-    -p $DEVNET_PKEY \
-    -r $DEVNET_RPC_URL \
-    -d $DEPLOYMENTS_PATH \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
     deploy-stylus \
     --contract verifier
 
 # Deploy Merkle contract
 cargo run \
-    -p scripts -- \
-    -p $DEVNET_PKEY \
-    -r $DEVNET_RPC_URL \
-    -d $DEPLOYMENTS_PATH \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
     deploy-stylus \
     --contract merkle
 
 # Deploy darkpool contract, setting the "--no-verify" flag
 # conditionally depending on whether the corresponding env var is set
 cargo run \
-    -p scripts -- \
-    -p $DEVNET_PKEY \
-    -r $DEVNET_RPC_URL \
-    -d $DEPLOYMENTS_PATH \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
     deploy-stylus \
     --contract darkpool-test-contract \
     $(no_verify)
 
 # Deploy the proxy contract
 cargo run \
-    -p scripts -- \
-    -p $DEVNET_PKEY \
-    -r $DEVNET_RPC_URL \
-    -d $DEPLOYMENTS_PATH \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
     deploy-proxy \
-    -o $DEVNET_ACCOUNT_ADDRESS
-
-# If the $UPLOAD_VKEYS env var is set, upload the verification keys
-if [[ -n $UPLOAD_VKEYS ]]; then
-    # Upload VALID WALLET CREATE verification key
-    cargo run \
-        -p scripts -- \
-        -p $DEVNET_PKEY \
-        -r $DEVNET_RPC_URL \
-        -d $DEPLOYMENTS_PATH \
-        upload-vkey \
-        -c valid-wallet-create
-
-    # Upload VALID WALLET UPDATE verification key
-    cargo run \
-        -p scripts -- \
-        -p $DEVNET_PKEY \
-        -r $DEVNET_RPC_URL \
-        -d $DEPLOYMENTS_PATH \
-        upload-vkey \
-        -c valid-wallet-update
-
-    # Upload VALID COMMITMENTS verification key
-    cargo run \
-        -p scripts -- \
-        -p $DEVNET_PKEY \
-        -r $DEVNET_RPC_URL \
-        -d $DEPLOYMENTS_PATH \
-        upload-vkey \
-        -c valid-commitments
-
-    # Upload VALID REBLIND verification key
-    cargo run \
-        -p scripts -- \
-        -p $DEVNET_PKEY \
-        -r $DEVNET_RPC_URL \
-        -d $DEPLOYMENTS_PATH \
-        upload-vkey \
-        -c valid-reblind
-
-    # Upload VALID MATCH SETTLE verification key
-    cargo run \
-        -p scripts -- \
-        -p $DEVNET_PKEY \
-        -r $DEVNET_RPC_URL \
-        -d $DEPLOYMENTS_PATH \
-        upload-vkey \
-        -c valid-match-settle
-fi
+    --owner $DEVNET_ACCOUNT_ADDRESS \
+    --test
 
 # If the $DEPLOY_DUMMY_ERC20 env var is set, deploy the dummy ERC20 contract
 if [[ -n $DEPLOY_DUMMY_ERC20 ]]; then
     cargo run \
-    -p scripts -- \
-    -p $DEVNET_PKEY \
-    -r $DEVNET_RPC_URL \
-    -d $DEPLOYMENTS_PATH \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
     deploy-stylus \
     --contract dummy-erc20
 fi


### PR DESCRIPTION
This PR updates the Arbitrum client to adapt to the new contract interface, in which, namely, there are no longer any setter methods, and events/external methods expect/return `uint256` types where `Scalar`s are used, as opposed to `bytes`. This also makes event parsing more straightforward, in that we no longer need to generate a hash of the serialized `Scalar` to listen for events containing it.

`arbitrum-client` integration tests pass.