### PR TITLE
workers: task-driver: Add `RunImmedate` job and initial preemption skeleton

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -44,7 +44,21 @@ pub enum QueuedTaskState {
     Running {
         /// The state description of the task
         state: String,
+        /// Whether the task has committed or not
+        committed: bool,
     },
+}
+
+impl QueuedTaskState {
+    /// Whether the task is running
+    pub fn is_running(&self) -> bool {
+        matches!(self, QueuedTaskState::Running { .. })
+    }
+
+    /// Whether the task is committed
+    pub fn is_committed(&self) -> bool {
+        matches!(self, QueuedTaskState::Running { committed: true, .. })
+    }
 }
 
 /// A wrapper around the task descriptors

--- a/workers/job-types/src/task_driver.rs
+++ b/workers/job-types/src/task_driver.rs
@@ -1,6 +1,9 @@
 //! Job types for the task driver
 
-use common::types::{tasks::QueuedTask, tasks::TaskIdentifier};
+use common::types::{
+    tasks::{QueuedTask, TaskDescriptor, TaskIdentifier},
+    wallet::WalletIdentifier,
+};
 use crossbeam::channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use tokio::sync::oneshot::{
     channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender,
@@ -31,6 +34,19 @@ pub fn new_task_notification(task_id: TaskIdentifier) -> (TaskNotificationReceiv
 pub enum TaskDriverJob {
     /// Run a task
     Run(QueuedTask),
+    /// Run a task immediately, bypassing the task queue
+    ///
+    /// This is used for tasks which need immediate settlement, e.g. matches
+    ///
+    /// Other tasks on a shared wallet will be preempted and the queue paused
+    RunImmediate {
+        /// The ID to assign the task
+        task_id: TaskIdentifier,
+        /// The wallet that this task modifies
+        wallet_id: WalletIdentifier,
+        /// The task to run
+        task: TaskDescriptor,
+    },
     /// Request that the task driver notify a worker when a task is complete
     Notify {
         /// The task id to notify the worker about


### PR DESCRIPTION
### Purpose
This PR adds a `RunImmediate` job type for the `task-driver`. This job will preempt any running tasks on the wallet it modifies and run in place. This will be used for match settlement which should be run as soon as the match completes, bypassing the queue.

However, running a preemption is not always possible: other tasks may have committed state on-chain, and cannot be preempted. In this case the match must fail and the task queue should resume.

### Todo
- Do not schedule matches on orders with in-flight updates

### Testing
- State tests pass
- Testing deferred until more components are refactored