### PR TITLE
task-driver: integration: Refactor integration tests over task queue

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -67,9 +67,9 @@ impl StateApplicator {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
             StateTransition::AppendTask { task } => self.append_task(task),
-            StateTransition::PopTask { key } => self.pop_task(key),
-            StateTransition::TransitionTask { key, state } => {
-                self.transition_task_state(key, state)
+            StateTransition::PopTask { task_id } => self.pop_task(task_id),
+            StateTransition::TransitionTask { task_id, state } => {
+                self.transition_task_state(task_id, state)
             },
             StateTransition::PreemptTaskQueue { key } => self.preempt_task_queue(key),
             StateTransition::ResumeTaskQueue { key } => self.resume_task_queue(key),

--- a/state/src/interface/error.rs
+++ b/state/src/interface/error.rs
@@ -37,3 +37,9 @@ impl From<StateError> for String {
         e.to_string()
     }
 }
+
+impl From<ReplicationError> for StateError {
+    fn from(e: ReplicationError) -> Self {
+        StateError::Replication(e)
+    }
+}

--- a/state/src/interface/notifications.rs
+++ b/state/src/interface/notifications.rs
@@ -43,7 +43,7 @@ impl Future for ProposalWaiter {
         for recv in self.recvs.iter_mut() {
             ready!(recv.poll_unpin(cx))
                 .map_err(err_str!(StateError::Proposal))? // RecvError
-                .map_err(err_str!(StateError::Proposal))?; // ReplicationError
+                .map_err(Into::<StateError>::into)?; // ReplicationError
         }
 
         Poll::Ready(Ok(()))

--- a/workers/task-driver/src/error.rs
+++ b/workers/task-driver/src/error.rs
@@ -5,12 +5,7 @@ use std::fmt::Display;
 
 use state::error::StateError;
 
-use crate::tasks::create_new_wallet::NewWalletTaskError;
-use crate::tasks::lookup_wallet::LookupWalletTaskError;
-use crate::tasks::settle_match::SettleMatchTaskError;
-use crate::tasks::settle_match_internal::SettleMatchInternalTaskError;
-use crate::tasks::update_merkle_proof::UpdateMerkleProofTaskError;
-use crate::tasks::update_wallet::UpdateWalletTaskError;
+use crate::traits::TaskError;
 
 /// The error type emitted by the task driver
 #[derive(Clone, Debug)]
@@ -40,38 +35,8 @@ impl From<StateError> for TaskDriverError {
     }
 }
 
-impl From<NewWalletTaskError> for TaskDriverError {
-    fn from(e: NewWalletTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
-    }
-}
-
-impl From<LookupWalletTaskError> for TaskDriverError {
-    fn from(e: LookupWalletTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
-    }
-}
-
-impl From<SettleMatchInternalTaskError> for TaskDriverError {
-    fn from(e: SettleMatchInternalTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
-    }
-}
-
-impl From<SettleMatchTaskError> for TaskDriverError {
-    fn from(e: SettleMatchTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
-    }
-}
-
-impl From<UpdateWalletTaskError> for TaskDriverError {
-    fn from(e: UpdateWalletTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
-    }
-}
-
-impl From<UpdateMerkleProofTaskError> for TaskDriverError {
-    fn from(e: UpdateMerkleProofTaskError) -> Self {
-        TaskDriverError::TaskError(e.to_string())
+impl<E: TaskError> From<E> for TaskDriverError {
+    fn from(value: E) -> Self {
+        TaskDriverError::TaskError(value.to_string())
     }
 }

--- a/workers/task-driver/src/lib.rs
+++ b/workers/task-driver/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod driver;
 pub mod error;
 mod helpers;
+mod running_task;
 pub mod tasks;
 pub mod traits;
 pub mod worker;

--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -1,0 +1,139 @@
+//! Encapsulates the running task's bookkeeping structure to simplify the driver
+//! logic
+
+use common::types::tasks::TaskIdentifier;
+use external_api::bus_message::{task_topic_name, SystemBusMessage};
+use state::{error::StateError, State};
+use system_bus::SystemBus;
+use tracing::log;
+
+use crate::{
+    driver::StateWrapper,
+    error::TaskDriverError,
+    traits::{Task, TaskContext, TaskError},
+};
+
+// ----------------
+// | Running Task |
+// ----------------
+
+/// The container type for a task running in the driver
+///
+/// Used to simplify driver logic
+pub struct RunnableTask<T: Task> {
+    /// Whether or not the task is a preemptive task
+    preemptive: bool,
+    /// The id of the underlying task
+    task_id: TaskIdentifier,
+    /// The underlying task
+    task: T,
+    /// A handle to the relayer-global state
+    state: State,
+    /// A sender to the system bus for state updates
+    bus: SystemBus<SystemBusMessage>,
+}
+
+impl<T: Task> RunnableTask<T> {
+    /// Creates a new running task from the given task and state
+    pub fn new(
+        preemptive: bool,
+        task_id: TaskIdentifier,
+        task: T,
+        state: State,
+        bus: SystemBus<SystemBusMessage>,
+    ) -> Self {
+        Self { preemptive, task_id, task, state, bus }
+    }
+
+    /// Create a runnable from the given descriptor and context
+    pub async fn from_descriptor(
+        preemptive: bool,
+        id: TaskIdentifier,
+        descriptor: T::Descriptor,
+        ctx: TaskContext,
+    ) -> Result<Self, TaskDriverError> {
+        let state = ctx.state.clone();
+        let bus = ctx.bus.clone();
+        let task = T::new(descriptor, ctx).await?;
+
+        Ok(Self::new(preemptive, id, task, state, bus))
+    }
+
+    /// The ID of the underlying task
+    pub fn id(&self) -> TaskIdentifier {
+        self.task_id
+    }
+
+    /// Whether the underlying task completed
+    pub fn completed(&self) -> bool {
+        self.task.completed()
+    }
+
+    /// Returns the state of the underlying task
+    pub fn state(&self) -> StateWrapper {
+        self.task.state().into()
+    }
+
+    /// Step the underlying task, returns whether the driver should continue or
+    /// abort. `Ok(true)` means successful step, `Ok(false)` means that the task
+    /// step failed and should be retried, an error should be aborted
+    ///
+    /// This includes a state transition in the consensus engine, if this method
+    /// returns an error the driver should abort the task
+    pub async fn step(&mut self) -> Result<bool, TaskDriverError> {
+        // Handle a failed step
+        if let Err(e) = self.task.step().await {
+            log::error!("error executing task step: {e}");
+            return if e.retryable() { Ok(false) } else { Err(e.into()) };
+        };
+
+        // Successful step, attempt to transition the state
+        self.transition_state().await?;
+        Ok(true)
+    }
+
+    /// Attempts to transition the state of the underlying task in the consensus
+    /// engine. If this method fails the driver should abort the task
+    pub async fn transition_state(&mut self) -> Result<(), StateError> {
+        let task_id = self.task_id;
+        let name = self.task.name();
+        let new_state = self.state();
+        log::info!("task {name}({task_id:?}) transitioning to state {new_state}");
+
+        // Preemptive tasks need not update state in the consensus engine
+        if self.preemptive {
+            return Ok(());
+        }
+
+        // If this state commits the task (first state past the commit point) then await
+        // consensus before continuing
+        let is_commit = new_state.is_committing();
+        let waiter = self.state.transition_task(task_id, new_state.into())?;
+        if is_commit {
+            waiter.await?;
+        }
+
+        // Publish the state to the system bus for listeners on this task
+        self.bus.publish(
+            task_topic_name(&task_id),
+            SystemBusMessage::TaskStatusUpdate { task_id, state: self.task.state().to_string() },
+        );
+        Ok(())
+    }
+
+    /// Cleanup the underlying task
+    pub async fn cleanup(&mut self) -> Result<(), TaskDriverError> {
+        // Do not propagate errors from cleanup, continue to cleanup
+        if let Err(e) = self.task.cleanup().await {
+            log::error!("error cleaning up task: {e:?}");
+        }
+
+        // Pop the task from the state
+        // Preemptive tasks are not indexed, so no work needs to be done
+        if !self.preemptive {
+            self.state.pop_task(self.task_id)?.await?;
+        }
+
+        Ok(())
+    }
+}

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -4,9 +4,11 @@ use std::fmt::{Debug, Display};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
+use external_api::bus_message::SystemBusMessage;
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
 use serde::{Deserialize, Serialize};
 use state::State;
+use system_bus::SystemBus;
 
 use crate::driver::StateWrapper;
 
@@ -99,4 +101,6 @@ pub struct TaskContext {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's queue
     pub proof_queue: ProofManagerQueue,
+    /// A handle on the system bus
+    pub bus: SystemBus<SystemBusMessage>,
 }


### PR DESCRIPTION
### Purpose
This PR refactors the task driver integration tests to use the new raft-backed task queue in the `state` crate. This includes fixing a few bugs that came up along the way.

Notably, the immediate vs non-immediate tasks required some care to handle properly. For this reason I encapsulated more of the task execution logic in a `RunnableTask` struct that can cleanly handle difference in task types. The driver is then responsible only for retries and backoff.

### Testing
- All unit tests pass
- Integration tests pass