### PR TITLE
constants: Update testnet block number

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -74,7 +74,7 @@ pub const MAINNET_CONTRACT_DEPLOYMENT_BLOCK: u64 = 0;
 pub const DEVNET_DEPLOY_BLOCK: u64 = 0;
 
 /// The block number at which the darkpool was deployed on testnet
-pub const TESTNET_DEPLOY_BLOCK: u64 = 604069;
+pub const TESTNET_DEPLOY_BLOCK: u64 = 0;
 
 // ----------------------
 // | Pubsub Topic Names |


### PR DESCRIPTION
This PR fixes the value of the block number that the darkpool contract is deployed to on testnet.