### PR TITLE
ga: upgrade: use env-specific number of clusters

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -52,7 +52,17 @@ jobs:
 
       - id: gen-cluster-names
         run: |
-          names=$(python -c "import json; print(json.dumps([ \"${{ github.ref_name }}-cluster\" + str(i) for i in range(${{ vars.NUM_CLUSTERS }})]))")
+          if [[ "${{ github.ref_name }}" == "staging" ]]; then
+            NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_STAGING }}
+          elif [[ "${{ github.ref_name }}" == "testnet" ]]; then
+            NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_TESTNET }}
+          elif [[ "${{ github.ref_name }}" == "mainnet" ]]; then
+            NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_MAINNET }}
+          else
+            echo "Unsupported branch. Defaulting to 1 cluster."
+            NUM_CLUSTERS=1
+          fi
+          names=$(python -c "import json; print(json.dumps([ \"${{ github.ref_name }}-cluster\" + str(i) for i in range($NUM_CLUSTERS)]))")
           echo "cluster_names={ \"cluster\": $names }" >> $GITHUB_OUTPUT
 
   upgrade-relayer-clusters:


### PR DESCRIPTION
This PR changes the way we decide how many clusters to upgrade by using environment-specific variables as opposed to a single `NUM_CLUSTERS` variable regardless of targeting `staging`, `testnet`, or `mainnet`