### PR TITLE
statev2, task-driver: Update `new-wallet` and `lookup-wallet` tasks

### DIFF
--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -5,6 +5,7 @@ FROM offchainlabs/stylus-node:v0.1.0-f47fec1-dev
 USER root
 
 RUN apt-get update && apt-get install -y \
+    ca-certificates \
     pkg-config \
     libssl-dev \
     build-essential \

--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 # Used to enable mocks from other crates in tests
 all-tests = ["common/mocks"]
-mocks = []
+mocks = ["dep:tempfile"]
 
 [dependencies]
 
@@ -39,6 +39,7 @@ libp2p = { workspace = true }
 rand = "0.8"
 serde_json = "1.0"
 slog = { verison = "2.2", features = ["max_level_trace"] }
+tempfile = { version = "3.8", optional = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
 uuid = "1.1.2"

--- a/statev2/src/interface/mod.rs
+++ b/statev2/src/interface/mod.rs
@@ -91,32 +91,10 @@ impl State {
 }
 
 #[cfg(test)]
-mod test_helpers {
-    use crate::{
-        replication::network::test_helpers::MockNetwork,
-        test_helpers::{sleep_ms, tmp_db_path},
-        State,
-    };
-    use config::RelayerConfig;
-    use system_bus::SystemBus;
-
-    /// Create a mock state instance
-    pub fn mock_state() -> State {
-        let config = RelayerConfig { db_path: tmp_db_path(), ..Default::default() };
-        let net = MockNetwork::new_n_way_mesh(1 /* n_nodes */).remove(0);
-        let state = State::new(&config, net, SystemBus::new()).unwrap();
-
-        // Wait for a leader election before returning
-        sleep_ms(500);
-        state
-    }
-}
-
-#[cfg(test)]
 mod test {
     use common::types::wallet_mocks::mock_empty_wallet;
 
-    use crate::interface::test_helpers::mock_state;
+    use crate::test_helpers::mock_state;
 
     /// Test adding a wallet to the state
     #[tokio::test]

--- a/statev2/src/interface/notifications.rs
+++ b/statev2/src/interface/notifications.rs
@@ -3,7 +3,7 @@
 //!
 //! The underlying raft node will dequeue a proposal and apply it to the state
 //! machine. Only then will the notification be sent to the worker.
-use futures::future::FutureExt;
+use futures::{future::FutureExt, ready};
 use std::{
     future::Future,
     pin::Pin,
@@ -19,14 +19,20 @@ use crate::{error::StateError, replication::error::ReplicationError};
 /// log
 #[derive(Debug)]
 pub struct ProposalWaiter {
-    /// The channel on which the notification will be sent
-    recv: Receiver<Result<(), ReplicationError>>,
+    /// The channels on which the notifications will be sent
+    recvs: Vec<Receiver<Result<(), ReplicationError>>>,
 }
 
 impl ProposalWaiter {
     /// Create a new proposal waiter
     pub fn new(recv: Receiver<Result<(), ReplicationError>>) -> Self {
-        Self { recv }
+        Self { recvs: vec![recv] }
+    }
+
+    /// Join two proposal waiters into one
+    pub fn join(self, other: Self) -> Self {
+        let recvs = self.recvs.into_iter().chain(other.recvs).collect();
+        Self { recvs }
     }
 }
 
@@ -34,9 +40,56 @@ impl Future for ProposalWaiter {
     type Output = Result<(), StateError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.recv
-            .poll_unpin(cx)
-            .map_err(err_str!(StateError::Proposal))? // RecvError
-            .map_err(err_str!(StateError::Proposal)) // ReplicationError
+        for recv in self.recvs.iter_mut() {
+            ready!(recv.poll_unpin(cx))
+                .map_err(err_str!(StateError::Proposal))? // RecvError
+                .map_err(err_str!(StateError::Proposal))?; // ReplicationError
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::replication::error::ReplicationError;
+
+    use super::ProposalWaiter;
+
+    /// Test a waiter on a single proposal
+    #[tokio::test]
+    async fn test_single_proposal() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let waiter = ProposalWaiter::new(rx);
+
+        // Send an Ok
+        tx.send(Ok(())).unwrap();
+        assert!(waiter.await.is_ok());
+    }
+
+    /// Tests a waiter on multiple proposals
+    #[tokio::test]
+    async fn test_multi_proposal_ok() {
+        let (tx1, rx1) = tokio::sync::oneshot::channel();
+        let (tx2, rx2) = tokio::sync::oneshot::channel();
+        let waiter = ProposalWaiter::new(rx1).join(ProposalWaiter::new(rx2));
+
+        // Send two Oks
+        tx1.send(Ok(())).unwrap();
+        tx2.send(Ok(())).unwrap();
+        assert!(waiter.await.is_ok());
+    }
+
+    /// Tests a waiter on multiple proposals in which an error is returned
+    #[tokio::test]
+    async fn test_multi_proposal_err() {
+        let (tx1, rx1) = tokio::sync::oneshot::channel();
+        let (tx2, rx2) = tokio::sync::oneshot::channel();
+        let waiter = ProposalWaiter::new(rx1).join(ProposalWaiter::new(rx2));
+
+        // Send an Ok and an Err
+        tx1.send(Ok(())).unwrap();
+        tx2.send(Err(ReplicationError::ProposalResponse("test".to_string()))).unwrap();
+        assert!(waiter.await.is_err());
     }
 }

--- a/statev2/src/interface/order_book.rs
+++ b/statev2/src/interface/order_book.rs
@@ -49,7 +49,7 @@ mod test {
         proof_bundles::mocks::dummy_validity_proof_bundle,
     };
 
-    use crate::interface::test_helpers::mock_state;
+    use crate::test_helpers::mock_state;
 
     /// Test adding an order to the state
     #[tokio::test]

--- a/statev2/src/replication/network.rs
+++ b/statev2/src/replication/network.rs
@@ -27,8 +27,9 @@ pub trait RaftNetwork {
     fn try_recv(&mut self) -> Result<Option<RaftMessage>, Self::Error>;
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "mocks"))]
 pub(crate) mod test_helpers {
+    //! Test helpers for the network abstraction
     use crossbeam::channel::{
         unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,
     };
@@ -66,6 +67,7 @@ pub(crate) mod test_helpers {
         }
 
         /// Create a double sided mock connection
+        #[allow(dead_code)]
         pub fn new_duplex_conn() -> (Self, Self) {
             let mut res = Self::new_n_way_mesh(2 /* n_nodes */);
             (res.remove(0), res.remove(0))

--- a/statev2/src/replication/raft_node.rs
+++ b/statev2/src/replication/raft_node.rs
@@ -349,7 +349,7 @@ impl<N: RaftNetwork> ReplicationNode<N> {
                     let transition: StateTransition = serde_json::from_slice(entry_bytes)
                         .map_err(err_str!(ReplicationError::ParseValue))?;
 
-                    log::info!(
+                    log::debug!(
                         "node {} applying state transition {transition:?}",
                         self.inner.raft.id
                     );

--- a/task-driver/Dockerfile
+++ b/task-driver/Dockerfile
@@ -11,8 +11,7 @@ FROM rust:1.63-slim-buster AS builder
 
 # Install pkg-config, openssl
 RUN apt-get update && \
-    apt-get install -y pkg-config && \
-    apt-get install -y libssl-dev 
+    apt-get install -y pkg-config libssl-dev clang 
 
 # Build the rust toolchain before adding any dependencies; this is the slowest
 # step and we would like to cache it before anything else

--- a/task-driver/integration/helpers.rs
+++ b/task-driver/integration/helpers.rs
@@ -13,7 +13,7 @@ use common::types::{
 use constants::Scalar;
 use ethers::types::Address;
 use external_api::types::ApiWallet;
-use eyre::{eyre, Result};
+use eyre::Result;
 use num_bigint::BigUint;
 use rand::thread_rng;
 use renegade_crypto::hash::{evaluate_hash_chain, PoseidonCSPRNG};
@@ -63,13 +63,7 @@ pub(crate) async fn lookup_wallet_and_check_result(
 
     // Check the global state for the wallet and verify that it was correctly
     // recovered
-    let state_wallet = state
-        .read_wallet_index()
-        .await
-        .read_wallet(&wallet_id)
-        .await
-        .ok_or_else(|| eyre!("Wallet not found in global state"))?
-        .clone();
+    let state_wallet = state.get_wallet(&wallet_id)?.unwrap();
 
     // Compare the secret shares directly
     assert_eq_result!(state_wallet.blinded_public_shares, expected_wallet.blinded_public_shares)?;
@@ -111,14 +105,7 @@ pub(crate) async fn setup_initial_wallet(
     lookup_wallet_and_check_result(wallet, blinder_seed, share_seed, test_args.clone()).await?;
 
     // Read the wallet from the global state so that order IDs match
-    *wallet = test_args
-        .global_state
-        .read_wallet_index()
-        .await
-        .read_wallet(&wallet.wallet_id)
-        .await
-        .ok_or_else(|| eyre!("Wallet not found in global state"))?
-        .clone();
+    *wallet = test_args.global_state.get_wallet(&wallet.wallet_id)?.unwrap();
     Ok(())
 }
 

--- a/task-driver/integration/main.rs
+++ b/task-driver/integration/main.rs
@@ -22,8 +22,7 @@ use gossip_api::gossip::GossipOutbound;
 use helpers::new_mock_task_driver;
 use job_types::proof_manager::ProofManagerJob;
 use proof_manager::mock::MockProofManager;
-use state::mock::StateMockBuilder;
-use state::RelayerState;
+use statev2::{test_helpers::mock_state, State};
 use task_driver::driver::TaskDriver;
 use test_helpers::{
     arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
@@ -90,7 +89,7 @@ struct IntegrationTestArgs {
     /// Held here to avoid closing the channel on `Drop`
     _network_receiver: Arc<TokioReceiver<GossipOutbound>>,
     /// A reference to the global state of the mock proof manager
-    global_state: RelayerState,
+    global_state: State,
     /// The job queue for the mock proof manager
     proof_job_queue: CrossbeamSender<ProofManagerJob>,
     /// The mock task driver created for these tests
@@ -134,8 +133,8 @@ impl From<CliArgs> for IntegrationTestArgs {
 }
 
 /// Create a global state mock for the `task-driver` integration tests
-fn setup_global_state_mock() -> RelayerState {
-    StateMockBuilder::default().disable_fee_validation().build()
+fn setup_global_state_mock() -> State {
+    mock_state()
 }
 
 /// Setup a mock `ArbitrumClient` for the integration tests

--- a/task-driver/integration/tests/mod.rs
+++ b/task-driver/integration/tests/mod.rs
@@ -2,5 +2,5 @@
 
 pub mod create_new_wallet;
 pub mod lookup_wallet;
-pub mod settle_match;
-pub mod update_wallet;
+// pub mod settle_match;
+// pub mod update_wallet;

--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -19,6 +19,8 @@ use tokio::{
 use tracing::log;
 use uuid::Uuid;
 
+use crate::{create_new_wallet::NewWalletTaskState, lookup_wallet::LookupWalletTaskState};
+
 /// The amount to increase the backoff delay by every retry
 const BACKOFF_AMPLIFICATION_FACTOR: u32 = 2;
 /// The maximum to increase the backoff to in milliseconds
@@ -104,10 +106,10 @@ pub trait Task: Send {
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "task_type", content = "state")]
 pub enum StateWrapper {
-    // /// The state object for the lookup wallet task
-    // LookupWallet(LookupWalletTaskState),
-    // /// The state object for the new wallet task
-    // NewWallet(NewWalletTaskState),
+    /// The state object for the lookup wallet task
+    LookupWallet(LookupWalletTaskState),
+    /// The state object for the new wallet task
+    NewWallet(NewWalletTaskState),
     // /// The state object for the settle match task
     // SettleMatch(SettleMatchTaskState),
     // /// The state object for the settle match internal task
@@ -121,13 +123,12 @@ pub enum StateWrapper {
 impl Display for StateWrapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
-            // StateWrapper::LookupWallet(state) => state.to_string(),
-            // StateWrapper::NewWallet(state) => state.to_string(),
+            StateWrapper::LookupWallet(state) => state.to_string(),
+            StateWrapper::NewWallet(state) => state.to_string(),
             // StateWrapper::SettleMatch(state) => state.to_string(),
             // StateWrapper::SettleMatchInternal(state) => state.to_string(),
             // StateWrapper::UpdateWallet(state) => state.to_string(),
             // StateWrapper::UpdateMerkleProof(state) => state.to_string(),
-            _ => "Unknown".to_string(),
         };
         write!(f, "{out}")
     }

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -14,10 +14,10 @@
 #![feature(generic_const_exprs)]
 #![feature(iter_advance_by)]
 
-// pub mod create_new_wallet;
+pub mod create_new_wallet;
 pub mod driver;
 mod helpers;
-// pub mod lookup_wallet;
+pub mod lookup_wallet;
 // pub mod settle_match;
 // pub mod settle_match_internal;
 // pub mod update_merkle_proof;


### PR DESCRIPTION
### Purpose
This PR updates the `new-wallet` and `lookup-wallet` tasks to use the new raft-based state refactor. This includes the integration tests for these two tasks.

### Testing
- Unit tests pass
- Integration tests pass for refactored tests
- Other tests fail and will be repaired throughout the rest of the refactor