### PR TITLE
add upgrade Github Action

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,91 @@
+on:
+  push:
+    branches:
+      - 'staging'
+      - 'testnet'
+      - 'mainnet'
+
+name: Upgrade Relayer Clusters
+
+jobs:
+  build-and-push-ecr:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ fromJson(steps.docker-build-push.outputs.metadata)['image.name'] }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: docker-build-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/release/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  setup-cluster-names:
+    runs-on: ubuntu-latest
+    outputs:
+      cluster_names: ${{ steps.gen-cluster-names.outputs.cluster_names }}
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - id: gen-cluster-names
+        run: |
+          names=$(python -c "import json; print(json.dumps([ \"${{ github.ref_name }}-cluster\" + str(i) for i in range(${{ vars.NUM_CLUSTERS }})]))")
+          echo "cluster_names={ \"cluster\": $names }" >> $GITHUB_OUTPUT
+
+  upgrade-relayer-clusters:
+    runs-on: ubuntu-latest
+    needs: [build-and-push-ecr, setup-cluster-names]
+    strategy:
+      matrix: ${{fromJson(needs.setup-cluster-names.outputs.cluster_names)}}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Get the existing task definitions
+        id: fetch-task-def
+        run: |
+          aws ecs describe-task-definition --task-definition "${{ matrix.cluster }}-task-def" --query 'taskDefinition' > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: update-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: relayer-node
+          image: ${{ needs.build-and-push-ecr.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.update-task-def.outputs.task-definition }}
+          service: ${{ matrix.cluster }}-service
+          cluster: ${{ matrix.cluster }}
+          wait-for-service-stability: true

--- a/bin/release.zsh
+++ b/bin/release.zsh
@@ -1,8 +1,8 @@
 set -e
 
-# Check if the first argument is either "staging" or "production"
-if [[ $1 != "staging" && $1 != "production" ]]; then
-    echo "Error: First argument must be either 'staging' or 'production'."
+# Check if the first argument is either "staging", "testnet", or "mainnet"
+if [[ $1 != "staging" && $1 != "testnet" && $1 != "mainnet" ]]; then
+    echo "Error: First argument must be either 'staging', 'testnet', or 'mainnet'."
     exit 1
 fi
 

--- a/bin/release.zsh
+++ b/bin/release.zsh
@@ -1,9 +1,15 @@
 set -e
 
+# Check if the first argument is either "staging" or "production"
+if [[ $1 != "staging" && $1 != "production" ]]; then
+    echo "Error: First argument must be either 'staging' or 'production'."
+    exit 1
+fi
+
 # Set variables
 aws_account_id="377928551571"
 aws_region="ca-central-1"
-ecr_repository_name="renegade"
+ecr_repository_name="renegade-$1"
 image_name="renegade-relayer"
 image_tag="latest"
 
@@ -27,4 +33,4 @@ docker tag $image_name:$image_tag $aws_account_id.dkr.ecr.$aws_region.amazonaws.
 # Push the Docker image to ECR
 docker push $aws_account_id.dkr.ecr.$aws_region.amazonaws.com/$ecr_repository_name:$image_tag
 
-echo "Successfully released production build"
+echo "Successfully released $1 build"


### PR DESCRIPTION
This PR adds a Github Action for upgrading the relayer clusters in a given environment. This includes building the relayer image, pushing it to AWS ECR, updating the ECS task definition, and re-deploying the ECS service.

I tested this locally using [nektos/act](https://github.com/nektos/act), and it successfully builds/pushes/deploys.

This approach is admittedly a bit brittle for one reason: we need to exactly match the names of the AWS ECS task definition, service, and cluster, as defined in AWS. This is because none of the associated AWS ECS API endpoints support querying the resource by tag, so we can't make use of a consistent tagging scheme.

For a v1, I think this is fine. Down the line, we could write a more involved script that lists all of the {task definitions, services, clusters}, queries for each of their tags, and gets the most recent one's name / metadata. Even then, changing the tagging scheme in Terraform would require updating this Github Action, similar to how changing the naming scheme currently necessitates this.