### PR TITLE
api-server: auth: Expect signatures as b64 encoded bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
+# Build
 **/target
 **/build
+**/flamegraph.svg
+
+# Config
 **/no_commit
+**/deployments.json
+
+# vscode + vim
 .idea
 .vscode
 *.sw[a-p]
 secrets.env
-**/flamegraph.svg
 /.gitattributes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrum-client",
  "async-trait",
+ "base64 0.21.5",
  "circuit-types",
  "common",
  "constants",

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -1,16 +1,13 @@
 //! Groups API type definitions for wallet API operations
 
-use common::types::{
-    tasks::TaskIdentifier,
-    wallet::{KeyChain, WalletIdentifier},
-};
+use common::types::{tasks::TaskIdentifier, wallet::WalletIdentifier};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
     deserialize_biguint_from_hex_string, serialize_biguint_to_hex_string,
-    types::{ApiBalance, ApiFee, ApiOrder, ApiWallet},
+    types::{ApiBalance, ApiFee, ApiKeychain, ApiOrder, ApiWallet},
 };
 
 // --------------------
@@ -51,7 +48,7 @@ pub struct FindWalletRequest {
     /// The seed for the wallet's secret share CSPRNG
     pub secret_share_seed: BigUint,
     /// The keychain to use for management after the wallet is found
-    pub key_chain: KeyChain,
+    pub key_chain: ApiKeychain,
 }
 
 /// The response type to a request to find a wallet in contract storage

--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -38,7 +38,7 @@ const TASK_DRIVER_THREAD_NAME: &str = "renegade-task-driver";
 /// The number of times to retry a step in a task before propagating the error
 ///
 /// TODO: This is high for now, bring this down as Starknet stabilizes
-const TASK_DRIVER_N_RETRIES: usize = 20;
+const TASK_DRIVER_N_RETRIES: usize = 5;
 
 // ----------
 // | Config |

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -37,6 +37,7 @@ task-driver = { path = "../../task-driver" }
 
 # === Misc Dependencies === #
 async-trait = "0.1.60"
+base64 = "0.21"
 itertools = "0.11"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -9,7 +9,7 @@ use circuit_types::{
     order::Order,
     transfers::{ExternalTransfer, ExternalTransferDirection},
 };
-use common::types::wallet::{Wallet, WalletIdentifier};
+use common::types::wallet::{KeyChain, Wallet, WalletIdentifier};
 use constants::{MAX_FEES, MAX_ORDERS};
 use crossbeam::channel::Sender as CrossbeamSender;
 use external_api::{
@@ -291,11 +291,14 @@ impl TypedHandler for FindWalletHandler {
     ) -> Result<Self::Response, ApiServerError> {
         // Create a task in thew driver to find and prove validity for
         // the wallet
+        let keychain: KeyChain =
+            req.key_chain.try_into().map_err(|e: String| bad_request(e.to_string()))?;
+
         let task = LookupWalletTask::new(
             req.wallet_id,
             biguint_to_scalar(&req.blinder_seed),
             biguint_to_scalar(&req.secret_share_seed),
-            req.key_chain,
+            keychain,
             self.arbitrum_client.clone(),
             self.network_sender.clone(),
             self.global_state.clone(),


### PR DESCRIPTION
### Purpose
This PR changes the signature verification scheme to expect signatures encoded in base 64. This is how the relayer functioned before the refactor and what is expected in both the frontend and the dev tool proxy.

### Testing
- All unit tests pass
- Tested against the internal proxy's signatures