### PR TITLE
state: interface: Add task queue getters and setters

### DIFF
--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -7,6 +7,7 @@ pub mod notifications;
 pub mod order_book;
 pub mod peer_index;
 pub mod raft;
+pub mod task_queue;
 pub mod wallet_index;
 
 use std::{

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -1,0 +1,142 @@
+//! The interface for interacting with the task queue
+
+use common::types::{
+    task_descriptors::{QueuedTask, QueuedTaskState, TaskDescriptor},
+    tasks::TaskIdentifier,
+    wallet::WalletIdentifier,
+};
+
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
+
+impl State {
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Get the length of the task queue for a wallet
+    pub fn get_wallet_task_queue_len(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<usize, StateError> {
+        self.get_wallet_tasks(wallet_id).map(|tasks| tasks.len())
+    }
+
+    /// Get the list of tasks for a wallet
+    pub fn get_wallet_tasks(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<Vec<QueuedTask>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let tasks = tx.get_wallet_tasks(wallet_id)?;
+        tx.commit()?;
+
+        Ok(tasks)
+    }
+
+    /// Get a task by ID and wallet
+    pub fn get_wallet_task_by_id(
+        &self,
+        wallet_id: &WalletIdentifier,
+        task_id: &TaskIdentifier,
+    ) -> Result<Option<QueuedTask>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let task = tx.get_wallet_task_by_id(wallet_id, task_id)?;
+        tx.commit()?;
+
+        Ok(task)
+    }
+
+    // -----------
+    // | Setters |
+    // -----------
+
+    /// Append a wallet task to the queue
+    pub fn append_wallet_task(
+        &self,
+        wallet_id: &WalletIdentifier,
+        task: TaskDescriptor,
+    ) -> Result<(TaskIdentifier, ProposalWaiter), StateError> {
+        // Pick a task ID and create a task from the description
+        let id = TaskIdentifier::new_v4();
+        let self_id = self.get_peer_id()?;
+        let task =
+            QueuedTask { id, state: QueuedTaskState::Queued, executor: self_id, descriptor: task };
+
+        // Propose the task to the task queue
+        let waiter =
+            self.send_proposal(StateTransition::AppendWalletTask { wallet_id: *wallet_id, task })?;
+        Ok((id, waiter))
+    }
+
+    /// Pop a wallet task from the queue
+    pub fn pop_wallet_task(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<ProposalWaiter, StateError> {
+        // Propose the task to the task queue
+        self.send_proposal(StateTransition::PopWalletTask { wallet_id: *wallet_id })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use common::types::{
+        task_descriptors::{mocks::mock_queued_task, QueuedTaskState},
+        wallet::WalletIdentifier,
+    };
+
+    use crate::test_helpers::mock_state;
+
+    /// Tests getter methods on an empty queue
+    #[test]
+    fn test_empty_queue() {
+        let state = mock_state();
+
+        let wallet_id = WalletIdentifier::new_v4();
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 0);
+        assert!(state.get_wallet_tasks(&wallet_id).unwrap().is_empty());
+    }
+
+    /// Tests appending to an empty queue
+    #[tokio::test]
+    async fn test_append() {
+        let state = mock_state();
+
+        // Propose a task to the queue
+        let wallet_id = WalletIdentifier::new_v4();
+        let task = mock_queued_task().descriptor;
+
+        let (task_id, waiter) = state.append_wallet_task(&wallet_id, task).unwrap();
+        waiter.await.unwrap();
+
+        // Check that the task was added
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 1);
+
+        let tasks = state.get_wallet_tasks(&wallet_id).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, task_id);
+        assert_eq!(tasks[0].state, QueuedTaskState::Running); // Should be started
+
+        assert!(state.get_wallet_task_by_id(&wallet_id, &task_id).unwrap().is_some());
+    }
+
+    /// Tests popping from a queue
+    #[tokio::test]
+    async fn test_pop() {
+        let state = mock_state();
+
+        // Propose a task to the queue
+        let wallet_id = WalletIdentifier::new_v4();
+        let task = mock_queued_task().descriptor;
+
+        let (_task_id, waiter) = state.append_wallet_task(&wallet_id, task).unwrap();
+        waiter.await.unwrap();
+
+        // Pop the task from the queue
+        let waiter = state.pop_wallet_task(&wallet_id).unwrap();
+        waiter.await.unwrap();
+
+        // Check that the task was removed
+        assert_eq!(state.get_wallet_task_queue_len(&wallet_id).unwrap(), 0);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds interface methods for the task queue. This includes appending and popping from the queue. These methods will be used by other workers to start tasks and by the task driver to mark a task as complete.

### Todo
- Update callsites to enqueue tasks
- Task preemption
- Task failover

### Testing
- Unit tests pass