### PR TITLE
task-driver: Refactor task traits to allow task queue impl

### DIFF
--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -20,7 +20,7 @@ use crate::{
 /// sacrifice one bit of precision to ensure that the difference in prices is
 /// divisible by two
 #[circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MatchResult {
     /// The mint of the order token in the asset pair being matched
     pub quote_mint: BigUint,

--- a/common/src/types/handshake.rs
+++ b/common/src/types/handshake.rs
@@ -3,13 +3,14 @@
 use circuit_types::fixed_point::FixedPoint;
 use constants::Scalar;
 use crossbeam::channel::Sender;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::wallet::OrderIdentifier;
 
 /// The role in an MPC network setup; either Dialer or Listener depending on
 /// which node initiates the connection
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ConnectionRole {
     /// Dials the peer, initiating the connection
     /// The dialer also plays the role of the king in the subsequent MPC
@@ -31,7 +32,7 @@ impl ConnectionRole {
 }
 
 /// The state of a given handshake execution
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HandshakeState {
     /// The request identifier of the handshake, used to uniquely identify a
     /// handshake correspondence between peers
@@ -52,11 +53,12 @@ pub struct HandshakeState {
     /// The current state information of the
     pub state: State,
     /// The cancel channel that the coordinator may use to cancel MPC execution
+    #[serde(skip)]
     pub cancel_channel: Option<Sender<()>>,
 }
 
 /// A state enumeration for the valid states a handshake may take
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum State {
     /// The state entered into when order pair negotiation beings, i.e. the
     /// initial state This state is exited when either:

--- a/task-driver/src/lib.rs
+++ b/task-driver/src/lib.rs
@@ -20,5 +20,6 @@ mod helpers;
 pub mod lookup_wallet;
 pub mod settle_match;
 pub mod settle_match_internal;
+pub mod traits;
 pub mod update_merkle_proof;
 pub mod update_wallet;

--- a/task-driver/src/traits.rs
+++ b/task-driver/src/traits.rs
@@ -1,0 +1,102 @@
+//! Defines traits that tasks must implement to be driven by the task driver and
+//! queued by the consensus engine
+use std::fmt::{Debug, Display};
+
+use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
+use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use serde::{Deserialize, Serialize};
+use state::State;
+
+use crate::driver::StateWrapper;
+
+// ------------------
+// | Task and State |
+// ------------------
+
+/// The task trait defines a sequence of largely async flows, each of which is
+/// possibly unreliable and may need to be retried until completion or to some
+/// retry threshold
+///
+/// The task must be constructable from a descriptor, which is a serializable
+/// description of the task's state transition, and a set of dependency
+/// injections from the task driver that may include: network manager queue,
+/// arbitrum client, etc.
+#[async_trait]
+pub trait Task: Send + Sized {
+    /// The descriptor of a task, this may be used to construct the task
+    ///
+    /// The descriptor must be serializable so that it can be placed into the
+    /// task queue and managed by the consensus engine
+    type Descriptor: Debug + Serialize + for<'de> Deserialize<'de>;
+    /// The state type of the task, used for task introspection
+    ///
+    /// The state must be orderable so that a commit point can be defined and
+    /// measured against
+    type State: TaskState;
+    /// The error type that the task may give
+    type Error: TaskError;
+
+    /// A constructor for the task that takes a descriptor and a set of
+    /// dependency injections
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error>;
+    /// Get the current state of the task
+    fn state(&self) -> Self::State;
+    /// Whether or not the task is completed
+    fn completed(&self) -> bool {
+        self.state().completed()
+    }
+    /// Get a displayable name for the task
+    fn name(&self) -> String;
+    /// Take a step in the task, steps should represent largely async behavior
+    async fn step(&mut self) -> Result<(), Self::Error>;
+    /// A cleanup step that is run in the event of a task failure
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// The state of a task
+///
+/// Must implement methods determining whether a task has completed or committed
+pub trait TaskState: Debug + Display + Ord + Send + Serialize + Into<StateWrapper> {
+    /// Whether or not the task is completed
+    fn completed(&self) -> bool;
+    /// The state in which the task may be considered (at least partially)
+    /// committed
+    ///
+    /// Beyond this point the task may not be preempted
+    fn commit_point() -> Self;
+    /// Whether or not the task is committed
+    fn committed(&self) -> bool {
+        *self >= Self::commit_point()
+    }
+}
+
+/// The error type of a task
+/// Must implement a method to determine if an error is retryable or permanent
+pub trait TaskError: Debug + Display + Send {
+    /// Whether or not the error is retryable
+    fn retryable(&self) -> bool;
+}
+
+// ------------------------------
+// | Dependency Injection Types |
+// ------------------------------
+
+/// The context given to a task by the driver in its constructor
+///
+/// This allows the task to be serializable into the consensus-maintained queue
+/// by injecting non-serializable dependencies into the task's constructor via
+/// the driver
+#[derive(Clone)]
+pub struct TaskContext {
+    /// An arbitrum client
+    pub arbitrum_client: ArbitrumClient,
+    /// A handle on the global state
+    pub state: State,
+    /// A sender to the network manager's queue
+    pub network_queue: NetworkManagerQueue,
+    /// A sender to the proof manager's queue
+    pub proof_queue: ProofManagerQueue,
+}


### PR DESCRIPTION
### Purpose
This PR refactors the traits on the `task-driver`'s task definitions to build a task queue on top of. Specifically, each task now has:
- A `TaskState`: this type in particular realizes the notion of a commit point in each task. After the commit point has been crossed the task cannot be preempted by a match -- it has modified contract state.
- A `TaskError`: this type segments the error types returned by the task into retryable and fatal, allowing the driver to avoid repeating fallible steps
- A `TaskDescriptor`: this type minimally parameterizes the task and must be serializable. The consensus engine will write the descriptor to storage in the form of a task queue. When a task starts up the `task-driver` will inject the `TaskDescriptor` and a `TaskContext` into the task's constructor. The `TaskContext` encodes non-serializable task information: network queues, proof queues, arbitrum client, etc.

### Todo
- Modify the driver to use the new task errors, states, and work with the queue
- Validate that the commit points are correctly adhered to in the task implementations
- Define the storage and consensus layer on top of the descriptors