### PR TITLE
workers: api-server: Refactor to use new task-queue abstraction

### DIFF
--- a/common/src/types/task_descriptors.rs
+++ b/common/src/types/task_descriptors.rs
@@ -75,6 +75,12 @@ pub struct NewWalletTaskDescriptor {
     pub wallet: Wallet,
 }
 
+impl From<NewWalletTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: NewWalletTaskDescriptor) -> Self {
+        TaskDescriptor::NewWallet(descriptor)
+    }
+}
+
 /// The task descriptor containing only the parameterization of the
 /// `LookupWallet` task
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -87,6 +93,12 @@ pub struct LookupWalletTaskDescriptor {
     pub secret_share_seed: Scalar,
     /// The keychain to manage the wallet with
     pub key_chain: KeyChain,
+}
+
+impl From<LookupWalletTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: LookupWalletTaskDescriptor) -> Self {
+        TaskDescriptor::LookupWallet(descriptor)
+    }
 }
 
 /// The task descriptor containing only the parameterization of the
@@ -111,6 +123,12 @@ pub struct SettleMatchInternalTaskDescriptor {
     pub match_result: MatchResult,
 }
 
+impl From<SettleMatchInternalTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: SettleMatchInternalTaskDescriptor) -> Self {
+        TaskDescriptor::SettleMatchInternal(descriptor)
+    }
+}
+
 /// The task descriptor containing only the parameterization of the
 /// `SettleMatch` task
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -128,12 +146,24 @@ pub struct SettleMatchTaskDescriptor {
     pub party1_validity_proof: OrderValidityProofBundle,
 }
 
+impl From<SettleMatchTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: SettleMatchTaskDescriptor) -> Self {
+        TaskDescriptor::SettleMatch(descriptor)
+    }
+}
+
 /// The task descriptor containing only the parameterization of the
 /// `UpdateMerkleProof` task
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UpdateMerkleProofTaskDescriptor {
     /// The wallet to update
     pub wallet: Wallet,
+}
+
+impl From<UpdateMerkleProofTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: UpdateMerkleProofTaskDescriptor) -> Self {
+        TaskDescriptor::UpdateMerkleProof(descriptor)
+    }
 }
 
 /// The task descriptor containing only the parameterization of the
@@ -151,6 +181,12 @@ pub struct UpdateWalletTaskDescriptor {
     /// A signature of the `VALID WALLET UPDATE` statement by the wallet's root
     /// key, the contract uses this to authorize the update
     pub wallet_update_signature: Vec<u8>,
+}
+
+impl From<UpdateWalletTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: UpdateWalletTaskDescriptor) -> Self {
+        TaskDescriptor::UpdateWallet(descriptor)
+    }
 }
 
 #[cfg(any(test, feature = "mocks"))]

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -33,6 +33,7 @@ gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
 state = { path = "../../state" }
 system-bus = { path = "../../system-bus" }
+util = { path = "../../util" }
 
 # === Misc Dependencies === #
 async-trait = "0.1.60"

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -59,3 +59,8 @@ pub(crate) fn unauthorized(e: String) -> ApiServerError {
 pub(crate) fn not_found(e: String) -> ApiServerError {
     ApiServerError::HttpStatusCode(StatusCode::NOT_FOUND, e)
 }
+
+/// Create an `ApiServerError` with a 500 internal server error code
+pub(crate) fn internal_error(e: String) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::INTERNAL_SERVER_ERROR, e)
+}

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -217,7 +217,7 @@ impl HttpServer {
             &Method::GET,
             GET_TASK_STATUS_ROUTE.to_string(),
             false, // auth_required
-            GetTaskStatusHandler::new(config.task_driver.clone()),
+            GetTaskStatusHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id" route
@@ -233,12 +233,7 @@ impl HttpServer {
             &Method::POST,
             CREATE_WALLET_ROUTE.to_string(),
             false, // auth_required
-            CreateWalletHandler::new(
-                config.arbitrum_client.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            CreateWalletHandler::new(global_state.clone()),
         );
 
         // The "/wallet/lookup" route
@@ -246,13 +241,7 @@ impl HttpServer {
             &Method::POST,
             FIND_WALLET_ROUTE.to_string(),
             false, // auth_required
-            FindWalletHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                config.global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            FindWalletHandler::new(global_state.clone()),
         );
 
         // Getter for the "/wallet/:id/orders" route
@@ -268,13 +257,7 @@ impl HttpServer {
             &Method::POST,
             WALLET_ORDERS_ROUTE.to_string(),
             true, // auth_required
-            CreateOrderHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                config.global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            CreateOrderHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/orders/:id" route
@@ -290,13 +273,7 @@ impl HttpServer {
             &Method::POST,
             UPDATE_ORDER_ROUTE.to_string(),
             true, // auth_required
-            UpdateOrderHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                config.global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            UpdateOrderHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/orders/:id/cancel" route
@@ -304,13 +281,7 @@ impl HttpServer {
             &Method::POST,
             CANCEL_ORDER_ROUTE.to_string(),
             true, // auth_required
-            CancelOrderHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                config.global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            CancelOrderHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/balances" route
@@ -334,13 +305,7 @@ impl HttpServer {
             &Method::POST,
             DEPOSIT_BALANCE_ROUTE.to_string(),
             true, // auth_required
-            DepositBalanceHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            DepositBalanceHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/balances/:mint/withdraw" route
@@ -348,13 +313,7 @@ impl HttpServer {
             &Method::POST,
             WITHDRAW_BALANCE_ROUTE.to_string(),
             true, // auth_required
-            WithdrawBalanceHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            WithdrawBalanceHandler::new(global_state.clone()),
         );
 
         // The GET "/wallet/:id/fees" route
@@ -370,13 +329,7 @@ impl HttpServer {
             &Method::POST,
             FEES_ROUTE.to_string(),
             true, // auth_required
-            AddFeeHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            AddFeeHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/fees/:index/remove" route
@@ -384,13 +337,7 @@ impl HttpServer {
             &Method::POST,
             REMOVE_FEE_ROUTE.to_string(),
             true, // auth_required
-            RemoveFeeHandler::new(
-                config.arbitrum_client.clone(),
-                config.network_sender.clone(),
-                global_state.clone(),
-                config.proof_generation_work_queue.clone(),
-                config.task_driver.clone(),
-            ),
+            RemoveFeeHandler::new(global_state.clone()),
         );
 
         // The "/order_book/orders" route

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -154,7 +154,7 @@ impl WebsocketServer {
             .insert(
                 TASK_STATUS_TOPIC,
                 Box::new(TaskStatusHandler::new(
-                    config.task_driver.clone(),
+                    config.global_state.clone(),
                     config.system_bus.clone(),
                 )),
             )

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -11,7 +11,6 @@ use job_types::{
 use state::State;
 use std::thread::{self, JoinHandle};
 use system_bus::SystemBus;
-use task_driver::driver::TaskDriver;
 use tokio::{
     runtime::{Builder as TokioBuilder, Runtime},
     task::JoinHandle as TokioJoinHandle,
@@ -55,8 +54,6 @@ pub struct ApiServerConfig {
     pub proof_generation_work_queue: ProofManagerQueue,
     /// The relayer-global state
     pub global_state: State,
-    /// The task driver, used to create and manage long-running async tasks
-    pub task_driver: TaskDriver,
     /// The system pubsub bus that all workers have access to
     /// The ApiServer uses this bus to forward internal events onto open
     /// websocket connections


### PR DESCRIPTION
### Purpose
This PR adjusts the `api-server` to use the task queue when creating tasks. This involves going through the raft-backed state. For now, we await consensus on the queue update in the `api-server`, if this proves too burdensome (unlikely for now) we can return early or have an option to do so.'

### Todo
- Validity checks at the API layer

### Testing
- Unit tests pass, will test API more directly after codebase builds