### PR TITLE
workers: task-driver: pause and unpause state in `RunImmediate`

### DIFF
--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -2,6 +2,8 @@
 
 use std::{error::Error, fmt::Display};
 
+use common::types::wallet::WalletIdentifier;
+
 use crate::storage::error::StorageError;
 
 /// The error type emitted by the storage applicator
@@ -15,6 +17,10 @@ pub enum StateApplicatorError {
     Storage(StorageError),
     /// An error parsing a message separately from proto errors
     Parse(String),
+    /// An error trying to preempt a committed task
+    Preemption,
+    /// An error updating a task state when a queue is paused
+    QueuePaused(WalletIdentifier),
 }
 
 impl Display for StateApplicatorError {

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -73,6 +73,8 @@ impl StateApplicator {
             StateTransition::TransitionWalletTask { wallet_id, state } => {
                 self.transition_task_state(wallet_id, state)
             },
+            StateTransition::PreemptTaskQueue { wallet_id } => self.preempt_task_queue(wallet_id),
+            StateTransition::ResumeTaskQueue { wallet_id } => self.resume_task_queue(wallet_id),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
     }

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -144,6 +144,22 @@ impl State {
         // Propose the task to the task queue
         self.send_proposal(StateTransition::TransitionWalletTask { wallet_id, state })
     }
+
+    /// Pause the task queue for a wallet
+    pub fn pause_wallet_task_queue(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::PreemptTaskQueue { wallet_id: *wallet_id })
+    }
+
+    /// Resume the task queue for a wallet
+    pub fn resume_wallet_task_queue(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::ResumeTaskQueue { wallet_id: *wallet_id })
+    }
 }
 
 #[cfg(test)]

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -94,6 +94,12 @@ pub enum StateTransition {
     PopWalletTask { wallet_id: WalletIdentifier },
     /// Transition the state of the top task in the task queue
     TransitionWalletTask { wallet_id: WalletIdentifier, state: QueuedTaskState },
+    /// Preempt the task queue on a given wallet
+    ///
+    /// Returns any running tasks to `Queued` state and pauses the queue
+    PreemptTaskQueue { wallet_id: WalletIdentifier },
+    /// Resume a task queue on a given wallet
+    ResumeTaskQueue { wallet_id: WalletIdentifier },
 
     // --- Raft --- //
     /// Add a raft learner to the cluster

--- a/workers/task-driver/src/error.rs
+++ b/workers/task-driver/src/error.rs
@@ -15,12 +15,16 @@ use crate::tasks::update_wallet::UpdateWalletTaskError;
 /// The error type emitted by the task driver
 #[derive(Clone, Debug)]
 pub enum TaskDriverError {
+    /// A task failed to execute
+    TaskFailed,
     /// The job channel for the task driver is closed
     JobQueueClosed,
-    /// An error running a task
-    TaskError(String),
+    /// A task was preempted while running
+    Preempted,
     /// An error querying global state
     State(String),
+    /// An error running a task
+    TaskError(String),
 }
 
 impl Display for TaskDriverError {


### PR DESCRIPTION
### Purpose
This PR implements task queue pausing and unpausing and makes these transitions in the `task-driver` during a `RunImmediate` job. When a queue is paused it places any running tasks onto the queue in the `Queued` state. As well, if a task tries to transition its state when a queue is paused, the raft will fail to apply the log.

In the task driver we check for these failed applications when a task is _first_ committing. If failed, we assume the task has been preempted. 

### Testing
- State unit tests pass
- Testing deferred until more components implemented