### PR TITLE
circuits: zk-circuits: Add proof-linking to witness types

### DIFF
--- a/circuit-macros/src/circuit_type/proof_linking.rs
+++ b/circuit-macros/src/circuit_type/proof_linking.rs
@@ -6,7 +6,7 @@
 //! allocate `field1` into groups `group1` and `group2` and `field2` into group
 //! `group3`:
 //!
-//! ```
+//! ```ignore
 //! #[circuit-type(singleprover)]
 //! struct MyCircuit {
 //!    #[link_groups = "group1, group2")]

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -681,6 +681,11 @@ pub fn setup_preprocessed_keys<C: SingleProverCircuit>(
     let statement = C::Statement::from_scalars(&mut scalars);
 
     let mut cs = PlonkCircuit::new_turbo_plonk();
+    let circuit_layout = C::get_circuit_layout().unwrap();
+    for (id, layout) in circuit_layout.group_layouts.into_iter() {
+        cs.create_link_group(id, Some(layout));
+    }
+
     let witness_var = witness.create_witness(&mut cs);
     let statement_var = statement.create_public_var(&mut cs);
 

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -17,7 +17,7 @@ use circuit_types::{
 };
 use constants::Scalar;
 use itertools::Itertools;
-use mpc_relation::traits::Circuit;
+use mpc_relation::{proof_linking::LinkableCircuit, traits::Circuit};
 
 /// The group name for the VALID REBLIND <-> VALID COMMITMENTS link
 pub const VALID_REBLIND_COMMITMENTS_LINK: &str = "valid_reblind_commitments";
@@ -38,6 +38,11 @@ pub fn check_constraint_satisfaction<C: SingleProverCircuit>(
 ) -> bool {
     // Apply the constraints
     let mut cs = PlonkCircuit::new_turbo_plonk();
+    let circuit_layout = C::get_circuit_layout().unwrap();
+    for (id, layout) in circuit_layout.group_layouts.into_iter() {
+        cs.create_link_group(id, Some(layout));
+    }
+
     let witness_var = witness.create_witness(&mut cs);
     let statement_var = statement.create_public_var(&mut cs);
 
@@ -56,6 +61,11 @@ pub fn check_constraint_satisfaction_multiprover<C: MultiProverCircuit>(
     fabric: &Fabric,
 ) -> bool {
     let mut cs = MpcPlonkCircuit::new(fabric.clone());
+    let circuit_layout = C::get_circuit_layout().unwrap();
+    for (id, layout) in circuit_layout.group_layouts.into_iter() {
+        cs.create_link_group(id, Some(layout));
+    }
+
     let witness_var = witness.create_shared_witness(&mut cs);
     let statement_var = statement.create_shared_public_var(&mut cs);
 

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -16,7 +16,12 @@ use constants::{Scalar, ScalarField};
 use constants::{MAX_BALANCES, MAX_FEES, MAX_ORDERS, MERKLE_HEIGHT};
 use itertools::{izip, Itertools};
 use mpc_plonk::errors::PlonkError;
-use mpc_relation::{errors::CircuitError, proof_linking::GroupLayout, traits::Circuit, Variable};
+use mpc_relation::{
+    errors::CircuitError,
+    proof_linking::{GroupLayout, LinkableCircuit},
+    traits::Circuit,
+    Variable,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -290,8 +295,10 @@ pub struct ValidReblindWitness<
     /// The public secret shares of the original wallet
     pub original_wallet_public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The private secret shares of the reblinded wallet
+    #[link_groups = "valid_reblind_commitments"]
     pub reblinded_wallet_private_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The public secret shares of the reblinded wallet
+    #[link_groups = "valid_reblind_commitments"]
     pub reblinded_wallet_public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS, MAX_FEES>,
     /// The Merkle opening from the commitment to the original wallet's shares
     pub original_share_opening: MerkleOpening<MERKLE_HEIGHT>,


### PR DESCRIPTION
### Purpose
This PR annotates the witness types of `VALID REBLIND`, `VALID COMMITMENTS`, and `VALID MATCH SETTLE` with the proof-linking `link_groups` attribute. This allocates the witness types into their appropriate link groups.

### Todo
- Add helpers to prove and verify the linking relation between proofs
- Call these helpers in the appropriate locations throughout the relayer

### Testing
- All unit tests now pass, more to be added when the proof linking helpers are defined