### PR TITLE
common: types: tasks: Implement task constructors with safety checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "common",
  "constants",
  "crossbeam",
- "ecdsa",
+ "ecdsa 0.16.9",
  "external-api",
  "futures",
  "futures-util",
@@ -225,7 +225,7 @@ dependencies = [
  "hyper",
  "itertools 0.11.0",
  "job-types",
- "k256",
+ "k256 0.13.3",
  "matchit",
  "num-bigint",
  "num-traits",
@@ -698,22 +698,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.0.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
 name = "async-io"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
- "async-lock",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.2.0",
  "parking",
- "polling",
- "rustix",
+ "polling 3.4.0",
+ "rustix 0.38.31",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -722,9 +764,60 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener",
- "event-listener-strategy",
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.31",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+dependencies = [
+ "async-io 2.3.1",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.31",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
+name = "async-timer-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e817a8b8569bd1a709f7308dd1fa9928b4c28a5ef0ddfee224e6d96fc444a29"
+dependencies = [
+ "log",
+ "once_cell",
 ]
 
 [[package]]
@@ -770,6 +863,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic_float"
@@ -825,6 +924,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1009,6 +1114,22 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "piper",
+ "tracing",
+]
 
 [[package]]
 name = "bls12_381"
@@ -1311,7 +1432,7 @@ dependencies = [
  "futures",
  "itertools 0.10.5",
  "jf-primitives",
- "k256",
+ "k256 0.13.3",
  "lazy_static",
  "mpc-plonk",
  "mpc-relation",
@@ -1469,7 +1590,7 @@ dependencies = [
  "coins-core",
  "digest 0.10.7",
  "hmac",
- "k256",
+ "k256 0.13.3",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -1512,6 +1633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ff9609e6555556c6a5c8a59cbef56e3458b4d341b8a9c31df1bc393e08f886"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,12 +1668,13 @@ dependencies = [
  "constants",
  "crossbeam",
  "derivative",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek 1.0.1",
+ "ethers-rs",
  "indexmap 2.2.2",
  "itertools 0.10.5",
  "jf-primitives",
- "k256",
+ "k256 0.13.3",
  "lazy_static",
  "libp2p",
  "libp2p-identity",
@@ -1558,10 +1686,33 @@ dependencies = [
  "renegade-crypto",
  "serde",
  "serde_json",
+ "signature 2.0.0",
  "tokio",
  "tracing",
  "util",
  "uuid 1.7.0",
+]
+
+[[package]]
+name = "completeq-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6ca18ff0980e125c5164882fd8a2c99e8535d09eb43dff892a05808abaddab"
+dependencies = [
+ "async-timer-rs",
+ "futures",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "concat-idents"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
+dependencies = [
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1863,6 +2014,18 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -2028,6 +2191,16 @@ checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2221,16 +2394,28 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 2.0.0",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.8",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature 2.2.0",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.0.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2249,8 +2434,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature 2.2.0",
+ "pkcs8 0.10.2",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -2291,19 +2476,39 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.0",
  "generic-array 0.14.7",
  "group 0.13.0",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2341,7 +2546,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "hex 0.4.3",
- "k256",
+ "k256 0.13.3",
  "log",
  "rand 0.8.5",
  "rlp",
@@ -2364,12 +2569,25 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -2381,7 +2599,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "humantime",
+ "humantime 2.1.0",
  "is-terminal",
  "log",
  "regex",
@@ -2461,6 +2679,62 @@ dependencies = [
  "sha3 0.10.8",
  "thiserror",
  "uint",
+]
+
+[[package]]
+name = "ethbind"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "319f16262e9bc96893472a1dadce354aa1567e62e7ee793a60c7dd474be7b1d6"
+dependencies = [
+ "ethbind-gen",
+ "ethbind-json",
+ "ethbind-rust",
+]
+
+[[package]]
+name = "ethbind-gen"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2230c6dccee4a0bde1113c421b94366f711e36f3cf4fd57d7d040ae76bd37b"
+dependencies = [
+ "anyhow",
+ "ethbind-json",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethbind-json"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13983c0ee920d12fc72e4d767807cf15bbc0639c5291f7d26864d7516fa435c"
+dependencies = [
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethbind-rust"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80e07423bd8c279e24a7d07e92f18cec8645115bf6475204ec3b9157b399f54"
+dependencies = [
+ "anyhow",
+ "ethbind-gen",
+ "ethbind-json",
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+ "sha3 0.10.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -2619,10 +2893,10 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "ethabi 18.0.0",
  "generic-array 0.14.7",
- "k256",
+ "k256 0.13.3",
  "num_enum 0.7.2",
  "once_cell",
  "open-fastrlp",
@@ -2719,6 +2993,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-rs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190434061be1a9f84df976eda39be26da349a08fc3695aef5938c2a3844f1233"
+dependencies = [
+ "anyhow",
+ "ethbind",
+ "ethers_eip2718",
+ "ethers_eip712",
+ "ethers_hardhat",
+ "ethers_macros",
+ "ethers_primitives",
+ "ethers_provider",
+ "ethers_signer",
+ "ethers_wallet",
+ "log",
+ "serde",
+ "serde_eip712",
+ "serde_ethabi",
+ "serde_ethrlp",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "ethers-signers"
 version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,7 +3027,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
@@ -2770,10 +3069,192 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers_eip2718"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb82c4b09377fca9fa4af2c386d0e4b51085b131f235faa59f86143cd2d57fae"
+dependencies = [
+ "anyhow",
+ "ethers_primitives",
+ "serde",
+ "serde_ethrlp",
+ "serde_json",
+ "sha3 0.10.8",
+]
+
+[[package]]
+name = "ethers_eip712"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aff087ffc9085aa6a62bed31080876578f2f72a141ca2df2e989e6191ed6d85"
+dependencies = [
+ "anyhow",
+ "ethers_primitives",
+ "serde",
+ "serde_eip712",
+ "sha3 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers_hardhat"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9623f872d50c4dcef41b43ea9072ae42b65425e7b3b788c56a66a50dbb28f94c"
+dependencies = [
+ "anyhow",
+ "async-process",
+ "async-trait",
+ "colorable",
+ "ethers_primitives",
+ "ethers_provider",
+ "ethers_signer",
+ "ethers_wallet",
+ "futures",
+ "log",
+ "once_cell",
+ "pretty_env_logger",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c0633d7e52392cb996cf14d66c4ab8dbf989f73138bf29558349d647d8ee97"
+dependencies = [
+ "ethbind",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ethers_primitives"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09f911b310407d93be5468422f310df8a7f8d4ad3b3c6c13514f12ce6b5fb32"
+dependencies = [
+ "anyhow",
+ "concat-idents",
+ "hex 0.4.3",
+ "k256 0.12.0",
+ "log",
+ "num",
+ "serde",
+ "serde_ethabi",
+ "serde_ethrlp",
+ "sha3 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers_provider"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc3896dbfd8e77bb32a0bcf723e04489c5c8ffcf05904edba2c62d14a9fe25e"
+dependencies = [
+ "anyhow",
+ "async-timer-rs",
+ "completeq-rs",
+ "ethers_eip2718",
+ "ethers_primitives",
+ "futures",
+ "jsonrpc-rs",
+ "log",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.18.0",
+]
+
+[[package]]
+name = "ethers_signer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1258f348aa02a15b3b08308d3fe23526e7898609799230877539db196cd91bc9"
+dependencies = [
+ "anyhow",
+ "ethers_eip2718",
+ "ethers_eip712",
+ "ethers_primitives",
+ "ethers_wallet",
+ "futures",
+ "jsonrpc-rs",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers_wallet"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402b21e2f8e1235f33911a1258c8a34e34cd9176aa2a8ff9d9cdda6389a8a79c"
+dependencies = [
+ "aes",
+ "anyhow",
+ "ctr",
+ "digest 0.10.7",
+ "ethers_primitives",
+ "hmac",
+ "k256 0.12.0",
+ "log",
+ "num",
+ "once_cell",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "regex",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "thiserror",
+ "uuid 1.7.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2786,7 +3267,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.0.0",
  "pin-project-lite",
 ]
 
@@ -2815,6 +3306,15 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -3015,6 +3515,21 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-lite"
@@ -3526,6 +4041,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -3653,7 +4177,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io",
+ "async-io 2.3.1",
  "core-foundation",
  "fnv",
  "futures",
@@ -3775,6 +4299,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.5",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,7 +4334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi 0.3.5",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -3945,6 +4480,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad976fa82c385ef31fb1871f953b59c306ce4edb80d7cbd06535911fdae9cc2"
+dependencies = [
+ "anyhow",
+ "async-timer-rs",
+ "bytes",
+ "completeq-rs",
+ "futures",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,16 +4527,30 @@ dependencies = [
 
 [[package]]
 name = "k256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a55e0ff3b72c262bcf041d9e97f1b84492b68f1c1a384de2323d3dc9403397"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.15.1",
+ "elliptic-curve 0.12.3",
+ "once_cell",
+ "sha2 0.10.8",
+ "signature 2.0.0",
+]
+
+[[package]]
+name = "k256"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.8",
- "signature 2.2.0",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -4436,6 +5003,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4899,6 +5472,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4918,6 +5505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4937,14 +5525,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5473,13 +6074,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.8",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -5524,6 +6146,22 @@ dependencies = [
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
@@ -5531,7 +6169,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.31",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -5585,6 +6223,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
 
 [[package]]
 name = "prettyplease"
@@ -6224,6 +6872,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6241,6 +6890,17 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -6405,6 +7065,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
@@ -6412,7 +7086,7 @@ dependencies = [
  "bitflags 2.4.2",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
 ]
 
@@ -6596,14 +7270,28 @@ dependencies = [
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.8",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6718,6 +7406,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_eip712"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa4aeabc78ef60112b5bfd217db4301e9fbb4cc0441cf5d99959c9f4a7b4cec"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "ethers_primitives",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_ethabi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2796fdb42db1cf045772e41179fa65d22a9d5c0e6737822313bcd6c4d259019"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_ethrlp"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "127a5e93c14d5ddcf90698301a6c3d0dc655bd3baf00031080be0edbb773c0f8"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6784,7 +7517,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -6924,9 +7657,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -7135,12 +7868,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -7443,8 +8186,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
- "fastrand",
- "rustix",
+ "fastrand 2.0.1",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -7640,6 +8383,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 
@@ -8190,6 +8945,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"

--- a/circuit-types/src/wallet.rs
+++ b/circuit-types/src/wallet.rs
@@ -5,7 +5,7 @@
 use std::ops::Add;
 
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar, ScalarField};
+use constants::{AuthenticatedScalar, Scalar, ScalarField, MAX_BALANCES, MAX_FEES, MAX_ORDERS};
 use itertools::Itertools;
 use mpc_relation::{traits::Circuit, Variable};
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,8 @@ pub type WalletShareStateCommitment = Scalar;
 pub type NoteCommitment = Scalar;
 /// Nullifier type alias for readability
 pub type Nullifier = Scalar;
+/// A type alias for a wallet with default sizing parameters
+pub type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS, MAX_FEES>;
 
 // --------------------
 // | Wallet Base Type |

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ mocks = [
     "mpc-plonk",
     "ark-ec",
     "ark-poly",
-    "k256",
+    "k256/expose-field",
     "ecdsa",
 ]
 
@@ -22,11 +22,13 @@ ark-ec = { version = "0.4", optional = true }
 ark-poly = { version = "0.4", optional = true }
 ecdsa = { version = "0.16", optional = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
+ethers-rs = { version = "0.2" }
 jf-primitives = { workspace = true, optional = true }
-k256 = { version = "0.13", features = ["expose-field"], optional = true }
+k256 = { version = "0.13", features = ["ecdsa"] }
 mpc-plonk = { workspace = true, optional = true }
 mpc-relation = { workspace = true, optional = true }
 num-bigint = { workspace = true }
+signature = "2.0"
 
 # === Runtime + Networking === #
 crossbeam = { workspace = true }

--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -1,6 +1,6 @@
 //! Defines API type definitions used in request/response messages
 
-use std::{collections::HashMap, convert::TryInto, sync::atomic::Ordering};
+use std::{collections::HashMap, convert::TryInto};
 
 use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_string};
 use circuit_types::{
@@ -54,10 +54,6 @@ pub struct ApiWallet {
     pub private_shares: Vec<BigUint>,
     /// The wallet blinder, used to blind wallet secret shares
     pub blinder: BigUint,
-    /// The state of update lock of the wallet, used to protect against
-    /// concurrent updates to the wallet
-    #[serde(default)]
-    pub update_locked: bool,
 }
 
 /// Conversion from a wallet that has been indexed in the global state to the
@@ -89,7 +85,6 @@ impl From<Wallet> for ApiWallet {
             blinded_public_shares,
             private_shares,
             blinder: scalar_to_biguint(&wallet.blinder),
-            update_locked: wallet.update_locked.load(Ordering::Relaxed),
         }
     }
 }
@@ -127,7 +122,6 @@ impl TryFrom<ApiWallet> for Wallet {
             private_shares,
             merkle_proof: None,
             merkle_staleness: Default::default(),
-            update_locked: Default::default(),
         })
     }
 }

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -191,7 +191,7 @@ impl OnChainEventListenerExecutor {
         &self,
         wallet: Wallet,
     ) -> Result<(), OnChainEventListenerError> {
-        let task = UpdateMerkleProofTaskDescriptor { wallet };
+        let task = UpdateMerkleProofTaskDescriptor::new(wallet).unwrap();
         let (_task_id, waiter) = self.global_state.append_task(task.into())?;
         waiter.await?;
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -459,13 +459,14 @@ impl HandshakeExecutor {
             .get_wallet_for_order(&handshake_state.local_order_id)?
             .ok_or_else(|| HandshakeManagerError::State(ERR_NO_WALLET.to_string()))?;
 
-        let task: TaskDescriptor = SettleMatchTaskDescriptor {
+        let task: TaskDescriptor = SettleMatchTaskDescriptor::new(
             wallet_id,
             handshake_state,
             match_bundle,
-            party0_validity_proof: party0_proof,
-            party1_validity_proof: party1_proof,
-        }
+            party0_proof,
+            party1_proof,
+        )
+        .unwrap()
         .into();
 
         // Signal the task driver to preempt its queue with the task

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -146,16 +146,17 @@ impl HandshakeExecutor {
         };
 
         // Submit the match to the task driver
-        let task: TaskDescriptor = SettleMatchInternalTaskDescriptor {
-            execution_price: price,
+        let task: TaskDescriptor = SettleMatchInternalTaskDescriptor::new(
+            price,
             order_id1,
             order_id2,
-            order1_validity_witness: validity_witness1,
-            order2_validity_witness: validity_witness2,
-            order1_proof: validity_proof1,
-            order2_proof: validity_proof2,
+            validity_proof1,
+            validity_witness1,
+            validity_proof2,
+            validity_witness2,
             match_result,
-        }
+        )
+        .unwrap()
         .into();
 
         let wallet_id1 = self

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -59,7 +59,9 @@ pub(crate) async fn lookup_wallet_and_check_result(
     let state = &test_args.state;
 
     let key_chain = expected_wallet.key_chain.clone();
-    let task = LookupWalletTaskDescriptor { wallet_id, blinder_seed, secret_share_seed, key_chain };
+    let task =
+        LookupWalletTaskDescriptor::new(wallet_id, blinder_seed, secret_share_seed, key_chain)
+            .unwrap();
     await_task(task.into(), &test_args).await?;
 
     // Check the global state for the wallet and verify that it was correctly

--- a/workers/task-driver/integration/tests/create_new_wallet.rs
+++ b/workers/task-driver/integration/tests/create_new_wallet.rs
@@ -1,9 +1,7 @@
 //! Integration tests for the `NewWalletTask`
 
 use common::types::{tasks::NewWalletTaskDescriptor, wallet_mocks::mock_empty_wallet};
-use constants::Scalar;
-use eyre::{eyre, Result};
-use rand::thread_rng;
+use eyre::Result;
 use test_helpers::integration_test_async;
 
 use crate::{helpers::await_task, IntegrationTestArgs};
@@ -20,21 +18,3 @@ async fn create_valid_wallet(test_args: IntegrationTestArgs) -> Result<()> {
     await_task(descriptor.into(), &test_args).await
 }
 integration_test_async!(create_valid_wallet);
-
-/// Tests creating a new wallet with invalid secret shares, the task should fail
-/// in the constructor
-#[allow(non_snake_case)]
-async fn create_invalid_wallet(test_args: IntegrationTestArgs) -> Result<()> {
-    let mut wallet = mock_empty_wallet();
-    wallet.blinded_public_shares.balances[0].amount = Scalar::random(&mut thread_rng());
-    let descriptor = NewWalletTaskDescriptor { wallet };
-
-    // Run the task, should fail
-    let res = await_task(descriptor.into(), &test_args).await;
-    if res.is_ok() {
-        Err(eyre!("task constructor should have failed"))
-    } else {
-        Ok(())
-    }
-}
-integration_test_async!(create_invalid_wallet);

--- a/workers/task-driver/integration/tests/lookup_wallet.rs
+++ b/workers/task-driver/integration/tests/lookup_wallet.rs
@@ -19,12 +19,13 @@ use crate::{
 #[allow(non_snake_case)]
 async fn test_lookup_wallet__invalid_wallet(test_args: IntegrationTestArgs) -> Result<()> {
     let wallet = mock_empty_wallet();
-    let descriptor = LookupWalletTaskDescriptor {
-        wallet_id: Uuid::new_v4(),
-        blinder_seed: Scalar::zero(),
-        secret_share_seed: Scalar::zero(),
-        key_chain: wallet.key_chain,
-    };
+    let descriptor = LookupWalletTaskDescriptor::new(
+        Uuid::new_v4(),
+        Scalar::zero(),
+        Scalar::zero(),
+        wallet.key_chain,
+    )
+    .unwrap();
 
     assert_true_result!(await_task(descriptor.into(), &test_args).await.is_err())
 }

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -295,16 +295,17 @@ async fn test_settle_internal_match(test_args: IntegrationTestArgs) -> Result<()
         setup_match_result(buy_wallet.clone(), sell_wallet.clone(), &test_args).await?;
 
     // Create the task
-    let task = SettleMatchInternalTaskDescriptor {
-        execution_price: FixedPoint::from_f64_round_down(EXECUTION_PRICE),
-        order_id1: buy_wallet.orders.first().unwrap().0,
-        order_id2: sell_wallet.orders.first().unwrap().0,
-        match_result: match_res.clone(),
-        order1_proof: get_first_order_proofs(&buy_wallet, state)?,
-        order2_proof: get_first_order_proofs(&sell_wallet, state)?,
-        order1_validity_witness: get_first_order_witness(&buy_wallet, state)?,
-        order2_validity_witness: get_first_order_witness(&sell_wallet, state)?,
-    };
+    let task = SettleMatchInternalTaskDescriptor::new(
+        FixedPoint::from_f64_round_down(EXECUTION_PRICE),
+        buy_wallet.orders.first().unwrap().0,
+        sell_wallet.orders.first().unwrap().0,
+        get_first_order_proofs(&buy_wallet, state)?,
+        get_first_order_witness(&buy_wallet, state)?,
+        get_first_order_proofs(&sell_wallet, state)?,
+        get_first_order_witness(&sell_wallet, state)?,
+        match_res.clone(),
+    )
+    .unwrap();
 
     let modified_wallets = vec![buy_wallet.wallet_id, sell_wallet.wallet_id];
     await_immediate_task(modified_wallets, task.into(), &test_args).await?;
@@ -343,13 +344,14 @@ async fn test_settle_mpc_match(test_args: IntegrationTestArgs) -> Result<()> {
     };
 
     // Start a task to settle the match
-    let task = SettleMatchTaskDescriptor {
-        wallet_id: buy_wallet.wallet_id,
+    let task = SettleMatchTaskDescriptor::new(
+        buy_wallet.wallet_id,
         handshake_state,
-        match_bundle: match_settle_proof,
-        party0_validity_proof: get_first_order_proofs(&buy_wallet, state)?,
-        party1_validity_proof: get_first_order_proofs(&sell_wallet, state)?,
-    };
+        match_settle_proof,
+        get_first_order_proofs(&buy_wallet, state)?,
+        get_first_order_proofs(&sell_wallet, state)?,
+    )
+    .unwrap();
 
     let modified_wallets = vec![buy_wallet.wallet_id];
     let res = await_immediate_task(modified_wallets, task.into(), &test_args).await;

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -238,7 +238,6 @@ impl LookupWalletTask {
             blinded_public_shares,
             merkle_proof: None, // constructed below
             merkle_staleness: Default::default(),
-            update_locked: Default::default(),
         };
 
         // Find the authentication path for the wallet

--- a/workers/task-driver/src/tasks/update_merkle_proof.rs
+++ b/workers/task-driver/src/tasks/update_merkle_proof.rs
@@ -145,11 +145,6 @@ impl Task for UpdateMerkleProofTask {
     type Descriptor = UpdateMerkleProofTaskDescriptor;
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
-        // TODO: remove wallet locks
-        if !descriptor.wallet.try_lock_wallet() {
-            return Err(UpdateMerkleProofTaskError::WalletLocked);
-        }
-
         Ok(Self {
             wallet: descriptor.wallet,
             arbitrum_client: ctx.arbitrum_client,
@@ -179,12 +174,6 @@ impl Task for UpdateMerkleProofTask {
             },
         }
 
-        Ok(())
-    }
-
-    // Unlock the update lock if the task fails
-    async fn cleanup(&mut self) -> Result<(), UpdateMerkleProofTaskError> {
-        self.wallet.unlock_wallet();
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -182,10 +182,6 @@ impl Task for UpdateWalletTask {
     type Descriptor = UpdateWalletTaskDescriptor;
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
-        if !descriptor.old_wallet.try_lock_wallet() {
-            return Err(UpdateWalletTaskError::WalletLocked);
-        }
-
         // Safety check, the new wallet's secret shares must recover the new wallet
         Self::check_wallet_shares(&descriptor.new_wallet)?;
 
@@ -236,12 +232,6 @@ impl Task for UpdateWalletTask {
             },
         }
 
-        Ok(())
-    }
-
-    // Unlock the update lock if the task fails
-    async fn cleanup(&mut self) -> Result<(), UpdateWalletTaskError> {
-        self.old_wallet.unlock_wallet();
         Ok(())
     }
 


### PR DESCRIPTION
### Purpose
This PR implements task constructors for each of the task descriptors and changes the callsites to use these constructors. The constructors enforce safety checks: valid blinding, wallet update signatures, etc. And can give an immediate failure in the case a task will not be able to run.

I also removed wallet locks while modifying the `Wallet` type. These are subsumed by the wallet task queue.

### Testing
- Unit tests pass
- Tested the constructor safety checks for the fallible descriptor types