### PR TITLE
common: Add wallet balance to request amount when depositing

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -79,11 +79,9 @@ impl Wallet {
     /// Add a balance to the wallet, replacing the first default balance
     pub fn add_balance(&mut self, balance: Balance) -> Result<(), String> {
         // If the balance exists, increment it
-        if let Some(balance) = self.balances.get_mut(&balance.mint) {
-            balance.amount = balance
-                .amount
-                .checked_add(balance.amount)
-                .ok_or(ERR_BALANCE_OVERFLOW.to_string())?;
+        if let Some(bal) = self.balances.get_mut(&balance.mint) {
+            bal.amount =
+                bal.amount.checked_add(balance.amount).ok_or(ERR_BALANCE_OVERFLOW.to_string())?;
             return Ok(());
         }
 


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the `add_balance` function where the `balance` variable was being overloaded with both the value to be added (deposited) and the balance that was currently in the wallet. This resulted in the post-deposit amount being incorrect (deposits would go from 1, 2, 4, 8, etc.)

### Testing
- Tested in the frontend