### PR TITLE
circuit-types: Impl for `usize` and use in `OrderSettlementIndices`

### DIFF
--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -140,9 +140,9 @@ pub fn to_contract_valid_commitments_statement(
     statement: ValidCommitmentsStatement,
 ) -> ContractValidCommitmentsStatement {
     ContractValidCommitmentsStatement {
-        balance_send_index: statement.indices.balance_send,
-        balance_receive_index: statement.indices.balance_receive,
-        order_index: statement.indices.order,
+        balance_send_index: statement.indices.balance_send as u64,
+        balance_receive_index: statement.indices.balance_receive as u64,
+        order_index: statement.indices.order as u64,
     }
 }
 
@@ -157,12 +157,12 @@ pub fn to_contract_valid_match_settle_statement(
     ContractValidMatchSettleStatement {
         party0_modified_shares,
         party1_modified_shares,
-        party0_send_balance_index: statement.party0_indices.balance_send,
-        party0_receive_balance_index: statement.party0_indices.balance_receive,
-        party0_order_index: statement.party0_indices.order,
-        party1_send_balance_index: statement.party1_indices.balance_send,
-        party1_receive_balance_index: statement.party1_indices.balance_receive,
-        party1_order_index: statement.party1_indices.order,
+        party0_send_balance_index: statement.party0_indices.balance_send as u64,
+        party0_receive_balance_index: statement.party0_indices.balance_receive as u64,
+        party0_order_index: statement.party0_indices.order as u64,
+        party1_send_balance_index: statement.party1_indices.balance_send as u64,
+        party1_receive_balance_index: statement.party1_indices.balance_receive as u64,
+        party1_order_index: statement.party1_indices.order as u64,
     }
 }
 

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -60,10 +60,10 @@ pub struct MatchResult {
 pub struct OrderSettlementIndices {
     /// The index of the balance that holds the mint that the wallet will
     /// send if a successful match occurs
-    pub balance_send: u64,
+    pub balance_send: usize,
     /// The index of the balance that holds the mint that the wallet will
     /// receive if a successful match occurs
-    pub balance_receive: u64,
+    pub balance_receive: usize,
     /// The index of the order that is to be matched
-    pub order: u64,
+    pub order: usize,
 }

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -359,6 +359,18 @@ impl BaseType for u64 {
     }
 }
 
+impl BaseType for usize {
+    const NUM_SCALARS: usize = 1;
+
+    fn to_scalars(&self) -> Vec<Scalar> {
+        vec![Scalar::from(*self as u64)]
+    }
+
+    fn from_scalars<I: Iterator<Item = Scalar>>(i: &mut I) -> Self {
+        scalar_to_u64(&i.next().unwrap()) as usize
+    }
+}
+
 impl BaseType for bool {
     const NUM_SCALARS: usize = 1;
 
@@ -421,6 +433,10 @@ impl CircuitBaseType for Scalar {
 }
 
 impl CircuitBaseType for u64 {
+    type VarType = Variable;
+}
+
+impl CircuitBaseType for usize {
     type VarType = Variable;
 }
 
@@ -522,6 +538,10 @@ impl MpcBaseType for Scalar {
 }
 
 impl MpcBaseType for u64 {
+    type AllocatedType = AuthenticatedScalar;
+}
+
+impl MpcBaseType for usize {
     type AllocatedType = AuthenticatedScalar;
 }
 
@@ -637,6 +657,10 @@ impl SecretShareBaseType for Scalar {
 }
 
 impl SecretShareBaseType for u64 {
+    type ShareType = Scalar;
+}
+
+impl SecretShareBaseType for usize {
     type ShareType = Scalar;
 }
 

--- a/circuits/integration/mpc_circuits/match_settle.rs
+++ b/circuits/integration/mpc_circuits/match_settle.rs
@@ -82,7 +82,7 @@ fn add_balances_to_wallet(
 ) {
     let mut rng = thread_rng();
 
-    let order = &wallet.orders[ind.order as usize];
+    let order = &wallet.orders[ind.order];
     let base_amt = order.amount;
     let quote_amt = (price * Scalar::from(base_amt)).floor();
     let quote_amt = scalar_to_u64(&quote_amt);
@@ -100,8 +100,8 @@ fn add_balances_to_wallet(
     };
 
     // Add balances for the order
-    wallet.balances[ind.balance_send as usize] = send;
-    wallet.balances[ind.balance_receive as usize] = recv;
+    wallet.balances[ind.balance_send] = send;
+    wallet.balances[ind.balance_receive] = recv;
 }
 
 /// Run the match settle process
@@ -128,9 +128,9 @@ fn max_amount_at_price(
     price: FixedPoint,
 ) -> u64 {
     // Lookup the amount on the order and the send balance
-    let order = &wallet.orders[indices.order as usize];
+    let order = &wallet.orders[indices.order];
     let order_amt = order.amount;
-    let mut send_bal = wallet.balances[indices.balance_send as usize].amount;
+    let mut send_bal = wallet.balances[indices.balance_send].amount;
 
     // Convert the send balance to the base mint amount
     // I.e. convert if the send balance is the quote
@@ -160,8 +160,8 @@ fn run_match_settle_with_amounts(
     let (_, pre_public_shares2) = create_wallet_shares(w2);
 
     // Allocate inputs in the fabric
-    let order1 = w1.orders[ind1.order as usize].allocate(PARTY0, fabric);
-    let order2 = w2.orders[ind2.order as usize].allocate(PARTY0, fabric);
+    let order1 = w1.orders[ind1.order].allocate(PARTY0, fabric);
+    let order2 = w2.orders[ind2.order].allocate(PARTY0, fabric);
     let amount1 = amount1.allocate(PARTY0, fabric);
     let amount2 = amount2.allocate(PARTY0, fabric);
     let price = price.allocate(PARTY0, fabric);
@@ -185,11 +185,11 @@ fn run_match_settle_with_amounts(
         },
         SizedValidMatchSettleWitness {
             order1,
-            balance1: wallet1.balances[ind1.balance_send as usize].clone(),
+            balance1: wallet1.balances[ind1.balance_send].clone(),
             amount1,
             price1: price.clone(),
             order2,
-            balance2: wallet2.balances[ind2.balance_send as usize].clone(),
+            balance2: wallet2.balances[ind2.balance_send].clone(),
             amount2,
             price2: price,
             party0_public_shares: party0_pre_shares,
@@ -253,7 +253,7 @@ async fn test_witness_generation__undercapitalized(test_args: IntegrationTestArg
     // Set the amount for party 1 to a value that will not cover the amount in its
     // order
     // Balances are initialized to values that marginally cover the order
-    w1.balances[ind1.balance_send as usize].amount /= 2;
+    w1.balances[ind1.balance_send].amount /= 2;
     let amt1 = max_amount_at_price(&w1, ind1, price);
     let amt2 = max_amount_at_price(&w2, ind2, price);
 

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -242,9 +242,9 @@ pub mod test_helpers {
     }
 
     /// Generate a random index bounded by a max
-    fn random_index(max: usize) -> u64 {
+    fn random_index(max: usize) -> usize {
         let mut rng = thread_rng();
-        rng.gen_range(0..max) as u64
+        rng.gen_range(0..max)
     }
 
     /// Get a dummy set of wallet shares

--- a/circuits/src/mpc_circuits/settle.rs
+++ b/circuits/src/mpc_circuits/settle.rs
@@ -28,8 +28,8 @@ where
     let mut party1_new_shares = party1_public_share.clone();
 
     // Subtract the amount of base token exchanged from each party's order
-    let party0_order = &mut party0_new_shares.orders[party0_settle_indices.order as usize];
-    let party1_order = &mut party1_new_shares.orders[party1_settle_indices.order as usize];
+    let party0_order = &mut party0_new_shares.orders[party0_settle_indices.order];
+    let party1_order = &mut party1_new_shares.orders[party1_settle_indices.order];
     party0_order.amount = &party0_order.amount - &match_res.base_amount;
     party1_order.amount = &party1_order.amount - &match_res.base_amount;
 
@@ -44,20 +44,16 @@ where
     let party0_sell = amounts.remove(0);
 
     // Update the balances of the two parties
-    let party0_buy_balance =
-        &mut party0_new_shares.balances[party0_settle_indices.balance_receive as usize];
+    let party0_buy_balance = &mut party0_new_shares.balances[party0_settle_indices.balance_receive];
     party0_buy_balance.amount = &party0_buy_balance.amount + &party0_buy;
 
-    let party1_buy_balance =
-        &mut party1_new_shares.balances[party1_settle_indices.balance_receive as usize];
+    let party1_buy_balance = &mut party1_new_shares.balances[party1_settle_indices.balance_receive];
     party1_buy_balance.amount = &party1_buy_balance.amount + &party0_sell;
 
-    let party0_sell_balance =
-        &mut party0_new_shares.balances[party0_settle_indices.balance_send as usize];
+    let party0_sell_balance = &mut party0_new_shares.balances[party0_settle_indices.balance_send];
     party0_sell_balance.amount = &party0_sell_balance.amount - &party0_sell;
 
-    let party1_sell_balance =
-        &mut party1_new_shares.balances[party1_settle_indices.balance_send as usize];
+    let party1_sell_balance = &mut party1_new_shares.balances[party1_settle_indices.balance_send];
     party1_sell_balance.amount = &party1_sell_balance.amount - &party0_buy;
 
     (party0_new_shares, party1_new_shares)

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -484,9 +484,9 @@ pub mod test_helpers {
 
         let statement = ValidCommitmentsStatement {
             indices: OrderSettlementIndices {
-                balance_send: ind_send as u64,
-                balance_receive: ind_receive as u64,
-                order: ind_order as u64,
+                balance_send: ind_send,
+                balance_receive: ind_receive,
+                order: ind_order,
             },
         };
 
@@ -643,8 +643,7 @@ mod test {
 
         // Prover attempt to augment the wallet with a non-zero balance
         let augmented_balance_index = statement.indices.balance_receive;
-        witness.augmented_public_shares.balances[augmented_balance_index as usize].amount +=
-            Scalar::one();
+        witness.augmented_public_shares.balances[augmented_balance_index].amount += Scalar::one();
         witness.balance_receive.amount += 1u64;
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
@@ -659,7 +658,7 @@ mod test {
 
         // Reset the original wallet such that the augmented balance was non-zero
         let augmentation_index = statement.indices.balance_receive;
-        witness.public_secret_shares.balances[augmentation_index as usize] =
+        witness.public_secret_shares.balances[augmentation_index] =
             BalanceShare { amount: Scalar::one(), mint: Scalar::one() };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement))
@@ -757,7 +756,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the send balance from the order
-        witness.augmented_public_shares.balances[statement.indices.balance_send as usize] =
+        witness.augmented_public_shares.balances[statement.indices.balance_send] =
             BalanceShare { mint: Scalar::zero(), amount: Scalar::zero() };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
@@ -770,7 +769,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the receive balance from the order
-        witness.augmented_public_shares.balances[statement.indices.balance_receive as usize] =
+        witness.augmented_public_shares.balances[statement.indices.balance_receive] =
             BalanceShare { mint: Scalar::zero(), amount: Scalar::zero() };
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
@@ -798,7 +797,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the order being proved on
-        witness.augmented_public_shares.orders[statement.indices.order as usize] = OrderShare {
+        witness.augmented_public_shares.orders[statement.indices.order] = OrderShare {
             quote_mint: Scalar::zero(),
             base_mint: Scalar::zero(),
             side: Scalar::zero(),

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -287,11 +287,11 @@ pub mod test_helpers {
         (
             ValidMatchSettleWitness {
                 order1: o1,
-                balance1: wallet1.balances[party0_indices.balance_send as usize].clone(),
+                balance1: wallet1.balances[party0_indices.balance_send].clone(),
                 price1: price,
                 amount1,
                 order2: o2,
-                balance2: wallet2.balances[party1_indices.balance_send as usize].clone(),
+                balance2: wallet2.balances[party1_indices.balance_send].clone(),
                 price2: price,
                 amount2,
                 match_res,
@@ -327,11 +327,7 @@ pub mod test_helpers {
 
         (
             wallet,
-            OrderSettlementIndices {
-                balance_send: send as u64,
-                balance_receive: recv as u64,
-                order: order_ind as u64,
-            },
+            OrderSettlementIndices { balance_send: send, balance_receive: recv, order: order_ind },
         )
     }
 
@@ -630,9 +626,8 @@ mod tests {
         let (witness, mut statement) = dummy_witness_and_statement();
 
         // Modify the send balance of party 0
-        statement.party0_modified_shares.balances
-            [statement.party0_indices.balance_send as usize]
-            .amount += Scalar::one();
+        statement.party0_modified_shares.balances[statement.party0_indices.balance_send].amount +=
+            Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(
             &witness.clone(),
@@ -646,8 +641,7 @@ mod tests {
         let (witness, mut statement) = dummy_witness_and_statement();
 
         // Modify the receive balance of party 1
-        statement.party1_modified_shares.balances
-            [statement.party1_indices.balance_receive as usize]
+        statement.party1_modified_shares.balances[statement.party1_indices.balance_receive]
             .amount += Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(
@@ -662,7 +656,7 @@ mod tests {
         let (witness, mut statement) = dummy_witness_and_statement();
 
         // Modify the order of party 0
-        statement.party0_modified_shares.orders[statement.party0_indices.order as usize].amount -=
+        statement.party0_modified_shares.orders[statement.party0_indices.order].amount -=
             Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(
@@ -679,9 +673,8 @@ mod tests {
 
         // Modify a balance that should not be modified
         let mut statement = original_statement.clone();
-        statement.party0_modified_shares.balances
-            [statement.party0_indices.balance_send as usize]
-            .mint += Scalar::one();
+        statement.party0_modified_shares.balances[statement.party0_indices.balance_send].mint +=
+            Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(
             &witness.clone(),
@@ -690,7 +683,7 @@ mod tests {
 
         // Modify an order that should not be modified
         let mut statement = original_statement.clone();
-        statement.party1_modified_shares.orders[statement.party1_indices.order as usize].amount -=
+        statement.party1_modified_shares.orders[statement.party1_indices.order].amount -=
             Scalar::one();
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(

--- a/task-driver/src/helpers.rs
+++ b/task-driver/src/helpers.rs
@@ -209,9 +209,9 @@ fn find_balances_and_indices(
 
     Ok((
         OrderSettlementIndices {
-            order: order_index as u64,
-            balance_send: send_index as u64,
-            balance_receive: receive_index as u64,
+            order: order_index,
+            balance_send: send_index,
+            balance_receive: receive_index,
         },
         send_balance,
         receive_balance,

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -146,9 +146,9 @@ pub fn apply_match_to_shares<
         OrderSide::Sell => (match_res.base_amount, match_res.quote_amount),
     };
 
-    shares.balances[indices.balance_send as usize].amount -= Scalar::from(send_amt);
-    shares.balances[indices.balance_receive as usize].amount += Scalar::from(recv_amt);
-    shares.orders[indices.order as usize].amount -= Scalar::from(match_res.base_amount);
+    shares.balances[indices.balance_send].amount -= Scalar::from(send_amt);
+    shares.balances[indices.balance_receive].amount += Scalar::from(recv_amt);
+    shares.orders[indices.order].amount -= Scalar::from(match_res.base_amount);
 }
 
 #[cfg(test)]
@@ -249,9 +249,9 @@ mod tests {
         }
 
         OrderSettlementIndices {
-            order: (0..MAX_ORDERS).sample_single(&mut rng) as u64,
-            balance_send: send as u64,
-            balance_receive: recv as u64,
+            order: (0..MAX_ORDERS).sample_single(&mut rng),
+            balance_send: send,
+            balance_receive: recv,
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR changes the type from `u64` -> `usize` for settlement indices in circuit types. This makes out-of-circuit indexing for e.g. witness generation much easier. Concretely this involves:
- Define a base type impl for `usize`
- Replace all instances of u64 with usize

The one exception is in `arbitrum-client`. I keep the types `u64` here to ensure correct serialization independent of machine architecture. @akirillo Please let me know if this is unnecessary.

### Testing
- Unit tests pass workspace-wide