### PR TITLE
proof-manager: mock: Check constraint satisfaction in mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -96,13 +96,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "arrayvec",
  "bytes",
- "smol_str",
 ]
 
 [[package]]
@@ -115,7 +114,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -203,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.76"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "api-server"
@@ -266,7 +265,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.4.11",
+ "clap 4.4.13",
  "colored",
  "common",
  "constants",
@@ -730,13 +729,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.75"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -892,7 +891,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1133,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
  "serde",
 ]
@@ -1148,7 +1147,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.20",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "thiserror",
@@ -1337,7 +1336,7 @@ dependencies = [
  "chrono",
  "circuit-macros",
  "circuit-types",
- "clap 4.4.11",
+ "clap 4.4.13",
  "colored",
  "constants",
  "criterion",
@@ -1365,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -1393,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.7",
@@ -1403,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1435,7 +1434,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1578,7 +1577,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
- "clap 4.4.11",
+ "clap 4.4.13",
  "common",
  "ed25519-dalek 1.0.1",
  "libp2p",
@@ -1662,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -1703,7 +1702,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.11",
+ "clap 4.4.13",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1740,9 +1739,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+checksum = "6eb9105919ca8e40d437fc9cbb8f1975d916f1bd28afe795a48aae32a2cc8920"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -1754,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
+checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1775,21 +1774,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bcf5bdbfdd6030fb4a1c497b5d5fc5921aa2f60d359a17e249c0e6df3de153"
+checksum = "adc6598521bb5a83d491e8c1fe51db7296019d2ca3cb93cc6c2a20369a4d78a2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1797,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
  "cfg-if",
 ]
@@ -1943,7 +1941,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1991,7 +1989,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2013,7 +2011,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2081,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2230,7 +2228,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2643,7 +2641,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.42",
+ "syn 2.0.48",
  "toml 0.8.2",
  "walkdir",
 ]
@@ -2661,7 +2659,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2687,7 +2685,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.42",
+ "syn 2.0.48",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2703,7 +2701,7 @@ dependencies = [
  "chrono",
  "ethers-core",
  "reqwest",
- "semver 1.0.20",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "thiserror",
@@ -2812,7 +2810,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver 1.0.20",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "solang-parser",
@@ -2827,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f2cdcf274580f2d63697192d744727b3198894b1bf02923643bf59e2c26712"
+checksum = "218a870470cce1469024e9fb66b901aa983929d81304a1cdb299f28118e550d5"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -3025,9 +3023,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3040,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3050,15 +3048,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3068,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -3094,13 +3092,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3116,15 +3114,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -3138,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3633,16 +3631,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3844,13 +3842,13 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi 0.3.3",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3880,7 +3878,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#29ada3432028ec8e7fd0abddf1c1f0e57c44c25e"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#797775559fb73d73b6fa87b424ccd8e9a14095c4"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3924,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#29ada3432028ec8e7fd0abddf1c1f0e57c44c25e"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#797775559fb73d73b6fa87b424ccd8e9a14095c4"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4105,12 +4103,12 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4586,18 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memuse"
@@ -4653,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#29ada3432028ec8e7fd0abddf1c1f0e57c44c25e"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#797775559fb73d73b6fa87b424ccd8e9a14095c4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4687,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#29ada3432028ec8e7fd0abddf1c1f0e57c44c25e"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#797775559fb73d73b6fa87b424ccd8e9a14095c4"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5064,7 +5053,7 @@ dependencies = [
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5078,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -5145,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -5166,7 +5155,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5177,9 +5166,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -5418,9 +5407,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5477,7 +5466,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5515,7 +5504,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5548,9 +5537,9 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "platforms"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "plotters"
@@ -5646,12 +5635,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5758,9 +5747,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
@@ -5785,7 +5774,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5853,7 +5842,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.42",
+ "syn 2.0.48",
  "tempfile",
  "which",
 ]
@@ -5868,7 +5857,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5990,9 +5979,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -6494,7 +6483,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.20",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -6662,11 +6651,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6763,9 +6752,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
 ]
@@ -6793,38 +6782,38 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -6878,7 +6867,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7150,15 +7139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
-name = "smol_str"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "snafu"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7404,7 +7384,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7424,7 +7404,7 @@ dependencies = [
  "hex 0.4.3",
  "once_cell",
  "reqwest",
- "semver 1.0.20",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -7446,9 +7426,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.42"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7464,7 +7444,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7559,7 +7539,7 @@ dependencies = [
  "async-trait",
  "circuit-types",
  "circuits",
- "clap 4.4.11",
+ "clap 4.4.13",
  "colored",
  "common",
  "constants",
@@ -7590,15 +7570,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7651,22 +7631,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7771,7 +7751,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7932,7 +7912,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8374,7 +8354,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -8408,7 +8388,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8573,7 +8553,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core",
+ "windows-core 0.51.1",
  "windows-targets 0.48.5",
 ]
 
@@ -8584,6 +8564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -8777,9 +8766,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "8434aeec7b290e8da5c3f0d628cb0eac6cabcb31d14bb74f779a08109a5914d6"
 dependencies = [
  "memchr",
 ]
@@ -8878,7 +8867,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8898,7 +8887,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ members = [
 	"workers/proof-manager",
 ]
 
-[profile.test]
-debug-assertions = false
-
 [profile.bench]
 opt-level = 3 # Full optimizations
 lto = true

--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -12,7 +12,7 @@ use k256::{
 };
 use mpc_relation::{traits::Circuit, Variable};
 use num_bigint::BigUint;
-use renegade_crypto::fields::get_scalar_field_modulus;
+use renegade_crypto::{fields::get_scalar_field_modulus, hash::compute_poseidon_hash};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -88,6 +88,14 @@ impl From<PublicIdentificationKey> for Scalar {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct SecretIdentificationKey {
     pub key: Scalar,
+}
+
+impl SecretIdentificationKey {
+    /// Get the public key corresponding to this secret key
+    pub fn get_public_key(&self) -> PublicIdentificationKey {
+        let key = compute_poseidon_hash(&[self.key]);
+        PublicIdentificationKey { key }
+    }
 }
 
 impl Serialize for SecretIdentificationKey {

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -64,6 +64,24 @@ impl Order {
         self.amount == 0
     }
 
+    /// The mint of the token sent by the creator of this order in the event
+    /// that the order is matched
+    pub fn send_mint(&self) -> &BigUint {
+        match self.side {
+            OrderSide::Buy => &self.quote_mint,
+            OrderSide::Sell => &self.base_mint,
+        }
+    }
+
+    /// The mint of the token received by the creator of this order in the event
+    /// that the order is matched
+    pub fn receive_mint(&self) -> &BigUint {
+        match self.side {
+            OrderSide::Buy => &self.base_mint,
+            OrderSide::Sell => &self.quote_mint,
+        }
+    }
+
     /// Determines whether the given price is within the allowable range for the
     /// order
     pub fn price_in_range(&self, price: FixedPoint) -> bool {

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -673,6 +673,9 @@ pub trait SingleProverCircuit: Sized {
     /// the underlying NP statement being proven
     type Statement: CircuitBaseType;
 
+    /// The name of the circuit
+    fn name() -> String;
+
     /// Returns a reference to the proving key for the circuit
     #[cfg(not(feature = "test-helpers"))]
     fn proving_key() -> Arc<ProvingKey<SystemCurve>> {
@@ -780,6 +783,11 @@ pub trait MultiProverCircuit {
         Witness = <Self::Witness as MultiproverCircuitBaseType>::BaseType,
         Statement = <Self::Statement as MultiproverCircuitBaseType>::BaseType,
     >;
+
+    /// The name of the circuit
+    fn name() -> String {
+        Self::BaseCircuit::name()
+    }
 
     /// Returns a reference to the proving key for the circuit
     fn proving_key() -> Arc<ProvingKey<SystemCurve>> {

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -324,6 +324,10 @@ where
     type Statement = ValidCommitmentsStatement;
     type Witness = ValidCommitmentsWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
+    fn name() -> String {
+        "Valid Commitments".to_string()
+    }
+
     fn apply_constraints(
         witness_var: ValidCommitmentsWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement_var: ValidCommitmentsStatementVar,
@@ -483,10 +487,8 @@ mod test {
     use lazy_static::lazy_static;
 
     use crate::zk_circuits::{
-        test_helpers::{
-            check_constraint_satisfaction, SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES,
-            MAX_ORDERS,
-        },
+        check_constraint_satisfaction,
+        test_helpers::{SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS},
         valid_commitments::test_helpers::{create_witness_and_statement, find_balance_or_augment},
     };
 

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -186,6 +186,10 @@ where
     type Witness = ValidMatchSettleWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Statement = ValidMatchSettleStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
+    fn name() -> String {
+        "Valid Match Settle".to_string()
+    }
+
     fn apply_constraints(
         witness: ValidMatchSettleWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement: ValidMatchSettleStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
@@ -345,7 +349,7 @@ mod tests {
     use crate::{
         multiprover_prove_and_verify,
         zk_circuits::{
-            test_helpers::check_constraint_satisfaction,
+            check_constraint_satisfaction,
             valid_match_settle::test_helpers::{
                 dummy_witness_and_statement, SizedValidMatchSettle,
             },

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -331,6 +331,10 @@ where
     type Witness = ValidReblindWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>;
     type Statement = ValidReblindStatement;
 
+    fn name() -> String {
+        "Valid Reblind".to_string()
+    }
+
     fn apply_constraints(
         witness_var: ValidReblindWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>,
         statement_var: ValidReblindStatementVar,
@@ -435,9 +439,9 @@ mod test {
     use rand::{thread_rng, Rng};
 
     use crate::zk_circuits::{
+        check_constraint_satisfaction,
         test_helpers::{
-            check_constraint_satisfaction, SizedWallet, SizedWalletShare, INITIAL_WALLET,
-            MAX_BALANCES, MAX_FEES, MAX_ORDERS,
+            SizedWallet, SizedWalletShare, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS,
         },
         valid_reblind::test_helpers::construct_witness_statement,
     };

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -143,6 +143,10 @@ where
     type Statement = ValidWalletCreateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
     type Witness = ValidWalletCreateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
+    fn name() -> String {
+        "Valid Wallet Create".to_string()
+    }
+
     fn apply_constraints(
         witness_var: ValidWalletCreateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
         statement_var: ValidWalletCreateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
@@ -221,10 +225,8 @@ pub mod tests {
     use crate::{
         singleprover_prove_and_verify,
         zk_circuits::{
-            test_helpers::{
-                check_constraint_satisfaction, INITIAL_BALANCES, INITIAL_ORDERS, MAX_BALANCES,
-                MAX_FEES, MAX_ORDERS,
-            },
+            check_constraint_satisfaction,
+            test_helpers::{INITIAL_BALANCES, INITIAL_ORDERS, MAX_BALANCES, MAX_FEES, MAX_ORDERS},
             valid_wallet_create::{
                 test_helpers::create_default_witness_statement, ValidWalletCreate,
             },

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -479,6 +479,10 @@ where
     type Witness = ValidWalletUpdateWitness<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>;
     type Statement = ValidWalletUpdateStatement<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
+    fn name() -> String {
+        "Valid Wallet Update".to_string()
+    }
+
     fn apply_constraints(
         witness_var: ValidWalletUpdateWitnessVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>,
         statement_var: ValidWalletUpdateStatementVar<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
@@ -595,9 +599,9 @@ mod test {
     use rand::{thread_rng, RngCore};
 
     use crate::zk_circuits::{
+        check_constraint_satisfaction,
         test_helpers::{
-            check_constraint_satisfaction, SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES,
-            MAX_ORDERS, TIMESTAMP,
+            SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_FEES, MAX_ORDERS, TIMESTAMP,
         },
         valid_wallet_update::test_helpers::NEW_TIMESTAMP,
     };

--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -382,9 +382,7 @@ pub mod mocks {
     };
 
     use circuit_types::{
-        keychain::{
-            PublicIdentificationKey, PublicKeyChain, PublicSigningKey, SecretIdentificationKey,
-        },
+        keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey},
         traits::BaseType,
         SizedWalletShare,
     };
@@ -408,20 +406,17 @@ pub mod mocks {
         let key = K256SigningKey::random(&mut rng);
         let pk_root = PublicSigningKey::from(key.verifying_key());
 
+        let sk_match = SecretIdentificationKey::from(Scalar::random(&mut rng));
+        let pk_match = sk_match.get_public_key();
+
         let mut wallet = Wallet {
             wallet_id: Uuid::new_v4(),
             orders: IndexMap::default(),
             balances: IndexMap::default(),
             fees: vec![],
             key_chain: KeyChain {
-                public_keys: PublicKeyChain {
-                    pk_root,
-                    pk_match: PublicIdentificationKey::from(Scalar::zero()),
-                },
-                secret_keys: PrivateKeyChain {
-                    sk_root: None,
-                    sk_match: SecretIdentificationKey::from(Scalar::zero()),
-                },
+                public_keys: PublicKeyChain { pk_root, pk_match },
+                secret_keys: PrivateKeyChain { sk_root: None, sk_match },
             },
             blinder: Scalar::random(&mut rng),
             private_shares: SizedWalletShare::from_scalars(&mut iter::repeat_with(|| {

--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -220,17 +220,18 @@ impl RelayerState {
         for peer in peer_ids.iter() {
             // Skip this peer if peer info wasn't sent, or if their cluster auth signature
             // doesn't verify
-            if let Some(info) = peer_info.get(peer) && info.verify_cluster_auth_sig().is_ok() {
+            if let Some(info) = peer_info.get(peer)
+                && info.verify_cluster_auth_sig().is_ok()
+            {
                 // Record a dummy heartbeat to setup the initial state
                 info.successful_heartbeat();
                 locked_peer_index.add_peer(info.clone()).await;
 
                 // Push a message onto the bus indicating the new peer discovery
-                self.system_bus
-                    .publish(
-                        NETWORK_TOPOLOGY_TOPIC.to_string(),
-                        SystemBusMessage::NewPeer { peer: info.clone() }
-                    );
+                self.system_bus.publish(
+                    NETWORK_TOPOLOGY_TOPIC.to_string(),
+                    SystemBusMessage::NewPeer { peer: info.clone() },
+                );
             } else {
                 continue;
             }

--- a/statev2/state/src/replication/log_store.rs
+++ b/statev2/state/src/replication/log_store.rs
@@ -281,7 +281,7 @@ impl Storage for LogStore {
                 } else {
                     Err(RaftError::Store(RaftStorageError::Unavailable))
                 }
-            }
+            },
             res => res.map_err(RaftError::from),
         }
     }

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -300,9 +300,8 @@ impl LookupWalletTask {
 
         let mut updating_tx = None;
 
-        while
-            let (blinder, private_share) = blinder_csprng.next_tuple().unwrap() &&
-            let Some(tx) = self
+        while let (blinder, private_share) = blinder_csprng.next_tuple().unwrap()
+            && let Some(tx) = self
                 .arbitrum_client
                 .get_public_blinder_tx(blinder - private_share)
                 .await

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -231,9 +231,10 @@ impl SettleMatchTask {
         // the counterparty already submitted a `match` and move on to
         // settlement
         if let Err(ref tx_rejection) = tx_submit_res
-            && tx_rejection.to_string().contains(NULLIFIER_USED_ERROR_MSG){
-                return Ok(())
-            }
+            && tx_rejection.to_string().contains(NULLIFIER_USED_ERROR_MSG)
+        {
+            return Ok(());
+        }
 
         tx_submit_res.map_err(|e| SettleMatchTaskError::Arbitrum(e.to_string()))
     }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -898,7 +898,8 @@ impl TypedHandler for WithdrawBalanceHandler {
 
         let mut new_wallet = old_wallet.clone();
         if let Some(balance) = new_wallet.balances.get_mut(&mint)
-        && balance.amount >= withdrawal_amount {
+            && balance.amount >= withdrawal_amount
+        {
             balance.amount -= withdrawal_amount;
         } else {
             return Err(bad_request(ERR_INSUFFICIENT_BALANCE.to_string()));

--- a/workers/gossip-server/src/heartbeat.rs
+++ b/workers/gossip-server/src/heartbeat.rs
@@ -438,7 +438,9 @@ impl HeartbeatTimer {
             }; // cluster_metadata_locked released
 
             // Enqueue a job to send the heartbeat
-            if let Some(peer_id) = next_peer_id && peer_id != global_state.local_peer_id {
+            if let Some(peer_id) = next_peer_id
+                && peer_id != global_state.local_peer_id
+            {
                 if let Err(err) = job_queue.send(GossipServerJob::ExecuteHeartbeat(peer_id)) {
                     return GossipError::TimerFailed(err.to_string());
                 }

--- a/workers/gossip-server/src/orderbook.rs
+++ b/workers/gossip-server/src/orderbook.rs
@@ -257,18 +257,15 @@ impl GossipProtocolExecutor {
 
         // If the local peer has a copy of the witness stored locally, send it to the
         // peer
-        if let Some(order_info) = self
-            .global_state
-            .read_order_book()
-            .await
-            .get_order_info(&order_id)
-            .await
-        && let Some(witness) = order_info.validity_proof_witnesses
+        if let Some(order_info) =
+            self.global_state.read_order_book().await.get_order_info(&order_id).await
+            && let Some(witness) = order_info.validity_proof_witnesses
         {
             self.network_channel
-                .send(GossipOutbound::Request { peer_id: requesting_peer, message: GossipRequest::ValidityWitness {
-                    order_id, witness
-                }})
+                .send(GossipOutbound::Request {
+                    peer_id: requesting_peer,
+                    message: GossipRequest::ValidityWitness { order_id, witness },
+                })
                 .map_err(|err| GossipError::SendMessage(err.to_string()))?;
         }
 

--- a/workers/handshake-manager/src/state.rs
+++ b/workers/handshake-manager/src/state.rs
@@ -141,9 +141,10 @@ impl HandshakeStateIndex {
         // MPC runtime
         for request in requests.iter() {
             if let Some(state) = self.remove_handshake(request).await
-            && let Some(channel) = state.cancel_channel
+                && let Some(channel) = state.cancel_channel
             {
-                channel.send(())
+                channel
+                    .send(())
                     .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
             }
         }

--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -127,8 +127,7 @@ impl CoinbaseConnection {
         let json_blob = json_blob.unwrap();
 
         // Extract the list of events and update the order book
-        let update_events =
-            if let Some(coinbase_events) = json_blob[COINBASE_EVENTS].as_array()
+        let update_events = if let Some(coinbase_events) = json_blob[COINBASE_EVENTS].as_array()
             && let Some(update_events) = coinbase_events[0][COINBASE_EVENT_UPDATE].as_array()
         {
             update_events

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -1,12 +1,22 @@
 //! Defines a mock for the proof manager that doesn't prove statements, but
 //! instead immediately returns dummy proofs that will not verify
 
+use circuit_types::traits::SingleProverCircuit;
 use circuits::zk_circuits::{
-    valid_commitments::{SizedValidCommitmentsWitness, ValidCommitmentsStatement},
-    valid_match_settle::{SizedValidMatchSettleStatement, SizedValidMatchSettleWitness},
-    valid_reblind::{SizedValidReblindWitness, ValidReblindStatement},
-    valid_wallet_create::{SizedValidWalletCreateStatement, SizedValidWalletCreateWitness},
-    valid_wallet_update::{SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness},
+    check_constraint_satisfaction,
+    valid_commitments::{
+        SizedValidCommitments, SizedValidCommitmentsWitness, ValidCommitmentsStatement,
+    },
+    valid_match_settle::{
+        SizedValidMatchSettle, SizedValidMatchSettleStatement, SizedValidMatchSettleWitness,
+    },
+    valid_reblind::{SizedValidReblind, SizedValidReblindWitness, ValidReblindStatement},
+    valid_wallet_create::{
+        SizedValidWalletCreate, SizedValidWalletCreateStatement, SizedValidWalletCreateWitness,
+    },
+    valid_wallet_update::{
+        SizedValidWalletUpdate, SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
+    },
 };
 use common::types::proof_bundles::{
     mocks::dummy_proof, GenericMatchSettleBundle, GenericValidCommitmentsBundle,
@@ -19,6 +29,8 @@ use job_types::proof_manager::{ProofJob, ProofManagerJob};
 use tokio::{runtime::Handle, sync::oneshot::Sender as TokioSender};
 use tracing::log;
 
+use crate::error::ProofManagerError;
+
 /// The error message emitted when a response channel closes early
 const ERR_RESPONSE_CHANNEL_CLOSED: &str = "error sending proof, channel closed";
 
@@ -28,137 +40,124 @@ const ERR_RESPONSE_CHANNEL_CLOSED: &str = "error sending proof, channel closed";
 
 /// The mock proof manager
 pub struct MockProofManager;
+#[allow(clippy::needless_pass_by_value)]
 impl MockProofManager {
     /// Start a mock proof manager
     pub fn start(job_queue: Receiver<ProofManagerJob>) {
-        Handle::current().spawn_blocking(move || Self::execution_loop(&job_queue));
+        Handle::current().spawn_blocking(move || {
+            if let Err(e) = Self::execution_loop(&job_queue) {
+                log::error!("error in mock proof manager: {e}");
+            }
+        });
     }
 
     /// The execution loop for the mock
-    fn execution_loop(job_queue: &Receiver<ProofManagerJob>) {
+    fn execution_loop(job_queue: &Receiver<ProofManagerJob>) -> Result<(), ProofManagerError> {
         loop {
             match job_queue.recv() {
-                Err(e) => {
-                    log::error!("error receiving job: {e}... shutting down");
-                    break;
+                Err(_) => {
+                    return Err(ProofManagerError::JobQueueClosed("job queue closed".to_string()));
                 },
-                Ok(job) => Self::handle_job(job.type_, job.response_channel),
+                Ok(job) => Self::handle_job(job.type_, job.response_channel)?,
             }
         }
     }
 
     /// Handle a job by immediately returning a dummy proof
-    fn handle_job(job_type: ProofJob, response_channel: TokioSender<ProofBundle>) {
+    fn handle_job(
+        job_type: ProofJob,
+        response_channel: TokioSender<ProofBundle>,
+    ) -> Result<(), ProofManagerError> {
         let bundle = match job_type {
             ProofJob::ValidWalletCreate { witness, statement } => {
-                ProofBundle::ValidWalletCreate(Self::valid_wallet_create(&witness, statement))
+                ProofBundle::ValidWalletCreate(Self::valid_wallet_create(witness, statement)?)
             },
             ProofJob::ValidWalletUpdate { witness, statement } => {
-                ProofBundle::ValidWalletUpdate(Self::valid_wallet_update(&witness, statement))
+                ProofBundle::ValidWalletUpdate(Self::valid_wallet_update(witness, statement)?)
             },
             ProofJob::ValidReblind { witness, statement } => {
-                ProofBundle::ValidReblind(Self::valid_reblind(&witness, statement))
+                ProofBundle::ValidReblind(Self::valid_reblind(witness, statement)?)
             },
             ProofJob::ValidCommitments { witness, statement } => {
-                ProofBundle::ValidCommitments(Self::valid_commitments(&witness, statement))
+                ProofBundle::ValidCommitments(Self::valid_commitments(witness, statement)?)
             },
             ProofJob::ValidMatchSettleSingleprover { witness, statement } => {
-                ProofBundle::ValidMatchSettle(Self::valid_match_settle(&witness, statement))
+                ProofBundle::ValidMatchSettle(Self::valid_match_settle(witness, statement)?)
             },
         };
 
         response_channel.send(bundle).expect(ERR_RESPONSE_CHANNEL_CLOSED);
+        Ok(())
     }
 
     /// Generate a dummy proof of `VALID WALLET CREATE`
     fn valid_wallet_create(
-        _witness: &SizedValidWalletCreateWitness,
+        witness: SizedValidWalletCreateWitness,
         statement: SizedValidWalletCreateStatement,
-    ) -> ValidWalletCreateBundle {
+    ) -> Result<ValidWalletCreateBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidWalletCreate>(&witness, &statement)?;
+
         let proof = dummy_proof();
-        Box::new(GenericValidWalletCreateBundle { statement, proof })
+        Ok(Box::new(GenericValidWalletCreateBundle { statement, proof }))
     }
 
     /// Generate a dummy proof of `VALID WALLET UPDATE`
     fn valid_wallet_update(
-        _witness: &SizedValidWalletUpdateWitness,
+        witness: SizedValidWalletUpdateWitness,
         statement: SizedValidWalletUpdateStatement,
-    ) -> ValidWalletUpdateBundle {
+    ) -> Result<ValidWalletUpdateBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidWalletUpdate>(&witness, &statement)?;
+
         let proof = dummy_proof();
-        Box::new(GenericValidWalletUpdateBundle { statement, proof })
+        Ok(Box::new(GenericValidWalletUpdateBundle { statement, proof }))
     }
 
     /// Generate a dummy proof of `VALID REBLIND`
     fn valid_reblind(
-        _witness: &SizedValidReblindWitness,
+        witness: SizedValidReblindWitness,
         statement: ValidReblindStatement,
-    ) -> ValidReblindBundle {
+    ) -> Result<ValidReblindBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidReblind>(&witness, &statement)?;
+
         let proof = dummy_proof();
-        Box::new(GenericValidReblindBundle { statement, proof })
+        Ok(Box::new(GenericValidReblindBundle { statement, proof }))
     }
 
     /// Create a dummy proof of `VALID COMMITMENTS`
     fn valid_commitments(
-        _witness: &SizedValidCommitmentsWitness,
+        witness: SizedValidCommitmentsWitness,
         statement: ValidCommitmentsStatement,
-    ) -> ValidCommitmentsBundle {
+    ) -> Result<ValidCommitmentsBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidCommitments>(&witness, &statement)?;
+
         let proof = dummy_proof();
-        Box::new(GenericValidCommitmentsBundle { statement, proof })
+        Ok(Box::new(GenericValidCommitmentsBundle { statement, proof }))
     }
 
     /// Create a dummy proof of `VALID MATCH SETTLE`
     fn valid_match_settle(
-        _witness: &SizedValidMatchSettleWitness,
+        witness: SizedValidMatchSettleWitness,
         statement: SizedValidMatchSettleStatement,
-    ) -> ValidMatchSettleBundle {
+    ) -> Result<ValidMatchSettleBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidMatchSettle>(&witness, &statement)?;
+
         let proof = dummy_proof();
-        Box::new(GenericMatchSettleBundle { statement, proof })
+        Ok(Box::new(GenericMatchSettleBundle { statement, proof }))
     }
-}
 
-#[cfg(test)]
-mod test {
-    use std::iter;
-
-    use circuit_types::{traits::BaseType, wallet::WalletShare};
-    use circuits::zk_circuits::valid_wallet_create::{
-        SizedValidWalletCreateStatement, SizedValidWalletCreateWitness,
-    };
-    use constants::Scalar;
-    use crossbeam::channel::unbounded;
-    use job_types::proof_manager::{ProofJob, ProofManagerJob};
-    use tokio::{runtime::Builder as RuntimeBuilder, sync::oneshot::channel as oneshot_channel};
-
-    use super::MockProofManager;
-
-    /// Test the spawning and execution of a mock proof manager
-    #[tokio::test]
-    async fn test_simple_proof() {
-        // Create a runtime to manage spawn the mock within
-        let runtime = RuntimeBuilder::new_current_thread().enable_all().build().unwrap();
-
-        let (job_send, job_recv) = unbounded();
-        runtime.spawn_blocking(move || MockProofManager::start(job_recv));
-
-        // Create a dummy witness and statement
-        let witness = SizedValidWalletCreateWitness {
-            private_wallet_share: WalletShare::from_scalars(&mut iter::repeat(Scalar::zero())),
-        };
-        let statement = SizedValidWalletCreateStatement {
-            public_wallet_shares: WalletShare::from_scalars(&mut iter::repeat(Scalar::zero())),
-            private_shares_commitment: Scalar::zero(),
-        };
-
-        // Send a job to the mock and expect a mock proof back
-        let (response_send, response_recv) = oneshot_channel();
-        job_send
-            .send(ProofManagerJob {
-                response_channel: response_send,
-                type_: ProofJob::ValidWalletCreate { witness, statement },
-            })
-            .unwrap();
-
-        response_recv.await.unwrap();
-        runtime.shutdown_background()
+    /// Check constraint satisfaction for a witness and statement
+    ///
+    /// This helper effectively wraps a boolean in the error type needed by the
+    /// interface
+    fn check_constraints<C: SingleProverCircuit>(
+        witness: &C::Witness,
+        statement: &C::Statement,
+    ) -> Result<(), ProofManagerError> {
+        if !check_constraint_satisfaction::<C>(witness, statement) {
+            let err = format!("invalid witness and statement for {}", C::name());
+            Err(ProofManagerError::Prover(err))
+        } else {
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the behavior of the mock proof manager to check constraint satisfaction of the witness and statement. This allows us to check the validity of witness, statement pairs generated by the tasks.

As a result, this PR fixes a few bugs in the task driver integration tests.

### Testing
- Unit tests pass
- Integration tests mostly pass, some error for nitro specific reasons which will be fixed when time permits.