### PR TITLE
statev2, core: Refactor core crate over the `statev2` interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,7 +6187,7 @@ dependencies = [
  "network-manager",
  "price-reporter",
  "proof-manager",
- "state",
+ "statev2",
  "system-bus",
  "task-driver",
  "tokio",
@@ -7180,10 +7196,12 @@ dependencies = [
  "config",
  "constants",
  "crossbeam",
+ "crossterm 0.27.0",
  "external-api",
  "flexbuffers",
  "futures",
  "itertools 0.10.5",
+ "lazy_static",
  "libmdbx",
  "libp2p",
  "multiaddr",
@@ -7199,6 +7217,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-slog",
+ "tui",
+ "tui-logger",
  "util",
  "uuid 1.7.0",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,7 @@ job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
 price-reporter = { path = "../workers/price-reporter" }
 proof-manager = { path = "../workers/proof-manager" }
-state = { path = "../state" }
+statev2 = { path = "../statev2", features = ["mocks"] }
 system-bus = { path = "../system-bus" }
 task-driver = { path = "../task-driver" }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -3,6 +3,8 @@
 use std::error::Error;
 use std::fmt::Display;
 
+use statev2::error::StateError;
+
 /// An error type at the coordinator level
 #[derive(Clone, Debug)]
 pub enum CoordinatorError {
@@ -12,11 +14,19 @@ pub enum CoordinatorError {
     Recovery(String),
     /// Failure to send a cancel signal to a worker
     CancelSend(String),
+    /// An error setting up global state
+    State(String),
 }
 
 impl Error for CoordinatorError {}
 impl Display for CoordinatorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl From<StateError> for CoordinatorError {
+    fn from(value: StateError) -> Self {
+        CoordinatorError::State(value.to_string())
     }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -29,8 +29,8 @@ use job_types::{
 use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
 use price_reporter::{manager::PriceReporterManager, worker::PriceReporterManagerConfig};
 use proof_manager::{proof_manager::ProofManager, worker::ProofManagerConfig};
-use state::tui::StateTuiApp;
-use state::RelayerState;
+use statev2::tui::StateTuiApp;
+use statev2::{replication::network::test_helpers::MockNetwork, State};
 use system_bus::SystemBus;
 use task_driver::driver::{TaskDriver, TaskDriverConfig};
 
@@ -93,13 +93,10 @@ async fn main() -> Result<(), CoordinatorError> {
         mpsc::unbounded_channel::<PriceReporterManagerJob>();
     let (proof_generation_worker_sender, proof_generation_worker_receiver) = channel::unbounded();
 
-    // Construct the global state and warm up the config orders by generating proofs
-    // of `VALID COMMITMENTS`
-    let global_state = RelayerState::initialize_global_state(
-        &args,
-        handshake_worker_sender.clone(),
-        system_bus.clone(),
-    );
+    // Construct a global state
+    // TODO: Replace with gossip network once implemented
+    let network = MockNetwork::new_n_way_mesh(1 /* n_nodes */).remove(0);
+    let global_state = State::new(&args, network, system_bus.clone())?;
 
     // Configure logging and TUI
     if args.debug {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -17,7 +17,6 @@ pub mod peers;
 mod priority;
 #[allow(clippy::module_inception)]
 pub mod state;
-pub mod tui;
 pub mod wallet;
 
 pub use self::orderbook::NetworkOrderBook;

--- a/statev2/Cargo.toml
+++ b/statev2/Cargo.toml
@@ -34,7 +34,9 @@ system-bus = { path = "../system-bus" }
 util = { path = "../util" }
 
 # === Misc === #
+crossterm = "0.27"
 itertools = "0.10"
+lazy_static = "1.4.0"
 libp2p = { workspace = true }
 rand = "0.8"
 serde_json = "1.0"
@@ -42,6 +44,8 @@ slog = { verison = "2.2", features = ["max_level_trace"] }
 tempfile = { version = "3.8", optional = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-slog = "0.2"
+tui = "0.19"
+tui-logger = "0.8"
 uuid = "1.1.2"
 
 [dev-dependencies]

--- a/statev2/src/interface/peer_index.rs
+++ b/statev2/src/interface/peer_index.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use common::types::gossip::{PeerInfo, WrappedPeerId};
+use common::types::gossip::{ClusterId, PeerInfo, WrappedPeerId};
 
 use crate::{error::StateError, State};
 
@@ -27,5 +27,17 @@ impl State {
         tx.commit()?;
 
         Ok(info_map)
+    }
+
+    /// Get all the peers known in a given cluster
+    pub fn get_cluster_peers(
+        &self,
+        cluster_id: &ClusterId,
+    ) -> Result<Vec<WrappedPeerId>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let peers = tx.get_cluster_peers(cluster_id)?;
+        tx.commit()?;
+
+        Ok(peers)
     }
 }

--- a/statev2/src/lib.rs
+++ b/statev2/src/lib.rs
@@ -30,6 +30,7 @@ pub mod applicator;
 mod interface;
 pub mod replication;
 pub mod storage;
+pub mod tui;
 
 /// Re-export the state interface
 pub use interface::*;

--- a/statev2/src/replication/network.rs
+++ b/statev2/src/replication/network.rs
@@ -28,7 +28,7 @@ pub trait RaftNetwork {
 }
 
 #[cfg(any(test, feature = "mocks"))]
-pub(crate) mod test_helpers {
+pub mod test_helpers {
     //! Test helpers for the network abstraction
     use crossbeam::channel::{
         unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,


### PR DESCRIPTION
### Purpose
This PR refactors the `core` crate over the `statev2` interface. This also involves moving the TUI app definition from the `state` crate into the `statev2` crate.

### Testing
- Unit tests in `statev2` pass
- Other testing deferred until refactor complete