### PR TITLE
arbitrum-client: Add proof-linking interface changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
+checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -265,7 +265,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.4.16",
+ "clap 4.4.18",
  "colored",
  "common",
  "constants",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
+checksum = "fb41eb19024a91746eba0773aa5e16036045bbf45733766661099e182ea6a744"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -881,7 +881,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -918,9 +918,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitvec"
@@ -1340,7 +1340,7 @@ dependencies = [
  "chrono",
  "circuit-macros",
  "circuit-types",
- "clap 4.4.16",
+ "clap 4.4.18",
  "colored",
  "constants",
  "criterion",
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.16"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.7",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.16"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1582,7 +1582,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
- "clap 4.4.16",
+ "clap 4.4.18",
  "common",
  "ed25519-dalek 1.0.1",
  "libp2p",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "contracts-common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts.git#15e94d0ec07eed877e2945aa133a90d2cf7e84b3"
+source = "git+https://github.com/renegade-fi/renegade-contracts.git#369cb55dc9b6243c8301593b0f108aabe525f563"
 dependencies = [
  "alloy-primitives",
  "ark-bn254",
@@ -1721,7 +1721,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.16",
+ "clap 4.4.18",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -3306,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -3485,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -3856,7 +3856,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.4",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -4133,7 +4133,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f0bee397dc9a7003e7bd34fffc1dc2d4c4fdc96530a0c439a5f98c9402bc7bf"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "byteorder",
  "derive_more",
  "indexmap 1.9.3",
@@ -4483,7 +4483,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -4496,9 +4496,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -5020,7 +5020,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 
@@ -5060,7 +5060,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -5148,7 +5148,7 @@ version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5541,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "platforms"
@@ -5581,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.1"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -5732,9 +5732,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.0",
 ]
@@ -5821,7 +5821,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -6144,9 +6144,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -6154,9 +6154,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -6283,7 +6283,7 @@ dependencies = [
  "common",
  "config",
  "crossbeam",
- "env_logger 0.10.1",
+ "env_logger 0.10.2",
  "external-api",
  "gossip-api",
  "gossip-server",
@@ -6515,11 +6515,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7152,9 +7152,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "snafu"
@@ -7557,7 +7557,7 @@ dependencies = [
  "async-trait",
  "circuit-types",
  "circuits",
- "clap 4.4.16",
+ "clap 4.4.18",
  "colored",
  "common",
  "constants",
@@ -8161,9 +8161,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"

--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -1,8 +1,12 @@
 //! Integration tests for contract interaction client functionality
 
 use circuit_types::transfers::ExternalTransfer;
-use common::types::proof_bundles::mocks::{
-    dummy_valid_match_settle_bundle, dummy_valid_wallet_update_bundle, dummy_validity_proof_bundle,
+use common::types::proof_bundles::{
+    mocks::{
+        dummy_link_proof, dummy_valid_match_settle_bundle, dummy_valid_wallet_update_bundle,
+        dummy_validity_proof_bundle,
+    },
+    MatchBundle,
 };
 use eyre::Result;
 use test_helpers::{assert_eq_result, integration_test_async};
@@ -70,11 +74,17 @@ async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()>
     let party_1_new_shares = random_wallet_shares();
     valid_match_settle_proof_bundle.statement.party1_modified_shares = party_1_new_shares.clone();
 
+    let match_bundle = MatchBundle {
+        match_proof: valid_match_settle_proof_bundle.into(),
+        commitments_link0: dummy_link_proof(),
+        commitments_link1: dummy_link_proof(),
+    };
+
     client
         .process_match_settle(
             &party_0_validity_proof_bundle,
             &party_1_validity_proof_bundle,
-            &valid_match_settle_proof_bundle,
+            &match_bundle,
         )
         .await?;
 

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -16,7 +16,7 @@ abigen!(
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
@@ -37,12 +37,11 @@ abigen!(
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
         event NullifierSpent(uint256 nullifier)
-
 
         function clearMerkle() external
     ]"#
@@ -51,5 +50,5 @@ abigen!(
 sol! {
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external;
-    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_0_valid_commitments_proof, bytes memory party_0_valid_reblind_proof, bytes memory party_1_match_payload, bytes memory party_1_valid_commitments_proof, bytes memory party_1_valid_reblind_proof, bytes memory valid_match_settle_proof, bytes memory valid_match_settle_statement_bytes,) external;
+    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
 }

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -13,6 +13,7 @@ use ethers::{
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
+use tracing::log;
 
 use crate::{
     abi::{
@@ -139,7 +140,10 @@ impl ArbitrumClient {
             <processMatchSettleCall as SolCall>::SELECTOR => {
                 parse_shares_from_process_match_settle(&calldata, public_blinder_share)
             },
-            _ => Err(ArbitrumClientError::InvalidSelector),
+            sel => {
+                log::error!("invalid selector when parsing public shares: {sel:?}");
+                Err(ArbitrumClientError::InvalidSelector)
+            },
         }
     }
 }

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -88,7 +88,7 @@ pub fn parse_shares_from_process_match_settle(
         .map_err(|e| ArbitrumClientError::Serde(e.to_string()))?;
 
     let valid_match_settle_statement = deserialize_calldata::<ContractValidMatchSettleStatement>(
-        &call.valid_match_settle_statement_bytes.into(),
+        &call.valid_match_settle_statement.into(),
     )?;
 
     // The blinder is expected to be the last public wallet share

--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -415,6 +415,13 @@ pub struct MatchBundle {
     pub commitments_link1: PlonkLinkProof,
 }
 
+impl MatchBundle {
+    /// Clone the match proof out from behind the `Arc`
+    pub fn copy_match_proof(&self) -> SizedValidMatchSettleBundle {
+        SizedValidMatchSettleBundle::clone(&self.match_proof)
+    }
+}
+
 impl Serialize for MatchBundle {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -218,14 +218,12 @@ impl SettleMatchTask {
 
     /// Submit the match transaction to the contract
     async fn submit_match(&self) -> Result<(), SettleMatchTaskError> {
-        // TODO: Send proof links with the transaction
-        let match_settle_proof = &self.match_bundle.match_proof;
         let tx_submit_res = self
             .arbitrum_client
             .process_match_settle(
                 &self.party0_validity_proof,
                 &self.party1_validity_proof,
-                match_settle_proof,
+                &self.match_bundle,
             )
             .await;
 

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -267,11 +267,12 @@ impl SettleMatchInternalTask {
     /// Submit the match transaction
     async fn submit_match(&mut self) -> Result<(), SettleMatchInternalTaskError> {
         // Submit a `match` transaction
-
-        // TODO: Submit link proofs with the tx
-        let match_settle_proof = self.match_bundle.clone().unwrap().match_proof;
         self.arbitrum_client
-            .process_match_settle(&self.order1_proof, &self.order2_proof, &match_settle_proof)
+            .process_match_settle(
+                &self.order1_proof,
+                &self.order2_proof,
+                self.match_bundle.as_ref().unwrap(),
+            )
             .await
             .map_err(|e| SettleMatchInternalTaskError::Arbitrum(e.to_string()))
     }


### PR DESCRIPTION
### Purpose
This PR refactors the `arbitrum-client` interface to align with the proof-linking interface changes in the contracts. Specifically the interface changes to [`processMatchSettle`](https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-stylus/src/contracts/darkpool.rs#L355-L363).

### Todo
- Fix `task-driver` integration tests

### Testing
- Unit tests pass
- `arbitrum-client` integration tests pass against `renegade-contracts:main`