### PR TITLE
statev2: storage: tx: Add `wallet_index` access methods

### DIFF
--- a/common/src/types/wallet.rs
+++ b/common/src/types/wallet.rs
@@ -474,10 +474,11 @@ pub mod mocks {
 
     /// Create a mock Merkle path for a wallet
     pub fn mock_merkle_path() -> MerkleAuthenticationPath {
+        let mut rng = thread_rng();
         MerkleAuthenticationPath::new(
-            [Scalar::zero(); MERKLE_HEIGHT],
+            [Scalar::random(&mut rng); MERKLE_HEIGHT],
             BigUint::from(0u8),
-            Scalar::zero(),
+            Scalar::random(&mut rng),
         )
     }
 }

--- a/statev2/src/applicator/mod.rs
+++ b/statev2/src/applicator/mod.rs
@@ -7,7 +7,10 @@ use common::types::gossip::ClusterId;
 use external_api::bus_message::SystemBusMessage;
 use system_bus::SystemBus;
 
-use crate::{storage::db::DB, StateTransition};
+use crate::{
+    storage::db::DB, StateTransition, CLUSTER_MEMBERSHIP_TABLE, ORDERS_TABLE,
+    ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE, WALLETS_TABLE,
+};
 
 use self::error::StateApplicatorError;
 
@@ -22,21 +25,6 @@ pub mod wallet_index;
 
 /// A type alias for the result type given by the applicator
 pub(crate) type Result<T> = std::result::Result<T, StateApplicatorError>;
-
-/// The name of the db table that stores peer information
-pub(crate) const PEER_INFO_TABLE: &str = "peer-info";
-/// The name of the db table that stores cluster membership information
-pub(crate) const CLUSTER_MEMBERSHIP_TABLE: &str = "cluster-membership";
-
-/// The name of the db table that stores order and cluster priorities
-pub(crate) const PRIORITIES_TABLE: &str = "priorities";
-/// The name of the table that stores orders by their ID
-pub(crate) const ORDERS_TABLE: &str = "orders";
-
-/// The name of the db table that maps order to their encapsulating wallet
-pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";
-/// The name of the db table that stores wallet information
-pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
 /// The config for the state applicator
 #[derive(Clone)]

--- a/statev2/src/applicator/order_book.rs
+++ b/statev2/src/applicator/order_book.rs
@@ -19,8 +19,7 @@ use libmdbx::{TransactionKind, RW};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    applicator::{error::StateApplicatorError, ORDERS_TABLE, PRIORITIES_TABLE},
-    storage::tx::DbTxn,
+    applicator::error::StateApplicatorError, storage::tx::DbTxn, ORDERS_TABLE, PRIORITIES_TABLE,
 };
 
 use super::{Result, StateApplicator};
@@ -334,9 +333,9 @@ mod test {
     use rand::thread_rng;
     use uuid::Uuid;
 
-    use crate::applicator::{
-        order_book::OrderPriority, test_helpers::mock_applicator, StateApplicator, ORDERS_TABLE,
-        PRIORITIES_TABLE,
+    use crate::{
+        applicator::{order_book::OrderPriority, test_helpers::mock_applicator, StateApplicator},
+        ORDERS_TABLE, PRIORITIES_TABLE,
     };
 
     /// Creates a dummy `AddOrder` message for testing

--- a/statev2/src/interface/error.rs
+++ b/statev2/src/interface/error.rs
@@ -22,3 +22,9 @@ impl Display for StateError {
     }
 }
 impl Error for StateError {}
+
+impl From<StorageError> for StateError {
+    fn from(e: StorageError) -> Self {
+        StateError::Db(e)
+    }
+}

--- a/statev2/src/interface/wallet_index.rs
+++ b/statev2/src/interface/wallet_index.rs
@@ -2,10 +2,7 @@
 
 use common::types::wallet::{Wallet, WalletIdentifier};
 
-use crate::{
-    applicator::WALLETS_TABLE, error::StateError, notifications::ProposalWaiter, State,
-    StateTransition,
-};
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
 
 impl State {
     // -----------
@@ -14,11 +11,9 @@ impl State {
 
     /// Get the wallet with the given id
     pub fn get_wallet(&self, id: &WalletIdentifier) -> Result<Option<Wallet>, StateError> {
-        let db = self.db.clone();
-
-        let tx = db.new_raw_read_tx().map_err(StateError::Db)?;
-        let wallet = tx.read(WALLETS_TABLE, id).map_err(StateError::Db)?;
-        tx.commit().map_err(StateError::Db)?;
+        let tx = self.db.new_read_tx()?;
+        let wallet = tx.get_wallet(id)?;
+        tx.commit()?;
 
         Ok(wallet)
     }

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -34,6 +34,29 @@ pub mod storage;
 /// Re-export the state interface
 pub use interface::*;
 
+// -------------
+// | Constants |
+// -------------
+
+/// The name of the db table that stores peer information
+pub(crate) const PEER_INFO_TABLE: &str = "peer-info";
+/// The name of the db table that stores cluster membership information
+pub(crate) const CLUSTER_MEMBERSHIP_TABLE: &str = "cluster-membership";
+
+/// The name of the db table that stores order and cluster priorities
+pub(crate) const PRIORITIES_TABLE: &str = "priorities";
+/// The name of the table that stores orders by their ID
+pub(crate) const ORDERS_TABLE: &str = "orders";
+
+/// The name of the db table that maps order to their encapsulating wallet
+pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";
+/// The name of the db table that stores wallet information
+pub(crate) const WALLETS_TABLE: &str = "wallet-info";
+
+// ------------
+// | Proposal |
+// ------------
+
 /// The `Proposal` type wraps a state transition and the channel on which to
 /// send the result of the proposal's application
 #[derive(Debug)]
@@ -78,6 +101,10 @@ impl From<StateTransition> for Proposal {
         Self { transition, response }
     }
 }
+
+// ---------
+// | Tests |
+// ---------
 
 #[cfg(test)]
 pub(crate) mod test_helpers {

--- a/statev2/src/replication/raft_node.rs
+++ b/statev2/src/replication/raft_node.rs
@@ -647,13 +647,12 @@ mod test {
     use rand::{thread_rng, Rng};
 
     use crate::{
-        applicator::WALLETS_TABLE,
         replication::{
             network::test_helpers::MockNetwork, raft_node::test_helpers::MockReplicationCluster,
         },
         storage::db::DB,
         test_helpers::mock_db,
-        StateTransition,
+        StateTransition, WALLETS_TABLE,
     };
 
     use super::{ReplicationNode, ReplicationNodeConfig};

--- a/statev2/src/storage/cursor.rs
+++ b/statev2/src/storage/cursor.rs
@@ -37,6 +37,16 @@ impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
         Self { inner: cursor, buffered_value: None, _phantom: PhantomData }
     }
 
+    /// Return an iterator over only the keys in the table
+    pub fn keys(self) -> impl Iterator<Item = Result<K, StorageError>> {
+        <Self as Iterator>::map(self, |res| res.map(|(k, _v)| k))
+    }
+
+    /// Return an iterator over only the values in the table
+    pub fn values(self) -> impl Iterator<Item = Result<V, StorageError>> {
+        <Self as Iterator>::map(self, |res| res.map(|(_k, v)| v))
+    }
+
     /// Get the key/value at the current position
     pub fn get_current(&mut self) -> Result<Option<(K, V)>, StorageError> {
         if let Some((k, v)) = self.buffered_value.take() {

--- a/statev2/src/storage/tx/mod.rs
+++ b/statev2/src/storage/tx/mod.rs
@@ -7,6 +7,7 @@
 //! they expose
 
 pub mod raft_log;
+pub mod wallet_index;
 
 use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW};
 

--- a/statev2/src/storage/tx/wallet_index.rs
+++ b/statev2/src/storage/tx/wallet_index.rs
@@ -1,0 +1,205 @@
+//! Helpers for accessing wallet index information in the database
+
+use std::collections::HashMap;
+
+use common::types::wallet::{
+    OrderIdentifier, Wallet, WalletAuthenticationPath, WalletIdentifier, WalletMetadata,
+};
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, ORDER_TO_WALLET_TABLE, WALLETS_TABLE};
+
+use super::StateTxn;
+
+/// The error message emitted when a wallet is not found
+const ERR_WALLET_NOT_FOUND: &str = "Wallet not found";
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the wallet associated with the given ID
+    pub fn get_wallet(&self, wallet_id: &WalletIdentifier) -> Result<Option<Wallet>, StorageError> {
+        self.inner().read(WALLETS_TABLE, wallet_id)
+    }
+
+    /// Get the wallet managing a given order
+    pub fn get_wallet_for_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<WalletIdentifier>, StorageError> {
+        self.inner().read(ORDER_TO_WALLET_TABLE, order_id)
+    }
+
+    /// Get all the wallets in the database
+    pub fn get_all_wallets(&self) -> Result<Vec<Wallet>, StorageError> {
+        // Create a cursor and take only the values
+        let wallet_cursor = self.inner().cursor::<WalletIdentifier, Wallet>(WALLETS_TABLE)?;
+        let wallets = wallet_cursor.values().collect::<Result<Vec<_>, _>>()?;
+
+        Ok(wallets)
+    }
+
+    /// Get wallet metadata for all wallets
+    pub fn get_metadata_map(
+        &self,
+    ) -> Result<HashMap<WalletIdentifier, WalletMetadata>, StorageError> {
+        let wallet_cursor = self.inner().cursor::<WalletIdentifier, Wallet>(WALLETS_TABLE)?;
+
+        let mut res = HashMap::new();
+        for elem in wallet_cursor {
+            let (id, wallet) = elem?;
+            res.insert(id, wallet.metadata);
+        }
+
+        Ok(res)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Write a wallet to the table
+    pub fn write_wallet(&self, wallet: &Wallet) -> Result<(), StorageError> {
+        self.inner().write(WALLETS_TABLE, &wallet.wallet_id, wallet)
+    }
+
+    /// Add a Merkle proof to the wallet
+    pub fn add_wallet_merkle_proof(
+        &self,
+        wallet_id: &WalletIdentifier,
+        proof: WalletAuthenticationPath,
+    ) -> Result<(), StorageError> {
+        let mut wallet = self
+            .get_wallet(wallet_id)?
+            .ok_or(StorageError::NotFound(ERR_WALLET_NOT_FOUND.to_string()))?;
+        wallet.merkle_proof = Some(proof);
+
+        self.write_wallet(&wallet)
+    }
+
+    /// Update the mapping from order to wallet for each of the given orders
+    pub fn index_orders(
+        &self,
+        wallet_id: &WalletIdentifier,
+        orders: &[OrderIdentifier],
+    ) -> Result<(), StorageError> {
+        for order in orders.iter() {
+            self.inner().write(ORDER_TO_WALLET_TABLE, order, wallet_id)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod test {
+    use common::types::{
+        wallet::{OrderIdentifier, WalletIdentifier},
+        wallet_mocks::{mock_empty_wallet, mock_merkle_path},
+    };
+    use itertools::Itertools;
+
+    use crate::{test_helpers::mock_db, ORDER_TO_WALLET_TABLE, WALLETS_TABLE};
+
+    /// Tests adding a wallet then retrieving it
+    #[test]
+    fn test_add_wallet() {
+        let db = mock_db();
+        db.create_table(WALLETS_TABLE).unwrap();
+
+        // Write the wallet
+        let wallet = mock_empty_wallet();
+        let tx = db.new_write_tx().unwrap();
+        tx.write_wallet(&wallet).unwrap();
+        tx.commit().unwrap();
+
+        // Read the wallet
+        let tx = db.new_read_tx().unwrap();
+        let wallet_res = tx.get_wallet(&wallet.wallet_id).unwrap();
+        assert_eq!(wallet_res, Some(wallet));
+    }
+
+    /// Tests adding a Merkle proof to a wallet
+    #[test]
+    fn test_add_merkle_proof() {
+        let db = mock_db();
+        db.create_table(WALLETS_TABLE).unwrap();
+
+        // Write the wallet
+        let wallet = mock_empty_wallet();
+        let tx = db.new_write_tx().unwrap();
+        tx.write_wallet(&wallet).unwrap();
+        tx.commit().unwrap();
+
+        // Add a Merkle proof
+        let proof = mock_merkle_path();
+        let tx = db.new_write_tx().unwrap();
+        tx.add_wallet_merkle_proof(&wallet.wallet_id, proof.clone()).unwrap();
+        tx.commit().unwrap();
+
+        // Read the wallet
+        let tx = db.new_read_tx().unwrap();
+        let wallet_res = tx.get_wallet(&wallet.wallet_id).unwrap();
+        assert_eq!(wallet_res.unwrap().merkle_proof, Some(proof));
+    }
+
+    /// Tests creating multiple wallets and retrieving them all
+    #[test]
+    fn test_get_all_wallets() {
+        let db = mock_db();
+        db.create_table(WALLETS_TABLE).unwrap();
+
+        const N: usize = 10;
+        let mut wallets = (0..N).map(|_| mock_empty_wallet()).collect_vec();
+        let tx = db.new_write_tx().unwrap();
+        for wallet in wallets.iter() {
+            tx.write_wallet(wallet).unwrap();
+        }
+        tx.commit().unwrap();
+
+        // Read the wallets
+        let tx = db.new_read_tx().unwrap();
+        let mut wallets_res = tx.get_all_wallets().unwrap();
+
+        // Sort for comparison
+        wallets_res.sort_by_key(|wallet| wallet.wallet_id);
+        wallets.sort_by_key(|wallet| wallet.wallet_id);
+        assert_eq!(wallets_res, wallets);
+    }
+
+    /// Tests adding a wallet for an order then retrieving it
+    #[test]
+    fn test_get_wallet_for_order() {
+        let db = mock_db();
+        db.create_table(ORDER_TO_WALLET_TABLE).unwrap();
+
+        // Write the mapping
+        let order_id1 = OrderIdentifier::new_v4();
+        let order_id2 = OrderIdentifier::new_v4();
+        let order_id3 = OrderIdentifier::new_v4();
+        let wallet_id1 = WalletIdentifier::new_v4();
+        let wallet_id2 = WalletIdentifier::new_v4();
+
+        let tx = db.new_write_tx().unwrap();
+        tx.index_orders(&wallet_id1, &[order_id1, order_id2]).unwrap();
+        tx.index_orders(&wallet_id2, &[order_id3]).unwrap();
+        tx.commit().unwrap();
+
+        // Check all order mappings
+        let tx = db.new_read_tx().unwrap();
+        let wallet_res1 = tx.get_wallet_for_order(&order_id1).unwrap();
+        assert_eq!(wallet_res1, Some(wallet_id1));
+        let wallet_res2 = tx.get_wallet_for_order(&order_id2).unwrap();
+        assert_eq!(wallet_res2, Some(wallet_id1));
+        let wallet_res3 = tx.get_wallet_for_order(&order_id3).unwrap();
+        assert_eq!(wallet_res3, Some(wallet_id2));
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds getters and setters for the wallet index in the `StateTxn` abstraction. These are borrowed from the original state definition that `statev2` refactors. Some setters are left out involving replicas -- raft takes care of this automatically.

### Testing
- All unit tests pass