### PR TITLE
task-driver: update-wallet: Refactor task to use `statev2`

### DIFF
--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -38,4 +38,9 @@ impl Balance {
     pub fn is_default(&self) -> bool {
         self.eq(&Balance::default())
     }
+
+    /// Whether or not the balance is zero'd
+    pub fn is_zero(&self) -> bool {
+        self.amount == 0
+    }
 }

--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -369,6 +369,11 @@ impl OrderValidityWitnessBundle {
     pub fn copy_commitment_witness(&self) -> SizedValidCommitmentsWitness {
         SizedValidCommitmentsWitness::clone(&self.commitment_witness)
     }
+
+    /// Clone the linking hint out from behind the reference
+    pub fn copy_commitment_linking_hint(&self) -> ProofLinkingHint {
+        ProofLinkingHint::clone(&self.commitment_linking_hint)
+    }
 }
 
 impl Serialize for OrderValidityWitnessBundle {
@@ -376,7 +381,12 @@ impl Serialize for OrderValidityWitnessBundle {
     where
         S: serde::Serializer,
     {
-        (self.copy_reblind_witness(), self.copy_commitment_witness()).serialize(serializer)
+        (
+            self.copy_reblind_witness(),
+            self.copy_commitment_witness(),
+            self.copy_commitment_linking_hint(),
+        )
+            .serialize(serializer)
     }
 }
 

--- a/statev2/src/interface/wallet_index.rs
+++ b/statev2/src/interface/wallet_index.rs
@@ -26,4 +26,9 @@ impl State {
     pub fn new_wallet(&self, wallet: Wallet) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::AddWallet { wallet })
     }
+
+    /// Update a wallet in the index
+    pub fn update_wallet(&self, wallet: Wallet) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::UpdateWallet { wallet })
+    }
 }

--- a/task-driver/integration/tests/mod.rs
+++ b/task-driver/integration/tests/mod.rs
@@ -3,4 +3,4 @@
 pub mod create_new_wallet;
 pub mod lookup_wallet;
 // pub mod settle_match;
-// pub mod update_wallet;
+pub mod update_wallet;

--- a/task-driver/integration/tests/update_wallet.rs
+++ b/task-driver/integration/tests/update_wallet.rs
@@ -84,13 +84,7 @@ pub(crate) async fn execute_wallet_update(
     assert_true_result!(success)?;
 
     // Fetch the updated wallet from state
-    test_args
-        .global_state
-        .read_wallet_index()
-        .await
-        .get_wallet(&id)
-        .await
-        .ok_or_else(|| eyre::eyre!("Wallet not found in state"))
+    test_args.global_state.get_wallet(&id)?.ok_or_else(|| eyre::eyre!("Wallet not found in state"))
 }
 
 /// Execute a wallet update, then lookup the new wallet from on-chain state and
@@ -155,7 +149,7 @@ async fn test_update_wallet__place_order(test_args: IntegrationTestArgs) -> Resu
 
     // Update the wallet by inserting an order
     let old_wallet = wallet.clone();
-    wallet.orders.insert(Uuid::new_v4(), DUMMY_ORDER.clone());
+    wallet.add_order(Uuid::new_v4(), DUMMY_ORDER.clone()).unwrap();
     wallet.reblind_wallet();
 
     execute_wallet_update_and_verify_shares(

--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -19,7 +19,10 @@ use tokio::{
 use tracing::log;
 use uuid::Uuid;
 
-use crate::{create_new_wallet::NewWalletTaskState, lookup_wallet::LookupWalletTaskState};
+use crate::{
+    create_new_wallet::NewWalletTaskState, lookup_wallet::LookupWalletTaskState,
+    update_wallet::UpdateWalletTaskState,
+};
 
 /// The amount to increase the backoff delay by every retry
 const BACKOFF_AMPLIFICATION_FACTOR: u32 = 2;
@@ -116,8 +119,8 @@ pub enum StateWrapper {
     // SettleMatchInternal(SettleMatchInternalTaskState),
     // /// The state object for the update Merkle proof task
     // UpdateMerkleProof(UpdateMerkleProofTaskState),
-    // /// The state object for the update wallet task
-    // UpdateWallet(UpdateWalletTaskState),
+    /// The state object for the update wallet task
+    UpdateWallet(UpdateWalletTaskState),
 }
 
 impl Display for StateWrapper {
@@ -127,7 +130,7 @@ impl Display for StateWrapper {
             StateWrapper::NewWallet(state) => state.to_string(),
             // StateWrapper::SettleMatch(state) => state.to_string(),
             // StateWrapper::SettleMatchInternal(state) => state.to_string(),
-            // StateWrapper::UpdateWallet(state) => state.to_string(),
+            StateWrapper::UpdateWallet(state) => state.to_string(),
             // StateWrapper::UpdateMerkleProof(state) => state.to_string(),
         };
         write!(f, "{out}")

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -21,4 +21,4 @@ pub mod lookup_wallet;
 // pub mod settle_match;
 // pub mod settle_match_internal;
 // pub mod update_merkle_proof;
-// pub mod update_wallet;
+pub mod update_wallet;

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -226,7 +226,7 @@ impl LookupWalletTask {
             .map_err(|e| LookupWalletTaskError::Arbitrum(e.to_string()))?;
         wallet.merkle_proof = Some(authentication_path);
 
-        self.global_state.new_wallet(wallet.clone())?.await?;
+        self.global_state.update_wallet(wallet.clone())?.await?;
         self.wallet = Some(wallet);
 
         Ok(())


### PR DESCRIPTION
### Purpose
This PR refactors the `update-wallet` task to use the `statev2` implementation. This includes the `update-wallet` integration tests and bugs fixed by getting these test to pass.

I also changed the way in which we add balances and order to a wallet, overriding old (zero'd) values in the case that a wallet is full.

### Testing
- All unit tests pass
- Integration tests for update-wallet pass