### PR TITLE
workeres: chain-events: Refactor to use `statev2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
  "job-types",
  "lazy_static",
  "renegade-crypto",
- "state",
+ "statev2",
  "task-driver",
  "tokio",
  "tracing",

--- a/statev2/src/interface/node_metadata.rs
+++ b/statev2/src/interface/node_metadata.rs
@@ -14,19 +14,28 @@ impl State {
     /// Get the peer ID of the local node
     pub fn get_peer_id(&self) -> Result<WrappedPeerId, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_peer_id()?)
+        let peer_id = tx.get_peer_id()?;
+        tx.commit()?;
+
+        Ok(peer_id)
     }
 
     /// Get the cluster ID of the local node
     pub fn get_cluster_id(&self) -> Result<ClusterId, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_cluster_id()?)
+        let cluster_id = tx.get_cluster_id()?;
+        tx.commit()?;
+
+        Ok(cluster_id)
     }
 
     /// Get the libp2p keypair of the local node
     pub fn get_node_keypair(&self) -> Result<Keypair, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_node_keypair()?)
+        let keypair = tx.get_node_keypair()?;
+        tx.commit()?;
+
+        Ok(keypair)
     }
 
     // -----------

--- a/statev2/src/interface/order_book.rs
+++ b/statev2/src/interface/order_book.rs
@@ -20,7 +20,10 @@ impl State {
         order_id: &OrderIdentifier,
     ) -> Result<Option<NetworkOrder>, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_order_info(order_id)?)
+        let info = tx.get_order_info(order_id)?;
+        tx.commit()?;
+
+        Ok(info)
     }
 
     /// Get the validity proofs for an order
@@ -44,7 +47,10 @@ impl State {
     /// Get all known orders in the book
     pub fn get_all_orders(&self) -> Result<Vec<NetworkOrder>, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_all_orders()?)
+        let orders = tx.get_all_orders()?;
+        tx.commit()?;
+
+        Ok(orders)
     }
 
     // -----------

--- a/statev2/src/interface/peer_index.rs
+++ b/statev2/src/interface/peer_index.rs
@@ -14,12 +14,18 @@ impl State {
     /// Get the peer info for a given peer
     pub fn get_peer_info(&self, peer_id: &WrappedPeerId) -> Result<Option<PeerInfo>, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_peer_info(peer_id)?)
+        let peer_info = tx.get_peer_info(peer_id)?;
+        tx.commit()?;
+
+        Ok(peer_info)
     }
 
     /// Get the peer info map from the peer index
     pub fn get_peer_info_map(&self) -> Result<HashMap<WrappedPeerId, PeerInfo>, StateError> {
         let tx = self.db.new_read_tx()?;
-        Ok(tx.get_info_map()?)
+        let info_map = tx.get_info_map()?;
+        tx.commit()?;
+
+        Ok(info_map)
     }
 }

--- a/statev2/src/interface/wallet_index.rs
+++ b/statev2/src/interface/wallet_index.rs
@@ -30,6 +30,15 @@ impl State {
         Ok(wallet_id)
     }
 
+    /// Get the ids of all wallets managed by the local relayer
+    pub fn get_all_wallets(&self) -> Result<Vec<Wallet>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let wallets = tx.get_all_wallets()?;
+        tx.commit()?;
+
+        Ok(wallets)
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -18,7 +18,7 @@ common = { path = "../../common" }
 renegade-crypto = { path = "../../renegade-crypto" }
 gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
-state = { path = "../../state" }
+statev2 = { path = "../../statev2" }
 task-driver = { path = "../../task-driver" }
 
 # === Misc Dependencies === #

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -2,6 +2,8 @@
 
 use std::{error::Error, fmt::Display};
 
+use statev2::error::StateError;
+
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
 pub enum OnChainEventListenerError {
@@ -13,6 +15,8 @@ pub enum OnChainEventListenerError {
     SendMessage(String),
     /// Error setting up the on-chain event listener
     Setup(String),
+    /// Error interacting with global state
+    State(String),
     /// The stream unexpectedly stopped
     StreamEnded,
     /// An error starting up a task
@@ -25,3 +29,9 @@ impl Display for OnChainEventListenerError {
     }
 }
 impl Error for OnChainEventListenerError {}
+
+impl From<StateError> for OnChainEventListenerError {
+    fn from(e: StateError) -> Self {
+        OnChainEventListenerError::State(e.to_string())
+    }
+}


### PR DESCRIPTION
### Purpose
This PR refactors the `chain-events` worker over the `statev2` crate

### Testing
- Unit tests pass in affected crates