### PR TITLE
circuit-types: traits: Add `NUM_SCALARS` constant to `BaseType` trait

### DIFF
--- a/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
+++ b/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
@@ -68,6 +68,7 @@ fn build_circuit_base_type_impl(base_type: &ItemStruct) -> TokenStream2 {
     let base_name = base_type.ident.clone();
     let base_type_params = params_from_generics(generics.clone());
 
+    // Build the `VarType`
     let var_type_associated = new_ident(VAR_TYPE_ASSOCIATED_NAME);
     let var_type_name = ident_with_generics(
         &ident_with_suffix(&base_name.to_string(), VAR_TYPE_SUFFIX),

--- a/circuit-types/src/macro_tests.rs
+++ b/circuit-types/src/macro_tests.rs
@@ -22,13 +22,21 @@ mod test {
         Fabric,
     };
 
+    /// The number of scalars to place as an array in the `TestType` type
+    const NUM_TEST_SCALARS: usize = 2;
+
     #[circuit_type(singleprover_circuit, mpc, multiprover_circuit, secret_share)]
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct TestType {
         val: Scalar,
+        array_val: [Scalar; NUM_TEST_SCALARS],
     }
 
     impl TestType {
+        fn new(val: Scalar) -> Self {
+            Self { val, array_val: [val; NUM_TEST_SCALARS] }
+        }
+
         fn check_equal(&self, val: Scalar) -> bool {
             self.val.eq(&val)
         }
@@ -38,14 +46,15 @@ mod test {
     #[test]
     fn test_base_type_preserved() {
         // Test that the base type may still be constructed
-        let a = TestType { val: Scalar::one() };
+        let a = TestType::new(Scalar::one());
+        assert_eq!(TestType::num_scalars(), NUM_TEST_SCALARS + 1);
         assert!(a.check_equal(Scalar::one()))
     }
 
     /// Test that the `BaseType` trait was correctly implemented
     #[test]
     fn test_base_type_implementation() {
-        let a = TestType { val: Scalar::from(2u8) };
+        let a = TestType::new(Scalar::from(2u8));
         let serialized = a.to_scalars();
         let deserialized = TestType::from_scalars(&mut serialized.into_iter());
 
@@ -54,7 +63,7 @@ mod test {
 
     #[test]
     fn test_circuit_base_type_implementation() {
-        let a = TestType { val: Scalar::one() };
+        let a = TestType::new(Scalar::one());
 
         let mut circuit = PlonkCircuit::new_turbo_plonk();
 
@@ -66,13 +75,13 @@ mod test {
     #[test]
     fn test_circuit_base_type_derived_types() {
         let callback = |_: TestTypeVar| {};
-        let a = TestType { val: Scalar::one() };
+        let a = TestType::new(Scalar::one());
 
         let mut circuit = PlonkCircuit::new_turbo_plonk();
 
         // Commit to the type and verify that the callback typechecks
         let var = a.create_witness(&mut circuit);
-        let var2 = TestTypeVar { val: 2 };
+        let var2 = TestTypeVar { val: 2, array_val: [2; NUM_TEST_SCALARS] };
         callback(var);
         callback(var2);
     }
@@ -81,7 +90,7 @@ mod test {
     async fn test_mpc_derived_type() {
         // Execute an MPC that allocates the value then opens it
         let (party0_res, party1_res) = execute_mock_mpc(|fabric| async move {
-            let value = TestType { val: Scalar::from(2u8) };
+            let value = TestType::new(Scalar::from(2u8));
 
             let allocated = value.allocate(PARTY0, &fabric);
             allocated.open().await
@@ -89,7 +98,7 @@ mod test {
         .await;
 
         // Verify that both parties saw the same value: `TestType { 2 }`
-        let expected_value = TestType { val: Scalar::from(2u8) };
+        let expected_value = TestType::new(Scalar::from(2u8));
         assert_eq!(expected_value, party0_res.unwrap());
         assert_eq!(expected_value, party1_res.unwrap());
     }
@@ -98,7 +107,7 @@ mod test {
     async fn test_multiprover_derived_types() {
         let (party0_res, party1_res) = execute_mock_mpc(|fabric| async move {
             // Setup a dummy value to allocate in the constraint system
-            let value = TestType { val: Scalar::from(2u8) };
+            let value = TestType::new(Scalar::from(2u8));
 
             let mut circuit = MpcPlonkCircuit::new(fabric.clone());
 
@@ -112,7 +121,7 @@ mod test {
         })
         .await;
 
-        let expected_value = TestType { val: Scalar::from(2u8) };
+        let expected_value = TestType::new(Scalar::from(2u8));
 
         assert_eq!(party0_res.unwrap(), expected_value);
         assert_eq!(party1_res.unwrap(), expected_value);
@@ -121,25 +130,30 @@ mod test {
     #[test]
     fn test_secret_share_types() {
         // Build two secret shares
-        let share1 = TestTypeShare { val: Scalar::one() };
-        let share2 = TestTypeShare { val: Scalar::one() };
+        let share1 =
+            TestTypeShare { val: Scalar::one(), array_val: [Scalar::one(); NUM_TEST_SCALARS] };
+        let share2 = share1.clone();
 
         let recovered = share1.clone() + share2;
         assert_eq!(recovered.val, Scalar::from(2u8));
+        assert_eq!(recovered.array_val, [Scalar::from(2u8); NUM_TEST_SCALARS]);
 
         // Blind a secret share
         let blinded = share1.blind(Scalar::one());
         assert_eq!(blinded.val, Scalar::from(2u8));
+        assert_eq!(blinded.array_val, [Scalar::from(2u8); NUM_TEST_SCALARS]);
 
         // Unblind a secret share
         let unblinded = blinded.unblind(Scalar::one());
         assert_eq!(unblinded.val, Scalar::one());
+        assert_eq!(unblinded.array_val, [Scalar::one(); NUM_TEST_SCALARS]);
     }
 
     #[test]
     fn test_secret_share_vars() {
         // Build a secret share and allocate it
-        let share = TestTypeShare { val: Scalar::one() };
+        let share =
+            TestTypeShare { val: Scalar::one(), array_val: [Scalar::one(); NUM_TEST_SCALARS] };
 
         // Build a mock constraint system
         let mut circuit = PlonkCircuit::new_turbo_plonk();
@@ -152,8 +166,9 @@ mod test {
     fn test_secret_share_var_arithmetic() {
         // Build two secret shares, allocate them in the constraint system, then
         // evaluate their sum
-        let share1 = TestTypeShare { val: Scalar::one() };
-        let share2 = TestTypeShare { val: Scalar::one() };
+        let share1 =
+            TestTypeShare { val: Scalar::one(), array_val: [Scalar::one(); NUM_TEST_SCALARS] };
+        let share2 = share1.clone();
 
         // Build a mock prover
         let mut circuit = PlonkCircuit::new_turbo_plonk();
@@ -162,13 +177,22 @@ mod test {
         let var2 = share2.create_witness(&mut circuit);
 
         let sum: TestType = var1.add_shares(&var2, &mut circuit).eval(&circuit);
-        assert_eq!(TestType { val: Scalar::from(2u8) }, sum);
+        assert_eq!(TestType::new(Scalar::from(2u8)), sum);
 
         // Test blind and unblind
         let blinded = var1.blind(circuit.one(), &mut circuit);
-        assert_eq!(TestTypeShare { val: Scalar::from(2u8) }, blinded.eval(&circuit));
+        assert_eq!(
+            TestTypeShare {
+                val: Scalar::from(2u8),
+                array_val: [Scalar::from(2u8); NUM_TEST_SCALARS]
+            },
+            blinded.eval(&circuit)
+        );
 
         let unblinded = blinded.unblind(circuit.one(), &mut circuit);
-        assert_eq!(TestTypeShare { val: Scalar::one() }, unblinded.eval(&circuit));
+        assert_eq!(
+            TestTypeShare { val: Scalar::one(), array_val: [Scalar::one(); NUM_TEST_SCALARS] },
+            unblinded.eval(&circuit)
+        );
     }
 }

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -123,6 +123,8 @@ impl OrderSide {
 }
 
 impl BaseType for OrderSide {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![Scalar::from(*self as u8)]
     }

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -57,6 +57,13 @@ const ERR_TOO_FEW_VARS: &str = "from_vars: Invalid number of variables";
 /// and deserialization
 #[async_trait]
 pub trait BaseType: Clone {
+    /// The number of scalars required to represent the base type
+    const NUM_SCALARS: usize;
+    /// Get the number of scalars required to represent the base type
+    fn num_scalars() -> usize {
+        Self::NUM_SCALARS
+    }
+
     /// Convert the base type to its serialized scalar representation in the
     /// circuit
     fn to_scalars(&self) -> Vec<Scalar>;
@@ -309,6 +316,8 @@ pub trait SecretShareVarType: Sized + CircuitVarType {
 // --- Base Types --- //
 
 impl BaseType for Scalar {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![*self]
     }
@@ -319,6 +328,8 @@ impl BaseType for Scalar {
 }
 
 impl BaseType for u64 {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![Scalar::from(*self)]
     }
@@ -329,6 +340,8 @@ impl BaseType for u64 {
 }
 
 impl BaseType for bool {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![Scalar::from(*self as u8)]
     }
@@ -343,6 +356,8 @@ impl BaseType for bool {
 }
 
 impl BaseType for BigUint {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![biguint_to_scalar(self)]
     }
@@ -353,6 +368,8 @@ impl BaseType for BigUint {
 }
 
 impl BaseType for () {
+    const NUM_SCALARS: usize = 0;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![]
     }
@@ -361,6 +378,8 @@ impl BaseType for () {
 }
 
 impl<const N: usize, T: BaseType> BaseType for [T; N] {
+    const NUM_SCALARS: usize = N * T::NUM_SCALARS;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         self.iter().flat_map(|x| x.to_scalars()).collect()
     }

--- a/circuit-types/src/transfers.rs
+++ b/circuit-types/src/transfers.rs
@@ -39,6 +39,8 @@ pub enum ExternalTransferDirection {
 }
 
 impl BaseType for ExternalTransferDirection {
+    const NUM_SCALARS: usize = 1;
+
     fn to_scalars(&self) -> Vec<Scalar> {
         vec![Scalar::from(*self as u8)]
     }


### PR DESCRIPTION
### Purpose
This PR adds a `NUM_SCALARS` constant to the `BaseType` trait. This allows us to determine the number of scalars needed to serialize a circuit type. This will be used for determining layouts in the proof linking implementation.

### Testing
- All unit tests pass
- Tested the `NUM_SCALARS` derivation