### PR TITLE
task-driver: update-merkle-proof: Refactor task over statev2

### DIFF
--- a/task-driver/src/driver.rs
+++ b/task-driver/src/driver.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use crate::{
     create_new_wallet::NewWalletTaskState, lookup_wallet::LookupWalletTaskState,
     settle_match::SettleMatchTaskState, settle_match_internal::SettleMatchInternalTaskState,
-    update_wallet::UpdateWalletTaskState,
+    update_merkle_proof::UpdateMerkleProofTaskState, update_wallet::UpdateWalletTaskState,
 };
 
 /// The amount to increase the backoff delay by every retry
@@ -118,8 +118,8 @@ pub enum StateWrapper {
     SettleMatch(SettleMatchTaskState),
     /// The state object for the settle match internal task
     SettleMatchInternal(SettleMatchInternalTaskState),
-    // /// The state object for the update Merkle proof task
-    // UpdateMerkleProof(UpdateMerkleProofTaskState),
+    /// The state object for the update Merkle proof task
+    UpdateMerkleProof(UpdateMerkleProofTaskState),
     /// The state object for the update wallet task
     UpdateWallet(UpdateWalletTaskState),
 }
@@ -132,7 +132,7 @@ impl Display for StateWrapper {
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
             StateWrapper::UpdateWallet(state) => state.to_string(),
-            // StateWrapper::UpdateMerkleProof(state) => state.to_string(),
+            StateWrapper::UpdateMerkleProof(state) => state.to_string(),
         };
         write!(f, "{out}")
     }

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -20,5 +20,5 @@ mod helpers;
 pub mod lookup_wallet;
 pub mod settle_match;
 pub mod settle_match_internal;
-// pub mod update_merkle_proof;
+pub mod update_merkle_proof;
 pub mod update_wallet;


### PR DESCRIPTION
### Purpose
This PR refactors the `update-merkle-proof` task over the new raft-base statev2 implementation. This is the last task to refactor. Further PRs will focus on refactoring the workers that access these tasks.

### Testing
- Unit tests pass
- `task-driver` integration tests pass