### PR TITLE
common: type: proof-bundles: Use `Arc` to heap allocate instead of `Box`

### DIFF
--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -41,7 +41,7 @@ async fn test_update_wallet(test_args: IntegrationTestArgs) -> Result<()> {
     // Update the wallet
     client
         .update_wallet(
-            valid_wallet_update_bundle,
+            &valid_wallet_update_bundle,
             vec![], // statement_signature
         )
         .await?;
@@ -59,7 +59,7 @@ integration_test_async!(test_update_wallet);
 async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()> {
     let client = &test_args.client;
 
-    // Submit a match between two wallets using dummy proof bundleso
+    // Submit a match between two wallets using dummy proof bundles
     let party_0_validity_proof_bundle = dummy_validity_proof_bundle();
     let party_1_validity_proof_bundle = dummy_validity_proof_bundle();
     let mut valid_match_settle_proof_bundle = dummy_valid_match_settle_bundle();
@@ -72,9 +72,9 @@ async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()>
 
     client
         .process_match_settle(
-            party_0_validity_proof_bundle,
-            party_1_validity_proof_bundle,
-            valid_match_settle_proof_bundle,
+            &party_0_validity_proof_bundle,
+            &party_1_validity_proof_bundle,
+            &valid_match_settle_proof_bundle,
         )
         .await?;
 

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -30,7 +30,7 @@ pub async fn deploy_new_wallet(
 
     let statement = valid_wallet_create_bundle.statement.clone();
 
-    client.new_wallet(valid_wallet_create_bundle).await?;
+    client.new_wallet(&valid_wallet_create_bundle).await?;
 
     // The contract will compute the full commitment and insert it into the Merkle
     // tree; we repeat the same computation here for consistency

--- a/task-driver/integration/helpers.rs
+++ b/task-driver/integration/helpers.rs
@@ -117,7 +117,7 @@ pub async fn allocate_wallet_in_darkpool(
     proof.statement.public_wallet_shares = wallet.blinded_public_shares.clone();
     proof.statement.private_shares_commitment = share_comm;
 
-    client.new_wallet(proof).await?;
+    client.new_wallet(&proof).await?;
 
     // Find the Merkle opening for the wallet
     attach_merkle_opening(wallet, client).await
@@ -151,7 +151,7 @@ pub async fn mock_wallet_update(wallet: &mut Wallet, client: &ArbitrumClient) ->
     proof.statement.new_private_shares_commitment = share_comm;
     proof.statement.new_public_shares = wallet.blinded_public_shares.clone();
 
-    client.update_wallet(proof, vec![] /* statement_sig */).await.map_err(Into::into)
+    client.update_wallet(&proof, vec![] /* statement_sig */).await.map_err(Into::into)
 }
 
 /// Fund the wallet in the integration test args with a given amount of WETH and

--- a/task-driver/integration/tests/settle_match.rs
+++ b/task-driver/integration/tests/settle_match.rs
@@ -170,11 +170,11 @@ async fn setup_match_result(
     let witness1 = get_first_order_witness(&wallet1, state).await?;
     let witness2 = get_first_order_witness(&wallet2, state).await?;
 
-    wallet1.private_shares = witness1.reblind_witness.reblinded_wallet_private_shares;
-    wallet1.blinded_public_shares = witness1.commitment_witness.augmented_public_shares;
+    wallet1.private_shares = witness1.reblind_witness.reblinded_wallet_private_shares.clone();
+    wallet1.blinded_public_shares = witness1.commitment_witness.augmented_public_shares.clone();
 
-    wallet2.private_shares = witness2.reblind_witness.reblinded_wallet_private_shares;
-    wallet2.blinded_public_shares = witness2.commitment_witness.augmented_public_shares;
+    wallet2.private_shares = witness2.reblind_witness.reblinded_wallet_private_shares.clone();
+    wallet2.blinded_public_shares = witness2.commitment_witness.augmented_public_shares.clone();
 
     let proof = dummy_match_proof(&wallet1, &wallet2, match_.clone(), test_args).await?;
     Ok((match_, proof))

--- a/task-driver/src/create_new_wallet.rs
+++ b/task-driver/src/create_new_wallet.rs
@@ -245,7 +245,7 @@ impl NewWalletTask {
     async fn submit_wallet_tx(&mut self) -> Result<(), NewWalletTaskError> {
         let proof = self.proof_bundle.clone().unwrap();
         self.arbitrum_client
-            .new_wallet(proof)
+            .new_wallet(&proof)
             .await
             .map_err(|err| NewWalletTaskError::Arbitrum(err.to_string()))
     }

--- a/task-driver/src/helpers.rs
+++ b/task-driver/src/helpers.rs
@@ -1,5 +1,7 @@
 //! Helpers for common functionality across tasks
 
+use std::sync::Arc;
+
 use arbitrum_client::{client::ArbitrumClient, errors::ArbitrumClientError};
 use circuit_types::{
     balance::Balance,
@@ -346,8 +348,8 @@ async fn record_validity_witness(
     global_state: &RelayerState,
 ) {
     let witness_bundle = OrderValidityWitnessBundle {
-        reblind_witness: Box::new(valid_reblind_witness.clone()),
-        commitment_witness: Box::new(commitments_witness.clone()),
+        reblind_witness: Arc::new(valid_reblind_witness.clone()),
+        commitment_witness: Arc::new(commitments_witness.clone()),
     };
 
     global_state
@@ -370,8 +372,8 @@ pub(crate) async fn record_validity_proof(
 ) -> Result<(), String> {
     // Record the bundle in the global state
     let proof_bundle = OrderValidityProofBundle {
-        reblind_proof: Box::new(reblind_bundle.clone()),
-        commitment_proof: Box::new(commitments_bundle.clone()),
+        reblind_proof: reblind_bundle.clone(),
+        commitment_proof: commitments_bundle.clone(),
     };
     global_state.add_order_validity_proofs(order_id, proof_bundle.clone()).await;
 

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -36,7 +36,7 @@ use super::{
 pub(crate) const NULLIFIER_USED_ERROR_MSG: &str = "nullifier already used";
 /// The error message emitted when a wallet cannot be found in state
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found in global state";
-/// The error message emitted when a validity proof wintess cannot be found in
+/// The error message emitted when a validity proof witness cannot be found in
 /// state
 const ERR_VALIDITY_WITNESS_NOT_FOUND: &str = "validity witness not found in global state";
 
@@ -221,9 +221,9 @@ impl SettleMatchTask {
         let tx_submit_res = self
             .arbitrum_client
             .process_match_settle(
-                self.party0_validity_proof.clone(),
-                self.party1_validity_proof.clone(),
-                self.match_settle_proof.clone(),
+                &self.party0_validity_proof,
+                &self.party1_validity_proof,
+                &self.match_settle_proof,
             )
             .await;
 

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -264,11 +264,7 @@ impl SettleMatchInternalTask {
         // Submit a `match` transaction
         let match_settle_proof = self.proof_bundle.clone().unwrap();
         self.arbitrum_client
-            .process_match_settle(
-                self.order1_proof.clone(),
-                self.order2_proof.clone(),
-                match_settle_proof,
-            )
+            .process_match_settle(&self.order1_proof, &self.order2_proof, &match_settle_proof)
             .await
             .map_err(|e| SettleMatchInternalTaskError::Arbitrum(e.to_string()))
     }

--- a/task-driver/src/update_wallet.rs
+++ b/task-driver/src/update_wallet.rs
@@ -268,7 +268,7 @@ impl UpdateWalletTask {
     async fn submit_tx(&mut self) -> Result<(), UpdateWalletTaskError> {
         let proof = self.proof_bundle.clone().unwrap();
         self.arbitrum_client
-            .update_wallet(proof, self.wallet_update_signature.clone())
+            .update_wallet(&proof, self.wallet_update_signature.clone())
             .await
             .map_err(|e| e.to_string())
             .map_err(UpdateWalletTaskError::Arbitrum)

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -1,7 +1,7 @@
 //! Groups the handshake manager definitions necessary to run the MPC match
 //! computation and collaboratively generate a proof of `VALID MATCH MPC`
 
-use std::cmp;
+use std::{cmp, sync::Arc};
 
 use ark_mpc::{network::QuicTwoPartyNet, MpcFabric, PARTY0, PARTY1};
 use circuit_types::{
@@ -260,6 +260,6 @@ impl HandshakeExecutor {
         verify_singleprover_proof::<SizedValidMatchSettle>(statement.clone(), &proof)
             .map_err(|err| HandshakeManagerError::VerificationError(err.to_string()))?;
 
-        Ok(Box::new(GenericMatchSettleBundle { statement, proof }))
+        Ok(Arc::new(GenericMatchSettleBundle { statement, proof }))
     }
 }

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -1,6 +1,8 @@
 //! Defines a mock for the proof manager that doesn't prove statements, but
 //! instead immediately returns dummy proofs that will not verify
 
+use std::sync::Arc;
+
 use circuit_types::traits::SingleProverCircuit;
 use circuits::zk_circuits::{
     check_constraint_satisfaction,
@@ -98,7 +100,7 @@ impl MockProofManager {
         Self::check_constraints::<SizedValidWalletCreate>(&witness, &statement)?;
 
         let proof = dummy_proof();
-        Ok(Box::new(GenericValidWalletCreateBundle { statement, proof }))
+        Ok(Arc::new(GenericValidWalletCreateBundle { statement, proof }))
     }
 
     /// Generate a dummy proof of `VALID WALLET UPDATE`
@@ -109,7 +111,7 @@ impl MockProofManager {
         Self::check_constraints::<SizedValidWalletUpdate>(&witness, &statement)?;
 
         let proof = dummy_proof();
-        Ok(Box::new(GenericValidWalletUpdateBundle { statement, proof }))
+        Ok(Arc::new(GenericValidWalletUpdateBundle { statement, proof }))
     }
 
     /// Generate a dummy proof of `VALID REBLIND`
@@ -120,7 +122,7 @@ impl MockProofManager {
         Self::check_constraints::<SizedValidReblind>(&witness, &statement)?;
 
         let proof = dummy_proof();
-        Ok(Box::new(GenericValidReblindBundle { statement, proof }))
+        Ok(Arc::new(GenericValidReblindBundle { statement, proof }))
     }
 
     /// Create a dummy proof of `VALID COMMITMENTS`
@@ -131,7 +133,7 @@ impl MockProofManager {
         Self::check_constraints::<SizedValidCommitments>(&witness, &statement)?;
 
         let proof = dummy_proof();
-        Ok(Box::new(GenericValidCommitmentsBundle { statement, proof }))
+        Ok(Arc::new(GenericValidCommitmentsBundle { statement, proof }))
     }
 
     /// Create a dummy proof of `VALID MATCH SETTLE`
@@ -142,7 +144,7 @@ impl MockProofManager {
         Self::check_constraints::<SizedValidMatchSettle>(&witness, &statement)?;
 
         let proof = dummy_proof();
-        Ok(Box::new(GenericMatchSettleBundle { statement, proof }))
+        Ok(Arc::new(GenericMatchSettleBundle { statement, proof }))
     }
 
     /// Check constraint satisfaction for a witness and statement

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -149,7 +149,7 @@ impl ProofManager {
         let proof = singleprover_prove::<SizedValidWalletCreate>(witness, statement.clone())
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(Box::new(GenericValidWalletCreateBundle { statement, proof }))
+        Ok(Arc::new(GenericValidWalletCreateBundle { statement, proof }))
     }
 
     /// Create a proof of `VALID REBLIND`
@@ -161,7 +161,7 @@ impl ProofManager {
         let proof = singleprover_prove::<SizedValidReblind>(witness, statement.clone())
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(Box::new(GenericValidReblindBundle { statement, proof }))
+        Ok(Arc::new(GenericValidReblindBundle { statement, proof }))
     }
 
     /// Create a proof of `VALID COMMITMENTS`
@@ -173,7 +173,7 @@ impl ProofManager {
         let proof = singleprover_prove::<SizedValidCommitments>(witness, statement)
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(Box::new(GenericValidCommitmentsBundle { statement, proof }))
+        Ok(Arc::new(GenericValidCommitmentsBundle { statement, proof }))
     }
 
     /// Create a proof of `VALID WALLET UPDATE`
@@ -184,7 +184,7 @@ impl ProofManager {
         let proof = singleprover_prove::<SizedValidWalletUpdate>(witness, statement.clone())
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(Box::new(GenericValidWalletUpdateBundle { statement, proof }))
+        Ok(Arc::new(GenericValidWalletUpdateBundle { statement, proof }))
     }
 
     /// Create a proof of `VALID MATCH SETTLE`
@@ -195,6 +195,6 @@ impl ProofManager {
         let proof = singleprover_prove::<SizedValidMatchSettle>(witness, statement.clone())
             .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
-        Ok(Box::new(GenericMatchSettleBundle { statement, proof }))
+        Ok(Arc::new(GenericMatchSettleBundle { statement, proof }))
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the proof bundles to use `Arc` instead of `Box` to heap allocate. These bundles are effectively read only once they are created and `Arc` provides a much more convenient (thread safe) and efficient (atomic incr) clone method. I also changed the location in which these bundles were consumed to allow a borrow to the proof bundle and only clone necessary fields.

### Testing
- Unit tests pass