### PR TITLE
workers: api-server: Add `/v0/task_queue/:wallet_id` route + handler

### DIFF
--- a/external-api/src/http/task.rs
+++ b/external-api/src/http/task.rs
@@ -1,5 +1,6 @@
 //! Defines API types for task status introspection
 
+use common::types::tasks::{QueuedTask, QueuedTaskState, TaskIdentifier};
 use serde::Serialize;
 
 /// The response type for a request to fetch task status
@@ -7,4 +8,33 @@ use serde::Serialize;
 pub struct GetTaskStatusResponse {
     /// The status of the requested task
     pub status: String,
+}
+
+/// A type encapsulating status information for a task
+#[derive(Clone, Debug, Serialize)]
+pub struct TaskStatus {
+    /// The ID of the task
+    pub id: TaskIdentifier,
+    /// The status of the task
+    pub status: String,
+    /// Whether or not the task has already committed
+    pub committed: bool,
+}
+
+impl From<QueuedTask> for TaskStatus {
+    fn from(task: QueuedTask) -> Self {
+        let (status, committed) = match task.state {
+            QueuedTaskState::Queued => ("queued".to_string(), false),
+            QueuedTaskState::Running { state, committed } => (state, committed),
+        };
+
+        TaskStatus { id: task.id, status, committed }
+    }
+}
+
+/// The response type for a request to fetch all tasks on a wallet
+#[derive(Clone, Debug, Serialize)]
+pub struct TaskQueueListResponse {
+    /// The list of tasks on a wallet
+    pub tasks: Vec<TaskStatus>,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -34,7 +34,9 @@ use self::{
         GET_NETWORK_ORDER_BY_ID_ROUTE,
     },
     price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
-    task::{GetTaskStatusHandler, GET_TASK_STATUS_ROUTE},
+    task::{
+        GetTaskQueueHandler, GetTaskStatusHandler, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE,
+    },
     wallet::{
         AddFeeHandler, CancelOrderHandler, CreateOrderHandler, CreateWalletHandler,
         DepositBalanceHandler, FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler,
@@ -218,6 +220,14 @@ impl HttpServer {
             GET_TASK_STATUS_ROUTE.to_string(),
             false, // auth_required
             GetTaskStatusHandler::new(global_state.clone()),
+        );
+
+        // The "/task_queue/:wallet_id" route
+        router.add_route(
+            &Method::GET,
+            GET_TASK_QUEUE_ROUTE.to_string(),
+            true, // auth_required
+            GetTaskQueueHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id" route


### PR DESCRIPTION
### Purpose
This PR adds a `/v0/task_queue/:wallet_id` route and handler that returns a set of queued tasks for a wallet. 

### Testing
- Unit tests pass
- Tested a simple `GET` against this endpoint