### PR TITLE
circuits: fixed-point: Fix `constrain_eq_integer_ignore_fraction`

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! print_wire {
         use circuit_types::traits::CircuitVarType;
         use tracing::log;
         let x_eval = $x.eval($cs);
-        log::info!("eval({}): {x_eval}", stringify!($x));
+        log::info!("eval({}): {x_eval:?}", stringify!($x));
     }};
 }
 


### PR DESCRIPTION
### Purpose
This PR fixes two edge cases on `FixedPointGadget::constrain_eq_integer_ignore_fraction`:
1. The case in which the integer and fixed point value are identically equal (not just modulo 1)
2. The case in which the difference between integer and fraction is exactly 1, or slightly larger

### Testing
- All unit tests pass
- Tested the edge cases discussed above