### PR TITLE
docker: deploy vkeys contract if NO_VERIFY is unset

### DIFF
--- a/docker/contracts/Dockerfile
+++ b/docker/contracts/Dockerfile
@@ -36,7 +36,8 @@ RUN cargo build -p scripts
 # to cache the dependencies.
 # The actual deploy script will rebuild & deploy this contract, along with
 # the others.
-RUN cargo \
+RUN RUSTFLAGS="-C opt-level=3" \
+    cargo \
     +nightly \
     build \
     -r \


### PR DESCRIPTION
This PR amends the `deploy_contracts` script to also deploy the verification keys contract if the `$NO_VERIFY` flag is unset. It does this in a manner that ensures that dependencies cached from the image build are used for all the relevant contracts (now that we have different compilation settings for the verifier contract).

A dangling TODO here is to ensure that the verification keys in the contracts repo, which are written to the deployed contract, are the same (or at least use the same SRS) as those used in any relayer-side integration tests that test smart contract verification. Since we don't have any such integration testing stacks completely ported over to the Arbitrum client yet, this is left for a future PR (it requires a bit of thought around SRS generation).

The existing Arbitrum client integration tests pass, and an ad-hoc test where the `$NO_VERIFY` env var is unset shows that the verification keys and verifier contract are deployed as expected.