### PR TITLE
docker: sequencer: minimal image w/ predeployed contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "nitro-testnode"]
-	path = nitro-testnode
-	url = https://github.com/OffchainLabs/nitro-testnode.git
-	branch = stylus

--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -1,17 +1,20 @@
-# Builds and deploys the contracts to the (assumed to be running) local devnet
+FROM offchainlabs/stylus-node:v0.1.0-f47fec1-dev
 
-FROM rust:1.70-slim-buster AS builder
+# Need to run as root to install dependencies
+# (Stylus node base image sets user to `user`)
+USER root
 
-# Install dependencies
-RUN apt-get update && \
-    apt-get install -y pkg-config && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y build-essential && \
-    apt-get install -y git && \
-    apt-get install -y curl && \
-    apt-get install -y jq
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    build-essential \
+    git \
+    curl \
+    jq
 
-# Build the rust toolchain to cache it before adding any dependencies
+# Install the rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup toolchain install nightly
 RUN rustup component add rust-src --toolchain nightly
 RUN rustup target add wasm32-unknown-unknown
@@ -47,7 +50,22 @@ RUN RUSTFLAGS="-C opt-level=3" \
     -Z build-std=std,panic_abort \
     -Z build-std-features=panic_immediate_abort
 
-# Copy the deploy script
+# Copy over the contract deployment script
 COPY ./deploy_contracts.sh /deploy_contracts.sh
+RUN chmod +x /deploy_contracts.sh
 
-ENTRYPOINT /deploy_contracts.sh
+# Run the contract deployment script
+ARG NO_VERIFY
+RUN /deploy_contracts.sh
+
+CMD ["--node.dangerous.no-l1-listener",\
+    "--node.sequencer.dangerous.no-coordinator",\
+    "--node.sequencer.enable",\
+    "--node.staker.enable=false",\
+    "--init.dev-init",\
+    "--init.empty=false",\
+    "--chain.id=412346",\
+    "--chain.dev-wallet.private-key=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659",\
+    "--http.addr=0.0.0.0",\
+    "--http.vhosts=*",\
+    "--http.corsdomain=*"]

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -1,19 +1,29 @@
 #!/bin/bash
 
-# Deploys the contracts to the devnet, assumed to be running with an RPC endpoint at $DEVNET_RPC_URL.
+DEVNET_PKEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+DEVNET_ACCOUNT_ADDRESS=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
+DEVNET_RPC_URL=http://localhost:8547
+DEPLOYMENTS_PATH=/deployments.json
+
+# Spawn the sequencer in the background, using the same arguments expected by
+# the container's entrypoint
+nitro \
+    --node.dangerous.no-l1-listener \
+    --node.sequencer.dangerous.no-coordinator \
+    --node.sequencer.enable \
+    --node.staker.enable=false \
+    --init.dev-init \
+    --init.empty=false \
+    --chain.id=412346 \
+    --chain.dev-wallet.private-key=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
+    --http.addr=0.0.0.0 \
+    --http.vhosts=* \
+    --http.corsdomain=* \
+    > /dev/null 2>&1 &
 
 # Spinwait until the devnet is ready for contracts to be deployed to it
-while true; do
-    # Check that the token bridge contracts have been deployed, this is the last step of the devnet initialization.
-    response=$(curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["'$INIT_CHECK_ADDRESS'", "latest"],"id":1}' $DEVNET_RPC_URL 2> /dev/null)
-    result=$(echo $response | jq -r '.result')
-
-    # If the code is not empty, break out of the spinwait
-    if [ "$result" != "0x" ] && [ -n "$result" ]; then
-        break
-    else
-        sleep 1
-    fi
+while ! curl -sf http://localhost:8547 > /dev/null; do
+    sleep 1
 done
 
 # Exit on error
@@ -23,7 +33,7 @@ set -e
 # Otherwise, deploy the verification keys.
 if [[ -n $NO_VERIFY ]]; then
     # Write dummy addresses to the deployments file
-    dummy_address="0x0000000000000000000000000000000000000000"
+    dummy_address="0x0000000000000000000000000000000000000001"
     jq -n --arg dummy_address "$dummy_address" \
     '{
         deployments: {
@@ -58,6 +68,17 @@ cargo run \
     --contract merkle \
     $no_verify_flag
 
+# If the $DEPLOY_DUMMY_ERC20 env var is set, deploy the dummy ERC20 contract
+if [[ -n $DEPLOY_DUMMY_ERC20 ]]; then
+    cargo run \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
+    deploy-stylus \
+    --contract dummy-erc20
+fi
+
 # Deploy darkpool contract, setting the "--no-verify" flag
 # conditionally depending on whether the corresponding env var is set
 cargo run \
@@ -91,18 +112,5 @@ cargo run \
     --rpc-url $DEVNET_RPC_URL \
     --deployments-path $DEPLOYMENTS_PATH \
     deploy-proxy \
-    --owner $DEVNET_ACCOUNT_ADDRESS
-
-# If the $DEPLOY_DUMMY_ERC20 env var is set, deploy the dummy ERC20 contract
-if [[ -n $DEPLOY_DUMMY_ERC20 ]]; then
-    cargo run \
-    --package scripts -- \
-    --priv-key $DEVNET_PKEY \
-    --rpc-url $DEVNET_RPC_URL \
-    --deployments-path $DEPLOYMENTS_PATH \
-    deploy-stylus \
-    --contract dummy-erc20
-fi
-
-# Sleep forever to prevent the Docker Compose stack from aborting due to container exit
-sleep infinity
+    --owner $DEVNET_ACCOUNT_ADDRESS \
+    --fee 1


### PR DESCRIPTION
This PR introduces a minimal `sequencer` Docker image that has our contracts predeployed to it during the build stage.

This sequencer is configured to run without requiring `geth` or `redis` services colocated in the docker-compose stack.

This also requires no volumes. The plan wrt the `deployments.json` file is to copy it directly from the final build stage of the `sequencer` image into the `relayer` image.

Currently, this uses ~the same contract deployment script as we used to, I'll make the changes to e.g. remove `NO_VERIFY` later.

Additionally, this PR does not yet incorporate these changes into the `arbitrum-client` integration testing stack, that is saved for the next PR.

**Testing:**
I tested ad-hoc, using the `test_nullifier_set` method in the `renegade-contracts` repo, that the predeployed contracts are persisted and accessible using the same dev account (i.e., the test passes).