### PR TITLE
task-driver: helpers: Prove reblind <-> commitments link

### DIFF
--- a/task-driver/integration/tests/settle_match.rs
+++ b/task-driver/integration/tests/settle_match.rs
@@ -267,7 +267,9 @@ async fn dummy_match_proof(
     test_args.proof_job_queue.send(job)?;
 
     // Await a response
-    recv.await.map(|bundle| bundle.into()).map_err(|_| eyre!("Failed to receive proof bundle"))
+    recv.await
+        .map(|bundle| bundle.proof.into())
+        .map_err(|_| eyre!("Failed to receive proof bundle"))
 }
 
 /// Verify that a match has been correctly applied to a wallet

--- a/task-driver/src/create_new_wallet.rs
+++ b/task-driver/src/create_new_wallet.rs
@@ -235,9 +235,9 @@ impl NewWalletTask {
             .map_err(NewWalletTaskError::SendMessage)?;
 
         // Await the proof
-        let proof_bundle =
+        let bundle =
             proof_recv.await.map_err(|e| NewWalletTaskError::ProofGeneration(e.to_string()))?;
-        self.proof_bundle = Some(proof_bundle.into());
+        self.proof_bundle = Some(bundle.proof.into());
         Ok(())
     }
 

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -251,11 +251,11 @@ impl SettleMatchInternalTask {
             .map_err(SettleMatchInternalTaskError::EnqueuingJob)?;
 
         // Await the proof from the proof manager
-        let proof = proof_recv.await.map_err(|_| {
+        let bundle = proof_recv.await.map_err(|_| {
             SettleMatchInternalTaskError::EnqueuingJob(ERR_AWAITING_PROOF.to_string())
         })?;
 
-        self.proof_bundle = Some(proof.into());
+        self.proof_bundle = Some(bundle.proof.into());
         Ok(())
     }
 

--- a/task-driver/src/update_wallet.rs
+++ b/task-driver/src/update_wallet.rs
@@ -256,10 +256,10 @@ impl UpdateWalletTask {
             .map_err(UpdateWalletTaskError::ProofGeneration)?;
 
         // Await the proof
-        let proof =
+        let bundle =
             proof_recv.await.map_err(|e| UpdateWalletTaskError::ProofGeneration(e.to_string()))?;
 
-        self.proof_bundle = Some(proof.into());
+        self.proof_bundle = Some(bundle.proof.into());
         Ok(())
     }
 


### PR DESCRIPTION
### Purpose
This PR takes the steps to prove the `VALID REBLIND` <-> `VALID COMMITMENTS` link in the task driver's helper to update a wallet's validity proofs.

### Testing
- Unit tests pass crate wide, next step is to validate this in gossip