### PR TITLE
use tracing, tracing_subscriber for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,6 @@ dependencies = [
  "ark-mpc",
  "bigdecimal",
  "bitvec 1.0.1",
- "chrono",
  "circuit-macros",
  "circuit-types",
  "clap 4.4.18",
@@ -1464,7 +1463,6 @@ dependencies = [
  "criterion",
  "ctor",
  "dns-lookup",
- "env_logger 0.9.3",
  "eyre",
  "futures",
  "inventory",
@@ -1481,6 +1479,7 @@ dependencies = [
  "test-helpers",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.18",
  "util",
 ]
 
@@ -2574,33 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime 2.1.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime 2.1.0",
- "is-terminal",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -4083,12 +4056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5098,6 +5065,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matches"
@@ -6295,7 +6271,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
 ]
 
@@ -6826,8 +6802,17 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -6840,6 +6825,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -6880,13 +6871,11 @@ dependencies = [
  "api-server",
  "arbitrum-client",
  "chain-events",
- "chrono",
  "circuit-types",
  "clap 3.2.25",
  "common",
  "config",
  "crossbeam",
- "env_logger 0.10.2",
  "external-api",
  "gossip-api",
  "gossip-server",
@@ -6901,6 +6890,7 @@ dependencies = [
  "task-driver",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -8687,10 +8677,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -8943,10 +8937,8 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "util"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "circuit-types",
  "constants",
- "env_logger 0.9.3",
  "eyre",
  "futures",
  "hex 0.4.3",

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -10,7 +10,7 @@ use constants::Scalar;
 use eyre::{eyre, Result};
 use rand::thread_rng;
 use std::iter;
-use tracing::log::warn;
+use tracing::warn;
 
 use crate::PreAllocatedState;
 

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -10,7 +10,7 @@ use common::types::proof_bundles::{
 use constants::Scalar;
 use contracts_common::types::MatchPayload;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
-use tracing::log::info;
+use tracing::info;
 
 use crate::{
     conversion::{

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -13,7 +13,7 @@ use ethers::{
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
-use tracing::log;
+use tracing::error;
 
 use crate::{
     abi::{
@@ -141,7 +141,7 @@ impl ArbitrumClient {
                 parse_shares_from_process_match_settle(&calldata, public_blinder_share)
             },
             sel => {
-                log::error!("invalid selector when parsing public shares: {sel:?}");
+                error!("invalid selector when parsing public shares: {sel:?}");
                 Err(ArbitrumClientError::InvalidSelector)
             },
         }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test_helpers = ["dep:env_logger", "dep:ctor", "dep:util"]
+test_helpers = ["dep:tracing-subscriber", "dep:ctor", "dep:util"]
 large_benchmarks = []
 large_tests = []
 stats = ["ark-mpc/stats"]
@@ -70,7 +70,7 @@ util = { path = "../util", optional = true }
 # === Misc Dependencies === #
 bitvec = "1.0"
 ctor = { version = "0.1", optional = true }
-env_logger = { version = "0.9", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 futures = { workspace = true }
 itertools = "0.10"
 lazy_static = "1.4"
@@ -82,13 +82,11 @@ tracing = { version = "0.1", features = ["log"] }
 [dev-dependencies]
 ark-ec = "0.4"
 circuit-types = { path = "../circuit-types", features = ["test-helpers"] }
-chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 ctor = "0.1"
 dns-lookup = "1.0"
-env_logger = "0.9"
 eyre = { workspace = true }
 inventory = "0.3"
 mpc-plonk = { workspace = true, features = ["test_apis", "std"] }

--- a/common/src/worker.rs
+++ b/common/src/worker.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use tokio::sync::mpsc::Sender;
-use tracing::log;
+use tracing::error;
 
 /// The Worker trait abstracts over worker functionality with a series of
 /// callbacks that allow a worker to be started, cleaned up, and restarted
@@ -69,7 +69,7 @@ pub fn watch_worker<W: Worker>(worker: &mut W, failure_channel: &Sender<()>) {
             .spawn(move || {
                 #[allow(unused_must_use)]
                 let err = join_handle.join().unwrap();
-                log::error!("worker {worker_name} exited with error: {err:?}");
+                error!("worker {worker_name} exited with error: {err:?}");
                 channel_clone.blocking_send(()).unwrap();
             })
             .unwrap();

--- a/config/src/token_remaps.rs
+++ b/config/src/token_remaps.rs
@@ -6,7 +6,7 @@ use arbitrum_client::constants::Chain;
 use bimap::BiMap;
 use common::types::token::TOKEN_REMAPS;
 use serde::{Deserialize, Serialize};
-use tracing::log;
+use tracing::warn;
 use util::raw_err_str;
 
 /// The base URL for raw token remap files
@@ -59,7 +59,7 @@ pub fn setup_token_remaps(remap_file: Option<String>, chain: Chain) -> Result<()
     let remap = map.to_remap();
     match TOKEN_REMAPS.get() {
         Some(_) => {
-            log::warn!("Token remap already set, cannot override");
+            warn!("Token remap already set, cannot override");
             Ok(())
         },
         None => TOKEN_REMAPS.set(remap).map_err(raw_err_str!("Failed to set token remap: {:?}")),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,8 +32,7 @@ system-bus = { path = "../system-bus" }
 task-driver = { path = "../workers/task-driver" }
 
 # === Misc Dependencies === #
-chrono = "0.4.23"
 clap = { version = "3.2.8", features = ["derive"] }
-env_logger = "0.10"
 lazy_static = "1.4"
 tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -3,7 +3,7 @@
 use common::types::tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey};
 use job_types::task_driver::TaskDriverJob;
 use libmdbx::TransactionKind;
-use tracing::log;
+use tracing::error;
 use util::err_str;
 
 use crate::storage::tx::StateTxn;
@@ -95,7 +95,7 @@ impl StateApplicator {
         let current_running_task = tx.get_current_running_task(&key)?;
         if let Some(task) = current_running_task {
             if task.state.is_committed() {
-                log::error!("cannot preempt committed task: {}", task.id);
+                error!("cannot preempt committed task: {}", task.id);
                 return Err(StateApplicatorError::Preemption);
             }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -21,8 +21,6 @@ constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 
 # === Misc === #
-chrono = "0.4"
-env_logger = "0.9"
 eyre = { workspace = true }
 hex = "0.4"
 json = "0.12"

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use matchit::Router as MatchRouter;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use state::State;
-use tracing::log;
+use tracing::debug;
 
 use crate::error::{bad_request, not_found};
 
@@ -186,7 +186,7 @@ impl Router {
         auth_required: bool,
         handler: H,
     ) {
-        log::debug!("Attached handler to route {route} with method {method}");
+        debug!("Attached handler to route {route} with method {method}");
         let full_route = Self::create_full_route(method, route);
 
         self.router

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -14,7 +14,7 @@ use system_bus::TopicReader;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::StreamMap;
 use tokio_tungstenite::{accept_async, WebSocketStream};
-use tracing::log;
+use tracing::error;
 use tungstenite::Message;
 
 use crate::{
@@ -221,7 +221,7 @@ impl WebsocketServer {
                     match message {
                         Some(msg) => {
                             if let Err(e) = msg {
-                                log::error!("error handling websocket connection: {e}");
+                                error!("error handling websocket connection: {e}");
                                 return Err(ApiServerError::WebsocketServerFailure(e.to_string()));
                             }
 

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -16,7 +16,7 @@ use job_types::{
 };
 use renegade_crypto::fields::u256_to_scalar;
 use state::State;
-use tracing::log;
+use tracing::{error, info, warn};
 
 use super::error::OnChainEventListenerError;
 
@@ -98,7 +98,7 @@ impl OnChainEventListenerExecutor {
             .block_number()
             .await
             .map_err(|err| OnChainEventListenerError::Arbitrum(err.to_string()))?;
-        log::info!("Starting on-chain event listener from current block {starting_block_number}");
+        info!("Starting on-chain event listener from current block {starting_block_number}");
 
         // Build a filtered stream on events that the chain-events worker listens for
         let filter = Filter::default()
@@ -118,7 +118,7 @@ impl OnChainEventListenerExecutor {
             self.handle_event(event).await?;
         }
 
-        log::error!("on-chain event listener stream ended unexpectedly");
+        error!("on-chain event listener stream ended unexpectedly");
         Ok(())
     }
 
@@ -137,7 +137,7 @@ impl OnChainEventListenerExecutor {
             },
             _ => {
                 // Simply log the error and ignore the event
-                log::warn!("chain listener received unexpected event type: {event}");
+                warn!("chain listener received unexpected event type: {event}");
             },
         }
 

--- a/workers/chain-events/src/worker.rs
+++ b/workers/chain-events/src/worker.rs
@@ -3,7 +3,7 @@
 use common::worker::Worker;
 use std::thread::{Builder, JoinHandle};
 use tokio::runtime::Builder as RuntimeBuilder;
-use tracing::log;
+use tracing::error;
 
 use super::{
     error::OnChainEventListenerError,
@@ -53,7 +53,7 @@ impl Worker for OnChainEventListener {
                 let runtime = runtime.unwrap();
                 runtime.block_on(async {
                     if let Err(e) = executor.execute().await {
-                        log::error!("Chain event listener crashed with error: {e}");
+                        error!("Chain event listener crashed with error: {e}");
                         return e;
                     }
 

--- a/workers/gossip-server/src/orderbook.rs
+++ b/workers/gossip-server/src/orderbook.rs
@@ -20,7 +20,7 @@ use gossip_api::{
     pubsub::orderbook::OrderBookManagementMessage,
     request_response::{orderbook::OrderInfoResponse, GossipResponse},
 };
-use tracing::log;
+use tracing::debug;
 use util::err_str;
 
 use super::{errors::GossipError, server::GossipProtocolExecutor};
@@ -64,7 +64,7 @@ impl GossipProtocolExecutor {
             // consensus
             let is_local = order.cluster == self.global_state.get_cluster_id()?;
             if is_local {
-                log::debug!("skipping local order {order_id}");
+                debug!("skipping local order {order_id}");
                 continue;
             }
 

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::{
     GossipRequest,
 };
 use job_types::network_manager::NetworkManagerJob;
-use tracing::log;
+use tracing::info;
 use util::{err_str, get_current_time_seconds};
 
 use crate::{errors::GossipError, server::GossipProtocolExecutor};
@@ -113,7 +113,7 @@ impl GossipProtocolExecutor {
         // Find the peer's info in global state
         let peer_info = self.global_state.get_peer_info(&peer_id)?;
         if peer_info.is_none() {
-            log::info!("could not find info for peer {peer_id:?}");
+            info!("could not find info for peer {peer_id:?}");
             return Ok(());
         }
         let peer_info = peer_info.unwrap();
@@ -133,7 +133,7 @@ impl GossipProtocolExecutor {
         }
 
         // Remove expired peers from global state
-        log::info!("Expiring peer {peer_id}");
+        info!("Expiring peer {peer_id}");
         self.global_state.remove_peer(peer_id)?;
 
         // Add peers to expiry cache for the duration of their invisibility window. This

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::{
 };
 use itertools::Itertools;
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use tracing::log;
+use tracing::warn;
 use util::{err_str, get_current_time_seconds};
 
 use crate::{
@@ -89,7 +89,7 @@ impl GossipProtocolExecutor {
 
                     // Check that the cluster auth signature on the peer is valid
                     if peer.verify_cluster_auth_sig().is_err() {
-                        log::warn!("Peer {} info has invalid cluster auth signature", peer.peer_id);
+                        warn!("Peer {} info has invalid cluster auth signature", peer.peer_id);
                         return false;
                     }
 

--- a/workers/gossip-server/src/server.rs
+++ b/workers/gossip-server/src/server.rs
@@ -26,7 +26,7 @@ use std::{
     thread::{self, Builder, JoinHandle},
     time::Duration,
 };
-use tracing::log;
+use tracing::{error, info};
 use util::err_str;
 
 use crate::peer_discovery::{
@@ -191,7 +191,7 @@ impl GossipProtocolExecutor {
         mut self,
         job_sender: GossipServerQueue,
     ) -> Result<(), GossipError> {
-        log::info!("Starting executor loop for heartbeat protocol executor...");
+        info!("Starting executor loop for heartbeat protocol executor...");
 
         // Start a timer to enqueue outbound heartbeats
         HeartbeatTimer::new(
@@ -212,14 +212,14 @@ impl GossipProtocolExecutor {
                     let self_clone = self.clone();
                     tokio::spawn(async move {
                         if let Err(e) = self_clone.handle_job(job).await {
-                            log::error!("error handling gossip server job: {e}");
+                            error!("error handling gossip server job: {e}");
                         }}
                     );
                 },
 
                 // Await a cancel signal from the coordinator
                 _ = self.cancel_channel.changed() => {
-                    log::info!("Gossip server cancelled, shutting down...");
+                    info!("Gossip server cancelled, shutting down...");
                     return Err(GossipError::Cancelled("server cancelled".to_string()));
                 }
             }

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -46,7 +46,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use system_bus::SystemBus;
-use tracing::log;
+use tracing::info;
 use util::err_str;
 use uuid::Uuid;
 
@@ -167,14 +167,14 @@ impl HandshakeExecutor {
                     let self_clone = self.clone();
                     tokio::task::spawn(async move {
                         if let Err(e) = self_clone.handle_handshake_job(job).await {
-                            log::info!("error executing handshake: {e}")
+                            info!("error executing handshake: {e}")
                         }
                     });
                 },
 
                 // Await cancellation by the coordinator
                 _ = self.cancel.changed() => {
-                    log::info!("Handshake manager received cancel signal, shutting down...");
+                    info!("Handshake manager received cancel signal, shutting down...");
                     return HandshakeManagerError::Cancelled("received cancel signal".to_string());
                 }
             }

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -9,7 +9,7 @@ use common::types::{
 };
 use job_types::task_driver::TaskDriverJob;
 use rand::{seq::SliceRandom, thread_rng};
-use tracing::log;
+use tracing::{error, info};
 use util::{err_str, matching_engine::match_orders, res_some};
 
 use crate::{
@@ -39,7 +39,7 @@ impl HandshakeExecutor {
         &self,
         order: OrderIdentifier,
     ) -> Result<(), HandshakeManagerError> {
-        log::info!("Running internal matching engine on order {order}");
+        info!("Running internal matching engine on order {order}");
         let mut rng = thread_rng();
 
         // Lookup the order and its wallet
@@ -111,15 +111,14 @@ impl HandshakeExecutor {
                         return Ok(());
                     }
                 },
-                Err(e) => log::error!(
+                Err(e) => error!(
                     "internal match settlement failed for {} x {}: {e}",
-                    network_order.id,
-                    order_id,
+                    network_order.id, order_id,
                 ),
             }
         }
 
-        log::info!("No internal matches found for {order:?}");
+        info!("No internal matches found for {order:?}");
         Ok(())
     }
 

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -34,7 +34,7 @@ use common::types::{
 use constants::SystemCurveGroup;
 use crossbeam::channel::{bounded, Receiver};
 use test_helpers::mpc_network::mocks::PartyIDBeaverSource;
-use tracing::log;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::error::HandshakeManagerError;
@@ -112,7 +112,7 @@ impl HandshakeExecutor {
             .await;
 
         // Await MPC completion
-        log::info!("Match completed!");
+        info!("Match completed!");
         res
     }
 
@@ -127,7 +127,7 @@ impl HandshakeExecutor {
         mpc_net: QuicTwoPartyNet<SystemCurveGroup>,
         cancel_channel: Receiver<()>,
     ) -> Result<MatchBundle, HandshakeManagerError> {
-        log::info!("Matching order...");
+        info!("Matching order...");
 
         // Build a fabric
         // TODO: Replace the dummy beaver source

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::handshake::PriceVector;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};
 use lazy_static::lazy_static;
 use tokio::sync::oneshot;
-use tracing::log;
+use tracing::{error, warn};
 
 use super::{HandshakeExecutor, HandshakeManagerError};
 
@@ -150,7 +150,7 @@ impl HandshakeExecutor {
         for response_channel in channels.into_iter() {
             let res = response_channel.await;
             if res.is_err() {
-                log::error!("Error fetching price vector: {res:?}");
+                error!("Error fetching price vector: {res:?}");
                 continue;
             }
             let midpoint_state = res.unwrap();
@@ -176,7 +176,7 @@ impl HandshakeExecutor {
                 },
 
                 err_state => {
-                    log::warn!("Price report invalid during price agreement: {err_state:?}");
+                    warn!("Price report invalid during price agreement: {err_state:?}");
                 },
             }
         }

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use common::types::CancelChannel;
 use job_types::handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue};
 use state::State;
-use tracing::log;
+use tracing::info;
 use util::err_str;
 
 use crate::error::HandshakeManagerError;
@@ -62,7 +62,7 @@ impl HandshakeScheduler {
                 },
 
                 _ = self.cancel.changed() => {
-                    log::info!("Handshake manager cancelled, winding down");
+                    info!("Handshake manager cancelled, winding down");
                     return HandshakeManagerError::Cancelled("received cancel signal".to_string());
                 }
             }

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -14,7 +14,7 @@ use job_types::{
 use state::State;
 use system_bus::SystemBus;
 use tokio::runtime::Builder as RuntimeBuilder;
-use tracing::log;
+use tracing::info;
 
 use crate::manager::{
     init_price_streams, scheduler::HandshakeScheduler, HandshakeExecutor,
@@ -89,7 +89,7 @@ impl Worker for HandshakeManager {
     }
 
     fn start(&mut self) -> Result<(), Self::Error> {
-        log::info!("Starting executor loop for handshake protocol executor...");
+        info!("Starting executor loop for handshake protocol executor...");
 
         // Instruct the price reporter to being streaming prices for the default pairs
         init_price_streams(self.config.price_reporter_job_queue.clone())?;

--- a/workers/network-manager/src/manager.rs
+++ b/workers/network-manager/src/manager.rs
@@ -28,7 +28,7 @@ use libp2p::{
     Multiaddr, Swarm,
 };
 use state::{replication::network::traits::RaftMessageQueue, State};
-use tracing::log;
+use tracing::info;
 
 use std::thread::JoinHandle;
 
@@ -226,7 +226,7 @@ impl NetworkManagerExecutor {
     ///      2. Events from workers to be sent over the network
     /// It handles these in the tokio select! macro below
     pub async fn executor_loop(mut self) -> NetworkManagerError {
-        log::info!("Starting executor loop for network manager...");
+        info!("Starting executor loop for network manager...");
         let mut cancel_channel = self.cancel.take().unwrap();
         let mut job_channel = self.job_channel.take().unwrap();
 
@@ -236,7 +236,7 @@ impl NetworkManagerExecutor {
                 Some(job) = job_channel.recv() => {
                     // Forward the message
                     if let Err(err) = self.handle_job(job) {
-                        log::info!("Error sending outbound message: {}", err);
+                        info!("Error sending outbound message: {}", err);
                     }
                 },
 
@@ -247,14 +247,14 @@ impl NetworkManagerExecutor {
                             if let Err(err) = self.handle_inbound_message(
                                 event,
                             ) {
-                                log::info!("error in network manager: {:?}", err);
+                                info!("error in network manager: {:?}", err);
                             }
                         },
                         SwarmEvent::NewListenAddr { address, .. } => {
-                            log::info!("Listening on {}/p2p/{}\n", address, self.local_peer_id);
+                            info!("Listening on {}/p2p/{}\n", address, self.local_peer_id);
                         },
                         // This catchall may be enabled for fine-grained libp2p introspection
-                        x => { log::info!("Unhandled swarm event: {:?}", x) }
+                        x => { info!("Unhandled swarm event: {:?}", x) }
                     }
                 }
 

--- a/workers/network-manager/src/manager/control_directives.rs
+++ b/workers/network-manager/src/manager/control_directives.rs
@@ -13,7 +13,7 @@ use job_types::{
 use libp2p::PeerId;
 use libp2p_core::{Endpoint, Multiaddr};
 use libp2p_swarm::{ConnectionId, NetworkBehaviour};
-use tracing::log;
+use tracing::{error, info, warn};
 use util::networking::{is_dialable_addr, is_dialable_multiaddr, multiaddr_to_socketaddr};
 use uuid::Uuid;
 
@@ -70,7 +70,7 @@ impl NetworkManagerExecutor {
     fn handle_new_addr(&mut self, peer_id: PeerId, addr: Multiaddr) {
         // If we cannot parse the address or it is not dialable, skip indexing
         if !is_dialable_multiaddr(&addr, self.allow_local) {
-            log::info!("skipping local addr {addr:?}");
+            info!("skipping local addr {addr:?}");
             return;
         }
 
@@ -130,7 +130,7 @@ impl NetworkManagerExecutor {
             )
             .await
             {
-                log::error!("error brokering MPC network: {e}");
+                error!("error brokering MPC network: {e}");
             }
         });
 
@@ -168,11 +168,9 @@ impl NetworkManagerExecutor {
                     let mut net = QuicTwoPartyNet::new(party_id, local_addr, peer_addr);
 
                     if let Err(e) = net.connect().await {
-                        log::warn!(
-                            "failed to broker MPC network on address {peer_addr:?}, error: {e}"
-                        )
+                        warn!("failed to broker MPC network on address {peer_addr:?}, error: {e}")
                     } else {
-                        log::info!("successfully connected to peer at addr: {peer_addr:?}");
+                        info!("successfully connected to peer at addr: {peer_addr:?}");
                         // Forward the net to the handshake manager
                         brokered_net = Some(net);
                         break;

--- a/workers/network-manager/src/manager/identify.rs
+++ b/workers/network-manager/src/manager/identify.rs
@@ -3,7 +3,7 @@
 use job_types::gossip_server::GossipServerJob;
 use libp2p::identify::Event as IdentifyEvent;
 use libp2p_core::multiaddr::Protocol;
-use tracing::log;
+use tracing::{error, info};
 
 use crate::{error::NetworkManagerError, manager::replace_port};
 
@@ -27,7 +27,7 @@ impl NetworkManagerExecutor {
                 local_addr = local_addr.with(Protocol::P2p(self.local_peer_id.0.into()));
 
                 // Update the addr in the global state
-                log::info!("discovered local peer's public IP: {:?}", local_addr);
+                info!("discovered local peer's public IP: {:?}", local_addr);
                 self.global_state.update_local_peer_addr(&local_addr)?;
                 self.discovered_identity = true;
 
@@ -37,7 +37,7 @@ impl NetworkManagerExecutor {
                     if let Err(e) =
                         self.gossip_work_queue.send(GossipServerJob::ExecuteHeartbeat(peer))
                     {
-                        log::error!("error forwarding heartbeat to gossip server: {e}")
+                        error!("error forwarding heartbeat to gossip server: {e}")
                     }
                 }
             }

--- a/workers/network-manager/src/worker.rs
+++ b/workers/network-manager/src/worker.rs
@@ -21,7 +21,7 @@ use libp2p_core::muxing::StreamMuxerBox;
 use libp2p_core::Transport;
 use libp2p_swarm::SwarmBuilder;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
-use tracing::log;
+use tracing::info;
 
 use crate::composed_protocol::ComposedNetworkBehavior;
 
@@ -153,7 +153,7 @@ impl Worker for NetworkManager {
         // Add any bootstrap addresses to the peer info table
         let peer_index = self.config.global_state.get_peer_info_map()?;
         for (peer_id, peer_info) in peer_index.iter() {
-            log::info!("Adding {:?}: {} to routing table...", peer_id, peer_info.get_addr());
+            info!("Adding {:?}: {} to routing table...", peer_id, peer_info.get_addr());
             behavior.kademlia_dht.add_address(peer_id, peer_info.get_addr());
         }
 

--- a/workers/price-reporter/src/exchange/binance.rs
+++ b/workers/price-reporter/src/exchange/binance.rs
@@ -13,7 +13,7 @@ use common::types::{
 };
 use futures_util::{Sink, Stream, StreamExt};
 use serde_json::Value;
-use tracing::log;
+use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
@@ -161,7 +161,7 @@ impl ExchangeConnection for BinanceConnection {
                 Ok(mapped_stream) => mapped_stream.transpose(),
                 // Error on the incoming (filtered) stream
                 Err(e) => {
-                    log::error!("Error reading message from Binance ws: {}", e);
+                    error!("Error reading message from Binance ws: {}", e);
                     Some(Err(ExchangeConnectionError::ConnectionHangup(e.to_string())))
                 },
             }

--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -11,7 +11,7 @@ use common::types::{token::Token, Price};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use hmac_sha256::HMAC;
 use serde_json::json;
-use tracing::log;
+use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 use util::get_current_time_seconds;
@@ -224,7 +224,7 @@ impl ExchangeConnection for CoinbaseConnection {
                     },
 
                     Err(e) => {
-                        log::error!("Error reading message from Coinbase websocket: {e}");
+                        error!("Error reading message from Coinbase websocket: {e}");
                         Some(Err(ExchangeConnectionError::ConnectionHangup(e.to_string())))
                     },
                 }

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use tokio::net::TcpStream;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use tracing::log;
+use tracing::error;
 use tungstenite::Error as WsError;
 use url::Url;
 
@@ -50,7 +50,7 @@ pub(super) async fn ws_connect(
     let ws_conn = match connect_async(url.clone()).await {
         Ok((conn, _resp)) => conn,
         Err(e) => {
-            log::error!("Cannot connect to the remote URL: {}", url);
+            error!("Cannot connect to the remote URL: {}", url);
             return Err(ExchangeConnectionError::HandshakeFailure(e.to_string()));
         },
     };

--- a/workers/price-reporter/src/exchange/kraken.rs
+++ b/workers/price-reporter/src/exchange/kraken.rs
@@ -11,7 +11,7 @@ use common::types::{exchange::Exchange, token::Token, Price};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use lazy_static::lazy_static;
 use serde_json::json;
-use tracing::log;
+use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
@@ -147,7 +147,7 @@ impl ExchangeConnection for KrakenConnection {
 
                 // Error reading from the websocket
                 Err(e) => {
-                    log::error!("Error reading message from Kraken ws: {}", e);
+                    error!("Error reading message from Kraken ws: {}", e);
                     Some(Err(ExchangeConnectionError::ConnectionHangup(e.to_string())))
                 },
             }

--- a/workers/price-reporter/src/exchange/okx.rs
+++ b/workers/price-reporter/src/exchange/okx.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use common::types::{token::Token, Price};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use serde_json::json;
-use tracing::log;
+use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
@@ -147,7 +147,7 @@ impl ExchangeConnection for OkxConnection {
 
                 // Error reading from the websocket
                 Err(e) => {
-                    log::error!("Error reading message from Okx ws: {}", e);
+                    error!("Error reading message from Okx ws: {}", e);
                     Some(Err(ExchangeConnectionError::ConnectionHangup(e.to_string())))
                 },
             }

--- a/workers/price-reporter/src/exchange/uni_v3.rs
+++ b/workers/price-reporter/src/exchange/uni_v3.rs
@@ -13,7 +13,7 @@ use std::{
     str::FromStr,
     task::{Context, Poll},
 };
-use tracing::log;
+use tracing::error;
 use web3::{
     self,
     api::BaseFilter,
@@ -374,7 +374,7 @@ impl ExchangeConnection for UniswapV3Connection {
                     ))),
 
                     Err(e) => {
-                        log::error!("Error parsing Swap event from UniswapV3: {}", e);
+                        error!("Error parsing Swap event from UniswapV3: {}", e);
                         Some(Err(ExchangeConnectionError::ConnectionHangup(e.to_string())))
                     },
                 }

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -12,7 +12,7 @@ use common::types::Price;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::oneshot::Sender as OneshotSender;
-use tracing::log;
+use tracing::{debug, error};
 use util::get_current_time_seconds;
 
 use crate::errors::PriceReporterError;
@@ -62,7 +62,7 @@ impl MockPriceReporter {
             let job = self.job_queue.recv().await;
             if let Some(job) = job {
                 if let Err(e) = self.handle_job(job) {
-                    log::error!("error in mock price reporter: {e:?}");
+                    error!("error in mock price reporter: {e:?}");
                 }
             }
         }
@@ -72,7 +72,7 @@ impl MockPriceReporter {
     fn handle_job(&self, job: PriceReporterJob) -> Result<(), PriceReporterError> {
         match job {
             PriceReporterJob::StartPriceReporter { .. } => {
-                log::debug!("mock price reporter got `StartPriceReporter` job");
+                debug!("mock price reporter got `StartPriceReporter` job");
                 Ok(())
             },
             PriceReporterJob::PeekMedian { base_token, quote_token, channel } => {
@@ -103,7 +103,7 @@ impl MockPriceReporter {
         });
 
         if let Err(e) = channel.send(state) {
-            log::error!("error sending price report: {e:?}");
+            error!("error sending price report: {e:?}");
         }
 
         Ok(())
@@ -135,7 +135,7 @@ impl MockPriceReporter {
         }
 
         if let Err(e) = channel.send(state) {
-            log::error!("error sending price report: {e:?}");
+            error!("error sending price report: {e:?}");
         }
 
         Ok(())

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -24,7 +24,7 @@ use common::types::proof_bundles::{
 };
 use job_types::proof_manager::{ProofJob, ProofManagerReceiver};
 use tokio::{runtime::Handle, sync::oneshot::Sender as TokioSender};
-use tracing::log;
+use tracing::error;
 
 use crate::error::ProofManagerError;
 
@@ -43,7 +43,7 @@ impl MockProofManager {
     pub fn start(job_queue: ProofManagerReceiver) {
         Handle::current().spawn_blocking(move || {
             if let Err(e) = Self::execution_loop(&job_queue) {
-                log::error!("error in mock proof manager: {e}");
+                error!("error in mock proof manager: {e}");
             }
         });
     }

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -25,7 +25,7 @@ use circuits::{
 use common::types::{proof_bundles::ProofBundle, CancelChannel};
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
 use rayon::ThreadPool;
-use tracing::log;
+use tracing::{error, info};
 
 use super::error::ProofManagerError;
 
@@ -70,7 +70,7 @@ impl ProofManager {
                 .has_changed()
                 .map_err(|err| ProofManagerError::RecvError(err.to_string()))?
             {
-                log::info!("Proof manager cancelled, shutting down...");
+                info!("Proof manager cancelled, shutting down...");
                 return Err(ProofManagerError::Cancelled("received cancel signal".to_string()));
             }
 
@@ -81,7 +81,7 @@ impl ProofManager {
 
             thread_pool.spawn(move || {
                 if let Err(e) = Self::handle_proof_job(job) {
-                    log::error!("Error handling proof manager job: {}", e)
+                    error!("Error handling proof manager job: {}", e)
                 }
             });
         }

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -21,7 +21,7 @@ use test_helpers::{
     contract_interaction::{attach_merkle_opening, new_wallet_in_darkpool},
     integration_test_async,
 };
-use tracing::log;
+use tracing::info;
 use util::{get_current_time_seconds, hex::biguint_from_hex_string};
 use uuid::Uuid;
 
@@ -96,7 +96,7 @@ async fn execute_wallet_update_and_verify_shares(
     test_args: IntegrationTestArgs,
 ) -> Result<()> {
     execute_wallet_update(old_wallet, new_wallet.clone(), transfer, test_args.clone()).await?;
-    log::info!("Wallet updated successfully");
+    info!("Wallet updated successfully");
     lookup_wallet_and_check_result(&new_wallet, blinder_seed, share_seed, test_args).await
 }
 

--- a/workers/task-driver/src/helpers.rs
+++ b/workers/task-driver/src/helpers.rs
@@ -40,7 +40,7 @@ use job_types::{
 use num_bigint::BigUint;
 use state::State;
 use tokio::sync::oneshot::{self, Receiver as TokioReceiver};
-use tracing::log;
+use tracing::debug;
 
 // -------------
 // | Constants |
@@ -288,7 +288,7 @@ pub(crate) async fn update_wallet_validity_proofs(
     // No validity proofs needed for an empty wallet, they will be re-proven on
     // the next update that adds a non-empty order
     if !wallet.has_orders_to_match() {
-        log::debug!(
+        debug!(
             "wallet {} has no orders ready for matching, skipping validity proofs",
             wallet.wallet_id
         );

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -19,7 +19,7 @@ use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManage
 use renegade_crypto::hash::PoseidonCSPRNG;
 use serde::Serialize;
 use state::{error::StateError, State};
-use tracing::log;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{
@@ -343,7 +343,7 @@ impl LookupWalletTask {
 
         let latest_tx = updating_tx
             .ok_or_else(|| LookupWalletTaskError::NotFound(ERR_WALLET_NOT_FOUND.to_string()))?;
-        log::info!("latest updating tx: {:#x}", latest_tx);
+        info!("latest updating tx: {:#x}", latest_tx);
 
         Ok((blinder_index, curr_blinder, curr_blinder_private_share))
     }


### PR DESCRIPTION
This PR replaces the use of `log` (re-exported through `tracing::log`) with the `tracing` `info!`, `error!`, etc. macros, and replaces usage of `env_logger` with the `EnvFilter` and `fmt::Layer` from `tracing_subscriber`.

This way, all of our logs will properly have span information attached to them, and can be configured to output both to `stdout` and to an OpenTelemetry collector using [`tracing_opentelemetry`](https://docs.rs/tracing-opentelemetry/0.22.0/tracing_opentelemetry/index.html).

I've tested that logs are properly being written to `stdout` by running the relayer.