### PR TITLE
circuit-macros: proof-linking: Define multipirover group witness allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3884,7 +3884,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#fa56ed9fe40b31c8d5583196a95da348004b78cd"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e345b24315b9d06bd289df1439c23daec0b9b490"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#fa56ed9fe40b31c8d5583196a95da348004b78cd"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e345b24315b9d06bd289df1439c23daec0b9b490"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4148,7 +4148,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#fa56ed9fe40b31c8d5583196a95da348004b78cd"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e345b24315b9d06bd289df1439c23daec0b9b490"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#fa56ed9fe40b31c8d5583196a95da348004b78cd"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e345b24315b9d06bd289df1439c23daec0b9b490"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -6101,7 +6101,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -6206,7 +6206,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libredox",
  "thiserror",
 ]
@@ -6381,7 +6381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -8278,7 +8278,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "serde",
 ]
 
@@ -8288,7 +8288,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "serde",
 ]
 

--- a/circuit-macros/src/circuit_type/mpc_types.rs
+++ b/circuit-macros/src/circuit_type/mpc_types.rs
@@ -97,7 +97,7 @@ fn build_mpc_type(base_struct: &ItemStruct, include_multiprover: bool) -> TokenS
 
     // Implement multiprover types
     if include_multiprover {
-        res.extend(build_multiprover_circuit_types(&mpc_type));
+        res.extend(build_multiprover_circuit_types(&mpc_type, base_struct));
     }
 
     res

--- a/circuit-macros/src/circuit_type/multiprover_circuit_types.rs
+++ b/circuit-macros/src/circuit_type/multiprover_circuit_types.rs
@@ -7,7 +7,10 @@ use syn::{parse_quote, ItemImpl, ItemStruct};
 use crate::circuit_type::{ident_with_suffix, new_ident};
 
 use super::{
-    ident_strip_prefix, ident_with_generics, mpc_types::MPC_TYPE_PREFIX, path_from_ident,
+    ident_strip_prefix, ident_with_generics,
+    mpc_types::MPC_TYPE_PREFIX,
+    path_from_ident,
+    proof_linking::{build_create_shared_witness_method, requires_proof_linking},
     singleprover_circuit_types::VAR_TYPE_ASSOCIATED_NAME,
 };
 
@@ -24,14 +27,17 @@ pub(crate) const VAR_SUFFIX: &str = "Var";
 // --------------------------
 
 /// Build the multiprover circuit types from a base type
-pub(crate) fn build_multiprover_circuit_types(mpc_type: &ItemStruct) -> TokenStream2 {
+pub(crate) fn build_multiprover_circuit_types(
+    mpc_type: &ItemStruct,
+    base_type: &ItemStruct,
+) -> TokenStream2 {
     // Build the variable and commitment types and the trait implementations
     // for committing to the base type in an MPC circuit
-    build_base_type_impl(mpc_type)
+    build_base_type_impl(mpc_type, base_type)
 }
 
 /// Build an `impl MultiproverCircuitBaseType` block
-fn build_base_type_impl(mpc_type: &ItemStruct) -> TokenStream2 {
+fn build_base_type_impl(mpc_type: &ItemStruct, base_type: &ItemStruct) -> TokenStream2 {
     let base_generics = mpc_type.generics.clone();
     let where_clause = mpc_type.generics.where_clause.clone();
 
@@ -53,12 +59,20 @@ fn build_base_type_impl(mpc_type: &ItemStruct) -> TokenStream2 {
     );
     let derived_var_type_ident = ident_with_generics(&var_type_ident, base_generics.clone());
 
+    // Maybe build a `create_shared_witness method`
+    let mut create_shared_witness_method = TokenStream2::new();
+    if requires_proof_linking(base_type) {
+        create_shared_witness_method = build_create_shared_witness_method(mpc_type, base_type);
+    }
+
     let impl_block: ItemImpl = parse_quote! {
         impl #base_generics #trait_name for #mpc_type_name
             #where_clause
         {
             type #base_type_associated_name = #derived_base_type_ident;
             type #var_type_associated_name = #derived_var_type_ident;
+
+            #create_shared_witness_method
         }
     };
     impl_block.to_token_stream()


### PR DESCRIPTION
### Purpose
This PR extends #319 to include support for multiprover circuits. This method by which this is done is essentially the same, though note that we need both the mpc and base type in context to infer proof links.

### Todo
- Apply proof linking macro to the application level circuit types

### Testing
- Macros unit tests pass
- Unit tests generally fail because the macros have not yet been applied to circuit types.