### PR TITLE
circuit-types, util: update public key serialization to use uncompressed bytes

### DIFF
--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -253,9 +253,9 @@ impl PublicSigningKey {
     }
 
     /// Convert the key to bytes
-    pub fn to_compressed_bytes(&self) -> Vec<u8> {
+    pub fn to_uncompressed_bytes(&self) -> Vec<u8> {
         let verifying_key = K256VerifyingKey::from(self);
-        verifying_key.to_sec1_bytes().to_vec()
+        verifying_key.to_encoded_point(false /* compress */).as_bytes().to_vec()
     }
 }
 

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -47,7 +47,7 @@ pub fn nonnative_scalar_from_hex_string<const NUM_WORDS: usize>(
 
 /// A helper to serialize a signing key to a hex string
 pub fn public_sign_key_to_hex_string(val: &PublicSigningKey) -> String {
-    let bytes = val.to_compressed_bytes();
+    let bytes = val.to_uncompressed_bytes();
     format!("0x{}", hex::encode(bytes))
 }
 


### PR DESCRIPTION
Adds a method to convert the PublicSigningKey to bytes in uncompressed form, for correct serialization to a hex string.