### PR TITLE
state: storage: cursor: Add key filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -264,7 +264,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.4.18",
+ "clap 4.5.0",
  "colored",
  "common",
  "constants",
@@ -1201,9 +1201,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1457,7 +1457,7 @@ dependencies = [
  "bitvec 1.0.1",
  "circuit-macros",
  "circuit-types",
- "clap 4.4.18",
+ "clap 4.5.0",
  "colored",
  "constants",
  "criterion",
@@ -1506,31 +1506,31 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive 4.5.0",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
- "strsim",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cobs"
@@ -1670,7 +1670,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-dalek 1.0.1",
  "ethers-rs",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.10.5",
  "jf-primitives",
  "k256 0.13.3",
@@ -1730,7 +1730,7 @@ dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
  "bimap",
- "clap 4.4.18",
+ "clap 4.5.0",
  "common",
  "ed25519-dalek 1.0.1",
  "json",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+checksum = "18d59688ad0945eaf6b84cb44fedbe93484c81b48970e98f09db8a22832d7961"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1847,9 +1847,9 @@ checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1873,7 +1873,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.18",
+ "clap 4.5.0",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2053,7 +2053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704722d1d929489c8528bb1882805700f1ba20f54325704973e786352320b1ed"
 dependencies = [
  "blake2",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "serdect",
 ]
@@ -2092,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -2130,23 +2130,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
 dependencies = [
  "darling_core",
  "quote",
@@ -2454,11 +2454,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
@@ -2469,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -3743,7 +3743,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3792,7 +3792,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.4.18",
+ "clap 4.5.0",
  "colored",
  "common",
  "constants",
@@ -3831,7 +3831,7 @@ dependencies = [
  "ark-mpc",
  "base64 0.13.1",
  "circuit-types",
- "clap 4.4.18",
+ "clap 4.5.0",
  "colored",
  "common",
  "config",
@@ -3949,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -4266,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -4305,7 +4305,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.6",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4330,12 +4330,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.5",
- "rustix 0.38.31",
+ "hermit-abi 0.3.6",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -4443,18 +4443,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4810,7 +4810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
  "bs58 0.4.0",
- "ed25519-dalek 2.1.0",
+ "ed25519-dalek 2.1.1",
  "log",
  "multiaddr",
  "multihash",
@@ -5541,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
  "serde",
@@ -5557,11 +5557,10 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -5591,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -5605,7 +5604,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.6",
  "libc",
 ]
 
@@ -6018,7 +6017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -6147,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
@@ -7540,16 +7539,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -7557,9 +7557,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8026,6 +8026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8205,7 +8211,7 @@ dependencies = [
  "async-trait",
  "circuit-types",
  "circuits",
- "clap 4.4.18",
+ "clap 4.5.0",
  "colored",
  "common",
  "constants",
@@ -8300,18 +8306,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8544,7 +8550,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.4",
+ "toml_edit 0.22.5",
 ]
 
 [[package]]
@@ -8562,9 +8568,9 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -8573,22 +8579,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "99e68c159e8f5ba8a28c4eb7b0c0c190d77bb479047ca713270048145a9ad28a"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.1",
 ]
 
 [[package]]
@@ -8862,9 +8868,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -9046,9 +9052,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "serde",
@@ -9058,9 +9064,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -9073,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9085,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9095,9 +9101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9108,9 +9114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-timer"
@@ -9129,9 +9135,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9467,9 +9473,18 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]

--- a/state/src/replication/log_store.rs
+++ b/state/src/replication/log_store.rs
@@ -124,7 +124,7 @@ impl Storage for LogStore {
         let mut entries = Vec::new();
         let mut remaining_space = max_size.into().map(|v| v as u32).unwrap_or(u32::MAX);
 
-        for record in cursor.map(|entry| {
+        for record in cursor.into_iter().map(|entry| {
             entry.map_err(RaftError::from).map(|(key, value)| (key, value.into_inner()))
         }) {
             let (key, entry) = record?;

--- a/state/src/storage/cursor.rs
+++ b/state/src/storage/cursor.rs
@@ -20,104 +20,178 @@ use super::{
 pub struct DbCursor<'txn, Tx: TransactionKind, K: Key, V: Value> {
     /// The underlying cursor
     inner: Cursor<'txn, Tx>,
-    /// The buffered kv pair at the current position
+    /// The filter applied to keys
     ///
-    /// This field is used to provide a `seek` implementation that does not
-    /// consume the value under the cursor after seeking. We prefer to seek
-    /// and then separately read the value out
-    buffered_value: Option<(K, V)>,
-    /// A phantom data field to hold the deserialized type of the table
+    /// Only keys for which this filter returns `true` will be returned by the
+    /// cursor methods
+    ///
+    /// Note however that the filter does not affect the position of the cursor,
+    /// so while methods like `next` and `prev` will skip over keys that do not
+    /// pass the filter, the cursor will still be positioned at those keys
+    key_filter: Option<fn(&K) -> bool>,
+    /// A phantom data field to hold the deserialized type of
+    /// the table
     _phantom: PhantomData<(K, V)>,
 }
 
-/// Query methods
+// -----------------
+// | Query Methods |
+// -----------------
+
 impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
     /// Constructor
     pub fn new(cursor: Cursor<'txn, Tx>) -> Self {
-        Self { inner: cursor, buffered_value: None, _phantom: PhantomData }
+        Self { inner: cursor, key_filter: None, _phantom: PhantomData }
     }
 
-    /// Return an iterator over only the keys in the table
-    pub fn keys(self) -> impl Iterator<Item = Result<K, StorageError>> {
-        <Self as Iterator>::map(self, |res| res.map(|(k, _v)| k))
-    }
-
-    /// Return an iterator over only the values in the table
-    pub fn values(self) -> impl Iterator<Item = Result<V, StorageError>> {
-        <Self as Iterator>::map(self, |res| res.map(|(_k, v)| v))
+    /// Set a filter on the keys
+    ///
+    /// Consumes the cursor to provide a builder-like pattern
+    pub fn with_key_filter(mut self, filter: fn(&K) -> bool) -> Self {
+        self.key_filter = Some(filter);
+        self
     }
 
     /// Get the key/value at the current position
+    ///
+    /// Assumes that the cursor is positioned at a valid key/value pair for the
+    /// filter, this invariant should be maintained by other cursor methods
     pub fn get_current(&mut self) -> Result<Option<(K, V)>, StorageError> {
-        if let Some((k, v)) = self.buffered_value.take() {
-            return Ok(Some((k, v)));
-        }
-
         let res = self.inner.get_current::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
-
-        res.map(|(k, v)| Self::deserialize_key_value(&k, &v)).transpose()
+        match res {
+            None => Ok(None),
+            Some(kv) => self.deserialize_and_filter(kv),
+        }
     }
 
-    /// Position the cursor at the previous key value pair and return it
-    pub fn prev(&mut self) -> Result<Option<(K, V)>, StorageError> {
-        let res = self.inner.prev::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
+    /// Position the cursor at the next key value pair
+    ///
+    /// Returns `true` if the cursor has reached the end of the table
+    pub fn seek_next(&mut self) -> Result<bool, StorageError> {
+        // Move the cursor forward and return early if it is exhausted
+        if self.inner.next::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?.is_none() {
+            return Ok(true);
+        }
 
-        res.map(|(k, v)| Self::deserialize_key_value(&k, &v)).transpose()
+        // Seek forward to the next valid key
+        let end = self.seek_next_filtered(true /* forward */)?.is_none();
+        Ok(end)
+    }
+
+    /// Position the cursor at the previous key value pair
+    ///
+    /// Returns `true` if the cursor has reached the start of the table
+    pub fn seek_prev(&mut self) -> Result<bool, StorageError> {
+        // Move the cursor back and return early if it is exhausted
+        if self.inner.prev::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?.is_none() {
+            return Ok(true);
+        }
+
+        // Seek backward to the previous valid key
+        let start = self.seek_next_filtered(false /* forward */)?.is_none();
+        Ok(start)
     }
 
     /// Seek to the first key in the table
     pub fn seek_first(&mut self) -> Result<(), StorageError> {
-        let res = self.inner.first::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
-
-        self.buffer_kv_pair(res)
+        // Position the cursor at the first key then seek forward to the next valid key
+        self.inner.first::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
+        self.seek_next_filtered(true /* forward */).map(|_| ())
     }
 
     /// Seek to the last key in the table
     pub fn seek_last(&mut self) -> Result<(), StorageError> {
-        let res = self.inner.last::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
-
-        self.buffer_kv_pair(res)
+        // Position the cursor at the last key then seek backwards to the next valid key
+        self.inner.last::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
+        self.seek_next_filtered(false /* forward */).map(|_| ())
     }
 
     /// Position the cursor at a specific key
+    ///
+    /// Note that if the key is not present, the cursor is positioned at an
+    /// empty value, the filter will then take effect on any further cursor
+    /// operations
     pub fn seek(&mut self, k: &K) -> Result<(), StorageError> {
-        let k_bytes = serialize_value(&k)?;
-        let res =
-            self.inner.set_key::<CowBuffer, CowBuffer>(&k_bytes).map_err(StorageError::TxOp)?;
+        // Validate the key
+        if let Some(filter) = self.key_filter
+            && !filter(k)
+        {
+            return Err(StorageError::InvalidKey(format!(
+                "Key {k:?} passed to `Cursor::seek` does not pass filter"
+            )));
+        }
 
-        self.buffer_kv_pair(res)
+        let k_bytes = serialize_value(&k)?;
+        self.inner.set_key::<CowBuffer, CowBuffer>(&k_bytes).map_err(StorageError::TxOp).map(|_| ())
     }
 
     /// Position at the first key greater than or equal to the given key
     pub fn seek_geq(&mut self, k: &K) -> Result<(), StorageError> {
+        // Position the cursor at the first key then seek forward to the next valid key
         let k_bytes = serialize_value(k)?;
-        let res =
-            self.inner.set_range::<CowBuffer, CowBuffer>(&k_bytes).map_err(StorageError::TxOp)?;
-
-        self.buffer_kv_pair(res)
+        self.inner.set_range::<CowBuffer, CowBuffer>(&k_bytes).map_err(StorageError::TxOp)?;
+        self.seek_next_filtered(true /* forward */).map(|_| ())
     }
 
     // -----------
     // | Helpers |
     // -----------
 
-    /// Deserialize a key-value pair to the type of the cursor
-    fn deserialize_key_value(
-        k_buffer: &CowBuffer,
-        v_buffer: &CowBuffer,
-    ) -> Result<(K, V), StorageError> {
-        Ok((deserialize_value(k_buffer)?, deserialize_value(v_buffer)?))
+    /// Seek to the next value passing the filter from (inclusive) the
+    /// current cursor position. Repositions the cursor to that location,
+    /// returns the value
+    ///
+    /// The `forward` parameter determines the direction of the search
+    fn seek_next_filtered(&mut self, forward: bool) -> Result<Option<(K, V)>, StorageError> {
+        // Try the current position
+        let curr = self.inner.get_current::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?;
+        if let Some(val) = curr
+            && let Some(kv) = self.deserialize_and_filter(val)?
+        {
+            return Ok(Some(kv));
+        }
+
+        // Otherwise, directionally search for the next valid key
+        let next_fn = if forward {
+            Cursor::<Tx>::next::<CowBuffer, CowBuffer>
+        } else {
+            Cursor::<Tx>::prev::<CowBuffer, CowBuffer>
+        };
+
+        while let Some(kv) = next_fn(&mut self.inner).map_err(StorageError::TxOp)? {
+            if let Some(kv) = self.deserialize_and_filter(kv)? {
+                return Ok(Some(kv));
+            }
+        }
+
+        Ok(None)
     }
 
-    /// Buffer the kv pair at the current position
-    fn buffer_kv_pair(&mut self, pair: Option<(CowBuffer, CowBuffer)>) -> Result<(), StorageError> {
-        self.buffered_value = pair.map(|(k, v)| Self::deserialize_key_value(&k, &v)).transpose()?;
+    /// Deserialize a key-value pair and filter the key
+    fn deserialize_and_filter(
+        &self,
+        kv: (CowBuffer, CowBuffer),
+    ) -> Result<Option<(K, V)>, StorageError> {
+        let (k_buf, v_buf) = kv;
 
-        Ok(())
+        // Deserialize and filter the key
+        let key = deserialize_value(&k_buf)?;
+        if let Some(filter) = self.key_filter
+            && !filter(&key)
+        {
+            return Ok(None);
+        }
+
+        // Deserialize the value
+        let value = deserialize_value(&v_buf)?;
+        Ok(Some((key, value)))
     }
 }
 
-/// Mutation methods
+// --------------------
+// | Mutation methods |
+// --------------------
+
 impl<'txn, K: Key, V: Value> DbCursor<'txn, RW, K, V> {
     /// Insert a key/value pair into the table, the cursor will be positioned at
     /// the inserted key or near it when this method fails
@@ -134,21 +208,58 @@ impl<'txn, K: Key, V: Value> DbCursor<'txn, RW, K, V> {
     }
 }
 
-impl<'txn, T: TransactionKind, K: Key, V: Value> Iterator for DbCursor<'txn, T, K, V> {
+// ---------------------------
+// | Iterator Implementation |
+// ---------------------------
+
+impl<'txn, T: TransactionKind, K: Key, V: Value> IntoIterator for DbCursor<'txn, T, K, V> {
+    type Item = Result<(K, V), StorageError>;
+    type IntoIter = DbCursorIter<'txn, T, K, V>;
+
+    fn into_iter(mut self) -> Self::IntoIter {
+        // Setup the initial value for the iterator
+        let initial = self.get_current().unwrap();
+        DbCursorIter { initial, cursor: self }
+    }
+}
+
+/// The iterator type for the cursor
+pub struct DbCursorIter<'txn, T: TransactionKind, K: Key, V: Value> {
+    /// The initial value of the iterator
+    initial: Option<(K, V)>,
+    /// The underlying cursor
+    cursor: DbCursor<'txn, T, K, V>,
+}
+
+impl<'txn, T: TransactionKind, K: Key, V: Value> DbCursorIter<'txn, T, K, V> {
+    /// Return an iterator over only the keys in the table
+    pub fn keys(self) -> impl Iterator<Item = Result<K, StorageError>> {
+        <Self as Iterator>::map(self, |res| res.map(|(k, _v)| k))
+    }
+
+    /// Return an iterator over only the values in the table
+    pub fn values(self) -> impl Iterator<Item = Result<V, StorageError>> {
+        <Self as Iterator>::map(self, |res| res.map(|(_k, v)| v))
+    }
+}
+
+impl<'txn, T: TransactionKind, K: Key, V: Value> Iterator for DbCursorIter<'txn, T, K, V> {
     type Item = Result<(K, V), StorageError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((k, v)) = self.buffered_value.take() {
+        if let Some((k, v)) = self.initial.take() {
             return Some(Ok((k, v)));
         }
 
-        let res = self.inner.next().map_err(StorageError::TxOp);
-        if let Err(e) = res {
-            return Some(Err(e));
-        }
+        // Increment the cursor
+        match self.cursor.seek_next() {
+            Err(e) => return Some(Err(e)),
+            Ok(true) => return None, // end of iterator
+            _ => {},
+        };
 
-        let res = res.unwrap();
-        res.map(|(k, v)| Self::deserialize_key_value(&k, &v))
+        // Get the current value under the cursor
+        self.cursor.get_current().transpose()
     }
 }
 
@@ -274,7 +385,7 @@ mod test {
         // Run a cursor over the table
         let tx = db.new_raw_read_tx().unwrap();
         let cursor = tx.cursor::<String, usize>(TEST_TABLE).unwrap();
-        for (i, pair) in cursor.enumerate() {
+        for (i, pair) in cursor.into_iter().enumerate() {
             let (k, v) = pair.unwrap();
             assert_eq!(k, i.to_string());
             assert_eq!(v, i);
@@ -308,7 +419,8 @@ mod test {
         assert_eq!(k, seek_index.to_string());
         assert_eq!(v, seek_index);
 
-        let (k, v) = cursor.next().unwrap().unwrap();
+        cursor.seek_next().unwrap();
+        let (k, v) = cursor.get_current().unwrap().unwrap();
         assert_eq!(k, (seek_index + 1).to_string());
         assert_eq!(v, seek_index + 1);
     }
@@ -340,7 +452,8 @@ mod test {
         assert_eq!(k, seek_index.to_string());
         assert_eq!(v, seek_index);
 
-        let (k, v) = cursor.prev().unwrap().unwrap();
+        cursor.seek_prev().unwrap();
+        let (k, v) = cursor.get_current().unwrap().unwrap();
         assert_eq!(k, (seek_index - 1).to_string());
         assert_eq!(v, seek_index - 1);
     }
@@ -395,5 +508,61 @@ mod test {
         let expected = seek_ind + 1;
         assert_eq!(k, expected.to_string());
         assert_eq!(v, expected);
+    }
+
+    /// Tests a filtered cursor
+    #[test]
+    fn test_filtered_cursor() {
+        // Create a db and insert 0..N into the table randomly
+        const N: usize = 1000;
+        let db = mock_db();
+        db.create_table(TEST_TABLE).unwrap();
+
+        insert_n_random(&db, N);
+
+        // Create a filtered cursor that only returns odd keys
+        let tx = db.new_raw_read_tx().unwrap();
+        let mut cursor = tx
+            .cursor::<String, usize>(TEST_TABLE)
+            .unwrap()
+            .with_key_filter(|k| k.parse::<usize>().unwrap() % 2 == 1);
+        cursor.seek_first().unwrap();
+
+        // Cursor is positioned at one, should return `Some`
+        let kv = cursor.get_current().unwrap().unwrap();
+        assert_eq!(kv, ("1".to_string(), 1));
+
+        // Move the cursor to the next key, should be the next odd key
+        cursor.seek_next().unwrap();
+        let next = cursor.get_current().unwrap().unwrap();
+        assert_eq!(next, ("3".to_string(), 3));
+
+        // Get the current key, should still be the second odd key
+        let curr = cursor.get_current().unwrap();
+        assert_eq!(curr.unwrap(), ("3".to_string(), 3));
+
+        // Get the previous key, should return `Some`
+        cursor.seek_prev().unwrap();
+        let prev = cursor.get_current().unwrap().unwrap();
+        assert_eq!(prev, ("1".to_string(), 1));
+
+        // Seek to the last key, should be N - 1
+        cursor.seek_last().unwrap();
+        let last = cursor.get_current().unwrap().unwrap();
+        let idx = N - 1;
+        assert_eq!(last, (idx.to_string(), idx));
+
+        // Iterate over the cursor, should only return odd keys
+        cursor.seek_first().unwrap();
+        let elems = cursor.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(elems.len(), N / 2);
+
+        for (i, pair) in elems.into_iter().enumerate() {
+            let idx = i * 2 + 1;
+
+            let (k, v) = pair;
+            assert_eq!(k, idx.to_string());
+            assert_eq!(v, idx);
+        }
     }
 }

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -18,6 +18,8 @@ pub enum StorageError {
     Commit(MdbxError),
     /// Error deserializing a value from storage
     Deserialization(FlexbuffersDeserializationError),
+    /// An invalid key was used to access the database
+    InvalidKey(String),
     /// An entry was not found in the database
     NotFound(String),
     /// Failure opening the database

--- a/state/src/storage/traits.rs
+++ b/state/src/storage/traits.rs
@@ -1,12 +1,13 @@
 //! Defines traits for storage access
 
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 /// An abstraction over keys in the database, which are concretely stored as
 /// byte slices. Keys must be serializable and deserializable from bytes
-pub trait Key: Serialize + for<'de> Deserialize<'de> + Clone {}
+pub trait Key: Debug + Serialize + for<'de> Deserialize<'de> + Clone {}
 
-impl<T: Serialize + for<'de> Deserialize<'de> + Clone> Key for T {}
+impl<T: Debug + Serialize + for<'de> Deserialize<'de> + Clone> Key for T {}
 
 /// An abstraction over values in the database, which are concretely stored as
 /// byte slices. Values must be serializable and deserializable from bytes

--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -109,11 +109,12 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
         // Build a cursor over the table
         let cursor = self
             .inner()
-            .cursor::<String, (NetworkOrder, Option<OrderValidityWitnessBundle>)>(ORDERS_TABLE)?;
+            .cursor::<String, (NetworkOrder, Option<OrderValidityWitnessBundle>)>(ORDERS_TABLE)?
+            .with_key_filter(|key| key.starts_with("order:"));
 
         // Destructure the result and handle errors
         let mut res = Vec::new();
-        for elem in cursor.values() {
+        for elem in cursor.into_iter().values() {
             let (order, _) = elem?;
             res.push(order);
         }

--- a/state/src/storage/tx/peer_index.rs
+++ b/state/src/storage/tx/peer_index.rs
@@ -35,7 +35,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Get all the peers known to the local node
     pub fn get_all_peer_ids(&self) -> Result<Vec<WrappedPeerId>, StorageError> {
         // Create a cursor and take only the values
-        let peer_cursor = self.inner().cursor::<WrappedPeerId, PeerInfo>(PEER_INFO_TABLE)?;
+        let peer_cursor =
+            self.inner().cursor::<WrappedPeerId, PeerInfo>(PEER_INFO_TABLE)?.into_iter();
         let peers = peer_cursor.keys().collect::<Result<Vec<_>, _>>()?;
 
         Ok(peers)

--- a/state/src/storage/tx/wallet_index.rs
+++ b/state/src/storage/tx/wallet_index.rs
@@ -31,7 +31,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Get all the wallets in the database
     pub fn get_all_wallets(&self) -> Result<Vec<Wallet>, StorageError> {
         // Create a cursor and take only the values
-        let wallet_cursor = self.inner().cursor::<WalletIdentifier, Wallet>(WALLETS_TABLE)?;
+        let wallet_cursor =
+            self.inner().cursor::<WalletIdentifier, Wallet>(WALLETS_TABLE)?.into_iter();
         let wallets = wallet_cursor.values().collect::<Result<Vec<_>, _>>()?;
 
         Ok(wallets)


### PR DESCRIPTION
### Purpose
This PR adds key filters to the cursor type. This allows us to filter only pass keys which are relevant to a query rather than the entire table into the cursor consumer. Filtering is particularly useful when a table has multiple key types in it, e.g. the network order table.

This fixes a bug that occurs when constructing heartbeat messages -- the network order table is incorrectly filtered, and the cursor attempts to deserialize other entry type to `PeerInfo` types. 

I also modified the iterator on the cursor to implement `IntoIterator` so that the semantics are more clear, i.e. iterating consumes the cursor rather than allowing for mutations in between iterations.

### Testing
- Replicated the bug that @sehyunc observed and verified it was fixed after this PR
- Unit tests pass workspace-wide