### PR TITLE
docker, ga: use `cargo-chef` & BuildJet

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -9,9 +9,9 @@ name: Upgrade Relayer Clusters
 
 jobs:
   build-and-push-ecr:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204-arm
     outputs:
-      image: ${{ fromJson(steps.docker-build-push.outputs.metadata)['image.name'] }}
+      image: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,11 +32,14 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         id: docker-build-push
         uses: docker/build-push-action@v5
+        env:
+          IMAGE: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}
         with:
+          platforms: linux/arm64
           context: .
           file: ./docker/release/Dockerfile
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}:${{ github.sha }}
+          tags: ${{ env.IMAGE }}:${{ github.sha }},${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/bin/release.zsh
+++ b/bin/release.zsh
@@ -23,6 +23,7 @@ aws ecr get-login-password --region $aws_region | \
 # Build the Docker image using buildkit for better caching
 export DOCKER_BUILDKIT=1
 docker build \
+    --platform linux/arm64 \
     -t $image_name:$image_tag \
     -f ./docker/release/Dockerfile \
     .

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,5 +1,6 @@
 # Used for running integration tests on a simulated MPC network
-FROM --platform=arm64 rust:latest AS builder
+
+FROM --platform=arm64 rust:latest AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -9,6 +10,16 @@ WORKDIR /build
 COPY ./rust-toolchain ./rust-toolchain
 RUN cat rust-toolchain | xargs rustup toolchain install
 
+# Install cargo-chef
+RUN cargo install cargo-chef
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+
 # Install protoc, openssl, and pkg-config
 RUN apt-get update && \
     apt-get install -y pkg-config && \
@@ -16,13 +27,15 @@ RUN apt-get update && \
     apt-get install -y libssl-dev && \
     apt-get install -y libclang-dev
 
-COPY ./ ./
-
 # Disable compiler warnings and enable backtraces for panic debugging
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
-# Build the target
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build the relayer
+COPY . .
 RUN cargo build --release
 
 # Release stage


### PR DESCRIPTION
This PR updates the `upgrade` Github Action to make use of [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef), which implements the "build dependencies first so they can be cached in Docker" pattern that we previously manually attempted.

Additionally, I switched the runner in the build step of our action to use an arm64 [BuildJet](https://buildjet.com/for-github-actions/docs/runners/hardware) machine, which bears a significant improvement in build time.