### PR TITLE
state: applicator: task-queue: Add `PopWalletTask` transition + impl

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -69,6 +69,7 @@ impl StateApplicator {
             StateTransition::AppendWalletTask { wallet_id, task } => {
                 self.append_wallet_task(wallet_id, task)
             },
+            StateTransition::PopWalletTask { wallet_id } => self.pop_wallet_task(wallet_id),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
     }

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -17,7 +17,7 @@ impl StateApplicator {
     // | State Transitions |
     // ---------------------
 
-    /// Apply a `AppendWalletTask` state transition
+    /// Apply an `AppendWalletTask` state transition
     pub fn append_wallet_task(
         &self,
         wallet_id: WalletIdentifier,
@@ -34,6 +34,23 @@ impl StateApplicator {
         }
 
         tx.add_wallet_task(&wallet_id, &task)?;
+        Ok(tx.commit()?)
+    }
+
+    /// Apply a `PopWalletTask` state transition
+    pub fn pop_wallet_task(&self, wallet_id: WalletIdentifier) -> Result<()> {
+        let tx = self.db().new_write_tx()?;
+
+        // Pop the task from the queue
+        tx.pop_wallet_task(&wallet_id)?;
+
+        // If the queue is non-empty, start the next task
+        let tasks = tx.get_wallet_tasks(&wallet_id)?;
+        if let Some(task) = tasks.first() {
+            tx.transition_wallet_task(&wallet_id, QueuedTaskState::Running)?;
+            self.maybe_start_task(task, &tx)?;
+        }
+
         Ok(tx.commit()?)
     }
 
@@ -68,7 +85,30 @@ mod test {
     };
     use job_types::task_driver::{new_task_driver_queue, TaskDriverJob};
 
-    use crate::applicator::test_helpers::mock_applicator_with_task_queue;
+    use crate::{applicator::test_helpers::mock_applicator_with_task_queue, storage::db::DB};
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Set the local peer ID
+    fn set_local_peer_id(peer_id: &WrappedPeerId, db: &DB) {
+        let tx = db.new_write_tx().unwrap();
+        tx.set_peer_id(peer_id).unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// Add a dummy task to the given wallet's queue
+    fn enqueue_dummy_task(wallet_id: &WalletIdentifier, db: &DB) {
+        let task = mock_queued_task();
+        let tx = db.new_write_tx().unwrap();
+        tx.add_wallet_task(wallet_id, &task).unwrap();
+        tx.commit().unwrap();
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
 
     /// Tests appending a task to an empty queue
     #[test]
@@ -78,9 +118,7 @@ mod test {
 
         // Set the local peer ID
         let peer_id = mock_peer().peer_id;
-        let tx = applicator.db().new_write_tx().unwrap();
-        tx.set_peer_id(&peer_id).unwrap();
-        tx.commit().unwrap();
+        set_local_peer_id(&peer_id, applicator.db());
 
         let wallet_id = WalletIdentifier::new_v4();
         let mut task = mock_queued_task();
@@ -101,11 +139,9 @@ mod test {
         // Check the task was started
         assert!(!task_recv.is_empty());
         let task = task_recv.recv().unwrap();
-        if let TaskDriverJob::Run(ref queued_task) = task {
-            assert_eq!(queued_task.id, task_id);
-        } else {
-            panic!("Expected a TaskDriverJob::Run variant");
-        }
+
+        let TaskDriverJob::Run(queued_task) = task;
+        assert_eq!(queued_task.id, task_id);
     }
 
     /// Test appending to an empty queue when the local peer is not the executor
@@ -116,9 +152,7 @@ mod test {
 
         // Set the local peer ID
         let peer_id = mock_peer().peer_id;
-        let tx = applicator.db().new_write_tx().unwrap();
-        tx.set_peer_id(&peer_id).unwrap();
-        tx.commit().unwrap();
+        set_local_peer_id(&peer_id, applicator.db());
 
         let wallet_id = WalletIdentifier::new_v4();
         let mut task = mock_queued_task();
@@ -143,17 +177,12 @@ mod test {
 
         // Set the local peer ID
         let peer_id = mock_peer().peer_id;
-        let tx = applicator.db().new_write_tx().unwrap();
-        tx.set_peer_id(&peer_id).unwrap();
-        tx.commit().unwrap();
+        set_local_peer_id(&peer_id, applicator.db());
 
         let wallet_id = WalletIdentifier::new_v4();
 
         // Add a task directly via the db
-        let task1 = mock_queued_task();
-        let tx = applicator.db().new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task1).unwrap();
-        tx.commit().unwrap();
+        enqueue_dummy_task(&wallet_id, applicator.db());
 
         // Add another task via the applicator
         let mut task2 = mock_queued_task();
@@ -171,5 +200,109 @@ mod test {
 
         // Ensure that the task queue is empty (no task is marked as running)
         assert!(task_recv.is_empty());
+    }
+
+    /// Test popping from a task queue of length one
+    #[test]
+    fn test_pop_singleton_queue() {
+        let (task_queue, task_recv) = new_task_driver_queue();
+        let applicator = mock_applicator_with_task_queue(task_queue);
+
+        // Set the local peer ID
+        let peer_id = mock_peer().peer_id;
+        set_local_peer_id(&peer_id, applicator.db());
+
+        let wallet_id = WalletIdentifier::new_v4();
+        enqueue_dummy_task(&wallet_id, applicator.db());
+
+        applicator.pop_wallet_task(wallet_id).expect("Failed to pop task");
+
+        // Ensure the task was removed from the queue
+        let tx = applicator.db().new_read_tx().unwrap();
+        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(tasks.len(), 0);
+
+        // Ensure no task was started
+        assert!(task_recv.is_empty());
+    }
+
+    /// Tests popping from a queue of length two in which the local peer is not
+    /// the executor of the next task
+    #[test]
+    fn test_pop_non_executor() {
+        let (task_queue, task_recv) = new_task_driver_queue();
+        let applicator = mock_applicator_with_task_queue(task_queue);
+
+        // Set the local peer ID
+        let peer_id = mock_peer().peer_id;
+        set_local_peer_id(&peer_id, applicator.db());
+
+        let wallet_id = WalletIdentifier::new_v4();
+
+        // Add a task directly via the db
+        enqueue_dummy_task(&wallet_id, applicator.db());
+
+        // Add another task via the applicator
+        let mut task2 = mock_queued_task();
+        task2.executor = WrappedPeerId::random(); // Assign a different executor
+        applicator.append_wallet_task(wallet_id, task2.clone()).unwrap();
+
+        // Pop the first task
+        applicator.pop_wallet_task(wallet_id).unwrap();
+
+        // Ensure the first task was removed from the queue
+        let tx = applicator.db().new_read_tx().unwrap();
+        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, task2.id);
+        assert_eq!(tasks[0].state, QueuedTaskState::Running); // should be started
+
+        // Ensure no task was started
+        assert!(task_recv.is_empty());
+    }
+
+    /// Tests popping from a queue of length two in which the local peer is the
+    /// executor of the next task
+    #[test]
+    fn test_pop_executor() {
+        let (task_queue, task_recv) = new_task_driver_queue();
+        let applicator = mock_applicator_with_task_queue(task_queue);
+
+        // Set the local peer ID
+        let peer_id = mock_peer().peer_id;
+        set_local_peer_id(&peer_id, applicator.db());
+
+        let wallet_id = WalletIdentifier::new_v4();
+
+        // Add a task directly via the db
+        enqueue_dummy_task(&wallet_id, applicator.db());
+
+        // Add another task via the applicator
+        let mut task2 = mock_queued_task();
+        task2.executor = peer_id; // Assign the local executor
+        applicator.append_wallet_task(wallet_id, task2.clone()).unwrap();
+
+        // Pop the first task
+        applicator.pop_wallet_task(wallet_id).unwrap();
+
+        // Ensure the first task was removed from the queue
+        let tx = applicator.db().new_read_tx().unwrap();
+        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, task2.id);
+        assert_eq!(tasks[0].state, QueuedTaskState::Running); // should be started
+
+        // Ensure the second task was started
+        assert!(!task_recv.is_empty());
+        let task = task_recv.recv().unwrap();
+
+        let TaskDriverJob::Run(queued_task) = task;
+        assert_eq!(queued_task.id, task2.id);
     }
 }

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -7,6 +7,7 @@ pub mod notifications;
 pub mod order_book;
 pub mod peer_index;
 pub mod raft;
+pub mod task_queue;
 pub mod wallet_index;
 
 use std::{

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -1,0 +1,142 @@
+//! The interface for interacting with the task queue
+
+use common::types::{
+    task_descriptors::{QueuedTask, QueuedTaskState, TaskDescriptor},
+    tasks::TaskIdentifier,
+    wallet::WalletIdentifier,
+};
+
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
+
+impl State {
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Get the length of the task queue for a wallet
+    pub fn get_wallet_task_queue_len(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<usize, StateError> {
+        self.get_wallet_tasks(wallet_id).map(|tasks| tasks.len())
+    }
+
+    /// Get the list of tasks for a wallet
+    pub fn get_wallet_tasks(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<Vec<QueuedTask>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let tasks = tx.get_wallet_tasks(wallet_id)?;
+        tx.commit()?;
+
+        Ok(tasks)
+    }
+
+    /// Get a task by ID and wallet
+    pub fn get_wallet_task_by_id(
+        &self,
+        wallet_id: &WalletIdentifier,
+        task_id: &TaskIdentifier,
+    ) -> Result<Option<QueuedTask>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let task = tx.get_wallet_task_by_id(wallet_id, task_id)?;
+        tx.commit()?;
+
+        Ok(task)
+    }
+
+    // -----------
+    // | Setters |
+    // -----------
+
+    /// Append a wallet task to the queue
+    pub fn append_wallet_task(
+        &self,
+        wallet_id: &WalletIdentifier,
+        task: TaskDescriptor,
+    ) -> Result<(TaskIdentifier, ProposalWaiter), StateError> {
+        // Pick a task ID and create a task from the description
+        let id = TaskIdentifier::new_v4();
+        let self_id = self.get_peer_id()?;
+        let task =
+            QueuedTask { id, state: QueuedTaskState::Queued, executor: self_id, descriptor: task };
+
+        // Propose the task to the task queue
+        let waiter =
+            self.send_proposal(StateTransition::AppendWalletTask { wallet_id: *wallet_id, task })?;
+        Ok((id, waiter))
+    }
+
+    /// Pop a wallet task from the queue
+    pub fn pop_wallet_task(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<ProposalWaiter, StateError> {
+        // Propose the task to the task queue
+        self.send_proposal(StateTransition::PopWalletTask { wallet_id: *wallet_id })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use common::types::{
+        task_descriptors::{mocks::mock_queued_task, QueuedTaskState},
+        wallet::WalletIdentifier,
+    };
+
+    use crate::test_helpers::mock_state;
+
+    /// Tests getter methods on an empty queue
+    #[test]
+    fn test_empty_queue() {
+        let state = mock_state();
+
+        let wallet_id = WalletIdentifier::new_v4();
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 0);
+        assert!(state.get_wallet_tasks(&wallet_id).unwrap().is_empty());
+    }
+
+    /// Tests appending to an empty queue
+    #[tokio::test]
+    async fn test_append() {
+        let state = mock_state();
+
+        // Propose a task to the queue
+        let wallet_id = WalletIdentifier::new_v4();
+        let task = mock_queued_task().descriptor;
+
+        let (task_id, waiter) = state.append_wallet_task(&wallet_id, task).unwrap();
+        waiter.await.unwrap();
+
+        // Check that the task was added
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 1);
+
+        let tasks = state.get_wallet_tasks(&wallet_id).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, task_id);
+        assert_eq!(tasks[0].state, QueuedTaskState::Running); // Should be started
+
+        assert!(state.get_wallet_task_by_id(&wallet_id, &task_id).unwrap().is_some());
+    }
+
+    /// Tests popping from a queue
+    #[tokio::test]
+    async fn test_pop() {
+        let state = mock_state();
+
+        // Propose a task to the queue
+        let wallet_id = WalletIdentifier::new_v4();
+        let task = mock_queued_task().descriptor;
+
+        let (_task_id, waiter) = state.append_wallet_task(&wallet_id, task).unwrap();
+        waiter.await.unwrap();
+
+        // Pop the task from the queue
+        let waiter = state.pop_wallet_task(&wallet_id).unwrap();
+        waiter.await.unwrap();
+
+        // Check that the task was removed
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 0);
+    }
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -88,6 +88,8 @@ pub enum StateTransition {
     // --- Task Queue --- //
     /// Add a task to the task queue
     AppendWalletTask { wallet_id: WalletIdentifier, task: QueuedTask },
+    /// Pop the top task from the task queue
+    PopWalletTask { wallet_id: WalletIdentifier },
 
     // --- Raft --- //
     /// Add a raft learner to the cluster


### PR DESCRIPTION
### Purpose
This PR adds a `PopWalletTask` state transition that removes the top task from the wallet's task queue. If the queue is non-empty the next task will start running on its executor node.

### Testing
- Unit tests pass