### PR TITLE
state: tx: task-queue: Add task queue access methods

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -5,6 +5,7 @@ pub mod handshake;
 pub mod merkle;
 pub mod network_order;
 pub mod proof_bundles;
+pub mod task_descriptors;
 pub mod tasks;
 pub mod token;
 pub mod wallet;

--- a/common/src/types/task_descriptors.rs
+++ b/common/src/types/task_descriptors.rs
@@ -1,0 +1,92 @@
+//! Descriptor types for various tasks, refactored here to avoid cyclic
+//! dependencies
+
+use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult, transfers::ExternalTransfer};
+use constants::Scalar;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    handshake::HandshakeState,
+    proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
+    wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
+};
+
+/// The task descriptor containing only the parameterization of the task
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewWalletTaskDescriptor {
+    /// The wallet to create
+    pub wallet: Wallet,
+}
+
+/// The task descriptor containing only the parameterization of the task
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LookupWalletTaskDescriptor {
+    /// The ID to provision for the wallet
+    pub wallet_id: WalletIdentifier,
+    /// The CSPRNG seed for the blinder stream
+    pub blinder_seed: Scalar,
+    /// The CSPRNG seed for the secret share stream
+    pub secret_share_seed: Scalar,
+    /// The keychain to manage the wallet with
+    pub key_chain: KeyChain,
+}
+
+/// The descriptor for the task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SettleMatchInternalTaskDescriptor {
+    /// The price at which the match was executed
+    pub execution_price: FixedPoint,
+    /// The identifier of the first order
+    pub order_id1: OrderIdentifier,
+    /// The identifier of the second order
+    pub order_id2: OrderIdentifier,
+    /// The validity proofs for the first order
+    pub order1_proof: OrderValidityProofBundle,
+    /// The validity proof witness for the first order
+    pub order1_validity_witness: OrderValidityWitnessBundle,
+    /// The validity proofs for the second order
+    pub order2_proof: OrderValidityProofBundle,
+    /// The validity proof witness for the second order
+    pub order2_validity_witness: OrderValidityWitnessBundle,
+    /// The match result
+    pub match_result: MatchResult,
+}
+
+/// The task descriptor containing only the parameterization of the task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SettleMatchTaskDescriptor {
+    /// The ID of the wallet that the local node matched an order from
+    pub wallet_id: WalletIdentifier,
+    /// The state entry from the handshake manager that parameterizes the
+    /// match process
+    pub handshake_state: HandshakeState,
+    /// The proof that comes from the collaborative match-settle process
+    pub match_bundle: MatchBundle,
+    /// The validity proofs submitted by the first party
+    pub party0_validity_proof: OrderValidityProofBundle,
+    /// The validity proofs submitted by the second party
+    pub party1_validity_proof: OrderValidityProofBundle,
+}
+
+/// The task descriptor, containing only the parameterization of the task
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateMerkleProofTaskDescriptor {
+    /// The wallet to update
+    pub wallet: Wallet,
+}
+
+/// The task descriptor, containing only the parameterization of the task
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateWalletTaskDescriptor {
+    /// The timestamp at which the task was initiated, used to timestamp orders
+    pub timestamp_received: u64,
+    /// The external transfer, if one exists
+    pub external_transfer: Option<ExternalTransfer>,
+    /// The old wallet before update
+    pub old_wallet: Wallet,
+    /// The new wallet after update
+    pub new_wallet: Wallet,
+    /// A signature of the `VALID WALLET UPDATE` statement by the wallet's root
+    /// key, the contract uses this to authorize the update
+    pub wallet_update_signature: Vec<u8>,
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -54,6 +54,9 @@ pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";
 /// The name of the db table that stores wallet information
 pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
+/// The name of the db table that stores task queues
+pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
+
 // ------------
 // | Proposal |
 // ------------

--- a/task-driver/src/create_new_wallet.rs
+++ b/task-driver/src/create_new_wallet.rs
@@ -20,9 +20,10 @@ use circuits::zk_circuits::valid_wallet_create::{
     SizedValidWalletCreateStatement, SizedValidWalletCreateWitness, ValidWalletCreateStatement,
     ValidWalletCreateWitness,
 };
+use common::types::task_descriptors::NewWalletTaskDescriptor;
 use common::types::{proof_bundles::ValidWalletCreateBundle, wallet::Wallet};
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::error::StateError;
 use state::State;
 
@@ -145,13 +146,6 @@ impl From<StateError> for NewWalletTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The task descriptor containing only the parameterization of the task
-#[derive(Debug, Serialize, Deserialize)]
-pub struct NewWalletTaskDescriptor {
-    /// The wallet to create
-    pub wallet: Wallet,
-}
 
 /// The task itself, containing the state, context, descriptor, etc
 pub struct NewWalletTask {

--- a/task-driver/src/lookup_wallet.rs
+++ b/task-driver/src/lookup_wallet.rs
@@ -9,12 +9,15 @@ use std::{
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
 use circuit_types::{traits::BaseType, SizedWalletShare};
-use common::types::wallet::{KeyChain, Wallet, WalletIdentifier, WalletMetadata};
+use common::types::{
+    task_descriptors::LookupWalletTaskDescriptor,
+    wallet::{KeyChain, Wallet, WalletIdentifier, WalletMetadata},
+};
 use constants::Scalar;
 use itertools::Itertools;
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
 use renegade_crypto::hash::PoseidonCSPRNG;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::{error::StateError, State};
 use tracing::log;
 use uuid::Uuid;
@@ -115,19 +118,6 @@ impl From<StateError> for LookupWalletTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The task descriptor containing only the parameterization of the task
-#[derive(Debug, Serialize, Deserialize)]
-pub struct LookupWalletTaskDescriptor {
-    /// The ID to provision for the wallet
-    pub wallet_id: WalletIdentifier,
-    /// The CSPRNG seed for the blinder stream
-    pub blinder_seed: Scalar,
-    /// The CSPRNG seed for the secret share stream
-    pub secret_share_seed: Scalar,
-    /// The keychain to manage the wallet with
-    pub key_chain: KeyChain,
-}
 
 /// Represents a task to lookup a wallet in contract storage
 pub struct LookupWalletTask {

--- a/task-driver/src/settle_match.rs
+++ b/task-driver/src/settle_match.rs
@@ -16,13 +16,14 @@ use ark_mpc::PARTY0;
 use async_trait::async_trait;
 use circuit_types::SizedWalletShare;
 use common::types::proof_bundles::MatchBundle;
+use common::types::task_descriptors::SettleMatchTaskDescriptor;
 use common::types::wallet::Wallet;
 use common::types::{
     handshake::HandshakeState, proof_bundles::OrderValidityProofBundle, wallet::WalletIdentifier,
 };
 use job_types::network_manager::NetworkManagerQueue;
 use job_types::proof_manager::ProofManagerQueue;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::error::StateError;
 use state::State;
 
@@ -138,22 +139,6 @@ impl From<StateError> for SettleMatchTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The task descriptor containing only the parameterization of the task
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SettleMatchTaskDescriptor {
-    /// The ID of the wallet that the local node matched an order from
-    pub wallet_id: WalletIdentifier,
-    /// The state entry from the handshake manager that parameterizes the
-    /// match process
-    pub handshake_state: HandshakeState,
-    /// The proof that comes from the collaborative match-settle process
-    pub match_bundle: MatchBundle,
-    /// The validity proofs submitted by the first party
-    pub party0_validity_proof: OrderValidityProofBundle,
-    /// The validity proofs submitted by the second party
-    pub party1_validity_proof: OrderValidityProofBundle,
-}
 
 /// Describes the settle task
 pub struct SettleMatchTask {

--- a/task-driver/src/settle_match_internal.rs
+++ b/task-driver/src/settle_match_internal.rs
@@ -16,6 +16,7 @@ use circuits::zk_circuits::valid_match_settle::{
     SizedValidMatchSettleStatement, SizedValidMatchSettleWitness,
 };
 use common::types::proof_bundles::{MatchBundle, ProofBundle, ValidMatchSettleBundle};
+use common::types::task_descriptors::SettleMatchInternalTaskDescriptor;
 use common::types::wallet::WalletIdentifier;
 use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
@@ -23,7 +24,7 @@ use common::types::{
 };
 use job_types::network_manager::NetworkManagerQueue;
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::error::StateError;
 use state::State;
 use tokio::task::JoinHandle as TokioJoinHandle;
@@ -127,27 +128,6 @@ impl From<StateError> for SettleMatchInternalTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The descriptor for the task
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SettleMatchInternalTaskDescriptor {
-    /// The price at which the match was executed
-    execution_price: FixedPoint,
-    /// The identifier of the first order
-    order_id1: OrderIdentifier,
-    /// The identifier of the second order
-    order_id2: OrderIdentifier,
-    /// The validity proofs for the first order
-    order1_proof: OrderValidityProofBundle,
-    /// The validity proof witness for the first order
-    order1_validity_witness: OrderValidityWitnessBundle,
-    /// The validity proofs for the second order
-    order2_proof: OrderValidityProofBundle,
-    /// The validity proof witness for the second order
-    order2_validity_witness: OrderValidityWitnessBundle,
-    /// The match result
-    match_result: MatchResult,
-}
 
 /// Describe the settle match internal task
 pub struct SettleMatchInternalTask {

--- a/task-driver/src/update_merkle_proof.rs
+++ b/task-driver/src/update_merkle_proof.rs
@@ -9,9 +9,9 @@ use std::{
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use common::types::wallet::Wallet;
+use common::types::{task_descriptors::UpdateMerkleProofTaskDescriptor, wallet::Wallet};
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::{error::StateError, State};
 
 use crate::{
@@ -121,13 +121,6 @@ impl From<StateError> for UpdateMerkleProofTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The task descriptor, containing only the parameterization of the task
-#[derive(Debug, Serialize, Deserialize)]
-pub struct UpdateMerkleProofTaskDescriptor {
-    /// The wallet to update
-    pub wallet: Wallet,
-}
 
 /// Defines the long running flow for updating the Merkle opening for a wallet
 pub struct UpdateMerkleProofTask {

--- a/task-driver/src/update_wallet.rs
+++ b/task-driver/src/update_wallet.rs
@@ -15,10 +15,11 @@ use circuit_types::{
 use circuits::zk_circuits::valid_wallet_update::{
     SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
 };
+use common::types::task_descriptors::UpdateWalletTaskDescriptor;
 use common::types::{proof_bundles::ValidWalletUpdateBundle, wallet::Wallet};
 use job_types::network_manager::NetworkManagerQueue;
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use state::error::StateError;
 use state::State;
 
@@ -146,22 +147,6 @@ impl From<StateError> for UpdateWalletTaskError {
 // -------------------
 // | Task Definition |
 // -------------------
-
-/// The task descriptor, containing only the parameterization of the task
-#[derive(Debug, Serialize, Deserialize)]
-pub struct UpdateWalletTaskDescriptor {
-    /// The timestamp at which the task was initiated, used to timestamp orders
-    pub timestamp_received: u64,
-    /// The external transfer, if one exists
-    pub external_transfer: Option<ExternalTransfer>,
-    /// The old wallet before update
-    pub old_wallet: Wallet,
-    /// The new wallet after update
-    pub new_wallet: Wallet,
-    /// A signature of the `VALID WALLET UPDATE` statement by the wallet's root
-    /// key, the contract uses this to authorize the update
-    pub wallet_update_signature: Vec<u8>,
-}
 
 /// Defines the long running flow for updating a wallet
 pub struct UpdateWalletTask {


### PR DESCRIPTION
### Purpose
This PR implements the storage access primitives for the task queue. This includes `append`, `pop`, and `change_state`. Further layers will build on this to change the state of tasks in the queue as the raft logs controlling the queue are committed.

### Testing
- Unit tests pass