### PR TITLE
state: applicator: order-book: Run internal match engine on proof update

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -105,6 +105,7 @@ async fn main() -> Result<(), CoordinatorError> {
         raft_receiver,
         &args,
         task_sender.clone(),
+        handshake_worker_sender.clone(),
         system_bus.clone(),
     )?;
 

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -258,10 +258,18 @@ impl MockNodeController {
         let network_queue = self.network_queue.0.clone();
         let raft_receiver = self.raft_queue.1.take().unwrap();
         let task_sender = self.task_queue.0.clone();
+        let handshake_queue = self.handshake_queue.0.clone();
         let bus = self.bus.clone();
 
-        let state = State::new(network_queue, raft_receiver, &self.config, task_sender, bus)
-            .expect("Failed to create state instance");
+        let state = State::new(
+            network_queue,
+            raft_receiver,
+            &self.config,
+            task_sender,
+            handshake_queue,
+            bus,
+        )
+        .expect("Failed to create state instance");
         self.state = Some(state);
 
         self

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -11,7 +11,9 @@ use common::types::{
 };
 use constants::ORDER_STATE_CHANGE_TOPIC;
 use external_api::bus_message::SystemBusMessage;
+use job_types::handshake_manager::HandshakeExecutionJob;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::applicator::error::StateApplicatorError;
 
@@ -80,6 +82,17 @@ impl StateApplicator {
             .get_order_info(&order_id)?
             .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_ORDER_MISSING.to_string()))?;
         tx.commit()?;
+
+        // Send a job to the handshake manager to run the internal matching engine on
+        // the order
+        if order_info.ready_for_match() {
+            // TODO: We should only have one node execute the internal matching engine,
+            // though this is okay for the moment
+            let job = HandshakeExecutionJob::InternalMatchingEngine { order: order_info.id };
+            if self.config.handshake_manager_queue.send(job).is_err() {
+                error!("Failed to send internal matching engine job to handshake manager");
+            }
+        }
 
         self.system_bus().publish(
             ORDER_STATE_CHANGE_TOPIC.to_string(),

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -79,7 +79,9 @@ impl State {
 #[cfg(test)]
 mod test {
     use config::RelayerConfig;
-    use job_types::task_driver::new_task_driver_queue;
+    use job_types::{
+        handshake_manager::new_handshake_manager_queue, task_driver::new_task_driver_queue,
+    };
     use system_bus::SystemBus;
 
     use crate::{replication::network::traits::test_helpers::MockNetwork, State};
@@ -91,8 +93,11 @@ mod test {
         let config = RelayerConfig::default();
         let (_controller, mut nets) = MockNetwork::new_n_way_mesh(1 /* n_nodes */);
         let (task_queue, _recv) = new_task_driver_queue();
+        let (handshake_queue, _recv) = new_handshake_manager_queue();
         let bus = SystemBus::new();
-        let state = State::new_with_network(&config, nets.remove(0), task_queue, bus).unwrap();
+        let state =
+            State::new_with_network(&config, nets.remove(0), task_queue, handshake_queue, bus)
+                .unwrap();
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -128,7 +128,10 @@ pub mod test_helpers {
     use std::{mem, time::Duration};
 
     use config::RelayerConfig;
-    use job_types::task_driver::{new_task_driver_queue, TaskDriverQueue};
+    use job_types::{
+        handshake_manager::new_handshake_manager_queue,
+        task_driver::{new_task_driver_queue, TaskDriverQueue},
+    };
     use system_bus::SystemBus;
     use tempfile::tempdir;
 
@@ -177,8 +180,15 @@ pub mod test_helpers {
         let config =
             RelayerConfig { db_path: tmp_db_path(), allow_local: true, ..Default::default() };
         let (_controller, mut nets) = MockNetwork::new_n_way_mesh(1 /* n_nodes */);
-        let state =
-            State::new_with_network(&config, nets.remove(0), task_queue, SystemBus::new()).unwrap();
+        let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
+        let state = State::new_with_network(
+            &config,
+            nets.remove(0),
+            task_queue,
+            handshake_manager_queue,
+            SystemBus::new(),
+        )
+        .unwrap();
 
         // Wait for a leader election before returning
         sleep_ms(500);

--- a/state/src/replication/raft_node.rs
+++ b/state/src/replication/raft_node.rs
@@ -11,7 +11,7 @@ use std::{
 use config::RelayerConfig;
 use crossbeam::channel::{Receiver as CrossbeamReceiver, TryRecvError};
 use external_api::bus_message::SystemBusMessage;
-use job_types::task_driver::TaskDriverQueue;
+use job_types::{handshake_manager::HandshakeManagerQueue, task_driver::TaskDriverQueue};
 use protobuf::{Message, RepeatedField};
 use raft::{
     eraftpb::ConfState,
@@ -76,6 +76,8 @@ pub struct ReplicationNodeConfig<N: RaftNetwork> {
     pub network: N,
     /// A queue for the task driver, used by the applicator to start tasks
     pub task_queue: TaskDriverQueue,
+    /// The handshake manager's work queue
+    pub handshake_manager_queue: HandshakeManagerQueue,
     /// A handle on the persistent storage layer underlying the raft node
     pub db: Arc<DB>,
     /// A handle to the system-global bus
@@ -124,6 +126,7 @@ impl<N: RaftNetwork> ReplicationNode<N> {
             allow_local: config.relayer_config.allow_local,
             cluster_id: config.relayer_config.cluster_id,
             task_queue: config.task_queue,
+            handshake_manager_queue: config.handshake_manager_queue,
             db: config.db.clone(),
             system_bus: config.system_bus,
         })
@@ -631,7 +634,9 @@ pub(crate) mod test_helpers {
     };
 
     use crossbeam::channel::{unbounded, Receiver as CrossbeamReceiver, Sender};
-    use job_types::task_driver::new_task_driver_queue;
+    use job_types::{
+        handshake_manager::new_handshake_manager_queue, task_driver::new_task_driver_queue,
+    };
     use raft::prelude::Config as RaftConfig;
     use system_bus::SystemBus;
 
@@ -810,8 +815,10 @@ pub(crate) mod test_helpers {
         network: MockNetwork,
         raft_config: &RaftConfig,
     ) -> ReplicationNode<MockNetwork> {
-        let (task_queue, recv) = new_task_driver_queue();
-        mem::forget(recv);
+        let (task_queue, task_recv) = new_task_driver_queue();
+        let (handshake_manager_queue, handshake_recv) = new_handshake_manager_queue();
+        mem::forget(task_recv);
+        mem::forget(handshake_recv);
 
         ReplicationNode::new_with_config(
             ReplicationNodeConfig {
@@ -820,6 +827,7 @@ pub(crate) mod test_helpers {
                 proposal_queue,
                 network,
                 task_queue,
+                handshake_manager_queue,
                 db,
                 system_bus: SystemBus::new(),
             },
@@ -856,7 +864,9 @@ mod test {
         wallet_mocks::mock_empty_wallet,
     };
     use crossbeam::channel::unbounded;
-    use job_types::task_driver::new_task_driver_queue;
+    use job_types::{
+        handshake_manager::new_handshake_manager_queue, task_driver::new_task_driver_queue,
+    };
     use rand::{thread_rng, Rng};
 
     use crate::{
@@ -886,12 +896,14 @@ mod test {
 
         let (_, proposal_receiver) = unbounded();
         let (task_queue, _recv) = new_task_driver_queue();
+        let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
         let node_config = ReplicationNodeConfig {
             tick_period_ms: 10,
             relayer_config: Default::default(),
             proposal_queue: proposal_receiver,
             network: net,
             task_queue,
+            handshake_manager_queue,
             db: db.clone(),
             system_bus: Default::default(),
         };


### PR DESCRIPTION
### Purpose
This PR starts the internal matching engine on any internally managed order when the validity proof for that order is updated. 

Currently all nodes will run the internal matching engine. Of course, only one will succeed and the others will error submitting the transaction, we can fix this later by adding a `internal_engine_runner: WrappedPeerId` that the proposer of the state transition sets. This is simple enough to get FE integration off the ground.

### Testing
- Unit tests pass workspace-wide