### PR TITLE
workers: handshake-manager: Refactor over `statev2` implementation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,3 +25,4 @@ jobs:
             -D clippy::missing_docs_in_private_items
             -D clippy::needless_pass_by_value
             -D clippy::needless_pass_by_ref_mut
+            -D clippy::unused_async

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,7 +3315,7 @@ dependencies = [
  "rand 0.8.5",
  "renegade-crypto",
  "serde",
- "state",
+ "statev2",
  "system-bus",
  "task-driver",
  "test-helpers",

--- a/statev2/src/applicator/mod.rs
+++ b/statev2/src/applicator/mod.rs
@@ -7,10 +7,7 @@ use common::types::gossip::ClusterId;
 use external_api::bus_message::SystemBusMessage;
 use system_bus::SystemBus;
 
-use crate::{
-    storage::db::DB, StateTransition, CLUSTER_MEMBERSHIP_TABLE, ORDERS_TABLE,
-    ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE, WALLETS_TABLE,
-};
+use crate::{storage::db::DB, StateTransition};
 
 use self::error::StateApplicatorError;
 
@@ -55,8 +52,6 @@ pub struct StateApplicator {
 impl StateApplicator {
     /// Create a new state applicator
     pub fn new(config: StateApplicatorConfig) -> Result<Self> {
-        Self::create_db_tables(&config.db)?;
-
         Ok(Self { config })
     }
 
@@ -74,24 +69,6 @@ impl StateApplicator {
             StateTransition::RemovePeer { peer_id } => self.remove_peer(peer_id),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
-    }
-
-    /// Create tables in the DB if not already created
-    fn create_db_tables(db: &DB) -> Result<()> {
-        for table in [
-            PEER_INFO_TABLE,
-            CLUSTER_MEMBERSHIP_TABLE,
-            PRIORITIES_TABLE,
-            ORDERS_TABLE,
-            ORDER_TO_WALLET_TABLE,
-            WALLETS_TABLE,
-        ]
-        .iter()
-        {
-            db.create_table(table).map_err(Into::<StateApplicatorError>::into)?;
-        }
-
-        Ok(())
     }
 
     /// Get a reference to the db

--- a/statev2/src/applicator/peer_index.rs
+++ b/statev2/src/applicator/peer_index.rs
@@ -58,8 +58,8 @@ impl StateApplicator {
 
 #[cfg(test)]
 mod tests {
-    use crate::applicator::{
-        test_helpers::mock_applicator, CLUSTER_MEMBERSHIP_TABLE, PEER_INFO_TABLE,
+    use crate::{
+        applicator::test_helpers::mock_applicator, CLUSTER_MEMBERSHIP_TABLE, PEER_INFO_TABLE,
     };
     use common::types::gossip::{mocks::mock_peer, PeerInfo, WrappedPeerId};
 

--- a/statev2/src/applicator/wallet_index.rs
+++ b/statev2/src/applicator/wallet_index.rs
@@ -47,8 +47,8 @@ impl StateApplicator {
         // Any new orders in the wallet should be added to the orderbook
         let nullifier = wallet.get_wallet_nullifier();
         for (id, _order) in wallet.orders.iter().filter(|(_id, order)| !order.is_zero()) {
-            Self::add_order_with_tx(
-                &NetworkOrder::new(
+            self.add_order_with_tx(
+                NetworkOrder::new(
                     *id,
                     nullifier,
                     self.config.cluster_id.clone(),
@@ -82,7 +82,7 @@ pub(crate) mod test {
     };
     use uuid::Uuid;
 
-    use crate::applicator::{test_helpers::mock_applicator, ORDER_TO_WALLET_TABLE, WALLETS_TABLE};
+    use crate::{applicator::test_helpers::mock_applicator, ORDER_TO_WALLET_TABLE, WALLETS_TABLE};
 
     // -----------
     // | Helpers |

--- a/statev2/src/interface/order_book.rs
+++ b/statev2/src/interface/order_book.rs
@@ -2,12 +2,22 @@
 
 use circuit_types::wallet::Nullifier;
 use common::types::{
+    gossip::WrappedPeerId,
     network_order::NetworkOrder,
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::OrderIdentifier,
 };
+use rand::{
+    distributions::{Distribution, WeightedIndex},
+    seq::SliceRandom,
+    thread_rng,
+};
+use util::res_some;
 
-use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
+use crate::{
+    error::StateError, notifications::ProposalWaiter, storage::error::StorageError, State,
+    StateTransition,
+};
 
 impl State {
     // -----------
@@ -24,6 +34,15 @@ impl State {
         tx.commit()?;
 
         Ok(info)
+    }
+
+    /// Get the nullifier for an order
+    pub fn get_nullifier_for_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<Nullifier>, StateError> {
+        let order = self.get_order(order_id)?;
+        Ok(order.map(|o| o.public_share_nullifier))
     }
 
     /// Get the validity proofs for an order
@@ -44,6 +63,17 @@ impl State {
         Ok(order.and_then(|o| o.validity_proof_witnesses))
     }
 
+    /// Return whether the given order is ready for a match
+    pub fn order_ready_for_match(&self, order_id: &OrderIdentifier) -> Result<bool, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let info = tx.get_order_info(order_id)?.ok_or(StateError::Db(StorageError::NotFound(
+            format!("order {order_id} not found in state"),
+        )))?;
+        tx.commit()?;
+
+        Ok(info.ready_for_match())
+    }
+
     /// Get all known orders in the book
     pub fn get_all_orders(&self) -> Result<Vec<NetworkOrder>, StateError> {
         let tx = self.db.new_read_tx()?;
@@ -51,6 +81,73 @@ impl State {
         tx.commit()?;
 
         Ok(orders)
+    }
+
+    /// Sample a peer in the cluster managing an order
+    pub fn get_peer_managing_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<WrappedPeerId>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let order = res_some!(tx.get_order_info(order_id)?);
+        let peers = tx.get_cluster_peers(&order.cluster)?;
+        tx.commit()?;
+
+        // Sample a peer
+        let mut rng = thread_rng();
+        let peer = peers.choose(&mut rng).cloned();
+        Ok(peer)
+    }
+
+    /// Get a list of order IDs that are locally managed and ready for match
+    ///
+    /// TODO: Optimize this if necessary, possibly by caching this list
+    pub fn get_locally_matchable_orders(&self) -> Result<Vec<OrderIdentifier>, StateError> {
+        let tx = self.db.new_read_tx()?;
+
+        // Get all the local orders
+        let local_order_ids = tx.get_local_orders()?;
+
+        let mut res = Vec::new();
+        for id in local_order_ids.into_iter() {
+            if let Some(info) = tx.get_order_info(&id)? {
+                if info.ready_for_match() {
+                    res.push(id);
+                }
+            }
+        }
+
+        tx.commit()?;
+        Ok(res)
+    }
+
+    /// Choose an order to handshake with according to their priorities
+    ///
+    /// TODO: Optimize this method if necessary
+    pub fn choose_handshake_order(&self) -> Result<Option<OrderIdentifier>, StateError> {
+        let tx = self.db.new_read_tx()?;
+
+        // Get all orders and filter by those that are not managed internally and ready
+        // for match
+        let mut all_orders = tx.get_all_orders()?;
+
+        let my_cluster = tx.get_cluster_id()?;
+        all_orders.retain(|o| o.cluster != my_cluster && o.ready_for_match());
+
+        // Get the priorities of each order
+        let mut priorities = Vec::with_capacity(all_orders.len());
+        for order in all_orders.iter().map(|o| o.id) {
+            let priority = tx.get_order_priority(&order)?;
+            priorities.push(priority.get_effective_priority());
+        }
+        tx.commit()?;
+
+        // Sample a random priority-weighted order from the result
+        let mut rng = thread_rng();
+        let distribution = WeightedIndex::new(&priorities).unwrap();
+        let sampled = all_orders.get(distribution.sample(&mut rng)).unwrap();
+
+        Ok(Some(sampled.id))
     }
 
     // -----------

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -141,10 +141,18 @@ pub mod test_helpers {
 
     /// Create a mock database in a temporary location
     pub fn mock_db() -> DB {
+        // Open the DB
         let path = tmp_db_path();
         let config = DbConfig { path: path.to_string() };
 
-        DB::new(&config).unwrap()
+        let db = DB::new(&config).unwrap();
+
+        // Setup the tables
+        let tx = db.new_write_tx().unwrap();
+        tx.setup_tables().unwrap();
+        tx.commit().unwrap();
+
+        db
     }
 
     /// Create a mock state instance

--- a/util/src/errors.rs
+++ b/util/src/errors.rs
@@ -9,3 +9,15 @@ macro_rules! err_str {
         |e| $x(e.to_string())
     };
 }
+
+/// A helper macro for returning early in the case that an option is `None`
+/// wherein the return type is `Result<Option<T>, E>`
+#[macro_export]
+macro_rules! res_some {
+    ($x:expr) => {
+        match $x {
+            Some(x) => x,
+            None => return Ok(None),
+        }
+    };
+}

--- a/workers/handshake-manager/Cargo.toml
+++ b/workers/handshake-manager/Cargo.toml
@@ -24,7 +24,7 @@ renegade-crypto = { path = "../../renegade-crypto" }
 external-api = { path = "../../external-api" }
 job-types = { path = "../job-types" }
 gossip-api = { path = "../../gossip-api" }
-state = { path = "../../state" }
+statev2 = { path = "../../statev2" }
 system-bus = { path = "../../system-bus" }
 task-driver = { path = "../../task-driver" }
 test-helpers = { path = "../../test-helpers" }

--- a/workers/handshake-manager/src/error.rs
+++ b/workers/handshake-manager/src/error.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Display;
 
+use statev2::error::StateError;
+
 /// The core error type for the handshake manager
 #[derive(Clone, Debug)]
 pub enum HandshakeManagerError {
@@ -24,11 +26,8 @@ pub enum HandshakeManagerError {
     SetupError(String),
     /// An error executing a settlement task
     TaskError(String),
-    /// A state element was referenced, but cannot be found locally
-    ///
-    /// This may happen if, for example, an order is cancelled during the course
-    /// of a match
-    StateNotFound(String),
+    /// Error interacting with global state
+    State(String),
     /// Error verifying a proof
     VerificationError(String),
 }
@@ -36,5 +35,11 @@ pub enum HandshakeManagerError {
 impl Display for HandshakeManagerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl From<StateError> for HandshakeManagerError {
+    fn from(value: StateError) -> Self {
+        HandshakeManagerError::State(value.to_string())
     }
 }

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -38,7 +38,7 @@ use job_types::{
 };
 use libp2p::request_response::ResponseChannel;
 use portpicker::pick_unused_port;
-use state::RelayerState;
+use statev2::State;
 use std::{
     convert::TryInto,
     thread::JoinHandle,
@@ -79,6 +79,8 @@ pub(super) const HANDSHAKE_EXECUTOR_N_THREADS: usize = 8;
 pub(super) const ERR_NO_WALLET: &str = "wallet not found in state";
 /// Error message emitted when an order cannot be found in the global state
 pub(super) const ERR_NO_ORDER: &str = "order not found in state";
+/// Error message emitted when an order validity proof cannot be found
+const ERR_NO_PROOF: &str = "no order validity proof found for order";
 /// Error message emitted when price data cannot be found for a token pair
 const ERR_NO_PRICE_DATA: &str = "no price data found for token pair";
 
@@ -125,12 +127,12 @@ pub struct HandshakeExecutor {
     pub(crate) network_channel: TokioSender<GossipOutbound>,
     /// The pricer reporter's work queue, used for fetching price reports
     pub(crate) price_reporter_job_queue: TokioSender<PriceReporterManagerJob>,
-    /// A Starknet client used for interacting with the contract
+    /// An Arbitrum client used for interacting with the contract
     pub(crate) arbitrum_client: ArbitrumClient,
     /// The channel on which to send proof manager jobs
     pub(crate) proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
     /// The global relayer state
-    pub(crate) global_state: RelayerState,
+    pub(crate) global_state: State,
     /// The task driver, used to manage long-running async tasks
     pub(crate) task_driver: TaskDriver,
     /// The system bus used to publish internal broadcast messages
@@ -149,7 +151,7 @@ impl HandshakeExecutor {
         price_reporter_job_queue: TokioSender<PriceReporterManagerJob>,
         arbitrum_client: ArbitrumClient,
         proof_manager_work_queue: CrossbeamSender<ProofManagerJob>,
-        global_state: RelayerState,
+        global_state: State,
         task_driver: TaskDriver,
         system_bus: SystemBus<SystemBusMessage>,
         cancel: CancelChannel,
@@ -284,15 +286,14 @@ impl HandshakeExecutor {
 
                 // Fetch the validity proofs of the party
                 let (party0_proof, party1_proof) = {
-                    let locked_order_book = self.global_state.read_order_book().await;
-                    let local_validity_proof = locked_order_book
-                        .get_validity_proofs(&order_state.local_order_id)
-                        .await
-                        .unwrap();
-                    let remote_validity_proof = locked_order_book
-                        .get_validity_proofs(&order_state.peer_order_id)
-                        .await
-                        .unwrap();
+                    let local_validity_proof = self
+                        .global_state
+                        .get_validity_proofs(&order_state.local_order_id)?
+                        .ok_or_else(|| HandshakeManagerError::State(ERR_NO_PROOF.to_string()))?;
+                    let remote_validity_proof = self
+                        .global_state
+                        .get_validity_proofs(&order_state.peer_order_id)?
+                        .ok_or_else(|| HandshakeManagerError::State(ERR_NO_PROOF.to_string()))?;
 
                     match order_state.role {
                         ConnectionRole::Dialer => (local_validity_proof, remote_validity_proof),
@@ -318,9 +319,7 @@ impl HandshakeExecutor {
 
                 // Record the match in the cache
                 self.record_completed_match(request_id).await?;
-                self.submit_match(party0_proof, party1_proof, order_state, res).await;
-
-                Ok(())
+                self.submit_match(party0_proof, party1_proof, order_state, res).await.map(|_| ())
             },
 
             // Indicates that in-flight MPCs on the given nullifier should be terminated
@@ -341,7 +340,7 @@ impl HandshakeExecutor {
     ) -> Result<(), HandshakeManagerError> {
         if let Some(local_order_id) = self.choose_match_proposal(peer_order_id).await {
             // Choose a peer to match this order with
-            let managing_peer = self.global_state.get_peer_managing_order(&peer_order_id).await;
+            let managing_peer = self.global_state.get_peer_managing_order(&peer_order_id)?;
             if managing_peer.is_none() {
                 // TODO: Lower the order priority for this order
                 return Ok(());
@@ -357,7 +356,7 @@ impl HandshakeExecutor {
                     message: GossipRequest::Handshake {
                         request_id,
                         message: HandshakeMessage::ProposeMatchCandidate {
-                            peer_id: self.global_state.local_peer_id(),
+                            peer_id: self.global_state.get_peer_id()?,
                             sender_order: local_order_id,
                             peer_order: peer_order_id,
                             price_vector: price_vector.clone(),
@@ -367,10 +366,10 @@ impl HandshakeExecutor {
                 .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
 
             // Determine the execution price for the new order
-            let order =
-                self.global_state.get_order(&local_order_id).await.ok_or_else(|| {
-                    HandshakeManagerError::StateNotFound(ERR_NO_WALLET.to_string())
-                })?;
+            let order = self
+                .global_state
+                .get_managed_order(&local_order_id)?
+                .ok_or_else(|| HandshakeManagerError::State(ERR_NO_WALLET.to_string()))?;
             let (base, quote) = self.token_pair_for_order(&order);
 
             let execution_price = price_vector
@@ -466,8 +465,7 @@ impl HandshakeExecutor {
     ) -> Result<(), HandshakeManagerError> {
         // Only accept the proposed order pair if the peer's order has already been
         // verified by the local node
-        let peer_order_info =
-            self.global_state.read_order_book().await.get_order_info(&sender_order).await;
+        let peer_order_info = self.global_state.get_order(&sender_order)?;
         if peer_order_info.is_none()
             || peer_order_info.unwrap().state != NetworkOrderState::Verified
         {
@@ -482,7 +480,7 @@ impl HandshakeExecutor {
 
         // Do not accept handshakes on local orders that we don't have
         // validity proof or witness for
-        if !self.global_state.read_order_book().await.order_ready_for_handshake(&my_order).await {
+        if !self.global_state.order_ready_for_match(&my_order)? {
             return self.reject_match_proposal(
                 request_id,
                 sender_order,
@@ -553,7 +551,7 @@ impl HandshakeExecutor {
         // Send a pubsub message indicating intent to match on the given order pair
         // Cluster peers will then avoid scheduling this match until the match either
         // completes, or the cache entry's invisibility window times out
-        let cluster_id = { self.global_state.local_cluster_id.clone() };
+        let cluster_id = self.global_state.get_cluster_id()?;
         self.network_channel
             .send(GossipOutbound::Pubsub {
                 topic: cluster_id.get_management_topic(),
@@ -565,7 +563,7 @@ impl HandshakeExecutor {
             .map_err(|err| HandshakeManagerError::SendMessage(err.to_string()))?;
 
         let resp = HandshakeMessage::AcceptMatchCandidate {
-            peer_id: self.global_state.local_peer_id(),
+            peer_id: self.global_state.get_peer_id()?,
             port: local_port,
             previously_matched,
             order1: my_order,
@@ -586,7 +584,7 @@ impl HandshakeExecutor {
         response_channel: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Result<(), HandshakeManagerError> {
         let message = HandshakeMessage::RejectMatchCandidate {
-            peer_id: self.global_state.local_peer_id,
+            peer_id: self.global_state.get_peer_id()?,
             peer_order,
             sender_order: local_order,
             reason,
@@ -692,8 +690,7 @@ impl HandshakeExecutor {
     /// Chooses an order to match against a remote order
     async fn choose_match_proposal(&self, peer_order: OrderIdentifier) -> Option<OrderIdentifier> {
         let locked_handshake_cache = self.handshake_cache.read().await;
-        let local_verified_orders =
-            self.global_state.read_order_book().await.get_local_scheduleable_orders().await;
+        let local_verified_orders = self.global_state.get_locally_matchable_orders().ok()?;
 
         // Choose an order that isn't cached
         for order_id in local_verified_orders.iter() {
@@ -718,16 +715,13 @@ impl HandshakeExecutor {
             .await
             .mark_completed(state.local_order_id, state.peer_order_id);
 
-        // Write to global state for debugging
-        self.global_state.mark_order_pair_matched(state.local_order_id, state.peer_order_id).await;
-
         // Update the state of the handshake in the completed state
         self.handshake_state_index.completed(&request_id).await;
 
         // Send a message to cluster peers indicating that the local peer has completed
         // a match Cluster peers should cache the matched order pair as
         // completed and not initiate matches on this pair going forward
-        let cluster_id = self.global_state.local_cluster_id.clone();
+        let cluster_id = self.global_state.get_cluster_id()?;
         self.network_channel
             .send(GossipOutbound::Pubsub {
                 topic: cluster_id.get_management_topic(),
@@ -776,7 +770,9 @@ impl HandshakeExecutor {
         )
         .await
         .map_err(|err| HandshakeManagerError::TaskError(err.to_string()))?;
-        self.task_driver.start_task(task).await.0
+
+        let (id, _handle) = self.task_driver.start_task(task).await;
+        Ok(id)
     }
 }
 
@@ -787,7 +783,7 @@ pub struct HandshakeScheduler {
     /// The UnboundedSender to enqueue jobs on
     job_sender: TokioSender<HandshakeExecutionJob>,
     /// A copy of the relayer-global state
-    global_state: RelayerState,
+    global_state: State,
     /// The cancel channel to receive cancel signals on
     cancel: CancelChannel,
 }
@@ -796,7 +792,7 @@ impl HandshakeScheduler {
     /// Construct a new timer
     pub fn new(
         job_sender: TokioSender<HandshakeExecutionJob>,
-        global_state: RelayerState,
+        global_state: State,
         cancel: CancelChannel,
     ) -> Self {
         Self { job_sender, global_state, cancel }
@@ -814,7 +810,7 @@ impl HandshakeScheduler {
                 // Enqueue handshakes periodically according to a timer
                 _ = tokio::time::sleep(refresh_interval) => {
                     // Enqueue a job to handshake with the randomly selected peer
-                    if let Some(order) = self.global_state.choose_handshake_order().await {
+                    if let Some(order) = self.global_state.choose_handshake_order().ok().flatten() {
                         if let Err(e) = self
                             .job_sender
                             .send(HandshakeExecutionJob::PerformHandshake { order })

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -88,9 +88,7 @@ impl HandshakeExecutor {
         // Fetch the handshake state from the state index
         let handshake_state =
             self.handshake_state_index.get_state(&request_id).await.ok_or_else(|| {
-                HandshakeManagerError::StateNotFound(
-                    "missing handshake state for request".to_string(),
-                )
+                HandshakeManagerError::State("missing handshake state for request".to_string())
             })?;
 
         // Build a cancel channel; the coordinator may use this to cancel (shootdown) an
@@ -141,12 +139,9 @@ impl HandshakeExecutor {
         // values in `VALID MATCH MPC`
         let proof_witnesses = self
             .global_state
-            .read_order_book()
-            .await
-            .get_validity_proof_witnesses(&handshake_state.local_order_id)
-            .await
+            .get_validity_proof_witness(&handshake_state.local_order_id)?
             .ok_or_else(|| {
-                HandshakeManagerError::StateNotFound(
+                HandshakeManagerError::State(
                     "missing validity proof witness, cannot link proofs".to_string(),
                 )
             })?;

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -201,9 +201,8 @@ impl HandshakeExecutor {
         // peer's proposed prices list
         let my_order = self
             .global_state
-            .get_order(my_order_id)
-            .await
-            .ok_or_else(|| HandshakeManagerError::StateNotFound(ERR_NO_WALLET.to_string()))?;
+            .get_managed_order(my_order_id)?
+            .ok_or_else(|| HandshakeManagerError::State(ERR_NO_WALLET.to_string()))?;
         let (base, quote) = self.token_pair_for_order(&my_order);
 
         let proposed_price = proposed_prices.find_pair(&base, &quote);

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -12,7 +12,7 @@ use job_types::{
     handshake_manager::HandshakeExecutionJob, price_reporter::PriceReporterManagerJob,
     proof_manager::ProofManagerJob,
 };
-use state::RelayerState;
+use statev2::State;
 use system_bus::SystemBus;
 use task_driver::driver::TaskDriver;
 use tokio::{
@@ -30,7 +30,7 @@ use super::{error::HandshakeManagerError, manager::HandshakeManager};
 /// The config type for the handshake manager
 pub struct HandshakeManagerConfig {
     /// The relayer-global state
-    pub global_state: RelayerState,
+    pub global_state: State,
     /// The channel on which to send outbound network requests
     pub network_channel: TokioSender<GossipOutbound>,
     /// The price reporter's job queue


### PR DESCRIPTION
### Purpose
This PR refactors the handshake manager over the `statev2` crate. This includes implementing the bespoke methods in the state interface that the handshake manager needs.

### Testing
- Unit tests pass for `statev2`
- Tested new methods in `statev2`
- `handshake-manager` testing deferred until `core` is refactored