### PR TITLE
workers: task-driver: Update global task queue state during task state transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7426,6 +7426,7 @@ dependencies = [
  "rand 0.8.5",
  "renegade-crypto",
  "serde",
+ "serde_json",
  "state",
  "system-bus",
  "test-helpers",

--- a/common/src/types/task_descriptors.rs
+++ b/common/src/types/task_descriptors.rs
@@ -31,11 +31,18 @@ pub struct QueuedTask {
 /// TODO: We can add completed and failed states if/when we implement a task
 /// history
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status")]
 pub enum QueuedTaskState {
     /// The task is waiting in the queue
     Queued,
     /// The task is being run
-    Running,
+    ///
+    /// The state is serialized to a string before being stored to give a better
+    /// API serialization
+    Running {
+        /// The state description of the task
+        state: String,
+    },
 }
 
 /// A wrapper around the task descriptors

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -70,6 +70,9 @@ impl StateApplicator {
                 self.append_wallet_task(wallet_id, task)
             },
             StateTransition::PopWalletTask { wallet_id } => self.pop_wallet_task(wallet_id),
+            StateTransition::TransitionWalletTask { wallet_id, state } => {
+                self.transition_task_state(wallet_id, state)
+            },
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
     }

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -33,7 +33,7 @@ impl State {
         Ok(tasks)
     }
 
-    /// Get the ID of the wallet that a task modified
+    /// Get the ID of the wallet that a task modifies
     pub fn get_task_wallet(
         &self,
         task_id: &TaskIdentifier,
@@ -167,7 +167,7 @@ mod test {
     async fn test_transition() {
         let state = mock_state();
 
-        // Propose a task to the queue
+        // Propose a new task to the queue
         let wallet_id = WalletIdentifier::new_v4();
         let task = mock_queued_task().descriptor;
 

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -17,7 +17,7 @@
 
 use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
-    task_descriptors::QueuedTask,
+    task_descriptors::{QueuedTask, QueuedTaskState},
     wallet::{OrderIdentifier, Wallet, WalletIdentifier},
 };
 use replication::{error::ReplicationError, RaftPeerId};
@@ -57,6 +57,8 @@ pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
 /// The name of the db table that stores task queues
 pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
+/// The name of the db table that maps tasks to wallet
+pub(crate) const TASK_TO_WALLET_TABLE: &str = "task-to-wallet";
 
 /// The `Proposal` type wraps a state transition and the channel on which to
 /// send the result of the proposal's application
@@ -90,6 +92,8 @@ pub enum StateTransition {
     AppendWalletTask { wallet_id: WalletIdentifier, task: QueuedTask },
     /// Pop the top task from the task queue
     PopWalletTask { wallet_id: WalletIdentifier },
+    /// Transition the state of the top task in the task queue
+    TransitionWalletTask { wallet_id: WalletIdentifier, state: QueuedTaskState },
 
     // --- Raft --- //
     /// Add a raft learner to the cluster

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 11;
+const NUM_TABLES: usize = 12;
 
 // -----------
 // | Helpers |

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -17,7 +17,7 @@ use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, Write
 
 use crate::{
     CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE, ORDER_TO_WALLET_TABLE,
-    PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, WALLETS_TABLE,
+    PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE, WALLETS_TABLE,
 };
 
 use self::raft_log::RAFT_METADATA_TABLE;
@@ -95,6 +95,7 @@ impl<'db> StateTxn<'db, RW> {
             ORDER_TO_WALLET_TABLE,
             WALLETS_TABLE,
             TASK_QUEUE_TABLE,
+            TASK_TO_WALLET_TABLE,
             NODE_METADATA_TABLE,
             RAFT_METADATA_TABLE,
         ]

--- a/state/src/storage/tx/task_queue.rs
+++ b/state/src/storage/tx/task_queue.rs
@@ -10,7 +10,7 @@ use common::types::{
 };
 use libmdbx::{TransactionKind, RW};
 
-use crate::{storage::error::StorageError, TASK_QUEUE_TABLE};
+use crate::{storage::error::StorageError, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE};
 
 use super::StateTxn;
 
@@ -36,6 +36,14 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
         self.read_queue(TASK_QUEUE_TABLE, wallet_id)
     }
 
+    /// Get the wallet that a given task is associated with
+    pub fn get_task_wallet(
+        &self,
+        task_id: &TaskIdentifier,
+    ) -> Result<Option<WalletIdentifier>, StorageError> {
+        self.inner().read(TASK_TO_WALLET_TABLE, task_id)
+    }
+
     /// Get the task for a given wallet and task id
     pub fn get_wallet_task_by_id(
         &self,
@@ -58,7 +66,10 @@ impl<'db> StateTxn<'db, RW> {
         wallet_id: &WalletIdentifier,
         task: &QueuedTask,
     ) -> Result<(), StorageError> {
-        self.push_to_queue(TASK_QUEUE_TABLE, wallet_id, task)
+        self.push_to_queue(TASK_QUEUE_TABLE, wallet_id, task)?;
+
+        // Add a mapping from the task to the wallet
+        self.inner().write(TASK_TO_WALLET_TABLE, &task.id, wallet_id)
     }
 
     /// Pop a task from the queue
@@ -66,7 +77,14 @@ impl<'db> StateTxn<'db, RW> {
         &self,
         wallet_id: &WalletIdentifier,
     ) -> Result<Option<QueuedTask>, StorageError> {
-        self.pop_from_queue(TASK_QUEUE_TABLE, wallet_id)
+        let res: Option<QueuedTask> = self.pop_from_queue(TASK_QUEUE_TABLE, wallet_id)?;
+
+        if let Some(ref task) = res {
+            // Remove the mapping from the task to the wallet
+            self.inner().delete(TASK_TO_WALLET_TABLE, &task.id)?;
+        }
+
+        Ok(res)
     }
 
     /// Transition the state of the top task in the queue
@@ -89,7 +107,7 @@ mod test {
         wallet::WalletIdentifier,
     };
 
-    use crate::{test_helpers::mock_db, TASK_QUEUE_TABLE};
+    use crate::{test_helpers::mock_db, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE};
 
     /// Tests getting the tasks for a wallet
     #[test]
@@ -168,7 +186,11 @@ mod test {
 
         // Transition the state of the task
         let tx = db.new_write_tx().unwrap();
-        tx.transition_wallet_task(&wallet_id, QueuedTaskState::Running).unwrap();
+        tx.transition_wallet_task(
+            &wallet_id,
+            QueuedTaskState::Running { state: "Running".to_string() },
+        )
+        .unwrap();
         tx.commit().unwrap();
 
         // Read the task back
@@ -176,6 +198,38 @@ mod test {
         let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
         tx.commit().unwrap();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].state, QueuedTaskState::Running);
+        assert!(matches!(tasks[0].state, QueuedTaskState::Running { .. }));
+    }
+
+    /// Test the task to wallet map
+    #[test]
+    fn test_task_to_wallet_map() {
+        // Setup the mock
+        let db = mock_db();
+        db.create_table(TASK_TO_WALLET_TABLE).unwrap();
+
+        // Add a task to the wallet
+        let wallet_id = WalletIdentifier::new_v4();
+        let task = mock_queued_task();
+        let tx = db.new_write_tx().unwrap();
+        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.commit().unwrap();
+
+        // Check the task is associated with the wallet
+        let tx = db.new_read_tx().unwrap();
+        let task_wallet = tx.get_task_wallet(&task.id).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(task_wallet, Some(wallet_id));
+
+        // Remove the task from the wallet
+        let tx = db.new_write_tx().unwrap();
+        tx.pop_wallet_task(&wallet_id).unwrap();
+        tx.commit().unwrap();
+
+        // Validate that the task is no longer associated with the wallet
+        let tx = db.new_read_tx().unwrap();
+        let task_wallet = tx.get_task_wallet(&task.id).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(task_wallet, None);
     }
 }

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -40,6 +40,7 @@ util = { path = "../../util" }
 # === Misc Dependencies === #
 itertools = "0.11"
 serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 

--- a/workers/task-driver/src/error.rs
+++ b/workers/task-driver/src/error.rs
@@ -17,6 +17,8 @@ pub enum TaskDriverError {
     JobQueueClosed,
     /// An error running a task
     TaskError(String),
+    /// An error querying global state
+    State(String),
 }
 
 impl Display for TaskDriverError {


### PR DESCRIPTION
### Purpose
This PR updates the global state's view of the task execution during state transitions in a task. This is done to allow API introspection into the task status via the `State` object.

### Todo
- Testing for the API once the task queue is fully integrated