### PR TITLE
circuit-types: traits: Use parsed SRS in circuit key generation

### DIFF
--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -397,26 +397,3 @@ pub mod native_helpers {
         (private_shares, blinded_public_shares)
     }
 }
-
-/// Helpers for tests
-#[cfg(feature = "test-helpers")]
-pub mod test_helpers {
-    use constants::SystemCurve;
-    use jf_primitives::pcs::prelude::UnivariateUniversalParams;
-    use lazy_static::lazy_static;
-    use mpc_plonk::proof_system::{PlonkKzgSnark, UniversalSNARK};
-    use rand::thread_rng;
-
-    /// The maximum degree SRS to allocate for testing circuits
-    const MAX_DEGREE_TESTING: usize = 65536;
-
-    lazy_static! {
-        /// A universal SRS for testing circuits that is generated once and used
-        /// across circuits
-        pub static ref TESTING_SRS: UnivariateUniversalParams<SystemCurve> = {
-            let mut rng = thread_rng();
-            PlonkKzgSnark::<SystemCurve>::universal_setup_for_testing(MAX_DEGREE_TESTING, &mut rng)
-                .unwrap()
-        };
-    }
-}


### PR DESCRIPTION
### Purpose
This PR replaces the `TESTING_SRS` of the `circuit-types` library with the SRS parsed by #336. This PR also adds a cache for circuit proving and verifying keys, much like we do for circuit layouts.

Tests pass using this SRS to prove.

### Testing
- All unit tests pass
- Added tests for SRS composition
- Added tests for shared caching
- Ran relayers to gossip proofs and ensure the proofs are verified correctly