### PR TITLE
circuits: zk-circuits: valid-wallet-update: Add fees and bounds checks

### DIFF
--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -10,14 +10,12 @@
 use ark_ff::{One, Zero};
 use circuit_macros::circuit_type;
 use circuit_types::{
-    fixed_point::FixedPointVar,
     keychain::PublicSigningKey,
     merkle::{MerkleOpening, MerkleRoot},
-    order::OrderVar,
     traits::{BaseType, CircuitBaseType, CircuitVarType, SecretShareVarType},
     transfers::{ExternalTransfer, ExternalTransferVar},
     wallet::{Nullifier, WalletShare, WalletShareStateCommitment, WalletVar},
-    PlonkCircuit, AMOUNT_BITS,
+    PlonkCircuit,
 };
 use constants::{Scalar, ScalarField, MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT};
 use mpc_plonk::errors::PlonkError;
@@ -26,11 +24,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     zk_gadgets::{
-        comparators::{
-            EqGadget, EqVecGadget, EqZeroGadget, GreaterThanEqZeroGadget, NotEqualGadget,
-        },
+        comparators::{EqGadget, EqVecGadget, EqZeroGadget, NotEqualGadget},
         merkle::PoseidonMerkleHashGadget,
-        wallet_operations::{NullifierGadget, WalletShareCommitGadget},
+        wallet_operations::{AmountGadget, NullifierGadget, WalletShareCommitGadget},
     },
     SingleProverCircuit,
 };
@@ -108,13 +104,7 @@ where
             statement.new_public_shares.unblind_shares(recovered_blinder, cs);
         let new_wallet = unblinded_public_shares.add_shares(&witness.new_wallet_private_shares, cs);
 
-        Self::verify_wallet_transition(
-            &old_wallet,
-            &new_wallet,
-            &statement.external_transfer,
-            statement.timestamp,
-            cs,
-        )
+        Self::verify_wallet_transition(&old_wallet, &new_wallet, &statement.external_transfer, cs)
     }
 
     /// Verify a state transition between two wallets
@@ -122,17 +112,90 @@ where
         old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
         new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
         external_transfer: &ExternalTransferVar,
-        update_timestamp: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // External transfer must have binary direction
-        cs.enforce_bool(external_transfer.direction)?;
+        // Validate the new wallet's orders
+        Self::validate_new_orders(new_wallet, cs)?;
 
-        // Validate updates to the orders within the wallet
-        Self::validate_order_updates(old_wallet, new_wallet, update_timestamp, cs)?;
+        // Validate the transfer
+        let transfer_is_zero = EqZeroGadget::eq_zero(external_transfer, cs)?;
+        Self::validate_external_transfer(transfer_is_zero, external_transfer, cs)?;
 
         // Validate updates to the balances within the wallet
-        Self::validate_balance_updates(old_wallet, new_wallet, external_transfer, cs)
+        Self::validate_balance_updates(
+            old_wallet,
+            new_wallet,
+            transfer_is_zero,
+            external_transfer,
+            cs,
+        )?;
+
+        // The match_fee and managing_cluster should remain unchanged
+        //
+        // Note that the keys are allowed to change to enable key rotation. The actual
+        // wallet transition is authorized by a signature from the old root key
+        // (checked on-chain) so rotation is protected outside of the circuit
+        EqGadget::constrain_eq(&old_wallet.match_fee, &new_wallet.match_fee, cs)?;
+        EqGadget::constrain_eq(&old_wallet.managing_cluster, &new_wallet.managing_cluster, cs)
+    }
+
+    // ----------
+    // | Orders |
+    // ----------
+
+    /// Validates the orders of the new wallet
+    ///
+    /// The order sides are implicitly constrained binary by their
+    /// representation as a `BoolVar`
+    fn validate_new_orders(
+        new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        for order in new_wallet.orders.iter() {
+            // Check that the amount is valid
+            AmountGadget::constrain_valid_amount(order.amount, cs)?;
+
+            // If either base or quote mint is zero then the whole order should be zero
+            let base_mint_zero = EqZeroGadget::eq_zero(&order.base_mint, cs)?;
+            let quote_mint_zero = EqZeroGadget::eq_zero(&order.quote_mint, cs)?;
+            let order_zero = EqZeroGadget::eq_zero(order, cs)?;
+
+            let either_mint_zero = cs.logic_or(base_mint_zero, quote_mint_zero)?;
+
+            // If both mints are zero the order should also be zero, if either
+            // mint is non-zero then the order is necessarily
+            // non-zero so constraining these two booleans to equal
+            // one another is equivalent to the "if" statement above
+            cs.enforce_equal(either_mint_zero.into(), order_zero.into())?;
+        }
+
+        Ok(())
+    }
+
+    // ------------
+    // | Transfer |
+    // ------------
+
+    /// Validates the external transfer in the statement
+    ///
+    /// The transfer direction is enforced to be binary by its representation as
+    /// a `BoolVar`
+    ///
+    /// Takes in a pre-computed wire indicating whether the transfer is zero, so
+    /// that we may reuse this computation in other components
+    pub fn validate_external_transfer(
+        is_zero: BoolVar,
+        transfer: &ExternalTransferVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        // Enforce that if the transfer mint is zero, the whole transfer struct must be
+        // zero This is equivalent to enforcing `mint_is_zero ==
+        // transfer_is_zero`
+        let mint_is_zero = EqZeroGadget::eq_zero(&transfer.mint, cs)?;
+        cs.enforce_equal(mint_is_zero.into(), is_zero.into())?;
+
+        // Check that the amount of transfer is a valid amount
+        AmountGadget::constrain_valid_amount(transfer.amount, cs)
     }
 
     // ------------
@@ -143,115 +206,35 @@ where
     fn validate_balance_updates(
         old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
         new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
+        transfer_is_zero: BoolVar,
         external_transfer: &ExternalTransferVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Ensure that all mints in the updated balances are unique
-        Self::constrain_unique_balance_mints(new_wallet, cs)?;
-        // Validate that the external transfer has been correctly applied
-        Self::validate_external_transfer(old_wallet, new_wallet, external_transfer, cs)
-    }
+        // Check that if the balance mint is zero the whole balance must be zero
+        // and that the balances have valid amounts in them after update
+        for balance in new_wallet.balances.iter() {
+            // If the mint is zero, the balance must be zero
+            // This is equivalent to enforcing `mint_is_zero == balance_is_zero`
+            let mint_is_zero = EqZeroGadget::eq_zero(&balance.mint, cs)?;
+            let balance_is_zero = EqZeroGadget::eq_zero(&balance.amount, cs)?;
+            cs.enforce_equal(mint_is_zero.into(), balance_is_zero.into())?;
 
-    /// Validates the application of the external transfer to the balance state
-    pub(crate) fn validate_external_transfer(
-        old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
-        new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
-        external_transfer: &ExternalTransferVar,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        let zero = ScalarField::zero();
-        let one = ScalarField::one();
-
-        // Zero out the external transfer amount if its mint is zero
-        let external_transfer_zero = EqZeroGadget::eq_zero(external_transfer.mint, cs)?;
-        let external_transfer_not_zero = cs.logic_neg(external_transfer_zero)?;
-
-        let transfer_amount =
-            cs.mul(external_transfer.amount, external_transfer_not_zero.into())?;
-        let neg_amount = cs.mul_constant(transfer_amount, &-one)?;
-
-        // The term added to the balance matching the external transfer mint
-        let external_transfer_term = cs.mux(
-            BoolVar::new_unchecked(external_transfer.direction),
-            neg_amount,
-            transfer_amount,
-        )?;
-
-        // Stores a boolean indicating whether the external transfer appeared in the new
-        // balances it must be applied to at least one balance
-        let mut external_transfer_applied = cs.false_var();
-
-        // Check the balance state transition for each balance
-        for (old_balance, new_balance) in old_wallet.balances.iter().zip(new_wallet.balances.iter())
-        {
-            // Add in the external transfer information term if applicable
-            // The external transfer term applies if either the old balance's mint or the
-            // new balance's mint equals the transfer mint. These two mints are
-            // constrained to be consistent with one another below
-            let equals_old_mint = EqGadget::eq(&old_balance.mint, &external_transfer.mint, cs)?;
-            let equals_new_mint = EqGadget::eq(&new_balance.mint, &external_transfer.mint, cs)?;
-            let equals_external_transfer_mint = cs.logic_or(equals_old_mint, equals_new_mint)?;
-
-            let external_transfer_term =
-                cs.mul(equals_external_transfer_mint.into(), external_transfer_term)?;
-            external_transfer_applied =
-                cs.logic_or(external_transfer_applied, equals_external_transfer_mint)?;
-
-            // Constrain the updated balance to be non-negative and correctly updated
-            //  `new_balance.amount - old_balance.amount - external_transfer_term`
-            cs.lc_gate(
-                &[
-                    new_balance.amount,
-                    old_balance.amount,
-                    external_transfer_term,
-                    cs.one(),
-                    cs.zero(), // output
-                ],
-                &[one, -one, -one, zero],
-            )?;
-
-            // Constrain the new balance to be non-negative
-            GreaterThanEqZeroGadget::<AMOUNT_BITS /* bitwidth */>::constrain_greater_than_zero(
-                new_balance.amount,
-                cs,
-            )?;
-
-            // Constrain the mints to be set correctly. A valid mint is one of:
-            //  1. The same mint as in the old wallet, if the balance previously existed and
-            //     was not zero'd
-            //  2. The mint of the transfer if the balance was previously zero; balances are
-            //     constrained to be unique elsewhere in the circuit
-            //  3. The zero mint, if the balance is zero
-            let mints_equal = EqGadget::eq(&old_balance.mint, &new_balance.mint, cs)?;
-            let equals_transfer_mint =
-                EqGadget::eq(&new_balance.mint, &external_transfer.mint, cs)?;
-            let mint_is_zero = EqZeroGadget::eq_zero(new_balance.mint, cs)?;
-            let new_balance_zero = EqZeroGadget::eq_zero(new_balance.amount, cs)?;
-            let prev_balance_zero = EqZeroGadget::eq_zero(old_balance.amount, cs)?;
-
-            // Condition 1 -- same mint as old wallet, balance not zero'd
-            let prev_balance_not_zero = cs.logic_neg(prev_balance_zero)?;
-            let new_balance_not_zero = cs.logic_neg(new_balance_zero)?;
-            let valid_mint1 =
-                cs.logic_and_all(&[mints_equal, prev_balance_not_zero, new_balance_not_zero])?;
-
-            // Condition 2 -- new mint added to wallet
-            let valid_mint2 =
-                cs.logic_and_all(&[equals_transfer_mint, prev_balance_zero, new_balance_not_zero])?;
-
-            // Condition 3 -- withdrawal of entire balance, mint is now zero
-            let valid_mint3 = cs.logic_and(mint_is_zero, new_balance_zero)?;
-
-            // Constrain one of the three mint conditions to hold
-            let valid_mint = cs.logic_or_all(&[valid_mint1, valid_mint2, valid_mint3])?;
-            cs.enforce_true(valid_mint)?;
+            // Constrain the amount to be valid
+            AmountGadget::constrain_valid_amount(balance.amount, cs)?;
         }
 
-        // Validate that the external transfer's mint did show up in exactly one of the
-        // balances
-        let transfer_applied_or_zero =
-            cs.logic_or(external_transfer_applied, external_transfer_zero)?;
-        cs.enforce_true(transfer_applied_or_zero)
+        // Ensure that all mints in the updated balances are unique
+        Self::constrain_unique_balance_mints(new_wallet, cs)?;
+        // Check that the fee balances did not change in the update
+        Self::validate_fee_balances_unchanged(old_wallet, new_wallet, cs)?;
+        // Validate that the external transfer has been correctly applied
+        Self::validate_transfer_application(
+            old_wallet,
+            new_wallet,
+            transfer_is_zero,
+            external_transfer,
+            cs,
+        )
     }
 
     /// Constrains all balance mints to be unique or zero
@@ -283,115 +266,137 @@ where
         Ok(())
     }
 
-    // ----------
-    // | Orders |
-    // ----------
-
-    /// Validates the orders of the new wallet
-    fn validate_order_updates(
+    /// Check that the fees on the balances are unchanged after update
+    fn validate_fee_balances_unchanged(
         old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
         new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
-        new_timestamp: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Ensure that all order's asset pairs are unique
-        Self::constrain_unique_order_pairs(new_wallet, cs)?;
-
-        // Ensure that the timestamps for all orders are properly set
-        Self::constrain_updated_order_timestamps(old_wallet, new_wallet, new_timestamp, cs)
-    }
-
-    /// Constrain the timestamps to be properly updated
-    /// For each order, if the order is unchanged from the previous wallet, the
-    /// timestamp should remain constant. Otherwise, the timestamp should be
-    /// updated to the current timestamp passed as a public variable
-    fn constrain_updated_order_timestamps(
-        old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
-        new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
-        new_timestamp: Variable,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        for (old_order, new_order) in old_wallet.orders.iter().zip(new_wallet.orders.iter()) {
-            let order_is_zero = Self::order_is_zero(new_order, cs)?;
-            let equals_old_order = Self::orders_equal_except_timestamp(old_order, new_order, cs)?;
-
-            let timestamp_not_updated =
-                EqGadget::eq(&new_order.timestamp, &old_order.timestamp, cs)?;
-            let timestamp_updated = EqGadget::eq(&new_order.timestamp, &new_timestamp, cs)?;
-
-            // Either the orders are equal and the timestamp is not updated, or the
-            // timestamp has been updated to the new timestamp
-            let equal_and_not_updated = cs.logic_and(equals_old_order, timestamp_not_updated)?;
-
-            let not_equal = cs.logic_neg(equals_old_order)?;
-            let not_equal_and_updated = cs.logic_and(not_equal, timestamp_updated)?;
-
-            // Validate that if the order is in one of the following states:
-            //  1. Updated order with updated timestamp
-            //  2. Non-updated order with non-updated timestamp
-            //  3. Cancelled order
-            let valid_order =
-                cs.logic_or_all(&[not_equal_and_updated, equal_and_not_updated, order_is_zero])?;
-            cs.enforce_true(valid_order)?;
+        for (old_balance, new_balance) in old_wallet.balances.iter().zip(new_wallet.balances.iter())
+        {
+            cs.enforce_equal(old_balance.relayer_fee_balance, new_balance.relayer_fee_balance)?;
+            cs.enforce_equal(old_balance.protocol_fee_balance, new_balance.protocol_fee_balance)?;
         }
 
         Ok(())
     }
 
-    /// Assert that all order pairs in a wallet have unique asset pairs
-    fn constrain_unique_order_pairs(
-        wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
+    /// Validates the application of the external transfer to the balance state
+    fn validate_transfer_application(
+        old_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
+        new_wallet: &WalletVar<MAX_BALANCES, MAX_ORDERS>,
+        transfer_is_zero: BoolVar,
+        external_transfer: &ExternalTransferVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Validate that all mints pairs are zero or unique
-        for i in 0..wallet.orders.len() {
-            let order_zero = Self::order_is_zero(&wallet.orders[i], cs)?;
+        let zero = ScalarField::zero();
+        let one = ScalarField::one();
 
-            for j in (i + 1)..wallet.orders.len() {
-                // Check if the ith order is unique
-                let mints_equal = EqVecGadget::eq_vec(
-                    &[wallet.orders[i].quote_mint, wallet.orders[i].base_mint],
-                    &[wallet.orders[j].quote_mint, wallet.orders[j].base_mint],
-                    cs,
-                )?;
+        // Negate out the external transfer amount if it is a withdrawal
+        let transfer_amount = external_transfer.amount;
+        let neg_amount = cs.mul_constant(transfer_amount, &-one)?;
 
-                let mints_not_equal = cs.logic_neg(mints_equal)?;
-                let valid_mints = cs.logic_or(order_zero, mints_not_equal)?;
-                cs.enforce_true(valid_mints)?;
-            }
+        // The term added to the balance matching the external transfer mint
+        let external_transfer_term =
+            cs.mux(external_transfer.direction, neg_amount, transfer_amount)?;
+
+        // Stores a counter indicating whether the external transfer appeared in the new
+        // balances; it must be applied to at least one balance
+        let mut external_transfer_applied = cs.zero();
+
+        // Check the balance state transition for each balance
+        for (old_balance, new_balance) in old_wallet.balances.iter().zip(new_wallet.balances.iter())
+        {
+            // --- Conditional Masking --- //
+
+            // Whether or not the transfer applies to this balance -- this is true if the
+            // transfer mint is equal to either the old or new balance mint
+            let equals_old_mint = EqGadget::eq(&old_balance.mint, &external_transfer.mint, cs)?;
+            let equals_new_mint = EqGadget::eq(&new_balance.mint, &external_transfer.mint, cs)?;
+            let transfer_applies = cs.logic_or(equals_old_mint, equals_new_mint)?;
+
+            // Mask the transfer amount according to whether the the transfer applies to
+            // this balance
+            let external_transfer_term = cs.mul(transfer_applies.into(), external_transfer_term)?;
+
+            // Mark the transfer as applied
+            external_transfer_applied =
+                cs.add(external_transfer_applied, transfer_applies.into())?;
+
+            // --- Amount Updates --- //
+
+            // Constrain the updated balance to be correctly updated
+            //  `new_balance.amount - old_balance.amount - external_transfer_term == 0`
+            cs.lc_gate(
+                &[
+                    new_balance.amount,
+                    old_balance.amount,
+                    external_transfer_term,
+                    cs.one(),
+                    cs.zero(), // output
+                ],
+                &[one, -one, -one, zero],
+            )?;
+
+            // --- Fee Violations --- //
+
+            // If the transfer is a withdrawal, the fees must be zero for the balance
+            let old_fees_are_zero = EqVecGadget::eq_zero_vec(
+                &[old_balance.relayer_fee_balance, old_balance.protocol_fee_balance],
+                cs,
+            )?;
+            let withdrawal_applied_to_balance =
+                cs.logic_and(transfer_applies, external_transfer.direction)?;
+            let withdrawal_not_applied = cs.logic_neg(withdrawal_applied_to_balance)?;
+
+            // Either no withdrawal was applied or the fees were zero pre-update
+            let valid_fee_update = cs.logic_or(withdrawal_not_applied, old_fees_are_zero)?;
+            cs.enforce_true(valid_fee_update)?;
+
+            // --- Mint Updates --- //
+
+            // Constrain the mints to be set correctly. A valid mint is one of:
+            //  1. The same mint as in the old wallet
+            //  2. The old mint was zero and the new mint is the transfer mint
+            //  3. The old mint was the transfer mint and the new mint is zero
+            //  4. The transfer or zero mint, if it replaces a balance that had zero amount
+            //     & fees
+            let mints_equal = EqGadget::eq(&old_balance.mint, &new_balance.mint, cs)?;
+            let old_mint_equals_transfer_mint =
+                EqGadget::eq(&old_balance.mint, &external_transfer.mint, cs)?;
+            let new_mint_equals_transfer_mint =
+                EqGadget::eq(&new_balance.mint, &external_transfer.mint, cs)?;
+            let old_mint_is_zero = EqZeroGadget::eq_zero(&old_balance.mint, cs)?;
+            let new_mint_is_zero = EqZeroGadget::eq_zero(&new_balance.mint, cs)?;
+            let old_amount_zero = EqZeroGadget::eq_zero(&old_balance.amount, cs)?;
+            let prev_balance_was_zerod = cs.logic_and(old_amount_zero, old_fees_are_zero)?;
+
+            // Condition 1 -- same mint as old wallet
+            let valid_mint1 = mints_equal;
+
+            // Condition 2 -- new mint added to wallet
+            let valid_mint2 = cs.logic_and(new_mint_equals_transfer_mint, old_mint_is_zero)?;
+
+            // Condition 3 -- withdrawal of entire balance, mint is now zero
+            let valid_mint3 = cs.logic_and(old_mint_equals_transfer_mint, new_mint_is_zero)?;
+
+            // Condition 4 -- A zero'd balance with non-zero mint was replaced either by a
+            // zero mint or the transfer mint
+            let new_mint_transfer_or_zero =
+                cs.logic_or(new_mint_equals_transfer_mint, new_mint_is_zero)?;
+            let valid_mint4 = cs.logic_and(new_mint_transfer_or_zero, prev_balance_was_zerod)?;
+
+            // Constrain one of the four mint conditions to hold
+            let valid_mint =
+                cs.logic_or_all(&[valid_mint1, valid_mint2, valid_mint3, valid_mint4])?;
+            cs.enforce_true(valid_mint)?;
         }
 
-        Ok(())
-    }
-
-    /// Returns 1 if the order is a zero'd order, otherwise 0
-    fn order_is_zero(order: &OrderVar, cs: &mut PlonkCircuit) -> Result<BoolVar, CircuitError> {
-        let zero = cs.zero();
-        Self::orders_equal_except_timestamp(
-            order,
-            &OrderVar {
-                quote_mint: zero,
-                base_mint: zero,
-                side: cs.false_var(),
-                amount: zero,
-                worst_case_price: FixedPointVar { repr: zero },
-                timestamp: zero,
-            },
-            cs,
-        )
-    }
-
-    /// Returns 1 if the orders are equal (except the timestamp) and 0 otherwise
-    fn orders_equal_except_timestamp(
-        order1: &OrderVar,
-        order2: &OrderVar,
-        cs: &mut PlonkCircuit,
-    ) -> Result<BoolVar, CircuitError> {
-        // Mutate the orders to have the same timestamp
-        let mut order2 = order2.clone();
-        order2.timestamp = order1.timestamp;
-
-        EqGadget::eq(order1, &order2, cs)
+        // Validate that the external transfer's mint did show up in exactly one of the
+        // balances
+        let single_transfer_applied = EqGadget::eq(&external_transfer_applied, &cs.one(), cs)?;
+        let transfer_applied_or_zero = cs.logic_or(single_transfer_applied, transfer_is_zero)?;
+        cs.enforce_true(transfer_applied_or_zero)
     }
 }
 
@@ -445,8 +450,6 @@ where
     pub external_transfer: ExternalTransfer,
     /// The public root key of the old wallet, rotated out after update
     pub old_pk_root: PublicSigningKey,
-    /// The timestamp this update is at
-    pub timestamp: u64,
 }
 /// A `VALID WALLET UPDATE` statement with default const generic sizing
 /// parameters
@@ -493,7 +496,7 @@ pub mod test_helpers {
     };
 
     use crate::zk_circuits::test_helpers::{
-        create_multi_opening, create_wallet_shares, MAX_BALANCES, MAX_ORDERS, TIMESTAMP,
+        create_multi_opening, create_wallet_shares, MAX_BALANCES, MAX_ORDERS,
     };
 
     use super::{ValidWalletUpdateStatement, ValidWalletUpdateWitness};
@@ -505,8 +508,6 @@ pub mod test_helpers {
 
     /// The height of the Merkle tree to test on
     pub(super) const MERKLE_HEIGHT: usize = 3;
-    /// The timestamp of update
-    pub(super) const NEW_TIMESTAMP: u64 = TIMESTAMP + 1;
 
     // -----------
     // | Helpers |
@@ -562,7 +563,6 @@ pub mod test_helpers {
             new_public_shares: new_wallet_public_shares,
             merkle_root,
             external_transfer,
-            timestamp: NEW_TIMESTAMP,
         };
 
         (witness, statement)
@@ -575,16 +575,22 @@ mod test {
 
     use circuit_types::{
         balance::Balance,
+        native_helpers::compute_wallet_private_share_commitment,
         order::Order,
+        traits::CircuitBaseType,
         transfers::{ExternalTransfer, ExternalTransferDirection},
+        AMOUNT_BITS,
     };
+    use constants::Scalar;
+    use mpc_relation::{traits::Circuit, PlonkCircuit};
     use num_bigint::BigUint;
     use rand::{thread_rng, RngCore};
+    use tracing::level_filters::LevelFilter;
+    use util::logging::setup_system_logger;
 
     use crate::zk_circuits::{
         check_constraint_satisfaction,
-        test_helpers::{SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_ORDERS, TIMESTAMP},
-        valid_wallet_update::test_helpers::NEW_TIMESTAMP,
+        test_helpers::{SizedWallet, INITIAL_WALLET, MAX_BALANCES, MAX_ORDERS},
     };
 
     use super::{
@@ -605,16 +611,20 @@ mod test {
         )
     }
 
-    // -------------------------
-    // | Order Placement Tests |
-    // -------------------------
+    /// Get the scalar representation of the maximum allowable amount
+    fn max_amount_scalar() -> Scalar {
+        Scalar::from(2).pow(AMOUNT_BITS as u64) - Scalar::from(1u8)
+    }
+
+    // ----------
+    // | Orders |
+    // ----------
 
     /// Tests a valid witness and statement for placing an order
     #[test]
     fn test_place_order__valid() {
         let mut old_wallet = INITIAL_WALLET.clone();
-        let mut new_wallet = INITIAL_WALLET.clone();
-        new_wallet.orders[0].timestamp = NEW_TIMESTAMP;
+        let new_wallet = INITIAL_WALLET.clone();
 
         // Remove an order from the initial wallet
         old_wallet.orders[0] = Order::default();
@@ -640,17 +650,95 @@ mod test {
         ))
     }
 
-    /// Tests placing an order with a timestamp that does not match the publicly
-    /// claimed timestamp
+    /// Tests multiple valid order updates at once
+    ///
+    /// Includes one cancellation and one placement
     #[test]
-    fn test_place_order__invalid_timestamp() {
+    fn test_multi_order_update() {
         let mut old_wallet = INITIAL_WALLET.clone();
         let mut new_wallet = INITIAL_WALLET.clone();
-        new_wallet.orders[0].timestamp = TIMESTAMP; // old timestamp
+        old_wallet.orders[0] = Order::default();
+        new_wallet.orders[1] = Order::default();
 
-        // Remove an order from the initial wallet
+        assert!(constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ))
+    }
+
+    /// Tests the case in which an order is placed with an amount that is too
+    /// large
+    #[test]
+    fn test_invalid_order_amount() {
+        let old_wallet = INITIAL_WALLET.clone();
+        let new_wallet = INITIAL_WALLET.clone();
+
+        // Construct a statement and witness then modify the order amount of the first
+        // order to be too large
+        let (mut witness, mut statement) =
+            construct_witness_statement(&old_wallet, &new_wallet, ExternalTransfer::default());
+
+        let blinder =
+            statement.new_public_shares.blinder + witness.new_wallet_private_shares.blinder;
+
+        statement.new_public_shares.orders[0].amount = max_amount_scalar() + Scalar::one();
+        witness.new_wallet_private_shares.orders[0].amount = blinder; // Cancels out the blinding on the public shares
+
+        // Recompute the wallet commitment
+        statement.new_private_shares_commitment =
+            compute_wallet_private_share_commitment(&witness.new_wallet_private_shares);
+
+        let res = check_constraint_satisfaction::<
+            ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>,
+        >(&witness, &statement);
+        assert!(!res);
+    }
+
+    /// Tests an invalid order side
+    #[test]
+    fn test_invalid_order_side() {
+        let old_wallet = INITIAL_WALLET.clone();
+        let new_wallet = INITIAL_WALLET.clone();
+
+        // Construct a statement and witness then modify the side of the first order
+        let (mut witness, mut statement) =
+            construct_witness_statement(&old_wallet, &new_wallet, ExternalTransfer::default());
+
+        // Change the side of the first order, changing the shares directly will work
+        witness.new_wallet_private_shares.orders[0].side += Scalar::from(2u8);
+
+        // Recompute the wallet commitment
+        statement.new_private_shares_commitment =
+            compute_wallet_private_share_commitment(&witness.new_wallet_private_shares);
+
+        let res = check_constraint_satisfaction::<
+            ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>,
+        >(&witness, &statement);
+        assert!(!res);
+    }
+
+    /// Tests an invalid order in which the zero mint is the quote or base mint
+    #[test]
+    fn test_invalid_order__zero_mint() {
+        let mut old_wallet = INITIAL_WALLET.clone();
+        let new_wallet = INITIAL_WALLET.clone();
         old_wallet.orders[0] = Order::default();
 
+        // Quote mint is zero in new order
+        let mut new_wallet = new_wallet.clone();
+        new_wallet.orders[0].quote_mint = BigUint::from(0u8);
+
+        assert!(!constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ));
+
+        // Base mint is zero in new order
+        let mut new_wallet = new_wallet.clone();
+        new_wallet.orders[0].base_mint = BigUint::from(0u8);
+
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
             &new_wallet,
@@ -658,13 +746,115 @@ mod test {
         ));
     }
 
-    /// Tests modifying the timestamp of an existing order
+    // -------------
+    // | Transfers |
+    // -------------
+
+    /// Tests the case in which the mint is zero but the amount is not
     #[test]
-    fn test_place_order__invalid_timestamp_update() {
-        // No update to the orders, but the timestamp is incorrect
+    fn test_zero_mint_transfer() {
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+
+        let transfer = ExternalTransfer {
+            account_addr: BigUint::from(0u8),
+            mint: BigUint::from(0u8),
+            amount: 1u128,
+            direction: ExternalTransferDirection::Deposit,
+        };
+        let transfer_var = transfer.create_witness(&mut cs);
+
+        let is_zero = cs.false_var();
+        ValidWalletUpdate::<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>::validate_external_transfer(
+            is_zero,
+            &transfer_var,
+            &mut cs,
+        )
+        .unwrap();
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+    }
+
+    /// Tests the case in which the transfer amount is too large
+    #[test]
+    fn test_invalid_transfer__large_amount() {
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let transfer = ExternalTransfer {
+            account_addr: BigUint::from(0u8),
+            mint: BigUint::from(1u8),
+            amount: 0, // replaced
+            direction: ExternalTransferDirection::Deposit,
+        };
+
+        // Allocate the transfer then replace its amount with a large one
+        let large_amt = max_amount_scalar() + Scalar::one();
+        let large_amt_var = large_amt.create_witness(&mut cs);
+
+        let mut transfer_var = transfer.create_witness(&mut cs);
+        transfer_var.amount = large_amt_var;
+
+        let is_zero = cs.false_var();
+        ValidWalletUpdate::<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>::validate_external_transfer(
+            is_zero,
+            &transfer_var,
+            &mut cs,
+        )
+        .unwrap();
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+    }
+
+    // ------------
+    // | Balances |
+    // ------------
+
+    /// Tests a non-zero balance for the zero mint -- invalid
+    #[test]
+    fn test_invalid_balance__non_zero_zero_mint() {
+        // To ablate any other constraints, make the zero mint present in both
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0].mint = BigUint::from(0u8);
+        let new_wallet = old_wallet.clone();
+
+        assert!(!constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ));
+    }
+
+    /// Tests an invalid balance amount
+    #[test]
+    fn test_invalid_balance__large_amount() {
+        // Transfer in an amount that pushes the balance over the maximum
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0].amount = max_amount_scalar() - Scalar::one();
+        let new_wallet = old_wallet.clone();
+
+        // Construct a statement and witness then modify the order amount of the first
+        // order to be too large
+        let transfer_amt = 2;
+        let (witness, mut statement) = construct_witness_statement(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer {
+                mint: old_wallet.balances[0].mint.clone(),
+                amount: transfer_amt,
+                direction: ExternalTransferDirection::Deposit,
+                account_addr: BigUint::from(0u8),
+            },
+        );
+
+        statement.new_public_shares.balances[0].amount += Scalar::from(transfer_amt);
+        let res = check_constraint_satisfaction::<
+            ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>,
+        >(&witness, &statement);
+        assert!(!res);
+    }
+
+    /// Tests the case in which a protocol fee balance is modified in the update
+    #[test]
+    fn test_invalid_balance__protocol_fee_modified() {
         let old_wallet = INITIAL_WALLET.clone();
         let mut new_wallet = INITIAL_WALLET.clone();
-        new_wallet.orders[0].timestamp = NEW_TIMESTAMP;
+        new_wallet.balances[0].protocol_fee_balance += 1u128;
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
@@ -673,20 +863,12 @@ mod test {
         ));
     }
 
-    /// Tests that orders with duplicate asset pairs will fail
+    /// Tests the case in which a relayer fee balance is modified in the update
     #[test]
-    fn test_place_order__duplicate_mint() {
-        // No update to the orders, but the timestamp is incorrect
-        let mut old_wallet = INITIAL_WALLET.clone();
+    fn test_invalid_balance__relayer_fee_modified() {
+        let old_wallet = INITIAL_WALLET.clone();
         let mut new_wallet = INITIAL_WALLET.clone();
-
-        // Create the wallet's second order as a duplicate of the first
-        new_wallet.orders[1] = new_wallet.orders[0].clone();
-        new_wallet.orders[1].amount += 10;
-        new_wallet.orders[1].timestamp = NEW_TIMESTAMP;
-
-        // Remove the order from the original wallet to simulate order placement
-        old_wallet.orders[1] = Order::default();
+        new_wallet.balances[0].relayer_fee_balance += 1u128;
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
@@ -699,15 +881,11 @@ mod test {
     #[test]
     fn test_duplicate_balance() {
         // No update to the orders, but the timestamp is incorrect
+        // To ablate any other constraints, make the duplicate balance present in both
+        // wallets
         let mut old_wallet = INITIAL_WALLET.clone();
-        let mut new_wallet = INITIAL_WALLET.clone();
-
-        // Create the wallet's second balance as a duplicate of the first
-        new_wallet.balances[1] = new_wallet.balances[0].clone();
-        new_wallet.balances[1].amount += 10;
-
-        // Remove the duplicated balance from the old wallet
-        old_wallet.balances[1] = Balance::default();
+        old_wallet.balances[1].mint = old_wallet.balances[0].mint.clone();
+        let new_wallet = old_wallet.clone();
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
@@ -716,9 +894,7 @@ mod test {
         ));
     }
 
-    // -------------------------
-    // | Withdrawal Test Cases |
-    // -------------------------
+    // --- Withdrawals --- //
 
     /// Tests a valid external transfer that withdraws a balance
     #[test]
@@ -730,7 +906,7 @@ mod test {
         new_wallet.balances[0] = Balance::default();
         let transfer = ExternalTransfer {
             mint: old_wallet.balances[0].mint.clone(),
-            amount: BigUint::from(old_wallet.balances[0].amount),
+            amount: old_wallet.balances[0].amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -753,7 +929,7 @@ mod test {
         // Build a valid transfer
         let transfer = ExternalTransfer {
             mint: withdrawn_mint,
-            amount: BigUint::from(withdrawn_amount),
+            amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -777,7 +953,7 @@ mod test {
         // Build a valid transfer
         let transfer = ExternalTransfer {
             mint: withdrawn_mint,
-            amount: BigUint::from(withdrawn_amount),
+            amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -801,7 +977,7 @@ mod test {
         // Build a valid transfer
         let transfer = ExternalTransfer {
             mint: withdrawn_mint,
-            amount: BigUint::from(withdrawn_amount),
+            amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -819,12 +995,12 @@ mod test {
         // Withdraw a random balance
         let mut rng = thread_rng();
         let withdrawn_mint = BigUint::from(rng.next_u32());
-        let withdrawn_amount = 1u8;
+        let withdrawn_amount = 1u128;
 
         // Build a valid transfer
         let transfer = ExternalTransfer {
             mint: withdrawn_mint,
-            amount: BigUint::from(withdrawn_amount),
+            amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -838,19 +1014,18 @@ mod test {
     fn test_external_transfer__invalid_withdrawal_extra_update() {
         let old_wallet = INITIAL_WALLET.clone();
         let mut new_wallet = INITIAL_WALLET.clone();
+        new_wallet.balances[1] = Balance::default();
 
         // Transfer units of an existing mint into the wallet
-        let withdrawal_mint = new_wallet.balances[1].mint.clone();
-        let withdrawal_amount = new_wallet.balances[1].amount;
-
-        new_wallet.balances[1].amount -= withdrawal_amount;
+        let withdrawal_mint = old_wallet.balances[1].mint.clone();
+        let withdrawal_amount = old_wallet.balances[1].amount;
 
         // Prover also tries to increment the non-updated balance
         new_wallet.balances[0].amount += 1;
 
         let transfer = ExternalTransfer {
             mint: withdrawal_mint,
-            amount: BigUint::from(withdrawal_amount),
+            amount: withdrawal_amount,
             direction: ExternalTransferDirection::Withdrawal,
             account_addr: BigUint::from(0u8),
         };
@@ -858,9 +1033,51 @@ mod test {
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer));
     }
 
-    // ----------------------
-    // | Deposit Test Cases |
-    // ----------------------
+    /// Try withdrawing from a balance with non-zero protocol fee -- this is
+    /// invalid
+    #[test]
+    fn test_invalid_withdrawal__non_zero_protocol_fee() {
+        // Setup a wallet with outstanding fees
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0].protocol_fee_balance = 1;
+
+        // Withdraw from the balance
+        let mut new_wallet = old_wallet.clone();
+        new_wallet.balances[0].amount -= 1;
+
+        let transfer = ExternalTransfer {
+            mint: old_wallet.balances[0].mint.clone(),
+            amount: 1,
+            direction: ExternalTransferDirection::Withdrawal,
+            account_addr: BigUint::from(0u8),
+        };
+
+        assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer));
+    }
+
+    /// Try withdrawing from a balance with non-zero relayer fee -- this is
+    /// invalid
+    #[test]
+    fn test_invalid_withdrawal__non_zero_relayer_fee() {
+        // Setup a wallet with outstanding fees
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0].relayer_fee_balance = 1;
+
+        // Withdraw from the wallet
+        let mut new_wallet = old_wallet.clone();
+        new_wallet.balances[0].amount -= 1;
+
+        let transfer = ExternalTransfer {
+            mint: old_wallet.balances[0].mint.clone(),
+            amount: 1,
+            direction: ExternalTransferDirection::Withdrawal,
+            account_addr: BigUint::from(0u8),
+        };
+
+        assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer));
+    }
+
+    // --- Deposits --- //
 
     /// Tests a valid deposit into the wallet that adds a new balance
     #[test]
@@ -877,7 +1094,7 @@ mod test {
 
         let transfer = ExternalTransfer {
             mint: deposit_mint,
-            amount: BigUint::from(deposit_amount),
+            amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
             account_addr: BigUint::from(0u8),
         };
@@ -899,7 +1116,7 @@ mod test {
 
         let transfer = ExternalTransfer {
             mint: deposit_mint,
-            amount: BigUint::from(deposit_amount),
+            amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
             account_addr: BigUint::from(0u8),
         };
@@ -922,7 +1139,7 @@ mod test {
 
         let transfer = ExternalTransfer {
             mint: deposit_mint,
-            amount: BigUint::from(deposit_amount),
+            amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
             account_addr: BigUint::from(0u8),
         };
@@ -948,12 +1165,80 @@ mod test {
 
         let transfer = ExternalTransfer {
             mint: deposit_mint,
-            amount: BigUint::from(deposit_amount),
+            amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
             account_addr: BigUint::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer));
+    }
+
+    /// Top up a balance with non-zero fees -- this is valid
+    #[test]
+    fn test_deposit_with_nonzero_fee() {
+        // Old wallet with outstanding fees
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0].protocol_fee_balance = 1;
+
+        // Deposit additional balance into it
+        let mut new_wallet = old_wallet.clone();
+        new_wallet.balances[0].amount += 1;
+
+        let transfer = ExternalTransfer {
+            mint: old_wallet.balances[0].mint.clone(),
+            amount: 1,
+            direction: ExternalTransferDirection::Deposit,
+            account_addr: BigUint::from(0u8),
+        };
+
+        assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer));
+    }
+
+    // --- Mint Updates --- //
+
+    /// Tests the case in which a zero'd balance with non-zero mint is replaced
+    /// in a withdrawal
+    #[test]
+    fn test_replace_zero_balance() {
+        let mut rng = thread_rng();
+
+        // Setup the old wallet with a balance of zero amount and fees
+        let mut old_wallet = INITIAL_WALLET.clone();
+        old_wallet.balances[0] = Balance::new_from_mint(old_wallet.balances[0].mint.clone());
+
+        // Replace that balance with a new deposit
+        let new_mint = BigUint::from(rng.next_u64());
+        let new_amt = 1;
+        let mut new_wallet = old_wallet.clone();
+        new_wallet.balances[0] = Balance::new_from_mint_and_amount(new_mint.clone(), new_amt);
+
+        let transfer = ExternalTransfer {
+            mint: new_mint,
+            amount: new_amt,
+            direction: ExternalTransferDirection::Deposit,
+            account_addr: BigUint::from(0u8),
+        };
+
+        assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, transfer,));
+    }
+
+    /// Tests the case in which a zero'd balance is replaced by a zero mint
+    #[test]
+    fn test_replace_zero_balance_with_zero_mint() {
+        let mut old_wallet = INITIAL_WALLET.clone();
+        let mut new_wallet = INITIAL_WALLET.clone();
+
+        // Set the first balance to have zero amount and fees
+        old_wallet.balances[0] = Balance::new_from_mint(BigUint::from(1u8));
+
+        // Replace it with an entirely zero'd balance
+        new_wallet.balances[0] = Balance::default();
+
+        assert!(constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ));
     }
 
     // -------------------------------
@@ -969,6 +1254,43 @@ mod test {
 
         // Prover spuriously zeros a balance without transfer
         new_wallet.balances[0] = Balance::default();
+
+        assert!(!constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ));
+    }
+
+    /// Tests the case in which the prover attempts to change the match fee of
+    /// the wallet
+    ///
+    /// This is invalid for now, we may allow the _user_ to do so in the future
+    #[test]
+    fn test_malicious_prover__increase_match_fee() {
+        let old_wallet = INITIAL_WALLET.clone();
+        let mut new_wallet = INITIAL_WALLET.clone();
+
+        new_wallet.match_fee = new_wallet.match_fee + Scalar::one();
+
+        assert!(!constraints_satisfied_on_wallets(
+            &old_wallet,
+            &new_wallet,
+            ExternalTransfer::default()
+        ));
+    }
+
+    /// Tests the case in which the prover attempts to change the managing
+    /// cluster of the wallet
+    ///
+    /// This is invalid for now, we may allow the _user_ to do so in the future
+    #[test]
+    fn test_malicious_prover__change_cluster() {
+        let mut rng = thread_rng();
+        let old_wallet = INITIAL_WALLET.clone();
+        let mut new_wallet = INITIAL_WALLET.clone();
+
+        new_wallet.managing_cluster = BigUint::from(rng.next_u64());
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,


### PR DESCRIPTION
### Purpose
This PR updates the `VALID WALLET UPDATE` circuit with a number of changes ahead of audit
- We now require that balance, order, transfer amounts be less than $2^{128}$
- We require that any balance, order, or transfer with zero mint(s) be zero in every field
- We require that fees be paid before any withdrawal on a balance takes place
- We no longer require order mints to be unique (a user may place both a sell and buy order for example)
- We remove the timestamp field from the orders, it currently does nothing

### Testing
- Added unit tests for each case written in our circuit spec. For failure cases, I removed constraints that enforce the case, verified that the test failed (constraints were satisfied with an invalid witness) then added back the constraints to ablate test malformation.