### PR TITLE
arbitrum-client, task-driver: make use of predeployed erc20s in sequencer

### DIFF
--- a/arbitrum-client/docker-compose.yml
+++ b/arbitrum-client/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       args:
         - NO_VERIFY=1
     attach: false
+    healthcheck:
+      test: curl -sf http://localhost:8547
+      interval: 1s
+      timeout: 5s
+      retries: 10
 
   relayer:
     image: arbitrum-client-integration-test:latest
@@ -20,4 +25,4 @@ services:
     tty: true
     depends_on:
       sequencer:
-        condition: service_started
+        condition: service_healthy

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -48,43 +48,6 @@ abigen!(
     ]"#
 );
 
-/// Represents an ERC20 contract's abi used in integration tests for
-/// deposit/withdrawal mechanics
-#[cfg(feature = "integration")]
-abigen!(
-    ERC20Contract,
-    r#"[
-        function totalSupply() external view returns (uint256)
-        function balanceOf(address account) external view returns (uint256)
-        function mint(address memory _address, uint256 memory value) external
-        function transfer(address to, uint256 value) external returns (bool)
-        function allowance(address owner, address spender) external view returns (uint256)
-        function approve(address spender, uint256 value) external returns (bool)
-        function transferFrom(address from, address to, uint256 value) external returns (bool)
-    ]"#
-);
-
-/// Represents the weth contract's abi used in integration tests for
-/// deposit/withdrawal mechanics
-///
-/// The WETH contract is exactly like an ERC20 but with the `deposit` and
-/// `withdraw` methods added for wrapping/unwrapping
-#[cfg(feature = "integration")]
-abigen!(
-    WethContract,
-    r#"[
-        function deposit() external payable
-        function withdraw(uint256 amount) external
-        function totalSupply() external view returns (uint256)
-        function balanceOf(address account) external view returns (uint256)
-        function mint(address memory _address, uint256 memory value) external
-        function transfer(address to, uint256 value) external returns (bool)
-        function allowance(address owner, address spender) external view returns (uint256)
-        function approve(address spender, uint256 value) external returns (bool)
-        function transferFrom(address from, address to, uint256 value) external returns (bool)
-    ]"#
-);
-
 sol! {
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external;

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -81,7 +81,7 @@ fn to_contract_external_transfer(
 }
 
 /// Convert a [`PublicSigningKey`] to its corresponding smart contract type
-fn to_contract_public_signing_key(
+pub fn to_contract_public_signing_key(
     public_signing_key: &PublicSigningKey,
 ) -> Result<ContractPublicSigningKey, ConversionError> {
     let x = try_unwrap_scalars(&public_signing_key.x.to_scalars())?;

--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -26,6 +26,8 @@ RUN RUSTFLAGS="-C link-args=-rdynamic" cargo install --force cargo-stylus
 RUN cargo install wasm-opt --locked
 
 # Clone the contracts repo
+# We ADD the version file first to cache the git clone appropriately
+ADD https://api.github.com/repos/renegade-fi/renegade-contracts/git/refs/heads/main /renegade-contracts-version.json
 WORKDIR /sources
 RUN git clone \
     https://github.com/renegade-fi/renegade-contracts.git

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -23,6 +23,7 @@ nitro \
 
 # Spinwait until the devnet is ready for contracts to be deployed to it
 while ! curl -sf http://localhost:8547 > /dev/null; do
+    echo "Waiting for sequencer to be ready..."
     sleep 1
 done
 
@@ -68,17 +69,6 @@ cargo run \
     --contract merkle \
     $no_verify_flag
 
-# If the $DEPLOY_DUMMY_ERC20 env var is set, deploy the dummy ERC20 contract
-if [[ -n $DEPLOY_DUMMY_ERC20 ]]; then
-    cargo run \
-    --package scripts -- \
-    --priv-key $DEVNET_PKEY \
-    --rpc-url $DEVNET_RPC_URL \
-    --deployments-path $DEPLOYMENTS_PATH \
-    deploy-stylus \
-    --contract dummy-erc20
-fi
-
 # Deploy darkpool contract, setting the "--no-verify" flag
 # conditionally depending on whether the corresponding env var is set
 cargo run \
@@ -114,3 +104,15 @@ cargo run \
     deploy-proxy \
     --owner $DEVNET_ACCOUNT_ADDRESS \
     --fee 1
+
+# Deploy the dummy ERC20 contracts
+# The funding amount here is 1 million of a token with 18 decimal places
+cargo run \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
+    deploy-erc20s \
+    --account-skeys $DEVNET_PKEY \
+    --tickers DUMMY1 DUMMY2 \
+    --funding-amount 1000000000000000000000000

--- a/task-driver/Dockerfile
+++ b/task-driver/Dockerfile
@@ -60,4 +60,6 @@ COPY task-driver/integration ./integration
 
 RUN cargo build --quiet --test integration --features "integration"
 
+COPY --from=sequencer /deployments.json /deployments.json
+
 CMD [ "cargo", "test" ]

--- a/task-driver/docker-compose.yml
+++ b/task-driver/docker-compose.yml
@@ -1,39 +1,32 @@
 services:
-  contracts:
-    build:
-      context: ../docker/contracts
-    image: renegade-contracts:latest
-    entrypoint: sleep infinity
   sequencer:
-    build:
-      context: ../docker/devnet
-    volumes:
-      - deployments:/deployments
+    image: sequencer
     ports:
-      - "5050:5050"
+      - "8547:8547"
+    build:
+      context: ../docker/sequencer
+      args:
+        - NO_VERIFY=1
+    attach: false
     healthcheck:
-      test: "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"starknet_chainId\",\"params\":[],\"id\":1}' http://localhost:5050/rpc || exit 1"
-      interval: 5s
-      timeout: 10s
-      retries: 3
-    depends_on:
-      - contracts
+      test: curl -sf http://localhost:8547
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
   relayer:
     image: task-driver-integration-test:latest
     build:
       context: ..
       dockerfile: task-driver/Dockerfile
-    volumes:
-      - deployments:/deployments
     ports:
       - "8000:8000"
     command: >
       cargo test --test integration --features "integration" -- 
-        --deployments-path /deployments/deployments.json
-        --verbose 
+        --deployments-path /deployments.json
+        --devnet-url http://sequencer:8547
+        --verbosity full
     tty: true
     depends_on:
       sequencer:
         condition: service_healthy
-volumes:
-  deployments:

--- a/task-driver/integration/tests/settle_match.rs
+++ b/task-driver/integration/tests/settle_match.rs
@@ -26,9 +26,7 @@ use job_types::proof_manager::{ProofJob, ProofManagerJob};
 use renegade_crypto::fields::scalar_to_u64;
 use state::RelayerState;
 use task_driver::{settle_match::SettleMatchTask, settle_match_internal::SettleMatchInternalTask};
-use test_helpers::{
-    arbitrum::PREDEPLOYED_WETH_ADDR, assert_eq_result, assert_true_result, integration_test_async,
-};
+use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 use tokio::sync::{mpsc::unbounded_channel, oneshot::channel};
 use util::{hex::biguint_from_hex_string, matching_engine::settle_match_into_wallets};
 use uuid::Uuid;
@@ -52,8 +50,8 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
     };
 
     Order {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(),
-        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(),
+        quote_mint: biguint_from_hex_string(&test_args.erc20_addr0).unwrap(),
+        base_mint: biguint_from_hex_string(&test_args.erc20_addr1).unwrap(),
         side,
         amount: ORDER_AMOUNT,
         worst_case_price: FixedPoint::from_integer(worst_cast_price),
@@ -65,10 +63,10 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
 fn dummy_balance(side: OrderSide, test_args: &IntegrationTestArgs) -> Balance {
     match side {
         OrderSide::Buy => {
-            Balance { mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(), amount: 100 }
+            Balance { mint: biguint_from_hex_string(&test_args.erc20_addr0).unwrap(), amount: 100 }
         },
         OrderSide::Sell => {
-            Balance { mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(), amount: 100 }
+            Balance { mint: biguint_from_hex_string(&test_args.erc20_addr1).unwrap(), amount: 100 }
         },
     }
 }
@@ -154,8 +152,8 @@ async fn setup_match_result(
     let direction = wallet1.orders.first().unwrap().1.side.is_sell();
 
     let match_ = MatchResult {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr).unwrap(),
-        base_mint: biguint_from_hex_string(PREDEPLOYED_WETH_ADDR).unwrap(),
+        quote_mint: biguint_from_hex_string(&test_args.erc20_addr0).unwrap(),
+        base_mint: biguint_from_hex_string(&test_args.erc20_addr1).unwrap(),
         quote_amount: scalar_to_u64(&quote_amount.floor()),
         base_amount,
         direction,

--- a/task-driver/integration/tests/update_wallet.rs
+++ b/task-driver/integration/tests/update_wallet.rs
@@ -277,7 +277,7 @@ async fn test_update_wallet__deposit_and_withdraw(test_args: IntegrationTestArgs
     // Update the wallet by depositing into the pool
     let old_wallet = wallet.clone();
 
-    let mint = biguint_from_hex_string(&test_args.erc20_addr).unwrap();
+    let mint = biguint_from_hex_string(&test_args.erc20_addr0).unwrap();
     let amount = 10u64;
 
     wallet.balances.insert(mint.clone(), Balance { mint: mint.clone(), amount });

--- a/test-helpers/src/arbitrum.rs
+++ b/test-helpers/src/arbitrum.rs
@@ -1,7 +1,5 @@
 //! Helpers related to interfacing with an Arbitrum devnet node
 
-/// The deployed address of the WETH ERC20 contract on a devnet node
-pub const PREDEPLOYED_WETH_ADDR: &str = "0x408Da76E87511429485C32E4Ad647DD14823Fdc4";
 /// The default hostport that the Nitro devnet L2 node runs on
 pub const DEFAULT_DEVNET_HOSTPORT: &str = "http://localhost:8547";
 /// The default private key that the Nitro devnet is seeded with

--- a/util/src/arbitrum.rs
+++ b/util/src/arbitrum.rs
@@ -6,12 +6,12 @@ use eyre::{eyre, Result};
 
 /// The deployments key in the `deployments.json` file
 pub const DEPLOYMENTS_KEY: &str = "deployments";
-/// The darkpool key in the `deployments.json` file
-pub const DARKPOOL_KEY: &str = "darkpool";
 /// The darkpool proxy contract key in the `deployments.json` file
 pub const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";
-/// The dummy erc20 contract key in a `deployments.json` file
-pub const DUMMY_ERC20_CONTRACT_KEY: &str = "dummy_erc20_contract";
+/// The first dummy erc20 contract key in a `deployments.json` file
+pub const DUMMY_ERC20_0_CONTRACT_KEY: &str = "DUMMY1";
+/// The second dummy erc20 contract key in a `deployments.json` file
+pub const DUMMY_ERC20_1_CONTRACT_KEY: &str = "DUMMY2";
 
 /// Parse the address of the deployed contract from the `deployments.json` file
 pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> Result<String> {


### PR DESCRIPTION
This PR updates the `arbitrum-client` and `task-driver` integration testing stacks to:
1. Use the new Arbitrum sequencer image
2. Make use of the pre-deployed, pre-approved dummy ERC20s in the sequencer image

In the case of the `task-driver` integration testing stack, this meant being able to remove a lot of WETH contract interaction code.

**Testing:**
All of the `arbitrum-client` integration tests other than `process_match_settle` pass, as expected.
All of the `task-driver` integration tests other than `test_update_wallet__place_order`, `test_settle_mpc_match`, `test_settle_internal_match`, and `test_lookup_wallet__invalid_wallet` pass (when using the `NO_VERIFY` flag). However these tests fail for reasons seemingly unrelated to the usage of predeployed ERC20s (as opposed to WETH), those failure messages being `wallet not found in wallet_last_updated map`, and `error enqueuing job with proof manager`.
Regardless, fixing these test cases is out of scope for this PR.