### PR TITLE
workers: gossip-server: Refactor to use the new gossip API

### DIFF
--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -57,6 +57,17 @@ impl State {
         Ok(peers)
     }
 
+    /// Get all the peers _not_ in the given cluster
+    pub fn get_non_cluster_peers(
+        &self,
+        cluster_id: &ClusterId,
+    ) -> Result<Vec<WrappedPeerId>, StateError> {
+        let mut info = self.get_peer_info_map()?;
+        info.retain(|_, peer_info| peer_info.get_cluster_id() != *cluster_id);
+
+        Ok(info.into_keys().collect())
+    }
+
     /// Construct a heartbeat message from the state
     pub fn construct_heartbeat(&self) -> Result<HeartbeatMessage, StateError> {
         let info_map = self.get_peer_info_map()?;

--- a/workers/gossip-server/src/errors.rs
+++ b/workers/gossip-server/src/errors.rs
@@ -28,6 +28,8 @@ pub enum GossipError {
     Arbitrum(String),
     /// Timer failed to send a heartbeat
     TimerFailed(String),
+    /// An unhandled request type was received
+    UnhandledRequest(String),
     /// An error verifying a peer's proof of `VALID COMMITMENTS`
     ValidCommitmentVerification(String),
     /// An error verifying a peer's proof of `VALID REBLIND`

--- a/workers/gossip-server/src/lib.rs
+++ b/workers/gossip-server/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(incomplete_features)]
 
 pub mod errors;
-mod heartbeat;
 mod orderbook;
+pub(crate) mod peer_discovery;
 pub mod server;
 pub mod worker;

--- a/workers/gossip-server/src/peer_discovery/bootstrap.rs
+++ b/workers/gossip-server/src/peer_discovery/bootstrap.rs
@@ -1,0 +1,19 @@
+//! Handles bootstrap requests and responses
+
+use gossip_api::request_response::{heartbeat::BootstrapRequest, GossipResponse};
+
+use crate::{errors::GossipError, server::GossipProtocolExecutor};
+
+impl GossipProtocolExecutor {
+    /// Handles a bootstrap request from a peer    
+    pub fn handle_bootstrap_req(
+        &self,
+        req: BootstrapRequest,
+    ) -> Result<GossipResponse, GossipError> {
+        // Add the peer to the index
+        self.add_new_peers(vec![req.peer_info])?;
+        let resp = self.build_heartbeat()?;
+
+        Ok(GossipResponse::Heartbeat(resp))
+    }
+}

--- a/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
@@ -1,0 +1,99 @@
+//! Timers which control the heartbeat interval
+
+use std::{thread, time::Duration};
+
+use job_types::gossip_server::GossipServerJob;
+use state::State;
+use tokio::sync::mpsc::UnboundedSender as TokioSender;
+
+use crate::errors::GossipError;
+
+/// HeartbeatTimer handles the process of enqueuing jobs to perform
+/// a heartbeat on regular intervals
+#[derive(Debug)]
+pub(super) struct HeartbeatTimer;
+
+impl HeartbeatTimer {
+    /// Spawns two timers, one for sending intra-cluster heartbeat messages,
+    /// another for inter-cluster The interval parameters specify how often
+    /// the timers should cycle through all peers in their target list
+    pub fn new(
+        job_queue: TokioSender<GossipServerJob>,
+        intra_cluster_interval_ms: u64,
+        inter_cluster_interval_ms: u64,
+        global_state: State,
+    ) -> Self {
+        // Narrowing cast is okay, precision is not important here
+        let intra_cluster_wait_period = Duration::from_millis(intra_cluster_interval_ms);
+        let inter_cluster_wait_period = Duration::from_millis(inter_cluster_interval_ms);
+
+        // Begin the timing loops
+        let job_queue_clone = job_queue.clone();
+        let global_state_clone = global_state.clone();
+        thread::Builder::new()
+            .name("intra-cluster-heartbeat-timer".to_string())
+            .spawn(move || {
+                Self::execution_loop(
+                    true, // intra_cluster
+                    job_queue_clone,
+                    intra_cluster_wait_period,
+                    global_state_clone,
+                )
+            })
+            .unwrap();
+
+        thread::Builder::new()
+            .name("non-cluster-heartbeat-timer".to_string())
+            .spawn(move || {
+                Self::execution_loop(
+                    false, // intra_cluster
+                    job_queue,
+                    inter_cluster_wait_period,
+                    global_state,
+                )
+            })
+            .unwrap();
+
+        Self {}
+    }
+
+    /// Main timing loop for heartbeats sent to nodes
+    ///
+    /// The `intra_cluster` flag determines whether this is the intra-cluster
+    /// loop or inter-cluster. We heartbeat cluster peers more frequently than
+    /// non-cluster peers, so they require different timing loops
+    ///
+    /// We space out the heartbeat requests to give a better traffic pattern.
+    /// This means that in each time quantum, one heartbeat is scheduled. We
+    /// compute the length of a time quantum with respect to the heartbeat
+    /// period constant defined above. That is, we specify the interval in
+    /// between heartbeats for a given peer, and space out all heartbeats in
+    /// that interval
+    fn execution_loop(
+        intra_cluster: bool,
+        job_queue: TokioSender<GossipServerJob>,
+        wait_period: Duration,
+        global_state: State,
+    ) -> Result<(), GossipError> {
+        let local_peer_id = global_state.get_peer_id()?;
+        let cluster_id = global_state.get_cluster_id()?;
+
+        loop {
+            // Get all peers in the local peer's cluster
+            let peers = if intra_cluster {
+                global_state.get_cluster_peers(&cluster_id)?
+            } else {
+                global_state.get_non_cluster_peers(&cluster_id)?
+            };
+
+            let wait_time = wait_period / (peers.len() as u32);
+            for peer in peers.into_iter().filter(|peer| peer != &local_peer_id) {
+                if let Err(err) = job_queue.send(GossipServerJob::ExecuteHeartbeat(peer)) {
+                    return Err(GossipError::TimerFailed(err.to_string()));
+                }
+
+                thread::sleep(wait_time);
+            }
+        }
+    }
+}

--- a/workers/gossip-server/src/peer_discovery/mod.rs
+++ b/workers/gossip-server/src/peer_discovery/mod.rs
@@ -1,0 +1,5 @@
+//! Groups handlers for peer discovery and indexing
+
+pub mod bootstrap;
+pub mod heartbeat;
+pub mod heartbeat_timer;

--- a/workers/gossip-server/src/worker.rs
+++ b/workers/gossip-server/src/worker.rs
@@ -6,8 +6,8 @@ use common::types::gossip::{ClusterId, WrappedPeerId};
 use common::types::CancelChannel;
 use common::worker::Worker;
 use futures::executor::block_on;
-use gossip_api::gossip::GossipOutbound;
 use job_types::gossip_server::GossipServerJob;
+use job_types::network_manager::NetworkManagerJob;
 use libp2p::Multiaddr;
 use state::State;
 use std::thread::{Builder, JoinHandle};
@@ -40,7 +40,7 @@ pub struct GossipServerConfig {
     /// A job queue to receive inbound heartbeat requests on
     pub job_receiver: DefaultWrapper<Option<TokioReceiver<GossipServerJob>>>,
     /// A job queue to send outbound network requests on
-    pub network_sender: TokioSender<GossipOutbound>,
+    pub network_sender: TokioSender<NetworkManagerJob>,
     /// The channel on which the coordinator may mandate that the
     /// gossip server cancel its execution
     pub cancel_channel: CancelChannel,

--- a/workers/job-types/src/gossip_server.rs
+++ b/workers/job-types/src/gossip_server.rs
@@ -14,9 +14,9 @@ pub enum GossipServerJob {
     /// Execute a heartbeat to a given peer
     ExecuteHeartbeat(WrappedPeerId),
     /// An incoming gossip request
-    NetworkRequest(GossipRequest, ResponseChannel<AuthenticatedGossipResponse>),
+    NetworkRequest(WrappedPeerId, GossipRequest, ResponseChannel<AuthenticatedGossipResponse>),
     /// An incoming gossip response
-    NetworkResponse(GossipResponse),
+    NetworkResponse(WrappedPeerId, GossipResponse),
     /// An incoming pubsub message
     Pubsub(PubsubMessage),
 }

--- a/workers/network-manager/src/error.rs
+++ b/workers/network-manager/src/error.rs
@@ -22,6 +22,8 @@ pub enum NetworkManagerError {
     Serialization(String),
     /// An error interacting with global state
     State(String),
+    /// An error when a given request type is unhandled
+    UnhandledRequest(String),
 }
 
 impl Display for NetworkManagerError {

--- a/workers/network-manager/src/manager.rs
+++ b/workers/network-manager/src/manager.rs
@@ -270,8 +270,8 @@ impl NetworkManagerExecutor {
     ) -> Result<(), NetworkManagerError> {
         match message {
             ComposedProtocolEvent::RequestResponse(request_response) => {
-                if let RequestResponseEvent::Message { message, .. } = request_response {
-                    self.handle_inbound_request_response_message(message)?;
+                if let RequestResponseEvent::Message { peer, message, .. } = request_response {
+                    self.handle_inbound_request_response_message(peer, message)?;
                 }
 
                 Ok(())

--- a/workers/network-manager/src/manager/request_response.rs
+++ b/workers/network-manager/src/manager/request_response.rs
@@ -1,13 +1,16 @@
 //! Defines handlers for the request-response protocol
 
+use common::types::gossip::WrappedPeerId;
 use gossip_api::{
     request_response::{
         AuthenticatedGossipRequest, AuthenticatedGossipResponse, GossipRequest, GossipResponse,
     },
     GossipDestination,
 };
+use job_types::gossip_server::GossipServerJob;
 use libp2p::request_response::{Message as RequestResponseMessage, ResponseChannel};
 use libp2p::PeerId;
+use util::err_str;
 
 use crate::error::NetworkManagerError;
 
@@ -21,17 +24,26 @@ impl NetworkManagerExecutor {
     /// Handle an incoming message from the network's request/response protocol
     pub(super) fn handle_inbound_request_response_message(
         &mut self,
+        peer: PeerId,
         message: RequestResponseMessage<AuthenticatedGossipRequest, AuthenticatedGossipResponse>,
     ) -> Result<(), NetworkManagerError> {
+        let peer = WrappedPeerId(peer);
+
         // Multiplex over request/response message types
         match message {
             // Handle inbound request from another peer
             RequestResponseMessage::Request { request, channel, .. } => {
                 // Authenticate the request then dispatch
                 request.verify_cluster_auth(&self.cluster_key.public)?;
-                match request.body.destination() {
-                    GossipDestination::NetworkManager => todo!(),
-                    GossipDestination::GossipServer => todo!(),
+                let body = request.body;
+                match body.destination() {
+                    GossipDestination::NetworkManager => self.handle_internal_request(body),
+                    GossipDestination::GossipServer => {
+                        let job = GossipServerJob::NetworkRequest(peer, body, channel);
+                        self.gossip_work_queue
+                            .send(job)
+                            .map_err(err_str!(NetworkManagerError::EnqueueJob))
+                    },
                     GossipDestination::HandshakeManager => todo!(),
                 }
             },
@@ -39,12 +51,40 @@ impl NetworkManagerExecutor {
             // Handle inbound response
             RequestResponseMessage::Response { response, .. } => {
                 response.verify_cluster_auth(&self.cluster_key.public)?;
-                match response.body.destination() {
-                    GossipDestination::NetworkManager => todo!(),
-                    GossipDestination::GossipServer => todo!(),
+                let body = response.body;
+                match body.destination() {
+                    GossipDestination::NetworkManager => self.handle_internal_response(body),
+                    GossipDestination::GossipServer => {
+                        let job = GossipServerJob::NetworkResponse(peer, body);
+                        self.gossip_work_queue
+                            .send(job)
+                            .map_err(err_str!(NetworkManagerError::EnqueueJob))
+                    },
                     GossipDestination::HandshakeManager => todo!(),
                 }
             },
+        }
+    }
+
+    /// Handle an internally routed request
+    #[allow(clippy::needless_pass_by_value)]
+    fn handle_internal_request(&self, req: GossipRequest) -> Result<(), NetworkManagerError> {
+        match req {
+            GossipRequest::Ack => Ok(()),
+            _ => Err(NetworkManagerError::UnhandledRequest(format!(
+                "unhandled internal request: {req:?}",
+            ))),
+        }
+    }
+
+    /// Handle an internally routed response
+    #[allow(clippy::needless_pass_by_value)]
+    fn handle_internal_response(&self, resp: GossipResponse) -> Result<(), NetworkManagerError> {
+        match resp {
+            GossipResponse::Ack => Ok(()),
+            _ => Err(NetworkManagerError::UnhandledRequest(format!(
+                "unhandled internal response: {resp:?}",
+            ))),
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR refactors the first half of the gossip server to use the new gossip API. This includes orderbook updates and bootstrapping. Heartbeat logic is left for a follow up.

The repo does not build and errors + lints are expected for the moment.

### Testing
- Testing deferred until repo builds