### PR TITLE
workers: handshake-manager-tests: Setup mock node in tests

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "renegade-relayer"
 version = "0.1.0"
 edition = "2018"
+default-run = "renegade-relayer"
 
 [features]
 debug-tui = []

--- a/mock-node/Cargo.toml
+++ b/mock-node/Cargo.toml
@@ -23,7 +23,7 @@ gossip-server = { path = "../workers/gossip-server" }
 handshake-manager = { path = "../workers/handshake-manager" }
 job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
-price-reporter = { path = "../workers/price-reporter" }
+price-reporter = { path = "../workers/price-reporter", features = ["mocks"] }
 proof-manager = { path = "../workers/proof-manager" }
 state = { path = "../state", features = ["mocks"] }
 system-bus = { path = "../system-bus" }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -415,7 +415,7 @@ impl HttpServer {
 }
 
 /// Handler for the ping route, returns a pong
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PingHandler;
 impl PingHandler {
     /// Create a new handler for "/ping"

--- a/workers/handshake-manager-tests/Cargo.toml
+++ b/workers/handshake-manager-tests/Cargo.toml
@@ -14,15 +14,19 @@ colored = "2"
 eyre = { workspace = true }
 inventory = "0.3"
 
-# === Runtime === #
+# === Runtime + Networking === #
+libp2p = { workspace = true }
 tokio = { workspace = true }
 
 # === Workspace Dependencies === #
+arbitrum-client = { path = "../../arbitrum-client" }
+config = { path = "../../config" }
 job-types = { path = "../job-types" }
-proof-manager = { path = "../proof-manager", features = ["mocks"] }
+mock-node = { path = "../../mock-node" }
 test-helpers = { path = "../../test-helpers" }
 util = { path = "../../util" }
 
 # === Misc Dependencies === #
+base64 = "0.13"
 lazy_static = "1.4"
 tracing = { workspace = true }

--- a/workers/handshake-manager/docker-compose.yml
+++ b/workers/handshake-manager/docker-compose.yml
@@ -23,8 +23,10 @@ services:
       - "8000:8000"
     command: >
       cargo run -- 
-        --my-addr /ip4/127.0.0.1/udp/8000/quic-v1/p2p/12D3KooWSAy34uc3jgrSSkmjmDvu6eNbY9rJ9HUfyujDsv3hkk7V
-        --peer-addr /ip4/127.0.0.1/udp/8001/quic-v1/p2p/12D3KooWRsF1H7RMoJC2ZBFfPi5dCESgz2WFexPmGFbVN48oJYKa
+        --my-key CAESQILfhGLsZ1CgLHRO5iozioKNXORP8+htmHzVm/PE77OHfqOQXKJivIdJrbwNMnXGZvS6yuzMDdaLb9dE692OPls=
+        --my-port 8000
+        --peer-key CAESQFEmvYSO+0/w0ZTTxQIvEudx7lwPZop8nbQvbkb+66ZQPU5BRHlgJuBSdljUBY4Eb/JAuPL3BM0sL3q8J6JCbek=
+        --peer-port 8001
         --deployments-path /deployments.json
         --devnet-url http://sequencer:8547
     tty: true
@@ -41,8 +43,10 @@ services:
       - "8001:8001"
     command: >
       cargo run --
-        --my-addr /ip4/127.0.0.1/udp/8001/quic-v1/p2p/12D3KooWRsF1H7RMoJC2ZBFfPi5dCESgz2WFexPmGFbVN48oJYKa
-        --peer-addr /ip4/127.0.0.1/udp/8000/quic-v1/p2p/12D3KooWSAy34uc3jgrSSkmjmDvu6eNbY9rJ9HUfyujDsv3hkk7V
+        --my-key CAESQFEmvYSO+0/w0ZTTxQIvEudx7lwPZop8nbQvbkb+66ZQPU5BRHlgJuBSdljUBY4Eb/JAuPL3BM0sL3q8J6JCbek=
+        --my-port 8001
+        --peer-key CAESQILfhGLsZ1CgLHRO5iozioKNXORP8+htmHzVm/PE77OHfqOQXKJivIdJrbwNMnXGZvS6yuzMDdaLb9dE692OPls=
+        --peer-port 8000
         --deployments-path /deployments.json
         --devnet-url http://sequencer:8547
         --verbosity full

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -129,7 +129,9 @@ impl MockPriceReporter {
 
         let mut state = HashMap::new();
         for exchange in ALL_EXCHANGES.iter() {
-            state.insert(*exchange, ExchangeConnectionState::Nominal(report.clone()));
+            let mut report_clone = report.clone();
+            report_clone.exchange = Some(*exchange);
+            state.insert(*exchange, ExchangeConnectionState::Nominal(report_clone));
         }
 
         if let Err(e) = channel.send(state) {


### PR DESCRIPTION
### Purpose
This PR updates the handshake manager tests to spawn a configured mock node in the integration stack. I added a dummy test to ensure things run alright, though this will be replaced in a follow-up with actual tests.

### Testing
- Unit tests pass workspace wide
- Dummy integration does not panic