### PR TITLE
task-driver: integration: Fix integration tests

### DIFF
--- a/task-driver/integration/helpers.rs
+++ b/task-driver/integration/helpers.rs
@@ -108,7 +108,18 @@ pub(crate) async fn setup_initial_wallet(
 ) -> Result<()> {
     setup_wallet_shares(blinder_seed, share_seed, wallet);
     allocate_wallet_in_darkpool(wallet, &test_args.arbitrum_client).await?;
-    lookup_wallet_and_check_result(wallet, blinder_seed, share_seed, test_args.clone()).await
+    lookup_wallet_and_check_result(wallet, blinder_seed, share_seed, test_args.clone()).await?;
+
+    // Read the wallet from the global state so that order IDs match
+    *wallet = test_args
+        .global_state
+        .read_wallet_index()
+        .await
+        .read_wallet(&wallet.wallet_id)
+        .await
+        .ok_or_else(|| eyre!("Wallet not found in global state"))?
+        .clone();
+    Ok(())
 }
 
 /// Create a wallet in the contract state and update the Merkle path on the

--- a/task-driver/integration/helpers.rs
+++ b/task-driver/integration/helpers.rs
@@ -179,7 +179,19 @@ pub fn create_empty_api_wallet() -> ApiWallet {
 pub fn empty_wallet_from_seed(blinder_stream_seed: Scalar, secret_share_seed: Scalar) -> Wallet {
     // Create a blank wallet then modify the shares
     let mut wallet = mock_empty_wallet();
+    setup_wallet_shares(blinder_stream_seed, secret_share_seed, &mut wallet);
 
+    wallet
+}
+
+/// Create shares for a mock wallet given the seeds for the blinder and secret
+///
+/// Mutates the wallet to set its shares and blinder
+pub fn setup_wallet_shares(
+    blinder_stream_seed: Scalar,
+    secret_share_seed: Scalar,
+    wallet: &mut Wallet,
+) {
     // Sample the blinder and blinder private share
     let blinder_and_private_share = evaluate_hash_chain(blinder_stream_seed, 2 /* length */);
     let new_blinder = blinder_and_private_share[0];
@@ -197,5 +209,4 @@ pub fn empty_wallet_from_seed(blinder_stream_seed: Scalar, secret_share_seed: Sc
     wallet.blinded_public_shares = blinded_public_shares;
     wallet.private_shares = private_shares;
     wallet.blinder = new_blinder;
-    wallet
 }

--- a/task-driver/src/helpers.rs
+++ b/task-driver/src/helpers.rs
@@ -41,6 +41,7 @@ use tokio::sync::{
     mpsc::UnboundedSender as TokioSender,
     oneshot::{self, Receiver as TokioReceiver},
 };
+use tracing::log;
 
 // -------------
 // | Constants |
@@ -289,7 +290,11 @@ pub(crate) async fn update_wallet_validity_proofs(
 ) -> Result<(), String> {
     // No validity proofs needed for an empty wallet, they will be re-proven on
     // the next update that adds a non-empty order
-    if wallet.orders.values().all(|o| o.is_zero()) {
+    if !wallet.has_orders_to_match() {
+        log::debug!(
+            "wallet {} has no orders ready for matching, skipping validity proofs",
+            wallet.wallet_id
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
### Purpose
This PR fixes the `task-driver` integration tests after the new integration testing stack was introduced in #337. The fixes are small and mostly relate to the setup code in how we allocate initial states into the darkpool.

### Testing
- All `task-driver` integration tests pass