### PR TITLE
circuits: mpc-gadgets: modulo: Fix `mod2m` gadget tests

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -52,12 +52,15 @@ macro_rules! print_wire {
 #[allow(unused)]
 macro_rules! print_mpc_wire {
     ($x:expr) => {{
-        use crypto::fields::scalar_to_biguint;
+        use circuit_types::traits::MpcType;
         use futures::executor::block_on;
+        use renegade_crypto::fields::scalar_to_biguint;
         use tracing::log;
 
         let x_eval = block_on($x.open());
-        log::info!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+        if $x.fabric().party_id() == 0 {
+            log::info!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+        }
     }};
 }
 


### PR DESCRIPTION
### Purpose
This PR fixes a flakey test in the `mod2m` gadget. For now the fix is to simply test on smaller values that will not wrap around the field modulus. Long term we need to define a maximum value for signed integers in the MPC gadgets. This will be done when the beaver source is built.

### Testing
- Unit tests pass