### PR TITLE
mock-node: Define initial mock node for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,6 +5189,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock-node"
+version = "0.1.0"
+dependencies = [
+ "api-server",
+ "arbitrum-client",
+ "chain-events",
+ "circuit-types",
+ "common",
+ "config",
+ "ed25519-dalek 1.0.1",
+ "external-api",
+ "futures",
+ "gossip-api",
+ "gossip-server",
+ "handshake-manager",
+ "job-types",
+ "libp2p",
+ "network-manager",
+ "price-reporter",
+ "proof-manager",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "state",
+ "system-bus",
+ "task-driver",
+ "test-helpers",
+ "tokio",
+]
+
+[[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
 source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#8fd52e2e84cccfa5ae7e7c929c375459cbd6b352"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 	"core",
 	"external-api",
 	"gossip-api",
+	"mock-node",
 	"renegade-crypto",
 	"state",
 	"system-bus",

--- a/common/src/default_wrapper.rs
+++ b/common/src/default_wrapper.rs
@@ -19,6 +19,10 @@ use std::{
 pub struct DefaultWrapper<D: Default>(D);
 /// A default wrapper for an option
 pub type DefaultOption<D> = DefaultWrapper<Option<D>>;
+/// Create a new default option
+pub fn default_option<D>(item: D) -> DefaultOption<D> {
+    DefaultWrapper::new(Some(item))
+}
 
 impl<D: Default> From<D> for DefaultWrapper<D> {
     fn from(d: D) -> Self {

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -13,10 +13,16 @@ pub mod wallet;
 #[cfg(feature = "mocks")]
 pub use wallet::mocks as wallet_mocks;
 
-use tokio::sync::watch::Receiver as WatchReceiver;
+use tokio::sync::watch::{
+    channel as watch_channel, Receiver as WatchReceiver, Sender as WatchSender,
+};
 
 /// A type alias for an empty channel used to signal cancellation to workers
 pub type CancelChannel = WatchReceiver<()>;
+/// Create a new cancel channel
+pub fn new_cancel_channel() -> (WatchSender<()>, CancelChannel) {
+    watch_channel(())
+}
 
 /// An alias for the price of an asset pair that abstracts away its
 /// representation

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -52,8 +52,8 @@ struct Cli {
     /// The chain that the relayer settles to
     #[clap(long, value_parser, default_value = "testnet")]
     pub chain_id: Chain,
-    /// The address of the darkpool contract, defaults to the Goerli deployment
-    #[clap(long, value_parser, default_value = "0xf96e457217cfaa498cf917f2da429814c587b064")]
+    /// The address of the darkpool contract, defaults to the internal testnet deployment
+    #[clap(long, value_parser, default_value = "0xe1080224b632a93951a7cfa33eeea9fd81558b5e")]
     pub contract_address: String,
     /// The path to the file containing deployments info for the darkpool contract
     #[clap(long, value_parser)]

--- a/mock-node/Cargo.toml
+++ b/mock-node/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "mock-node"
+version = "0.1.0"
+edition = "2021"
+description = "A mock relayer for testing"
+
+[dependencies]
+# === Runtime + Networking === #
+futures = { workspace = true }
+libp2p = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+
+# === Workspace Dependencies === #
+api-server = { path = "../workers/api-server" }
+arbitrum-client = { path = "../arbitrum-client" }
+circuit-types = { path = "../circuit-types" }
+chain-events = { path = "../workers/chain-events" }
+common = { path = "../common" }
+config = { path = "../config" }
+external-api = { path = "../external-api" }
+gossip-api = { path = "../gossip-api" }
+gossip-server = { path = "../workers/gossip-server" }
+handshake-manager = { path = "../workers/handshake-manager" }
+job-types = { path = "../workers/job-types" }
+network-manager = { path = "../workers/network-manager" }
+price-reporter = { path = "../workers/price-reporter" }
+proof-manager = { path = "../workers/proof-manager" }
+state = { path = "../state", features = ["mocks"] }
+system-bus = { path = "../system-bus" }
+task-driver = { path = "../workers/task-driver" }
+test-helpers = { path = "../test-helpers" }
+
+# === Misc Dependencies === #
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
+reqwest = { version = "0.11", features = ["blocking"] }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -1,0 +1,488 @@
+//! Defines mock node methods for integration testing
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+
+use std::mem;
+
+use api_server::worker::{ApiServer, ApiServerConfig};
+use arbitrum_client::client::{ArbitrumClient, ArbitrumClientConfig};
+use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
+use common::{
+    default_wrapper::{default_option, DefaultOption},
+    types::{new_cancel_channel, CancelChannel},
+    worker::Worker,
+};
+use config::RelayerConfig;
+use ed25519_dalek::Keypair;
+use external_api::bus_message::SystemBusMessage;
+use gossip_server::{server::GossipServer, worker::GossipServerConfig};
+use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};
+use job_types::{
+    gossip_server::{
+        new_gossip_server_queue, GossipServerJob, GossipServerQueue, GossipServerReceiver,
+    },
+    handshake_manager::{
+        new_handshake_manager_queue, HandshakeExecutionJob, HandshakeManagerQueue,
+        HandshakeManagerReceiver,
+    },
+    network_manager::{
+        new_network_manager_queue, NetworkManagerJob, NetworkManagerQueue, NetworkManagerReceiver,
+    },
+    price_reporter::{
+        new_price_reporter_queue, PriceReporterJob, PriceReporterQueue, PriceReporterReceiver,
+    },
+    proof_manager::{
+        new_proof_manager_queue, ProofManagerJob, ProofManagerQueue, ProofManagerReceiver,
+    },
+    task_driver::{new_task_driver_queue, TaskDriverJob, TaskDriverQueue, TaskDriverReceiver},
+};
+use libp2p::Multiaddr;
+use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
+use price_reporter::{manager::PriceReporter, worker::PriceReporterConfig};
+use proof_manager::{proof_manager::ProofManager, worker::ProofManagerConfig};
+use reqwest::{blocking::Client, Method};
+use serde::{de::DeserializeOwned, Serialize};
+use state::{
+    replication::network::traits::{new_raft_message_queue, RaftMessageQueue, RaftMessageReceiver},
+    State,
+};
+use system_bus::SystemBus;
+use task_driver::worker::{TaskDriver, TaskDriverConfig};
+use tokio::runtime::Runtime as TokioRuntime;
+
+/// Create a cancel channel and forget the sender to avoid drops
+fn mock_cancel() -> CancelChannel {
+    let (send, recv) = new_cancel_channel();
+    mem::forget(send);
+
+    recv
+}
+
+/// The mock node struct, used to build testing nodes
+///
+/// We store both ends of the queue for each worker because:
+///   1. Storing the sender allows testing code to send messages to the worker
+///      directly
+///   2. Storing the receiver prevents the receiver from being dropped, which
+///      would close the channel. We want the channel to remain open even if no
+///      worker is listening
+///
+/// The receiver end of each queue is stored in a `DefaultOption` so that
+/// if/when a worker is spawned for that queue they may take ownership of the
+/// receiver.
+pub struct MockNodeController {
+    /// The local addr that the relayer has bound to
+    local_addr: Multiaddr,
+    /// The relayer's config
+    config: RelayerConfig,
+
+    // --- Shared Handles --- //
+    /// The arbitrum client
+    arbitrum_client: Option<ArbitrumClient>,
+    /// The system bus
+    bus: SystemBus<SystemBusMessage>,
+    /// The global state (if initialized)
+    state: Option<State>,
+
+    // --- Worker Queues --- //
+    /// The network manager's queue
+    network_queue: (NetworkManagerQueue, DefaultOption<NetworkManagerReceiver>),
+    /// The raft message queue
+    raft_queue: (RaftMessageQueue, DefaultOption<RaftMessageReceiver>),
+    /// The gossip message queue
+    gossip_queue: (GossipServerQueue, DefaultOption<GossipServerReceiver>),
+    /// The handshake manager's queue
+    handshake_queue: (HandshakeManagerQueue, DefaultOption<HandshakeManagerReceiver>),
+    /// The price reporter's queue
+    price_queue: (PriceReporterQueue, DefaultOption<PriceReporterReceiver>),
+    /// The proof generation queue
+    proof_queue: (ProofManagerQueue, DefaultOption<ProofManagerReceiver>),
+    /// The task manager queue
+    task_queue: (TaskDriverQueue, DefaultOption<TaskDriverReceiver>),
+}
+
+/// All methods use a builder pattern to allow chained construction
+impl MockNodeController {
+    /// Constructor
+    pub fn new(config: RelayerConfig) -> Self {
+        let bus = SystemBus::new();
+        let (network_sender, network_recv) = new_network_manager_queue();
+        let (raft_sender, raft_recv) = new_raft_message_queue();
+        let (gossip_sender, gossip_recv) = new_gossip_server_queue();
+        let (handshake_send, handshake_recv) = new_handshake_manager_queue();
+        let (price_sender, price_recv) = new_price_reporter_queue();
+        let (proof_gen_sender, proof_gen_recv) = new_proof_manager_queue();
+        let (task_sender, task_recv) = new_task_driver_queue();
+
+        Self {
+            config,
+            local_addr: Multiaddr::empty(),
+            arbitrum_client: None,
+            bus,
+            state: None,
+            network_queue: (network_sender, default_option(network_recv)),
+            raft_queue: (raft_sender, default_option(raft_recv)),
+            gossip_queue: (gossip_sender, default_option(gossip_recv)),
+            handshake_queue: (handshake_send, default_option(handshake_recv)),
+            price_queue: (price_sender, default_option(price_recv)),
+            proof_queue: (proof_gen_sender, default_option(proof_gen_recv)),
+            task_queue: (task_sender, default_option(task_recv)),
+        }
+    }
+
+    /// A helper to clone the cluster keypair out of the config for workers
+    ///
+    /// The keypair type doesn't have a `Clone` method for safety so this
+    /// workaround is necessary
+    fn clone_cluster_key(&self) -> Keypair {
+        let key_bytes = self.config.cluster_keypair.to_bytes();
+        Keypair::from_bytes(&key_bytes).expect("Failed to clone cluster keypair")
+    }
+
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Get a copy of the global state
+    ///
+    /// Panics if the state is not initialized
+    pub fn state(&self) -> State {
+        self.state.clone().expect("State not initialized")
+    }
+
+    // -----------------
+    // | Worker Queues |
+    // -----------------
+
+    /// Send an API request to the mock node
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn send_api_req<B: Serialize, R: DeserializeOwned>(
+        &self,
+        route: &str,
+        method: Method,
+        body: B,
+    ) -> Result<R, String> {
+        let client = Client::new();
+        let url = format!("http://localhost:{}{}", self.config.http_port, route);
+
+        let resp = match method {
+            Method::GET => client.get(url).send().map_err(|e| e.to_string()),
+            Method::POST => client.post(url).json(&body).send().map_err(|e| e.to_string()),
+            _ => Err("Unsupported method".to_string()),
+        }
+        .map_err(|e| e.to_string())?;
+
+        if resp.status().is_success() {
+            resp.json().map_err(|e| e.to_string())
+        } else {
+            Err(format!("Request failed with status: {}", resp.status()))
+        }
+    }
+
+    /// Send a job to the task driver
+    pub fn send_task_job(&self, job: TaskDriverJob) -> Result<(), String> {
+        self.task_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    /// Send a job to the network manager
+    pub fn send_network_job(&self, job: NetworkManagerJob) -> Result<(), String> {
+        self.network_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    /// Send a job to the gossip server
+    pub fn send_gossip_job(&self, job: GossipServerJob) -> Result<(), String> {
+        self.gossip_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    /// Send a job to the handshake manager
+    pub fn send_handshake_job(&self, job: HandshakeExecutionJob) -> Result<(), String> {
+        self.handshake_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    /// Send a job to the price reporter
+    pub fn send_price_reporter_job(&self, job: PriceReporterJob) -> Result<(), String> {
+        self.price_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    /// Send a job to the proof manager
+    pub fn send_proof_job(&self, job: ProofManagerJob) -> Result<(), String> {
+        self.proof_queue.0.send(job).map_err(|e| e.to_string())
+    }
+
+    // ------------
+    // | Builders |
+    // ------------
+
+    /// Add an arbitrum client to the mock node
+    pub fn with_arbitrum_client(mut self) -> Self {
+        let conf = ArbitrumClientConfig {
+            darkpool_addr: self.config.contract_address.clone(),
+            chain: self.config.chain_id,
+            rpc_url: self.config.rpc_url.clone().unwrap(),
+            arb_priv_key: self.config.arbitrum_private_key.clone(),
+        };
+
+        // Expects to be running in a Tokio runtime
+        let rt = TokioRuntime::new().expect("Failed to create tokio runtime");
+        let client =
+            rt.block_on(ArbitrumClient::new(conf)).expect("Failed to create arbitrum client");
+        self.arbitrum_client = Some(client);
+
+        self
+    }
+
+    /// Add a global state instance to the mock node
+    pub fn with_state(mut self) -> Self {
+        // Create a global state instance
+        let network_queue = self.network_queue.0.clone();
+        let raft_receiver = self.raft_queue.1.take().unwrap();
+        let task_sender = self.task_queue.0.clone();
+        let bus = self.bus.clone();
+
+        let state = State::new(network_queue, raft_receiver, &self.config, task_sender, bus)
+            .expect("Failed to create state instance");
+        self.state = Some(state);
+
+        self
+    }
+
+    /// Add a task driver to the mock node
+    pub fn with_task_driver(mut self) -> Self {
+        let task_queue = self.task_queue.1.take().unwrap();
+        let arbitrum_client =
+            self.arbitrum_client.clone().expect("Arbitrum client not initialized");
+        let network_queue = self.network_queue.0.clone();
+        let proof_queue = self.proof_queue.0.clone();
+        let bus = self.bus.clone();
+        let state = self.state.clone().expect("State not initialized");
+
+        let conf = TaskDriverConfig::new(
+            task_queue,
+            arbitrum_client,
+            network_queue,
+            proof_queue,
+            bus,
+            state,
+        );
+        let mut driver = TaskDriver::new(conf).expect("Failed to create task driver");
+        driver.start().expect("Failed to start task driver");
+
+        self
+    }
+
+    /// Add a network manager to the mock node
+    pub fn with_network_manager(mut self) -> Self {
+        let config = &self.config;
+        let network_recv = self.network_queue.1.take().unwrap();
+        let raft_sender = self.raft_queue.0.clone();
+        let gossip_sender = self.gossip_queue.0.clone();
+        let handshake_send = self.handshake_queue.0.clone();
+        let cancel_channel = mock_cancel();
+
+        let conf = NetworkManagerConfig {
+            port: config.p2p_port,
+            bind_addr: config.bind_addr,
+            known_public_addr: config.public_ip,
+            allow_local: config.allow_local,
+            cluster_id: config.cluster_id.clone(),
+            cluster_keypair: Some(self.clone_cluster_key()),
+            send_channel: Some(network_recv),
+            raft_queue: raft_sender,
+            gossip_work_queue: gossip_sender,
+            handshake_work_queue: handshake_send,
+            system_bus: self.bus.clone(),
+            global_state: self.state.clone().expect("State not initialized"),
+            cancel_channel,
+        };
+        let mut manager = NetworkManager::new(conf).expect("Failed to create network manager");
+        manager.start().expect("Failed to start network manager");
+
+        // Set the local addr after the manager binds to it
+        self.local_addr = manager.local_addr;
+
+        self
+    }
+
+    /// Add a gossip server to the mock node
+    pub fn with_gossip_server(mut self) -> Self {
+        let config = &self.config;
+        let state = self.state.clone().expect("State not initialized");
+        let local_peer_id = state.get_peer_id().expect("Failed to get peer id");
+        let arbitrum_client =
+            self.arbitrum_client.clone().expect("Arbitrum client not initialized");
+
+        let job_sender = self.gossip_queue.0.clone();
+        let job_receiver = self.gossip_queue.1.take().unwrap();
+        let network_sender = self.network_queue.0.clone();
+
+        let conf = GossipServerConfig {
+            local_peer_id,
+            local_addr: self.local_addr.clone(),
+            cluster_id: config.cluster_id.clone(),
+            bootstrap_servers: config.bootstrap_servers.clone(),
+            arbitrum_client,
+            global_state: state,
+            job_sender,
+            job_receiver: default_option(job_receiver),
+            network_sender,
+            cancel_channel: mock_cancel(),
+        };
+        let mut server = GossipServer::new(conf).expect("Failed to create gossip server");
+        server.start().expect("Failed to start gossip server");
+
+        self
+    }
+
+    /// Add a handshake manager to the mock node
+    pub fn with_handshake_manager(mut self) -> Self {
+        let global_state = self.state.clone().expect("State not initialized");
+        let network_channel = self.network_queue.0.clone();
+        let price_reporter_job_queue = self.price_queue.0.clone();
+        let job_sender = self.handshake_queue.0.clone();
+        let job_receiver = self.handshake_queue.1.take().unwrap();
+        let cancel_channel = mock_cancel();
+        let system_bus = self.bus.clone();
+        let task_queue = self.task_queue.0.clone();
+
+        let conf = HandshakeManagerConfig {
+            global_state,
+            network_channel,
+            price_reporter_job_queue,
+            job_sender,
+            job_receiver: Some(job_receiver),
+            task_queue,
+            system_bus,
+            cancel_channel,
+        };
+        let mut manager = HandshakeManager::new(conf).expect("Failed to create handshake manager");
+        manager.start().expect("Failed to start handshake manager");
+
+        self
+    }
+
+    /// Add a price reporter to the mock node
+    pub fn with_price_reporter(mut self) -> Self {
+        let config = &self.config;
+        let job_receiver = self.price_queue.1.take().unwrap();
+        let cancel_channel = mock_cancel();
+        let system_bus = self.bus.clone();
+
+        let conf = PriceReporterConfig {
+            coinbase_api_key: config.coinbase_api_key.clone(),
+            coinbase_api_secret: config.coinbase_api_secret.clone(),
+            eth_websocket_addr: config.eth_websocket_addr.clone(),
+            disabled: config.disable_price_reporter,
+            disabled_exchanges: config.disabled_exchanges.clone(),
+            job_receiver: default_option(job_receiver),
+            system_bus,
+            cancel_channel,
+        };
+        let mut reporter = PriceReporter::new(conf).expect("Failed to create price reporter");
+        reporter.start().expect("Failed to start price reporter");
+
+        self
+    }
+
+    /// Add a chain even listener to the mock node
+    pub fn with_chain_event_listener(self) -> Self {
+        let config = &self.config;
+        let arbitrum_client =
+            self.arbitrum_client.clone().expect("Arbitrum client not initialized");
+        let global_state = self.state.clone().expect("State not initialized");
+        let handshake_manager_job_queue = self.handshake_queue.0.clone();
+        let proof_generation_work_queue = self.proof_queue.0.clone();
+        let network_sender = self.network_queue.0.clone();
+        let cancel_channel = mock_cancel();
+
+        let conf = OnChainEventListenerConfig {
+            max_root_staleness: config.max_merkle_staleness,
+            arbitrum_client,
+            global_state,
+            handshake_manager_job_queue,
+            proof_generation_work_queue,
+            network_sender,
+            cancel_channel,
+        };
+
+        let mut listener =
+            OnChainEventListener::new(conf).expect("Failed to create chain event listener");
+        listener.start().expect("Failed to start chain event listener");
+
+        self
+    }
+
+    /// Add an API server to the mock node
+    pub fn with_api_server(self) -> Self {
+        let config = &self.config;
+        let network_sender = self.network_queue.0.clone();
+        let global_state = self.state.clone().expect("State not initialized");
+        let system_bus = self.bus.clone();
+        let price_reporter_work_queue = self.price_queue.0.clone();
+        let proof_generation_work_queue = self.proof_queue.0.clone();
+        let cancel_channel = mock_cancel();
+
+        let conf = ApiServerConfig {
+            http_port: config.http_port,
+            websocket_port: config.websocket_port,
+            network_sender,
+            global_state,
+            system_bus,
+            price_reporter_work_queue,
+            proof_generation_work_queue,
+            cancel_channel,
+        };
+
+        let mut server = ApiServer::new(conf).expect("Failed to create API server");
+        server.start().expect("Failed to start API server");
+
+        // Forget the server to avoid dropping it and its runtime
+        mem::forget(server);
+
+        self
+    }
+
+    /// Add a proof generation module to the mock node
+    pub fn with_proof_generation(mut self) -> Self {
+        let job_queue = self.proof_queue.1.take().unwrap();
+        let cancel_channel = mock_cancel();
+
+        let conf = ProofManagerConfig { job_queue, cancel_channel };
+
+        let mut manager = ProofManager::new(conf).expect("Failed to create proof manager");
+        manager.start().expect("Failed to start proof manager");
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use api_server::http::PING_ROUTE;
+    use config::RelayerConfig;
+    use external_api::{http::PingResponse, EmptyRequestResponse};
+    use reqwest::Method;
+    use test_helpers::arbitrum::DEFAULT_DEVNET_PKEY;
+
+    use crate::MockNodeController;
+
+    /// Tests a simple constructor of the mock node
+    #[test]
+    fn test_ping_mock() {
+        let conf = RelayerConfig {
+            rpc_url: Some("http://localhost:1234".to_string()),
+            arbitrum_private_key: DEFAULT_DEVNET_PKEY.to_string(),
+            ..Default::default()
+        };
+
+        // A simple no-panic test
+        let node = MockNodeController::new(conf.clone()).with_state().with_api_server();
+
+        // Send a ping to check the health of the mock
+        let _ping_resp: PingResponse =
+            node.send_api_req(PING_ROUTE, Method::GET, EmptyRequestResponse {}).unwrap();
+    }
+}

--- a/state/src/replication/network/traits.rs
+++ b/state/src/replication/network/traits.rs
@@ -2,7 +2,7 @@
 //! sending and receiving raft messages from cluster peers
 
 use crate::replication::error::ReplicationError;
-use crossbeam::channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
+use crossbeam::channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use gossip_api::request_response::raft::RaftMessage;
 use raft::prelude::Message as RawRaftMessage;
 
@@ -10,6 +10,11 @@ use raft::prelude::Message as RawRaftMessage;
 pub type RaftMessageQueue = CrossbeamSender<RaftMessage>;
 /// The receiver end of the raft message queue inbound from the network
 pub type RaftMessageReceiver = CrossbeamReceiver<RaftMessage>;
+
+/// Create a new raft message queue and receiver
+pub fn new_raft_message_queue() -> (RaftMessageQueue, RaftMessageReceiver) {
+    unbounded()
+}
 
 // -----------
 // | Network |

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -59,7 +59,7 @@ mod task;
 mod wallet;
 
 /// Health check
-const PING_ROUTE: &str = "/v0/ping";
+pub const PING_ROUTE: &str = "/v0/ping";
 
 // ------------------
 // | Error Messages |

--- a/workers/api-server/src/lib.rs
+++ b/workers/api-server/src/lib.rs
@@ -12,7 +12,7 @@
 
 mod auth;
 pub mod error;
-mod http;
+pub mod http;
 mod router;
 mod websocket;
 pub mod worker;

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -1,6 +1,5 @@
 //! Defines the implementation of the `Worker` trait for the ApiServer
 
-use arbitrum_client::client::ArbitrumClient;
 use common::{types::CancelChannel, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use futures::executor::block_on;
@@ -44,8 +43,6 @@ pub struct ApiServerConfig {
     pub http_port: u16,
     /// The port that the websocket server should listen on
     pub websocket_port: u16,
-    /// An arbitrum client
-    pub arbitrum_client: ArbitrumClient,
     /// A sender to the network manager's work queue
     pub network_sender: NetworkManagerQueue,
     /// The worker job queue for the PriceReporter

--- a/workers/job-types/src/gossip_server.rs
+++ b/workers/job-types/src/gossip_server.rs
@@ -7,12 +7,19 @@ use gossip_api::{
     request_response::{AuthenticatedGossipResponse, GossipRequest, GossipResponse},
 };
 use libp2p::request_response::ResponseChannel;
-use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
+use tokio::sync::mpsc::{
+    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+};
 
 /// The queue sender type to send jobs to the gossip server
 pub type GossipServerQueue = TokioSender<GossipServerJob>;
 /// The queue receiver type to receive jobs from the gossip server
 pub type GossipServerReceiver = TokioReceiver<GossipServerJob>;
+
+/// Create a new gossip server queue and receiver
+pub fn new_gossip_server_queue() -> (GossipServerQueue, GossipServerReceiver) {
+    unbounded_channel()
+}
 
 /// Defines a heartbeat job that can be enqueued by other workers in a relayer
 #[derive(Debug)]

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -6,13 +6,20 @@ use common::types::{gossip::WrappedPeerId, wallet::OrderIdentifier};
 use constants::SystemCurveGroup;
 use gossip_api::request_response::{handshake::HandshakeMessage, AuthenticatedGossipResponse};
 use libp2p::request_response::ResponseChannel;
-use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
+use tokio::sync::mpsc::{
+    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+};
 use uuid::Uuid;
 
 /// The job queue for the handshake manager
 pub type HandshakeManagerQueue = TokioSender<HandshakeExecutionJob>;
 /// The job queue receiver for the handshake manager
 pub type HandshakeManagerReceiver = TokioReceiver<HandshakeExecutionJob>;
+
+/// Create a new handshake manager queue and receiver
+pub fn new_handshake_manager_queue() -> (HandshakeManagerQueue, HandshakeManagerReceiver) {
+    unbounded_channel()
+}
 
 /// Represents a job for the handshake manager's thread pool to execute
 #[allow(clippy::large_enum_variant)]

--- a/workers/job-types/src/network_manager.rs
+++ b/workers/job-types/src/network_manager.rs
@@ -7,13 +7,20 @@ use gossip_api::{
 };
 use libp2p::request_response::ResponseChannel;
 use libp2p_core::Multiaddr;
-use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
+use tokio::sync::mpsc::{
+    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+};
 use uuid::Uuid;
 
 /// The task queue type for the network manager
 pub type NetworkManagerQueue = TokioSender<NetworkManagerJob>;
 /// The task queue receiver type for the network manager
 pub type NetworkManagerReceiver = TokioReceiver<NetworkManagerJob>;
+
+/// Create a new network manager queue and receiver
+pub fn new_network_manager_queue() -> (NetworkManagerQueue, NetworkManagerReceiver) {
+    unbounded_channel()
+}
 
 /// The job type for the network manager
 #[derive(Debug)]

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -5,7 +5,8 @@ use common::types::{
 };
 use std::collections::HashMap;
 use tokio::sync::mpsc::{
-    UnboundedReceiver as TokioUnboundedReceiver, UnboundedSender as TokioUnboundedSender,
+    unbounded_channel, UnboundedReceiver as TokioUnboundedReceiver,
+    UnboundedSender as TokioUnboundedSender,
 };
 use tokio::sync::oneshot::Sender as TokioSender;
 
@@ -13,6 +14,11 @@ use tokio::sync::oneshot::Sender as TokioSender;
 pub type PriceReporterQueue = TokioUnboundedSender<PriceReporterJob>;
 /// The queue receiver type for the price reporter
 pub type PriceReporterReceiver = TokioUnboundedReceiver<PriceReporterJob>;
+
+/// Create a new price reporter queue and receiver
+pub fn new_price_reporter_queue() -> (PriceReporterQueue, PriceReporterReceiver) {
+    unbounded_channel()
+}
 
 /// All possible jobs that the PriceReporter accepts.
 #[derive(Debug)]

--- a/workers/job-types/src/proof_manager.rs
+++ b/workers/job-types/src/proof_manager.rs
@@ -12,13 +12,18 @@ use circuits::zk_circuits::{
     valid_wallet_update::{SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness},
 };
 use common::types::proof_bundles::ProofBundle;
-use crossbeam::channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
+use crossbeam::channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use tokio::sync::oneshot::Sender;
 
 /// The queue type for the proof manager
 pub type ProofManagerQueue = CrossbeamSender<ProofManagerJob>;
 /// The receiver type for the proof manager
 pub type ProofManagerReceiver = CrossbeamReceiver<ProofManagerJob>;
+
+/// Create a new proof manager queue and receiver
+pub fn new_proof_manager_queue() -> (ProofManagerQueue, ProofManagerReceiver) {
+    unbounded()
+}
 
 // -------------
 // | Job Types |


### PR DESCRIPTION
### Purpose
This PR adds a `mock-node` crate to the repo which will form the basis of integration testing the `handshake-manager`, `gossip-server`, and `api-server`. The mock node essentially ties together all desired workers and maintains access to their queues so that tests may directly interact with workers.

### Testing
- A simple unit test with an api-only node
- Unit tests pass workspace-wide
