### PR TITLE
state: Generalize task queue keys from wallet IDs to abstract keys

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -66,15 +66,13 @@ impl StateApplicator {
             StateTransition::AddOrderValidityBundle { order_id, proof, witness } => {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
-            StateTransition::AppendWalletTask { wallet_id, task } => {
-                self.append_wallet_task(wallet_id, task)
+            StateTransition::AppendTask { task } => self.append_task(task),
+            StateTransition::PopTask { key } => self.pop_task(key),
+            StateTransition::TransitionTask { key, state } => {
+                self.transition_task_state(key, state)
             },
-            StateTransition::PopWalletTask { wallet_id } => self.pop_wallet_task(wallet_id),
-            StateTransition::TransitionWalletTask { wallet_id, state } => {
-                self.transition_task_state(wallet_id, state)
-            },
-            StateTransition::PreemptTaskQueue { wallet_id } => self.preempt_task_queue(wallet_id),
-            StateTransition::ResumeTaskQueue { wallet_id } => self.resume_task_queue(wallet_id),
+            StateTransition::PreemptTaskQueue { key } => self.preempt_task_queue(key),
+            StateTransition::ResumeTaskQueue { key } => self.resume_task_queue(key),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
     }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -17,8 +17,8 @@
 
 use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
-    tasks::{QueuedTask, QueuedTaskState},
-    wallet::{OrderIdentifier, Wallet, WalletIdentifier},
+    tasks::{QueuedTask, QueuedTaskState, TaskQueueKey},
+    wallet::{OrderIdentifier, Wallet},
 };
 use replication::{error::ReplicationError, RaftPeerId};
 use serde::{Deserialize, Serialize};
@@ -57,8 +57,8 @@ pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
 /// The name of the db table that stores task queues
 pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
-/// The name of the db table that maps tasks to wallet
-pub(crate) const TASK_TO_WALLET_TABLE: &str = "task-to-wallet";
+/// The name of the db table that maps tasks to their queue key
+pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
 
 /// The `Proposal` type wraps a state transition and the channel on which to
 /// send the result of the proposal's application
@@ -89,17 +89,17 @@ pub enum StateTransition {
 
     // --- Task Queue --- //
     /// Add a task to the task queue
-    AppendWalletTask { wallet_id: WalletIdentifier, task: QueuedTask },
+    AppendTask { task: QueuedTask },
     /// Pop the top task from the task queue
-    PopWalletTask { wallet_id: WalletIdentifier },
+    PopTask { key: TaskQueueKey },
     /// Transition the state of the top task in the task queue
-    TransitionWalletTask { wallet_id: WalletIdentifier, state: QueuedTaskState },
-    /// Preempt the task queue on a given wallet
+    TransitionTask { key: TaskQueueKey, state: QueuedTaskState },
+    /// Preempt the given task queue
     ///
     /// Returns any running tasks to `Queued` state and pauses the queue
-    PreemptTaskQueue { wallet_id: WalletIdentifier },
-    /// Resume a task queue on a given wallet
-    ResumeTaskQueue { wallet_id: WalletIdentifier },
+    PreemptTaskQueue { key: TaskQueueKey },
+    /// Resume the given task queue
+    ResumeTaskQueue { key: TaskQueueKey },
 
     // --- Raft --- //
     /// Add a raft learner to the cluster

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -17,7 +17,7 @@ use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, Write
 
 use crate::{
     CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE, ORDER_TO_WALLET_TABLE,
-    PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE, WALLETS_TABLE,
+    PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
 };
 
 use self::raft_log::RAFT_METADATA_TABLE;
@@ -95,7 +95,7 @@ impl<'db> StateTxn<'db, RW> {
             ORDER_TO_WALLET_TABLE,
             WALLETS_TABLE,
             TASK_QUEUE_TABLE,
-            TASK_TO_WALLET_TABLE,
+            TASK_TO_KEY_TABLE,
             NODE_METADATA_TABLE,
             RAFT_METADATA_TABLE,
         ]

--- a/state/src/storage/tx/task_queue.rs
+++ b/state/src/storage/tx/task_queue.rs
@@ -3,20 +3,17 @@
 //! Tasks are indexed in queues identified by the shared resource they occupy.
 //! For now this is only wallets (i.e. wallet_id).
 
-use common::types::{
-    tasks::TaskIdentifier,
-    tasks::{QueuedTask, QueuedTaskState},
-    wallet::WalletIdentifier,
-};
+use common::types::tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey};
 use libmdbx::{TransactionKind, RW};
+use util::res_some;
 
-use crate::{storage::error::StorageError, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE};
+use crate::{storage::error::StorageError, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE};
 
 use super::StateTxn;
 
-/// Create the key for a "task queue paused" entry from a wallet ID
-fn paused_key(wallet_id: &WalletIdentifier) -> String {
-    format!("{wallet_id}-paused")
+/// Create the key for a "task queue paused" entry from a queue key
+fn paused_key(key: &TaskQueueKey) -> String {
+    format!("{key}-paused")
 }
 
 // -----------
@@ -25,55 +22,48 @@ fn paused_key(wallet_id: &WalletIdentifier) -> String {
 
 impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Check whether the current task queue is empty
-    pub fn is_wallet_queue_empty(
-        &self,
-        wallet_id: &WalletIdentifier,
-    ) -> Result<bool, StorageError> {
-        let tasks = self.get_wallet_tasks(wallet_id)?;
+    pub fn is_queue_empty(&self, key: &TaskQueueKey) -> Result<bool, StorageError> {
+        let tasks = self.get_queued_tasks(key)?;
         Ok(tasks.is_empty())
     }
 
-    /// Whether or not the task queue is paused for a wallet
-    pub fn is_task_queue_paused(&self, wallet_id: &WalletIdentifier) -> Result<bool, StorageError> {
-        let key = paused_key(wallet_id);
+    /// Whether or not the task queue is paused
+    pub fn is_queue_paused(&self, key: &TaskQueueKey) -> Result<bool, StorageError> {
+        let key = paused_key(key);
         let paused = self.inner().read(TASK_QUEUE_TABLE, &key)?;
 
         Ok(paused.unwrap_or(false))
     }
 
-    /// Get the tasks for a given wallet
-    pub fn get_wallet_tasks(
-        &self,
-        wallet_id: &WalletIdentifier,
-    ) -> Result<Vec<QueuedTask>, StorageError> {
-        self.read_queue(TASK_QUEUE_TABLE, wallet_id)
+    /// Get the tasks for a given queue
+    pub fn get_queued_tasks(&self, key: &TaskQueueKey) -> Result<Vec<QueuedTask>, StorageError> {
+        self.read_queue(TASK_QUEUE_TABLE, key)
     }
 
-    /// Get the wallet that a given task is associated with
-    pub fn get_task_wallet(
+    /// Get the task queue that a given task is associated with
+    pub fn get_queue_key_for_task(
         &self,
         task_id: &TaskIdentifier,
-    ) -> Result<Option<WalletIdentifier>, StorageError> {
-        self.inner().read(TASK_TO_WALLET_TABLE, task_id)
+    ) -> Result<Option<TaskQueueKey>, StorageError> {
+        self.inner().read(TASK_TO_KEY_TABLE, task_id)
     }
 
-    /// Get the task for a given wallet and task id
-    pub fn get_wallet_task_by_id(
-        &self,
-        wallet_id: &WalletIdentifier,
-        task_id: &TaskIdentifier,
-    ) -> Result<Option<QueuedTask>, StorageError> {
-        let tasks = self.get_wallet_tasks(wallet_id)?;
+    /// Get the task by ID
+    pub fn get_task(&self, task_id: &TaskIdentifier) -> Result<Option<QueuedTask>, StorageError> {
+        // Get the key for the task
+        let key = res_some!(self.get_queue_key_for_task(task_id)?);
+        let tasks = self.get_queued_tasks(&key)?;
+
         Ok(tasks.into_iter().find(|x| &x.id == task_id))
     }
 
-    /// Get the currently running task for a wallet, or `None` if there is no
+    /// Get the currently running task for a queue, or `None` if there is no
     /// running task
     pub fn get_current_running_task(
         &self,
-        wallet_id: &WalletIdentifier,
+        key: &TaskQueueKey,
     ) -> Result<Option<QueuedTask>, StorageError> {
-        let tasks = self.get_wallet_tasks(wallet_id)?;
+        let tasks = self.get_queued_tasks(key)?;
 
         Ok(tasks.first().cloned().filter(|task| task.state.is_running()))
     }
@@ -85,96 +75,86 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
 
 impl<'db> StateTxn<'db, RW> {
     /// Add a task to the queue
-    pub fn add_wallet_task(
-        &self,
-        wallet_id: &WalletIdentifier,
-        task: &QueuedTask,
-    ) -> Result<(), StorageError> {
-        self.push_to_queue(TASK_QUEUE_TABLE, wallet_id, task)?;
+    pub fn add_task(&self, key: &TaskQueueKey, task: &QueuedTask) -> Result<(), StorageError> {
+        self.push_to_queue(TASK_QUEUE_TABLE, key, task)?;
 
-        // Add a mapping from the task to the wallet
-        self.inner().write(TASK_TO_WALLET_TABLE, &task.id, wallet_id)
+        // Add a mapping from the task to the queue key
+        self.inner().write(TASK_TO_KEY_TABLE, &task.id, key)
     }
 
     /// Pop a task from the queue
-    pub fn pop_wallet_task(
-        &self,
-        wallet_id: &WalletIdentifier,
-    ) -> Result<Option<QueuedTask>, StorageError> {
-        let res: Option<QueuedTask> = self.pop_from_queue(TASK_QUEUE_TABLE, wallet_id)?;
+    pub fn pop_task(&self, key: &TaskQueueKey) -> Result<Option<QueuedTask>, StorageError> {
+        let res: Option<QueuedTask> = self.pop_from_queue(TASK_QUEUE_TABLE, key)?;
 
         if let Some(ref task) = res {
-            // Remove the mapping from the task to the wallet
-            self.inner().delete(TASK_TO_WALLET_TABLE, &task.id)?;
+            // Remove the mapping from the task to the queue key
+            self.inner().delete(TASK_TO_KEY_TABLE, &task.id)?;
         }
 
         Ok(res)
     }
 
     /// Transition the state of the top task in the queue
-    pub fn transition_wallet_task(
+    pub fn transition_task(
         &self,
-        wallet_id: &WalletIdentifier,
+        key: &TaskQueueKey,
         new_state: QueuedTaskState,
     ) -> Result<(), StorageError> {
-        let mut tasks = self.get_wallet_tasks(wallet_id)?;
+        let mut tasks = self.get_queued_tasks(key)?;
         tasks[0].state = new_state;
 
-        self.write_queue(TASK_QUEUE_TABLE, wallet_id, &tasks)
+        self.write_queue(TASK_QUEUE_TABLE, key, &tasks)
     }
 
-    /// Pause the task queue for a wallet
-    pub fn pause_task_queue(&self, wallet_id: &WalletIdentifier) -> Result<(), StorageError> {
-        let key = paused_key(wallet_id);
+    /// Pause the given task queue
+    pub fn pause_task_queue(&self, key: &TaskQueueKey) -> Result<(), StorageError> {
+        let key = paused_key(key);
         self.inner().write(TASK_QUEUE_TABLE, &key, &true)
     }
 
-    /// Resume the task queue for a wallet
-    pub fn resume_task_queue(&self, wallet_id: &WalletIdentifier) -> Result<(), StorageError> {
-        let key = paused_key(wallet_id);
+    /// Resume the given task queue
+    pub fn resume_task_queue(&self, key: &TaskQueueKey) -> Result<(), StorageError> {
+        let key = paused_key(key);
         self.inner().write(TASK_QUEUE_TABLE, &key, &false)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use common::types::{
-        tasks::{mocks::mock_queued_task, QueuedTaskState},
-        wallet::WalletIdentifier,
-    };
+    use common::types::tasks::{mocks::mock_queued_task, QueuedTaskState, TaskQueueKey};
 
-    use crate::{test_helpers::mock_db, TASK_QUEUE_TABLE, TASK_TO_WALLET_TABLE};
+    use crate::{test_helpers::mock_db, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE};
 
-    /// Tests getting the tasks for a wallet
+    /// Tests getting the tasks for a key
     #[test]
     fn test_append_and_get() {
         // Setup the mock
         let db = mock_db();
         db.create_table(TASK_QUEUE_TABLE).unwrap();
 
-        // Get the tasks for a wallet, should be empty
-        let wallet_id = WalletIdentifier::new_v4();
+        // Get the tasks for a key, should be empty
+        let key = TaskQueueKey::new_v4();
         let tx = db.new_read_tx().unwrap();
-        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        let tasks = tx.get_queued_tasks(&key).unwrap();
         tx.commit().unwrap();
         assert_eq!(tasks.len(), 0);
 
-        // Add a task to the wallet
-        let task = mock_queued_task();
+        // Add a task to the key
+        let task = mock_queued_task(key);
         let tx = db.new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.add_task(&key, &task).unwrap();
         tx.commit().unwrap();
 
         // Read the task back
         let tx = db.new_read_tx().unwrap();
-        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        let tasks = tx.get_queued_tasks(&key).unwrap();
         tx.commit().unwrap();
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].id, task.id);
 
         // Read the task back by ID
         let tx = db.new_read_tx().unwrap();
-        let task = tx.get_wallet_task_by_id(&wallet_id, &tasks[0].id).unwrap();
+        let task = tx.get_task(&tasks[0].id).unwrap();
         tx.commit().unwrap();
         assert_eq!(task.unwrap().id, tasks[0].id);
     }
@@ -183,34 +163,34 @@ mod test {
     #[test]
     fn test_current_running_task() {
         let db = mock_db();
-        let wallet_id = WalletIdentifier::new_v4();
+        let key = TaskQueueKey::new_v4();
 
         // Test on an empty queue
         let tx = db.new_read_tx().unwrap();
-        let task = tx.get_current_running_task(&wallet_id).unwrap();
+        let task = tx.get_current_running_task(&key).unwrap();
         tx.commit().unwrap();
 
         assert!(task.is_none());
 
         // Add a task, not running and test again
-        let task = mock_queued_task();
+        let task = mock_queued_task(key);
         let tx = db.new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.add_task(&key, &task).unwrap();
         tx.commit().unwrap();
 
         let tx = db.new_read_tx().unwrap();
-        let no_task = tx.get_current_running_task(&wallet_id).unwrap();
+        let no_task = tx.get_current_running_task(&key).unwrap();
         tx.commit().unwrap();
         assert!(no_task.is_none());
 
         // Transition the task to running and test again
         let tx = db.new_write_tx().unwrap();
         let state = QueuedTaskState::Running { state: "Running".to_string(), committed: false };
-        tx.transition_wallet_task(&wallet_id, state).unwrap();
+        tx.transition_task(&key, state).unwrap();
         tx.commit().unwrap();
 
         let tx = db.new_read_tx().unwrap();
-        let found_task = tx.get_current_running_task(&wallet_id).unwrap();
+        let found_task = tx.get_current_running_task(&key).unwrap();
         tx.commit().unwrap();
         assert!(found_task.is_some());
         assert_eq!(found_task.unwrap().id, task.id);
@@ -223,22 +203,22 @@ mod test {
         let db = mock_db();
         db.create_table(TASK_QUEUE_TABLE).unwrap();
 
-        // Add a task to the wallet
-        let wallet_id = WalletIdentifier::new_v4();
-        let task = mock_queued_task();
+        // Add a task to the key
+        let key = TaskQueueKey::new_v4();
+        let task = mock_queued_task(key);
         let tx = db.new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.add_task(&key, &task).unwrap();
         tx.commit().unwrap();
 
-        // Pop the task from the wallet
+        // Pop the task from the key
         let tx = db.new_write_tx().unwrap();
-        let popped_task = tx.pop_wallet_task(&wallet_id).unwrap();
+        let popped_task = tx.pop_task(&key).unwrap();
         tx.commit().unwrap();
         assert_eq!(popped_task.unwrap().id, task.id);
 
         // Check the queue is empty
         let tx = db.new_read_tx().unwrap();
-        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        let tasks = tx.get_queued_tasks(&key).unwrap();
         tx.commit().unwrap();
         assert_eq!(tasks.len(), 0);
     }
@@ -250,17 +230,17 @@ mod test {
         let db = mock_db();
         db.create_table(TASK_QUEUE_TABLE).unwrap();
 
-        // Add a task to the wallet
-        let wallet_id = WalletIdentifier::new_v4();
-        let task = mock_queued_task();
+        // Add a task to the key
+        let key = TaskQueueKey::new_v4();
+        let task = mock_queued_task(key);
         let tx = db.new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.add_task(&key, &task).unwrap();
         tx.commit().unwrap();
 
         // Transition the state of the task
         let tx = db.new_write_tx().unwrap();
-        tx.transition_wallet_task(
-            &wallet_id,
+        tx.transition_task(
+            &key,
             QueuedTaskState::Running { state: "Running".to_string(), committed: false },
         )
         .unwrap();
@@ -268,42 +248,42 @@ mod test {
 
         // Read the task back
         let tx = db.new_read_tx().unwrap();
-        let tasks = tx.get_wallet_tasks(&wallet_id).unwrap();
+        let tasks = tx.get_queued_tasks(&key).unwrap();
         tx.commit().unwrap();
         assert_eq!(tasks.len(), 1);
         assert!(matches!(tasks[0].state, QueuedTaskState::Running { .. }));
     }
 
-    /// Test the task to wallet map
+    /// Test the task to key map
     #[test]
-    fn test_task_to_wallet_map() {
+    fn test_task_to_key_map() {
         // Setup the mock
         let db = mock_db();
-        db.create_table(TASK_TO_WALLET_TABLE).unwrap();
+        db.create_table(TASK_TO_KEY_TABLE).unwrap();
 
-        // Add a task to the wallet
-        let wallet_id = WalletIdentifier::new_v4();
-        let task = mock_queued_task();
+        // Add a task to the key
+        let key = TaskQueueKey::new_v4();
+        let task = mock_queued_task(key);
         let tx = db.new_write_tx().unwrap();
-        tx.add_wallet_task(&wallet_id, &task).unwrap();
+        tx.add_task(&key, &task).unwrap();
         tx.commit().unwrap();
 
-        // Check the task is associated with the wallet
+        // Check the task is associated with the key
         let tx = db.new_read_tx().unwrap();
-        let task_wallet = tx.get_task_wallet(&task.id).unwrap();
+        let task_key = tx.get_queue_key_for_task(&task.id).unwrap();
         tx.commit().unwrap();
-        assert_eq!(task_wallet, Some(wallet_id));
+        assert_eq!(task_key, Some(key));
 
-        // Remove the task from the wallet
+        // Remove the task from the key
         let tx = db.new_write_tx().unwrap();
-        tx.pop_wallet_task(&wallet_id).unwrap();
+        tx.pop_task(&key).unwrap();
         tx.commit().unwrap();
 
-        // Validate that the task is no longer associated with the wallet
+        // Validate that the task is no longer associated with the key
         let tx = db.new_read_tx().unwrap();
-        let task_wallet = tx.get_task_wallet(&task.id).unwrap();
+        let task_key = tx.get_queue_key_for_task(&task.id).unwrap();
         tx.commit().unwrap();
-        assert_eq!(task_wallet, None);
+        assert_eq!(task_key, None);
     }
 
     /// Tests pausing and resuming the task queue
@@ -312,32 +292,32 @@ mod test {
         // Setup the mock
         let db = mock_db();
         db.create_table(TASK_QUEUE_TABLE).unwrap();
-        let wallet_id = WalletIdentifier::new_v4();
+        let key = TaskQueueKey::new_v4();
 
         let tx = db.new_read_tx().unwrap();
-        let paused = tx.is_task_queue_paused(&wallet_id).unwrap();
+        let paused = tx.is_queue_paused(&key).unwrap();
         tx.commit().unwrap();
         assert!(!paused);
 
         // Pause the task queue
         let tx = db.new_write_tx().unwrap();
-        tx.pause_task_queue(&wallet_id).unwrap();
+        tx.pause_task_queue(&key).unwrap();
         tx.commit().unwrap();
 
         // Check the task queue is paused
         let tx = db.new_read_tx().unwrap();
-        let paused = tx.is_task_queue_paused(&wallet_id).unwrap();
+        let paused = tx.is_queue_paused(&key).unwrap();
         tx.commit().unwrap();
         assert!(paused);
 
         // Resume the task queue
         let tx = db.new_write_tx().unwrap();
-        tx.resume_task_queue(&wallet_id).unwrap();
+        tx.resume_task_queue(&key).unwrap();
         tx.commit().unwrap();
 
         // Check the task queue is resumed
         let tx = db.new_read_tx().unwrap();
-        let paused = tx.is_task_queue_paused(&wallet_id).unwrap();
+        let paused = tx.is_queue_paused(&key).unwrap();
         tx.commit().unwrap();
         assert!(!paused);
     }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -98,11 +98,10 @@ fn find_wallet_for_update(
 
 /// Append a task to a task queue and await consensus on this queue update
 async fn append_task_and_await(
-    wallet: &WalletIdentifier,
     task: TaskDescriptor,
     state: &State,
 ) -> Result<TaskIdentifier, ApiServerError> {
-    let (task_id, waiter) = state.append_wallet_task(wallet, task)?;
+    let (task_id, waiter) = state.append_task(task)?;
     waiter.await.map_err(err_str!(internal_error))?;
 
     Ok(task_id)
@@ -228,7 +227,7 @@ impl TypedHandler for CreateWalletHandler {
         let task = NewWalletTaskDescriptor { wallet };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(CreateWalletResponse { wallet_id, task_id })
     }
 }
@@ -269,8 +268,7 @@ impl TypedHandler for FindWalletHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id =
-            append_task_and_await(&req.wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
 
         Ok(FindWalletResponse { wallet_id: req.wallet_id, task_id })
     }
@@ -406,7 +404,7 @@ impl TypedHandler for CreateOrderHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(CreateOrderResponse { id, task_id })
     }
 }
@@ -468,7 +466,7 @@ impl TypedHandler for UpdateOrderHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(UpdateOrderResponse { task_id })
     }
 }
@@ -520,7 +518,7 @@ impl TypedHandler for CancelOrderHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(CancelOrderResponse { task_id, order: (order_id, order).into() })
     }
 }
@@ -662,7 +660,7 @@ impl TypedHandler for DepositBalanceHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(DepositBalanceResponse { task_id })
     }
 }
@@ -725,7 +723,7 @@ impl TypedHandler for WithdrawBalanceHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(WithdrawBalanceResponse { task_id })
     }
 }
@@ -823,7 +821,7 @@ impl TypedHandler for AddFeeHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(AddFeeResponse { task_id })
     }
 }
@@ -878,7 +876,7 @@ impl TypedHandler for RemoveFeeHandler {
         };
 
         // Propose the task and await for it to be enqueued
-        let task_id = append_task_and_await(&wallet_id, task.into(), &self.global_state).await?;
+        let task_id = append_task_and_await(task.into(), &self.global_state).await?;
         Ok(RemoveFeeResponse { task_id, fee: removed_fee.into() })
     }
 }

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -191,9 +191,8 @@ impl OnChainEventListenerExecutor {
         &self,
         wallet: Wallet,
     ) -> Result<(), OnChainEventListenerError> {
-        let id = wallet.wallet_id;
         let task = UpdateMerkleProofTaskDescriptor { wallet };
-        let (_task_id, waiter) = self.global_state.append_wallet_task(&id, task.into())?;
+        let (_task_id, waiter) = self.global_state.append_task(task.into())?;
         waiter.await?;
 
         Ok(())

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -222,7 +222,7 @@ impl TaskExecutor {
 
         // Pause the queues for the affected local wallets
         for wallet_id in wallet_ids.iter() {
-            self.state().pause_wallet_task_queue(wallet_id)?;
+            self.state().pause_task_queue(wallet_id)?;
         }
 
         // Start the task optimistically assuming that the queues are paused
@@ -237,7 +237,7 @@ impl TaskExecutor {
             // Unpause the queues for the affected local wallets
             for wallet_id in wallet_ids.iter() {
                 state
-                    .resume_wallet_task_queue(wallet_id)
+                    .resume_task_queue(wallet_id)
                     .expect("error proposing wallet resume for {wallet_id}")
                     .await
                     .expect("error resuming wallet task queue for {wallet_id}");
@@ -387,7 +387,7 @@ impl TaskExecutor {
         // If this state commits the task, await consensus on the result of updating the
         // state, otherwise resume optimistically
         let is_commit = new_state.is_committing();
-        match global_state.transition_wallet_task(task_id, new_state.into()) {
+        match global_state.transition_task(task_id, new_state.into()) {
             Ok(waiter) => is_commit && waiter.await.is_err(),
             Err(e) => {
                 log::warn!("error updating task state: {e:?}");


### PR DESCRIPTION
### Purpose
This PR removes the notion of a wallet ID as the only task queue key and abstractly indexes task queues by a `TaskQueueKey`. This will allow us to generalize the notion of a queue key. As well, this allows us to derive the queue key from the task descriptor directly, giving a more ergonomic interface.

On top of this we can rebuild the task driver integration tests

### Testing
- Unit tests pass
- Todo: task driver integration tests