### PR TITLE
statev2: storage: tx: Add tx module and define high level tx

### DIFF
--- a/statev2/src/applicator/order_book.rs
+++ b/statev2/src/applicator/order_book.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     applicator::{error::StateApplicatorError, ORDERS_TABLE, PRIORITIES_TABLE},
-    storage::db::DbTxn,
+    storage::tx::DbTxn,
 };
 
 use super::{Result, StateApplicator};
@@ -75,7 +75,7 @@ impl StateApplicator {
     /// Add a new order to the network order book
     pub fn new_order(&self, order: NetworkOrder) -> Result<()> {
         // Index the order
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
         Self::write_order_priority_with_tx(&order, &tx)?;
         Self::add_order_with_tx(&order, &tx)?;
 
@@ -93,7 +93,7 @@ impl StateApplicator {
         order_id: OrderIdentifier,
         proof: OrderValidityProofBundle,
     ) -> Result<()> {
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
         Self::attach_validity_proof_with_tx(&order_id, proof, &tx)?;
         let order_info = Self::read_order_info_unchecked(&order_id, &tx)?;
         tx.commit().map_err(StateApplicatorError::Storage)?;
@@ -107,7 +107,7 @@ impl StateApplicator {
 
     /// Nullify orders indexed by a given wallet share nullifier
     pub fn nullify_orders(&self, nullifier: Nullifier) -> Result<()> {
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
 
         self.nullify_orders_with_tx(nullifier, &tx)?;
         tx.commit().map_err(StateApplicatorError::Storage)

--- a/statev2/src/applicator/peer_index.rs
+++ b/statev2/src/applicator/peer_index.rs
@@ -1,6 +1,6 @@
 //! Applicator methods for the peer index, separated out for discoverability
 
-use crate::storage::db::DbTxn;
+use crate::storage::tx::DbTxn;
 
 use super::{
     error::StateApplicatorError, Result, StateApplicator, CLUSTER_MEMBERSHIP_TABLE, PEER_INFO_TABLE,
@@ -17,7 +17,7 @@ impl StateApplicator {
 
     /// Add new peers to the peer index
     pub fn add_peers(&self, peers: Vec<PeerInfo>) -> Result<()> {
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
 
         // Index each peer
         for peer_info in peers.into_iter() {
@@ -42,7 +42,7 @@ impl StateApplicator {
 
     /// Remove a peer from the peer index
     pub fn remove_peer(&self, peer_id: WrappedPeerId) -> Result<()> {
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
 
         Self::remove_peer_with_tx(peer_id, &tx)?;
         tx.commit().map_err(StateApplicatorError::Storage)?;

--- a/statev2/src/applicator/wallet_index.rs
+++ b/statev2/src/applicator/wallet_index.rs
@@ -8,7 +8,7 @@ use external_api::bus_message::{wallet_topic_name, SystemBusMessage};
 use itertools::Itertools;
 use libmdbx::RW;
 
-use crate::{applicator::error::StateApplicatorError, storage::db::DbTxn};
+use crate::{applicator::error::StateApplicatorError, storage::tx::DbTxn};
 
 use super::{Result, StateApplicator, ORDER_TO_WALLET_TABLE, WALLETS_TABLE};
 
@@ -23,7 +23,7 @@ impl StateApplicator {
     /// a user on one cluster node, and the others must replicate it
     pub fn add_wallet(&self, wallet: &Wallet) -> Result<()> {
         // Add the wallet to the wallet indices
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
 
         Self::index_orders(&wallet.wallet_id, &wallet.orders.keys().cloned().collect_vec(), &tx)?;
         Self::write_wallet_with_tx(wallet, &tx)?;
@@ -50,7 +50,7 @@ impl StateApplicator {
     /// invariant that the state stored by this module is valid -- but
     /// possibly stale -- contract state
     pub fn update_wallet(&self, wallet: &Wallet) -> Result<()> {
-        let tx = self.db().new_write_tx().map_err(StateApplicatorError::Storage)?;
+        let tx = self.db().new_raw_write_tx().map_err(StateApplicatorError::Storage)?;
 
         // Any new orders in the wallet should be added to the orderbook
         let nullifier = wallet.get_wallet_nullifier();

--- a/statev2/src/interface/wallet_index.rs
+++ b/statev2/src/interface/wallet_index.rs
@@ -16,7 +16,7 @@ impl State {
     pub fn get_wallet(&self, id: &WalletIdentifier) -> Result<Option<Wallet>, StateError> {
         let db = self.db.clone();
 
-        let tx = db.new_read_tx().map_err(StateError::Db)?;
+        let tx = db.new_raw_read_tx().map_err(StateError::Db)?;
         let wallet = tx.read(WALLETS_TABLE, id).map_err(StateError::Db)?;
         tx.commit().map_err(StateError::Db)?;
 

--- a/statev2/src/storage/cursor.rs
+++ b/statev2/src/storage/cursor.rs
@@ -163,7 +163,7 @@ mod test {
         let mut values = (0..n).collect::<Vec<_>>();
         values.shuffle(&mut thread_rng());
 
-        let tx = db.new_write_tx().unwrap();
+        let tx = db.new_raw_write_tx().unwrap();
         for i in values.into_iter() {
             let key = i.to_string();
             tx.write(TEST_TABLE, &key, &i).unwrap();
@@ -182,7 +182,7 @@ mod test {
         db.create_table(TEST_TABLE).unwrap();
 
         // Read the first key, it should be `None`
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String /* key */, String /* value */>(TEST_TABLE).unwrap();
         cursor.seek_first().unwrap();
         let first = cursor.get_current().unwrap();
@@ -202,7 +202,7 @@ mod test {
         db.write(TEST_TABLE, &key, &value).unwrap();
 
         // Read the first key, it should be `Some`
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, String>(TEST_TABLE).unwrap();
         cursor.seek_first().unwrap();
         let first = cursor.get_current().unwrap();
@@ -220,7 +220,7 @@ mod test {
         insert_n_random(&db, N);
 
         // Read the last key, it should be `Some`
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         cursor.seek_last().unwrap();
         let last = cursor.get_current().unwrap();
@@ -242,7 +242,7 @@ mod test {
         db.write(TEST_TABLE, &k2, &v2).unwrap();
 
         // Read the values out of the cursor
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, String>(TEST_TABLE).unwrap();
         cursor.seek_first().unwrap();
         let first = cursor.get_current().unwrap().unwrap();
@@ -262,7 +262,7 @@ mod test {
         insert_n_random(&db, N);
 
         // Run a cursor over the table
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         for (i, pair) in cursor.enumerate() {
             let (k, v) = pair.unwrap();
@@ -286,7 +286,7 @@ mod test {
         let seek_index = (0..(N - 1)).choose(&mut thread_rng()).unwrap();
 
         // Seek to the value, assert its correctness, then check the next value
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         cursor.seek(&seek_index.to_string()).unwrap();
         let (k, v) = cursor.get_current().unwrap().unwrap();
@@ -318,7 +318,7 @@ mod test {
         let seek_index = (1..N).choose(&mut thread_rng()).unwrap();
 
         // Seek to the value, assert its correctness, then check the previous value
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         cursor.seek(&seek_index.to_string()).unwrap();
         let (k, v) = cursor.get_current().unwrap().unwrap();
@@ -350,7 +350,7 @@ mod test {
 
         // Insert all but one value
         let exclude = (0..(N - 1)).choose(&mut thread_rng()).unwrap();
-        let tx = db.new_write_tx().unwrap();
+        let tx = db.new_raw_write_tx().unwrap();
         for i in values.into_iter() {
             if i == exclude {
                 continue;
@@ -364,7 +364,7 @@ mod test {
         // Test `seek_geq` to a key that does exist
         let seek_ind = exclude - 1;
 
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         cursor.seek_geq(&seek_ind.to_string()).unwrap();
         let (k, v) = cursor.get_current().unwrap().unwrap();
@@ -377,7 +377,7 @@ mod test {
         // Now try seeking to a key that doesn't exist
         let seek_ind = exclude;
 
-        let tx = db.new_read_tx().unwrap();
+        let tx = db.new_raw_read_tx().unwrap();
         let mut cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
         cursor.seek_geq(&seek_ind.to_string()).unwrap();
         let (k, v) = cursor.get_current().unwrap().unwrap();

--- a/statev2/src/storage/mod.rs
+++ b/statev2/src/storage/mod.rs
@@ -10,6 +10,7 @@ pub mod cursor;
 pub mod db;
 pub mod error;
 pub mod traits;
+pub mod tx;
 
 /// A type alias used for reading from the database
 type CowBuffer<'a> = Cow<'a, [u8]>;

--- a/statev2/src/storage/tx/mod.rs
+++ b/statev2/src/storage/tx/mod.rs
@@ -1,0 +1,161 @@
+//! This module defines two transaction interfaces:
+//!     - A low level `DbTxn` interface that exposes a key-value interface
+//!     - A high level `StateTxn` interface that exposes a state machine
+//!       interface with helpers specific to the Renegade state
+//!
+//! Each of the files in this module are named after the high level interface
+//! they expose
+
+use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW};
+
+use super::{
+    cursor::DbCursor,
+    db::{deserialize_value, serialize_value},
+    error::StorageError,
+    traits::{Key, Value},
+    CowBuffer,
+};
+
+// --------------------------
+// | High Level Transaction |
+// --------------------------
+
+/// A high level transaction in the database
+pub struct StateTxn<'db, T: TransactionKind> {
+    /// The underlying `mdbx` transaction
+    inner: DbTxn<'db, T>,
+}
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Constructor
+    pub fn new(tx: DbTxn<'db, T>) -> Self {
+        Self { inner: tx }
+    }
+
+    /// Get the inner raw `DbTxn`
+    pub fn inner(&self) -> &DbTxn<'db, T> {
+        &self.inner
+    }
+}
+
+// -------------------------
+// | Low Level Transaction |
+// -------------------------
+
+/// A transaction in the database
+///
+/// MDBX guarantees isolation between transactions
+pub struct DbTxn<'db, T: TransactionKind> {
+    /// The underlying `mdbx` transaction
+    txn: Transaction<'db, T, WriteMap>,
+}
+
+impl<'db, T: TransactionKind> DbTxn<'db, T> {
+    /// Constructor
+    pub fn new(txn: Transaction<'db, T, WriteMap>) -> Self {
+        Self { txn }
+    }
+
+    /// Get a key from the database
+    pub fn read<K: Key, V: Value>(
+        &self,
+        table_name: &str,
+        key: &K,
+    ) -> Result<Option<V>, StorageError> {
+        // Read bytes then deserialize as a `serde::Serialize`
+        let value_bytes = self.read_bytes(table_name, key)?;
+        value_bytes.map(|bytes| deserialize_value(&bytes)).transpose()
+    }
+
+    /// Open a cursor in the txn
+    pub fn cursor<K: Key, V: Value>(
+        &self,
+        table_name: &str,
+    ) -> Result<DbCursor<'_, T, K, V>, StorageError> {
+        let table = self.open_table(table_name)?;
+        let cursor = self.txn.cursor(&table).map_err(StorageError::TxOp)?;
+
+        Ok(DbCursor::new(cursor))
+    }
+
+    /// Commit the transaction
+    pub fn commit(self) -> Result<(), StorageError> {
+        self.txn.commit().map_err(StorageError::Commit).map(|_| ())
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Read a byte array directly from the database
+    fn read_bytes<K: Key>(
+        &self,
+        table_name: &str,
+        key: &K,
+    ) -> Result<Option<CowBuffer>, StorageError> {
+        // Serialize the key
+        let key_bytes = serialize_value(key)?;
+
+        // Get the value
+        let table = self.open_table(table_name)?;
+        self.txn.get(&table, &key_bytes).map_err(StorageError::TxOp)
+    }
+
+    /// Open a table if the transaction has not done so already
+    fn open_table(&self, table_name: &str) -> Result<Table, StorageError> {
+        self.txn.open_table(Some(table_name)).map_err(StorageError::OpenTable)
+    }
+}
+
+// Write-enabled implementation
+impl<'db> DbTxn<'db, RW> {
+    /// Create a new table in the database
+    pub fn create_table(&self, table_name: &str) -> Result<(), StorageError> {
+        self.txn
+            .create_table(Some(table_name), TableFlags::default())
+            .map_err(StorageError::TxOp)
+            .map(|_| ())
+    }
+
+    /// Set a key in the database
+    pub fn write<K: Key, V: Value>(
+        &self,
+        table_name: &str,
+        key: &K,
+        value: &V,
+    ) -> Result<(), StorageError> {
+        let value_bytes = serialize_value(value)?;
+        self.write_bytes(table_name, key, &value_bytes)
+    }
+
+    /// Remove a key from the database
+    pub fn delete<K: Key>(&self, table_name: &str, key: &K) -> Result<bool, StorageError> {
+        // Serialize the key
+        let key_bytes = serialize_value(key)?;
+
+        // Delete the value
+        let table = self.open_table(table_name)?;
+        self.txn.del(&table, key_bytes, None /* data */).map_err(StorageError::TxOp)
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Write a byte array directly to the database
+    fn write_bytes<K: Key>(
+        &self,
+        table_name: &str,
+        key: &K,
+        value_bytes: &[u8],
+    ) -> Result<(), StorageError> {
+        // Serialize the key
+        let key_bytes = serialize_value(key)?;
+
+        // Set the value
+        let table = self.open_table(table_name)?;
+        self.txn
+            .put(&table, key_bytes, value_bytes, WriteFlags::default())
+            .map_err(StorageError::TxOp)
+    }
+}


### PR DESCRIPTION
### Purpose
This PR introduces the `StateTxn` type to the DB. On top of this we will build high level state access primitives that can be re-used between the applicator and the state interface. For now, all callsites still use the raw txn interface. This will be changed once the `StateTxn` implementation is built out.

### Testing
- All unit tests pass