### PR TITLE
arbitrum-client: reset preallocated state properly at test start

### DIFF
--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
-    helpers::{clear_merkle, deploy_new_wallet, random_wallet_shares},
+    helpers::{deploy_new_wallet, random_wallet_shares},
     IntegrationTestArgs,
 };
 
@@ -24,9 +24,7 @@ async fn test_new_wallet(test_args: IntegrationTestArgs) -> Result<()> {
         client.fetch_public_shares_for_blinder(public_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(public_shares, recovered_public_shares)?;
-
-    clear_merkle(client).await
+    assert_eq_result!(public_shares, recovered_public_shares)
 }
 integration_test_async!(test_new_wallet);
 
@@ -52,9 +50,7 @@ async fn test_update_wallet(test_args: IntegrationTestArgs) -> Result<()> {
         client.fetch_public_shares_for_blinder(new_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(new_shares, recovered_public_shares)?;
-
-    clear_merkle(client).await
+    assert_eq_result!(new_shares, recovered_public_shares)
 }
 integration_test_async!(test_update_wallet);
 
@@ -94,8 +90,6 @@ async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()>
         client.fetch_public_shares_for_blinder(party_1_new_shares.blinder).await?;
 
     // Check that the recovered public shares are the same as the original ones
-    assert_eq_result!(party_1_new_shares, recovered_party_1_shares)?;
-
-    clear_merkle(client).await
+    assert_eq_result!(party_1_new_shares, recovered_party_1_shares)
 }
 integration_test_async!(test_process_match_settle);

--- a/arbitrum-client/integration/event_indexing.rs
+++ b/arbitrum-client/integration/event_indexing.rs
@@ -7,15 +7,12 @@ use constants::MERKLE_HEIGHT;
 use eyre::Result;
 use test_helpers::{assert_eq_result, integration_test_async};
 
-use crate::{
-    helpers::{clear_merkle, setup_pre_allocated_state},
-    IntegrationTestArgs,
-};
+use crate::{helpers::setup_pre_allocated_state, IntegrationTestArgs};
 
 /// Tests finding a pre-allocated commitment in the Merkle state
 async fn test_find_commitment(test_args: IntegrationTestArgs) -> Result<()> {
-    let client = &test_args.client;
-    let state = setup_pre_allocated_state(client).await?;
+    let mut client = test_args.client;
+    let state = setup_pre_allocated_state(&mut client).await?;
 
     for (index, commitment) in
         [state.index0_commitment, state.index1_commitment, state.index2_commitment]
@@ -27,14 +24,14 @@ async fn test_find_commitment(test_args: IntegrationTestArgs) -> Result<()> {
         assert_eq_result!(commitment_index, index as u128)?;
     }
 
-    clear_merkle(client).await
+    Ok(())
 }
 integration_test_async!(test_find_commitment);
 
 /// Tests finding a Merkle authentication path for a pre-allocated commitment
 async fn test_find_merkle_path(test_args: IntegrationTestArgs) -> Result<()> {
-    let client = &test_args.client;
-    let state = setup_pre_allocated_state(client).await?;
+    let mut client = test_args.client;
+    let state = setup_pre_allocated_state(&mut client).await?;
 
     // Create Merkle openings to test against
     let (expected_root, expected_paths) = create_multi_opening_with_default_leaf::<MERKLE_HEIGHT>(
@@ -59,17 +56,15 @@ async fn test_find_merkle_path(test_args: IntegrationTestArgs) -> Result<()> {
     let final_root =
         client.find_merkle_authentication_path(state.index2_commitment).await?.compute_root();
 
-    assert_eq_result!(final_root, expected_root)?;
-
-    clear_merkle(client).await
+    assert_eq_result!(final_root, expected_root)
 }
 integration_test_async!(test_find_merkle_path);
 
 /// Tests looking up a wallet by its public blinder share and parsing the
 /// public shares from the calldata
 async fn test_parse_public_shares_from_calldata(test_args: IntegrationTestArgs) -> Result<()> {
-    let client = &test_args.client;
-    let state = setup_pre_allocated_state(client).await?;
+    let mut client = test_args.client;
+    let state = setup_pre_allocated_state(&mut client).await?;
 
     for expected_public_share in [
         state.index0_public_wallet_shares,
@@ -88,6 +83,6 @@ async fn test_parse_public_shares_from_calldata(test_args: IntegrationTestArgs) 
         assert_eq_result!(public_shares, expected_public_share)?;
     }
 
-    clear_merkle(client).await
+    Ok(())
 }
 integration_test_async!(test_parse_public_shares_from_calldata);

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -22,9 +22,6 @@ use crate::{
 
 use super::ArbitrumClient;
 
-// TODO: Replace `renegade_contracts_common::types::*` with relayer statement
-// types once they're adapted to Plonk
-
 impl ArbitrumClient {
     // -----------
     // | GETTERS |

--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -131,4 +131,15 @@ impl ArbitrumClient {
             .map(BlockNumber::Number)
             .map_err(|e| ArbitrumClientError::Rpc(e.to_string()))
     }
+
+    /// Resets the deploy block to the current block number.
+    ///
+    /// Used in integration tests to ensure that we are only querying for events
+    /// from the desired block onwards.
+    #[cfg(feature = "integration")]
+    pub async fn reset_deploy_block(&mut self) -> Result<(), ArbitrumClientError> {
+        self.deploy_block = self.block_number().await?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR makes a couple changes to how preallocated state is managed for the Arbitrum client integration tests:
1. Merkle state is now cleared at the beginning of the tests which need a blank slate, removing the need for all tests to clear at the end, and ensuring that a blank slate is used even if previous tests fail before clearing
2. We reset the deploy block of the client for the tests which need a blank slate. This fixes a testing bug where, if more than 3 previous tests were run which didn't reset the Merkle state, the authentication path in the `test_find_merkle_path` test would be incorrect (as the sibling of the 3rd commitment would no longer be the empty leaf value)

Arbitrum client integration tests pass, even after running more than 3 non-clearing tests in a row and running `test_find_merkle_path`