### PR TITLE
circuit-types: srs: Parse SRS from ptau file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,11 +1301,14 @@ dependencies = [
 name = "circuit-types"
 version = "0.1.0"
 dependencies = [
+ "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-mpc",
+ "ark-serialize 0.4.2",
  "async-trait",
  "bigdecimal",
+ "byteorder",
  "circuit-macros",
  "constants",
  "futures",

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -8,9 +8,11 @@ test-helpers = ["mpc-plonk/test-srs"]
 
 [dependencies]
 # === Crytography === #
+ark-bn254 = "0.4"
 ark-ff = "0.4"
 ark-ec = "0.4"
 ark-mpc = { workspace = true }
+ark-serialize = "0.4"
 jf-primitives = { workspace = true }
 k256 = { version = "0.13", features = ["expose-field"] }
 mpc-plonk = { workspace = true }
@@ -31,11 +33,11 @@ constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 
 # === Misc === #
+byteorder = "1.5"
 itertools = "0.10"
 lazy_static = "1.4"
 serde = { version = "1.0.139", features = ["serde_derive"] }
 serde_json = "1.0"
-
 
 [dev-dependencies]
 test-helpers = { path = "../test-helpers" }

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod macro_tests;
 pub mod r#match;
 pub mod merkle;
 pub mod order;
+pub mod srs;
 pub mod traits;
 pub mod transfers;
 pub mod wallet;
@@ -407,7 +408,7 @@ pub mod test_helpers {
     use rand::thread_rng;
 
     /// The maximum degree SRS to allocate for testing circuits
-    const MAX_DEGREE_TESTING: usize = 131072;
+    const MAX_DEGREE_TESTING: usize = 65536;
 
     lazy_static! {
         /// A universal SRS for testing circuits that is generated once and used

--- a/circuit-types/src/srs.rs
+++ b/circuit-types/src/srs.rs
@@ -1,0 +1,221 @@
+//! Defines the parsing logic for the SRS of the system
+//!
+//! The SRS was pulled from:
+//!     https://github.com/iden3/snarkjs?tab=readme-ov-file#7-prepare-phase-2
+//! For a max-constraints of 2^16
+//!
+//! The SRS can be verified with `snarkjs powersoftau verify srs.ptau`
+//! Which runs the algorithm in https://eprint.iacr.org/2017/1050.pdf
+//!
+//! The parsing logic here is heavily derived from:
+//!     https://docs.rs/crate/ppot-rs/0.1.1
+//! With special care taken to suit our use case:
+//!     - Read from an included byte artifact directly
+//!     - Parse directly into `UnivariateUniversalParams`
+//!     - Simplified interface for lazy initialization
+use std::io::{Cursor, Read, Result as IoResult, Seek, SeekFrom};
+
+use ark_bn254::{Bn254, Fq, Fq2, G1Affine, G2Affine};
+use ark_ff::BigInt;
+use ark_serialize::CanonicalDeserialize;
+use byteorder::{LittleEndian, ReadBytesExt};
+use constants::SystemCurve;
+use jf_primitives::pcs::prelude::UnivariateUniversalParams;
+use lazy_static::lazy_static;
+use num_bigint::BigUint;
+use renegade_crypto::fields::get_base_field_modulus;
+
+lazy_static! {
+    /// The system SRS included from the `.ptau` file
+    static ref SYSTEM_SRS: UnivariateUniversalParams<SystemCurve> = {
+        let bytes = include_bytes!("../../srs/srs.ptau");
+        parse_ptau_file(bytes).unwrap()
+    };
+}
+
+/// The maximum power of two that the SRS supports
+const MAX_SRS_POWER: usize = 16;
+/// The maximum degree that the SRS supports
+pub const MAX_SRS_DEGREE: usize = 1 << MAX_SRS_POWER;
+
+/// The number of bytes in the magic string
+const MAGIC_STRING_LEN: usize = 4;
+/// The expected magic string
+const MAGIC_STRING: &[u8; MAGIC_STRING_LEN] = b"ptau";
+/// The expected version of the ptau file
+const EXPECTED_VERSION: u32 = 1;
+/// The expected number of sections in a ptau file
+const EXPECTED_NUM_SECTIONS: u32 = 11;
+
+// -----------
+// | Parsing |
+// -----------
+
+/// Parse the bytes from the .ptau file into a set of params
+pub fn parse_ptau_file(bytes: &[u8]) -> IoResult<UnivariateUniversalParams<Bn254>> {
+    let mut cursor = Cursor::new(bytes);
+    read_ptau_header(&mut cursor)?;
+    read_ptau_section1(&mut cursor)?;
+    let powers_of_g = read_ptau_section2(&mut cursor)?;
+    let (h, beta_h) = read_ptau_section3(&mut cursor)?;
+
+    Ok(UnivariateUniversalParams { powers_of_g, h, beta_h })
+}
+
+/// Read the header of a ptau file and validate its contents
+fn read_ptau_header(cursor: &mut Cursor<&[u8]>) -> IoResult<()> {
+    // Read the first 4 bytes as a magic string "ptau"
+    let mut magic_string = [0u8; MAGIC_STRING_LEN];
+    cursor.read_exact(&mut magic_string)?;
+    assert_eq!(&magic_string, MAGIC_STRING);
+
+    // Read the version
+    let version = cursor.read_u32::<LittleEndian>()?;
+    assert_eq!(
+        version, EXPECTED_VERSION,
+        "Invalid version, cannot parse ptau files of version != 1"
+    );
+
+    // Read the number of sections
+    let num_sections = cursor.read_u32::<LittleEndian>()?;
+    assert_eq!(num_sections, EXPECTED_NUM_SECTIONS, "Invalid number of sections");
+
+    Ok(())
+}
+
+/// Read the first section of a ptau file, which contains the curve parameters
+fn read_ptau_section1(cursor: &mut Cursor<&[u8]>) -> IoResult<()> {
+    // Read the header of the section
+    let (section_num, header_size) = read_section_header(cursor)?;
+    assert_eq!(section_num, 1, "Invalid section number");
+
+    let header_end = cursor.stream_position()? + header_size;
+
+    // Read the number of bytes in the modulus
+    let mod_bytes = cursor.read_u32::<LittleEndian>()?;
+    let mut modulus = vec![0u8; mod_bytes as usize];
+    cursor.read_exact(&mut modulus)?;
+
+    let recovered_mod = BigUint::from_bytes_le(&modulus);
+    assert_eq!(recovered_mod, get_base_field_modulus());
+
+    // Read the power and the ceremony power
+    let power = cursor.read_u32::<LittleEndian>()?;
+    let _ceremony_power = cursor.read_u32::<LittleEndian>()?;
+    assert!(power >= MAX_SRS_POWER as u32);
+
+    // Seek to the next section
+    cursor.seek(SeekFrom::Start(header_end))?;
+    Ok(())
+}
+
+/// Read the second section of a ptau file, which contains the G1 points
+///
+/// These points are the powers of \tau from [0, MAX_SRS_DEGREE] multiplied by
+/// the generator of the G1 group
+fn read_ptau_section2(cursor: &mut Cursor<&[u8]>) -> IoResult<Vec<G1Affine>> {
+    // Read the header of the section
+    let (section_num, section_size) = read_section_header(cursor)?;
+    assert_eq!(section_num, 2, "Invalid section number");
+
+    let section_end = cursor.stream_position()? + section_size;
+
+    // Read in the G1 points, which are the powers of \tau from [0, MAX_SRS_DEGREE]
+    let mut powers_of_g = Vec::with_capacity(MAX_SRS_DEGREE + 1);
+    for _ in 0..=MAX_SRS_DEGREE {
+        let point = read_g1_point(cursor)?;
+        powers_of_g.push(point);
+    }
+
+    // Seek to the next section
+    cursor.seek(SeekFrom::Start(section_end))?;
+    Ok(powers_of_g)
+}
+
+/// Read the third section of a ptau file, which contains the G2 points
+///
+/// These points are the generator of the G2 group and \tau * the generator of
+/// the G2 group
+fn read_ptau_section3(cursor: &mut Cursor<&[u8]>) -> IoResult<(G2Affine, G2Affine)> {
+    // Read the header of the section
+    let (section_num, _size) = read_section_header(cursor)?;
+    assert_eq!(section_num, 3, "Invalid section number");
+
+    // Read in the G2 points, these are the G2 generator H and \tau * H
+    let h = read_g2_point(cursor)?;
+    let beta_h = read_g2_point(cursor)?;
+
+    Ok((h, beta_h))
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Read a section number and size from a cursor
+fn read_section_header(cursor: &mut Cursor<&[u8]>) -> IoResult<(u32, u64)> {
+    let section_num = cursor.read_u32::<LittleEndian>()?;
+    let section_size = cursor.read_u64::<LittleEndian>()?;
+
+    Ok((section_num, section_size))
+}
+
+/// Read a Bn254 G1 affine point from a cursor
+fn read_g1_point(cursor: &mut Cursor<&[u8]>) -> IoResult<G1Affine> {
+    let x = read_base_field_element(cursor)?;
+    let y = read_base_field_element(cursor)?;
+
+    // Use `new_unchecked` here to avoid the subgroup check -- which is very slow
+    // We check only whether the point is a valid curve member
+    let res = G1Affine::new_unchecked(x, y);
+    assert!(res.is_on_curve(), "point not on curve");
+
+    Ok(res)
+}
+
+/// Read a Bn254 G2 affine point from a cursor
+fn read_g2_point(cursor: &mut Cursor<&[u8]>) -> IoResult<G2Affine> {
+    let x0 = read_base_field_element(cursor)?;
+    let x1 = read_base_field_element(cursor)?;
+    let y0 = read_base_field_element(cursor)?;
+    let y1 = read_base_field_element(cursor)?;
+
+    let x = Fq2::new(x0, x1);
+    let y = Fq2::new(y0, y1);
+
+    let res = G2Affine::new_unchecked(x, y);
+    assert!(res.is_on_curve(), "point not on curve");
+
+    Ok(res)
+}
+
+/// Read a base field element from a cursor
+fn read_base_field_element(cursor: &mut Cursor<&[u8]>) -> IoResult<Fq> {
+    let biguint = BigInt::deserialize_uncompressed(cursor).map_err(|e| {
+        invalid_data_error(&format!("Failed to deserialize base field element: {}", e))
+    })?;
+
+    // Points are serialized in their Montgomery form, use `new_unchecked` to avoid
+    // the implicit conversion
+    Ok(Fq::new_unchecked(biguint))
+}
+
+/// Create a new invalid data error with a message
+fn invalid_data_error(msg: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg)
+}
+
+// TODO: Test the parsing logic
+#[cfg(test)]
+mod test {
+    use crate::srs::MAX_SRS_DEGREE;
+
+    use super::SYSTEM_SRS;
+
+    /// Tests that the parsed SRS is the correct length
+    #[test]
+    fn test_srs_length() {
+        let srs = SYSTEM_SRS.clone();
+        assert_eq!(srs.powers_of_g.len(), MAX_SRS_DEGREE + 1);
+    }
+}

--- a/renegade-crypto/src/fields.rs
+++ b/renegade-crypto/src/fields.rs
@@ -3,9 +3,10 @@
 
 use std::ops::Neg;
 
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use bigdecimal::BigDecimal;
-use constants::Scalar;
+use constants::{Scalar, SystemCurveGroup};
 use ethers_core::types::U256;
 use num_bigint::{BigInt, BigUint, Sign};
 
@@ -16,9 +17,14 @@ use num_bigint::{BigInt, BigUint, Sign};
 /// The number of bytes in a U256
 pub const U256_BYTES: usize = 256 / 8;
 
-/// Return the modulus `p` of the `Scalar` ($Z_p$) field as a `BigUint`
+/// Return the modulus `r` of the `Scalar` ($Z_r$) field as a `BigUint`
 pub fn get_scalar_field_modulus() -> BigUint {
     Scalar::Field::MODULUS.into()
+}
+
+/// Return the modulus `q` of the `Scalar` ($Z_q$) field as a `BigUint`
+pub fn get_base_field_modulus() -> BigUint {
+    <SystemCurveGroup as CurveGroup>::BaseField::MODULUS.into()
 }
 
 // ---------------------------


### PR DESCRIPTION
### Purpose
This PR sets up the system-wide SRS by pulling directly from the BN128 powers of tau `.ptau` file from [the iden3 repo](https://github.com/iden3/snarkjs?tab=readme-ov-file#7-prepare-phase-2).

This PR also adds parsing logic for the `.ptau` file into the `UnivariateUniversealParams` struct used in `mpc-jellyfish`. This parsing logic is borrowed heavily from [`ppot-rs`](https://docs.rs/crate/ppot-rs/0.1.1) but with modifications to include the SRS in the compiled binary (as opposed to an external file) and lazily parse it.

### Todo
- More thorough parsing tests -- i.e. test the structure of the parsed SRS.
- Remove the `TESTING_SRS` defined in `lib.rs`

### Testing
- Unit tests pass
- Tested parsing