### PR TITLE
state: replication: Remove raft nodes when their analogous peer expires

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,6 +24,11 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// async context
 pub type AsyncShared<T> = Arc<TokioRwLock<T>>;
 
+/// Wrap an abstract value in a shared lock
+pub fn new_shared<T>(wrapped: T) -> Shared<T> {
+    Arc::new(RwLock::new(wrapped))
+}
+
 /// Wrap an abstract value in an async shared lock
 pub fn new_async_shared<T>(wrapped: T) -> AsyncShared<T> {
     Arc::new(TokioRwLock::new(wrapped))

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -88,9 +88,9 @@ mod test {
     fn test_node_metadata() {
         // Build the state mock manually to use the generated config
         let config = RelayerConfig::default();
-        let network = MockNetwork::new_n_way_mesh(1 /* n_nodes */).remove(0);
+        let (_controller, mut nets) = MockNetwork::new_n_way_mesh(1 /* n_nodes */);
         let bus = SystemBus::new();
-        let state = State::new_with_network(&config, network, bus).unwrap();
+        let state = State::new_with_network(&config, nets.remove(0), bus).unwrap();
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -149,8 +149,8 @@ pub mod test_helpers {
     pub fn mock_state() -> State {
         let config =
             RelayerConfig { db_path: tmp_db_path(), allow_local: true, ..Default::default() };
-        let net = MockNetwork::new_n_way_mesh(1 /* n_nodes */).remove(0);
-        let state = State::new_with_network(&config, net, SystemBus::new()).unwrap();
+        let (_controller, mut nets) = MockNetwork::new_n_way_mesh(1 /* n_nodes */);
+        let state = State::new_with_network(&config, nets.remove(0), SystemBus::new()).unwrap();
 
         // Wait for a leader election before returning
         sleep_ms(500);

--- a/state/src/replication/error.rs
+++ b/state/src/replication/error.rs
@@ -42,6 +42,12 @@ impl Display for ReplicationError {
 
 impl Error for ReplicationError {}
 
+impl From<RaftError> for ReplicationError {
+    fn from(value: RaftError) -> Self {
+        Self::Raft(value)
+    }
+}
+
 impl From<ReplicationError> for RaftError {
     fn from(value: ReplicationError) -> Self {
         match value {

--- a/state/src/replication/log_store.rs
+++ b/state/src/replication/log_store.rs
@@ -215,6 +215,7 @@ impl Storage for LogStore {
         // Read the snapshot metadata from the metadata table
         let hard_state = tx.read_hard_state()?;
         md.index = hard_state.commit;
+        md.term = hard_state.term;
 
         let stored_metadata = tx.read_snapshot_metadata()?;
         md.term = match md.index.cmp(&stored_metadata.index) {

--- a/state/src/replication/network/traits.rs
+++ b/state/src/replication/network/traits.rs
@@ -40,15 +40,31 @@ pub trait RaftNetwork {
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_helpers {
     //! Test helpers for the network abstraction
+    use common::{new_shared, Shared};
     use crossbeam::channel::{
         unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender, TryRecvError,
     };
     use raft::prelude::Message as RaftMessage;
     use std::io::{Error as IOError, ErrorKind};
 
-    use crate::replication::error::ReplicationError;
+    use crate::replication::{error::ReplicationError, RaftPeerId};
 
     use super::RaftNetwork;
+
+    /// A mock controller for the network, allowing us to simulate network
+    /// interference
+    pub struct MockNetworkController {
+        /// A list of disconnected one way connections
+        disconnects: Shared<Vec<(RaftPeerId, RaftPeerId)>>,
+    }
+
+    impl MockNetworkController {
+        /// Sever the connection between two peers unidirectionally
+        pub fn disconnect(&self, from: RaftPeerId, to: RaftPeerId) {
+            let key = (from, to);
+            self.disconnects.write().unwrap().push(key);
+        }
+    }
 
     /// A mock network that is brokered by `N` channels
     ///
@@ -59,11 +75,17 @@ pub mod test_helpers {
         senders: Vec<CrossbeamSender<RaftMessage>>,
         /// The owner's receiver channel                                    
         receiver: CrossbeamReceiver<RaftMessage>,
+        /// A shared list of severed connections for testing failures
+        ///
+        /// This is a list of tuples, where each tuple represents a
+        /// unidirectionally severed point-to-point connection
+        disconnects: Shared<Vec<(RaftPeerId, RaftPeerId)>>,
     }
 
     impl MockNetwork {
         /// Constructor, returns a handle to the network mesh for each node
-        pub fn new_n_way_mesh(n_nodes: usize) -> Vec<Self> {
+        pub fn new_n_way_mesh(n_nodes: usize) -> (MockNetworkController, Vec<Self>) {
+            let disconnects = new_shared(Vec::new());
             let mut senders = Vec::with_capacity(n_nodes);
             let mut receivers = Vec::with_capacity(n_nodes);
 
@@ -73,14 +95,23 @@ pub mod test_helpers {
                 receivers.push(r);
             }
 
-            receivers.into_iter().map(|r| Self { senders: senders.clone(), receiver: r }).collect()
+            let endpoints = receivers
+                .into_iter()
+                .map(|r| Self {
+                    senders: senders.clone(),
+                    receiver: r,
+                    disconnects: disconnects.clone(),
+                })
+                .collect();
+
+            (MockNetworkController { disconnects }, endpoints)
         }
 
         /// Create a double sided mock connection
         #[allow(dead_code)]
-        pub fn new_duplex_conn() -> (Self, Self) {
-            let mut res = Self::new_n_way_mesh(2 /* n_nodes */);
-            (res.remove(0), res.remove(0))
+        pub fn new_duplex_conn() -> (MockNetworkController, Self, Self) {
+            let (controller, mut res) = Self::new_n_way_mesh(2 /* n_nodes */);
+            (controller, res.remove(0), res.remove(0))
         }
     }
 
@@ -88,6 +119,22 @@ pub mod test_helpers {
         type Error = ReplicationError;
 
         fn send(&mut self, message: RaftMessage) -> Result<(), Self::Error> {
+            // Check for a disconnect
+            let (to, from) = (message.to, message.from);
+            let disconnects = self.disconnects.read().unwrap();
+            if disconnects.contains(&(from, to)) {
+                return Err(ReplicationError::SendMessage(IOError::new(
+                    ErrorKind::ConnectionRefused,
+                    "Connection severed",
+                )));
+            }
+
+            // If the reverse path is disconnected, don't fail just do nothing
+            if disconnects.contains(&(to, from)) {
+                return Ok(());
+            }
+            drop(disconnects); // Unlock
+
             let recipient = (message.to - 1) as usize;
             self.senders[recipient]
                 .send(message)


### PR DESCRIPTION
### Purpose
This PR implements automatic peer removal in the state replication layer when the heartbeat sub-protocol determines a peer has failed.

In the standard case this is done through the normal consensus mechanism, wherein quorum is formed over a `StateTransition::RemoveRaftPeer` log entry. In the case that the cluster is of size two and one node dies, quorum cannot be established on such a log. Instead, we have to manually add a log entry to ensure that the raft may continue being available. This is a slight hack -- and certainly breaks raft semantics -- but allows us to be available in the case that only one node remains.

### Testing
- Unit tests pass
- Unit and ad-hoc tested node failure and removal from the raft. Specifically tested raft availability after this event by producing state updates.