### PR TITLE
workers: Persist wallet id from request in create-wallet task

### DIFF
--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -210,7 +210,8 @@ impl TypedHandler for CreateWalletHandler {
         // Create an async task to drive this new wallet into the on-chain state
         // and create proofs of validity
         let wallet_id = req.wallet.id;
-        let wallet: Wallet = req.wallet.try_into().map_err(|e: String| bad_request(e))?;
+        let mut wallet: Wallet = req.wallet.try_into().map_err(|e: String| bad_request(e))?;
+        wallet.wallet_id = wallet_id;
         let task = NewWalletTaskDescriptor::new(wallet).map_err(bad_request)?;
 
         // Propose the task and await for it to be enqueued


### PR DESCRIPTION
### Purpose
This PR ensures that the wallet id that is passed to the relayer in the HTTP request is assigned to the created wallet instead of a random identifier. Copies logic from pre state refactor code: https://github.com/renegade-fi/renegade/blob/150e135d38526036d474cbddb48d10b6c4df4faf/task-driver/src/create_new_wallet.rs#L199

### Testing
- Tested in the frontend
