### PR TITLE
statev2: interface: notifications: Add method to wait for proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7178,6 +7178,7 @@ dependencies = [
  "crossbeam",
  "external-api",
  "flexbuffers",
+ "futures",
  "itertools 0.10.5",
  "libmdbx",
  "multiaddr",
@@ -7193,6 +7194,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-slog",
+ "util",
  "uuid 1.7.0",
 ]
 

--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true, features = ["derive"] }
 
 # === Messaging + Concurrency === #
 crossbeam = { workspace = true }
+futures = { workspace = true }
 tokio = { workspace = true }
 
 # === Workspace Dependencies === #
@@ -29,6 +30,7 @@ config = { path = "../config" }
 constants = { path = "../constants" }
 external-api = { path = "../external-api" }
 system-bus = { path = "../system-bus" }
+util = { path = "../util" }
 
 # === Misc === #
 itertools = "0.10"

--- a/statev2/src/interface/notifications.rs
+++ b/statev2/src/interface/notifications.rs
@@ -1,0 +1,42 @@
+//! Defines a handle by which a consuming worker may await a state transition's
+//! application
+//!
+//! The underlying raft node will dequeue a proposal and apply it to the state
+//! machine. Only then will the notification be sent to the worker.
+use futures::future::FutureExt;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use util::err_str;
+
+use tokio::sync::oneshot::Receiver;
+
+use crate::{error::StateError, replication::error::ReplicationError};
+
+/// The proposal waiter awaits a proposal's successful application to the raft
+/// log
+#[derive(Debug)]
+pub struct ProposalWaiter {
+    /// The channel on which the notification will be sent
+    recv: Receiver<Result<(), ReplicationError>>,
+}
+
+impl ProposalWaiter {
+    /// Create a new proposal waiter
+    pub fn new(recv: Receiver<Result<(), ReplicationError>>) -> Self {
+        Self { recv }
+    }
+}
+
+impl Future for ProposalWaiter {
+    type Output = Result<(), StateError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.recv
+            .poll_unpin(cx)
+            .map_err(err_str!(StateError::Proposal))? // RecvError
+            .map_err(err_str!(StateError::Proposal)) // ReplicationError
+    }
+}

--- a/statev2/src/interface/wallet_index.rs
+++ b/statev2/src/interface/wallet_index.rs
@@ -2,7 +2,10 @@
 
 use common::types::wallet::{Wallet, WalletIdentifier};
 
-use crate::{applicator::WALLETS_TABLE, error::StateError, State, StateTransition};
+use crate::{
+    applicator::WALLETS_TABLE, error::StateError, notifications::ProposalWaiter, State,
+    StateTransition,
+};
 
 impl State {
     // -----------
@@ -25,7 +28,7 @@ impl State {
     // -----------
 
     /// Propose a new wallet to be added to the index
-    pub fn new_wallet(&self, wallet: Wallet) -> Result<(), StateError> {
+    pub fn new_wallet(&self, wallet: Wallet) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::AddWallet { wallet })
     }
 }

--- a/statev2/src/replication/error.rs
+++ b/statev2/src/replication/error.rs
@@ -1,7 +1,7 @@
 //! Defines error types emitted by the replication layer
 
 use raft::{Error as RaftError, StorageError as RaftStorageError};
-use std::io::Error as IOError;
+use std::io::{Error as IOError, ErrorKind as IOErrorKind};
 use std::{error::Error, fmt::Display};
 
 use crate::applicator::error::StateApplicatorError;
@@ -24,6 +24,8 @@ pub enum ReplicationError {
     RecvMessage(IOError),
     /// An error sending a message
     SendMessage(IOError),
+    /// An error sending a response to a proposal
+    ProposalResponse(String),
     /// An error serializing a value
     SerializeValue(String),
     /// An error interacting with storage
@@ -51,6 +53,9 @@ impl From<ReplicationError> for RaftError {
                 RaftError::Store(RaftStorageError::Other(Box::new(ReplicationError::ParseValue(s))))
             },
             ReplicationError::SendMessage(e) | ReplicationError::RecvMessage(e) => RaftError::Io(e),
+            ReplicationError::ProposalResponse(e) => {
+                RaftError::Io(IOError::new(IOErrorKind::Other, e))
+            },
         }
     }
 }

--- a/statev2/src/replication/raft_node.rs
+++ b/statev2/src/replication/raft_node.rs
@@ -406,7 +406,9 @@ impl<N: RaftNetwork> ReplicationNode<N> {
     ) -> Result<(), ReplicationError> {
         // If the proposal is not local to the node, or if the channel is dropped, no
         // notification is needed
-        if let Some(resp) = self.proposal_responses.remove(id) && !resp.is_closed() {
+        if let Some(resp) = self.proposal_responses.remove(id)
+            && !resp.is_closed()
+        {
             resp.send(res).map_err(|_| {
                 ReplicationError::ProposalResponse(ERR_PROPOSAL_RESPONSE.to_string())
             })?;

--- a/util/src/errors.rs
+++ b/util/src/errors.rs
@@ -1,0 +1,11 @@
+//! Helpers for error handling
+
+/// Expands a given error type to wrap a stringified version of a given error
+///
+/// To be used in a map_err() call
+#[macro_export]
+macro_rules! err_str {
+    ($x:expr) => {
+        |e| $x(e.to_string())
+    };
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -9,6 +9,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub mod arbitrum;
+pub mod errors;
 pub mod hex;
 pub mod logging;
 pub mod matching_engine;


### PR DESCRIPTION
### Purpose
This PR adds a primitive for a caller to await a proposal's completion, either with an error or successfully. This is done via a oneshot channel that the consensus layer maintains. Once a proposal is either accepted or rejected, the consensus layer responds on this channel.

This will be useful for example in the tasks, which cannot be considered complete until a raft entry is successfully appended representing the task's update.

### Testing
- Modified the tests to await response via this primitive
- All unit tests pass