### PR TITLE
gossip: orderbook: Validate reblind <-> commitments proof link on gossiped orders

### DIFF
--- a/circuits/src/zk_circuits/proof_linking.rs
+++ b/circuits/src/zk_circuits/proof_linking.rs
@@ -68,6 +68,20 @@ where
     .map_err(ProverError::Plonk)
 }
 
+/// Validate a link between a proof of VALID REBLIND with a proof of VALID
+/// COMMITMENTS using the system wide sizing constants
+pub fn validate_sized_commitments_reblind_link(
+    link_proof: &PlonkLinkProof,
+    reblind_proof: &PlonkProof,
+    commitments_proof: &PlonkProof,
+) -> Result<(), ProverError> {
+    validate_commitments_reblind_link::<MAX_BALANCES, MAX_ORDERS, MAX_FEES, MERKLE_HEIGHT>(
+        link_proof,
+        reblind_proof,
+        commitments_proof,
+    )
+}
+
 /// Validate a link between a proof of VALID COMMITMENTS with a proof of VALID
 /// REBLIND
 pub fn validate_commitments_reblind_link<
@@ -205,6 +219,22 @@ where
         fabric,
     )
     .map_err(ProverError::Plonk)
+}
+
+/// Validate a link between a proof of VALID COMMITMENTS with a proof of MATCH
+/// SETTLE using the system wide sizing constants
+pub fn validate_sized_commitments_match_settle_link(
+    party_id: PartyId,
+    link_proof: &PlonkLinkProof,
+    commitments_proof: &PlonkProof,
+    match_settle_proof: &PlonkProof,
+) -> Result<(), ProverError> {
+    validate_commitments_match_settle_link::<MAX_BALANCES, MAX_ORDERS, MAX_FEES>(
+        party_id,
+        link_proof,
+        commitments_proof,
+        match_settle_proof,
+    )
 }
 
 /// Validate a link between a proof of MATCH SETTLE with a proof of VALID

--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -317,7 +317,8 @@ impl Serialize for OrderValidityProofBundle {
     where
         S: serde::Serializer,
     {
-        (self.copy_reblind_proof(), self.copy_commitment_proof()).serialize(serializer)
+        (self.copy_reblind_proof(), self.copy_commitment_proof(), self.linking_proof.clone())
+            .serialize(serializer)
     }
 }
 

--- a/gossip-api/src/gossip.rs
+++ b/gossip-api/src/gossip.rs
@@ -308,9 +308,11 @@ impl From<AuthenticatedPubsubMessage> for Vec<u8> {
     }
 }
 
-impl From<Vec<u8>> for AuthenticatedPubsubMessage {
-    fn from(bytes: Vec<u8>) -> Self {
-        serde_json::from_slice(&bytes).unwrap()
+impl TryFrom<Vec<u8>> for AuthenticatedPubsubMessage {
+    type Error = String;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        serde_json::from_slice(&bytes).map_err(|e| e.to_string())
     }
 }
 

--- a/workers/gossip-server/src/errors.rs
+++ b/workers/gossip-server/src/errors.rs
@@ -7,6 +7,9 @@ use std::fmt;
 pub enum GossipError {
     /// An error resulting from a cancellation signal
     Cancelled(String),
+    /// An error validating the proof link between `VALID COMMITMENTS` and
+    /// `VALID REBLIND`
+    CommitmentsReblindLinkVerification(String),
     /// An error occurred looking up a critical state element
     MissingState(String),
     /// A nullifier has already been used in the contract
@@ -24,7 +27,6 @@ pub enum GossipError {
     /// An error verifying a peer's proof of `VALID COMMITMENTS`
     ValidCommitmentVerification(String),
     /// An error verifying a peer's proof of `VALID REBLIND`
-    #[allow(unused)]
     ValidReblindVerification(String),
 }
 

--- a/workers/network-manager/src/error.rs
+++ b/workers/network-manager/src/error.rs
@@ -15,6 +15,8 @@ pub enum NetworkManagerError {
     Network(String),
     /// An error while setting up the network manager
     SetupError(String),
+    /// An error serializing or deserializing a message
+    Serialization(String),
 }
 
 impl Display for NetworkManagerError {

--- a/workers/network-manager/src/manager/pubsub.rs
+++ b/workers/network-manager/src/manager/pubsub.rs
@@ -49,7 +49,9 @@ impl NetworkManagerExecutor {
         message: GossipsubMessage,
     ) -> Result<(), NetworkManagerError> {
         // Deserialize into API types and verify auth
-        let event: AuthenticatedPubsubMessage = message.data.into();
+        let event: AuthenticatedPubsubMessage =
+            message.data.try_into().map_err(NetworkManagerError::Serialization)?;
+
         if !event.verify_cluster_auth(&self.cluster_key.public) {
             return Err(NetworkManagerError::Authentication(ERR_SIG_VERIFY.to_string()));
         }


### PR DESCRIPTION
### Purpose
This PR adds proof link verification to the order book gossip flow. That is, after the recipient of a gossip validity bundle verifies the two R1CS proofs (`VALID COMMITMENTS` and `VALID REBLIND`), it will verify the proof-link between them.

### Testing
- Unit tests pass
- Spun up two nodes, created an order on one, ensured that the other received the proof and correctly validated the link bundle.