### PR TITLE
workers: basic instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8658,16 +8658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-slog"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8697,15 +8687,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8658,6 +8658,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-slog"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8687,12 +8697,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/arbitrum-client/Dockerfile
+++ b/arbitrum-client/Dockerfile
@@ -2,63 +2,39 @@
 # integration tests. We effectively copy all the sources and then remove the target
 # directory. This means that changes to `arbitrum-client` sources will invalidate the
 # cache for this stage only, as the end state is the same
-FROM alpine AS sources
-COPY . .
-RUN rm -rf arbitrum-client
+FROM --platform=arm64 rust:latest AS chef
 
-# Rust build stage
-FROM rust:1.63-slim-buster AS builder
+# Build dir, use cargo chef to cache dependencies
+WORKDIR /build
+COPY ./rust-toolchain ./rust-toolchain
+RUN cat rust-toolchain | xargs rustup toolchain install
 
-# Install pkg-config, openssl
+# Install protoc, openssl, and pkg-config
 RUN apt-get update && \
     apt-get install -y pkg-config && \
-    apt-get install -y libssl-dev 
+    apt-get install -y protobuf-compiler && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y libclang-dev
 
-# Build the rust toolchain before adding any dependencies; this is the slowest
-# step and we would like to cache it before anything else
-COPY ./rust-toolchain ./arbitrum-client/rust-toolchain
-RUN cat arbitrum-client/rust-toolchain | xargs rustup toolchain install
+# Install chef and generate a recipe
+RUN cargo install cargo-chef
 
-# Create a build dir and add local dependencies
-WORKDIR /build
-COPY --from=sources . .
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
-# transferring all workspace members to the docker image, and instead only transfer the
-# dependencies of the integration test. Every path dependency of the target crate is automatically
-# added to the workspace
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-RUN sed -i '/members = \[/,/\]/c\members = [ "arbitrum-client" ]' Cargo.toml
-
-# Place a set of dummy sources in the path, build the dummy executable
-# to cache built dependencies, then bulid the full executable
-WORKDIR /build/arbitrum-client
-RUN mkdir src
-RUN touch src/dummy-lib.rs
-
-RUN mkdir integration
-RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
-
-COPY arbitrum-client/Cargo.toml .
-
-# Modify the Cargo.toml to point to our dummy sources
-RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
-RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
-
-# Disable compiler warnings and enable backtraces for panic debugging
+# Disable compiler warnings and enable backtraces for panic
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --tests --features "integration" --recipe-path recipe.json
+
+# Copy back in the full sources and build the tests
+WORKDIR /build
+COPY . .
+
+WORKDIR /build/arbitrum-client
 RUN cargo build --quiet --test integration --features "integration"
 
-# Edit the Cargo.toml back to the original, build the full executable
-RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
-RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
-
-COPY arbitrum-client/src ./src
-COPY arbitrum-client/integration ./integration
-
-RUN cargo build --quiet --test integration --features "integration"
-
+# Copy in the deployments file from the sequencer
 COPY --from=sequencer /deployments.json /deployments.json

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -10,7 +10,7 @@ use common::types::proof_bundles::{
 use constants::Scalar;
 use contracts_common::types::MatchPayload;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::{
     conversion::{
@@ -31,6 +31,7 @@ impl ArbitrumClient {
     // -----------
 
     /// Get the current Merkle root in the contract
+    #[instrument(skip_all, err)]
     pub async fn get_merkle_root(&self) -> Result<Scalar, ArbitrumClientError> {
         self.darkpool_contract
             .get_root()
@@ -41,6 +42,7 @@ impl ArbitrumClient {
     }
 
     /// Check whether the given Merkle root is a valid historical root
+    #[instrument(skip_all, err, fields(root = %root))]
     pub async fn check_merkle_root_valid(
         &self,
         root: MerkleRoot,
@@ -53,6 +55,7 @@ impl ArbitrumClient {
     }
 
     /// Check whether the given nullifier is used
+    #[instrument(skip_all, err, fields(nullifier = %nullifier))]
     pub async fn check_nullifier_used(
         &self,
         nullifier: Nullifier,
@@ -72,6 +75,7 @@ impl ArbitrumClient {
     /// `VALID WALLET CREATE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
+    #[instrument(skip_all, err, fields(blinder = %valid_wallet_create.statement.public_wallet_shares.blinder))]
     pub async fn new_wallet(
         &self,
         valid_wallet_create: &SizedValidWalletCreateBundle,
@@ -99,6 +103,7 @@ impl ArbitrumClient {
     /// `VALID WALLET UPDATE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
+    #[instrument(skip_all, err, fields(blinder = %valid_wallet_update.statement.new_public_shares.blinder))]
     pub async fn update_wallet(
         &self,
         valid_wallet_update: &SizedValidWalletUpdateBundle,
@@ -128,6 +133,7 @@ impl ArbitrumClient {
     /// match payloads and `VALID MATCH SETTLE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
+    #[instrument(skip_all, err, fields(party0_blinder = %match_bundle.match_proof.statement.party0_modified_shares.blinder, party1_blinder = %match_bundle.match_proof.statement.party1_modified_shares.blinder))]
     pub async fn process_match_settle(
         &self,
         party0_validity_proofs: &OrderValidityProofBundle,

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -75,7 +75,10 @@ impl ArbitrumClient {
     /// `VALID WALLET CREATE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
-    #[instrument(skip_all, err, fields(blinder = %valid_wallet_create.statement.public_wallet_shares.blinder))]
+    #[instrument(skip_all, err, fields(
+        tx_hash,
+        blinder = %valid_wallet_create.statement.public_wallet_shares.blinder
+    ))]
     pub async fn new_wallet(
         &self,
         valid_wallet_create: &SizedValidWalletCreateBundle,
@@ -94,7 +97,9 @@ impl ArbitrumClient {
         )
         .await?;
 
-        info!("`new_wallet` tx hash: {:#x}", receipt.transaction_hash);
+        let tx_hash = format!("{:#x}", receipt.transaction_hash);
+        tracing::Span::current().record("tx_hash", &tx_hash);
+        info!("`new_wallet` tx hash: {}", tx_hash);
 
         Ok(())
     }
@@ -103,7 +108,10 @@ impl ArbitrumClient {
     /// `VALID WALLET UPDATE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
-    #[instrument(skip_all, err, fields(blinder = %valid_wallet_update.statement.new_public_shares.blinder))]
+    #[instrument(skip_all, err, fields(
+        tx_hash,
+        blinder = %valid_wallet_update.statement.new_public_shares.blinder
+    ))]
     pub async fn update_wallet(
         &self,
         valid_wallet_update: &SizedValidWalletUpdateBundle,
@@ -124,7 +132,9 @@ impl ArbitrumClient {
         ))
         .await?;
 
-        info!("`update_wallet` tx hash: {:#x}", receipt.transaction_hash);
+        let tx_hash = format!("{:#x}", receipt.transaction_hash);
+        tracing::Span::current().record("tx_hash", &tx_hash);
+        info!("`update_wallet` tx hash: {}", tx_hash);
 
         Ok(())
     }
@@ -133,7 +143,11 @@ impl ArbitrumClient {
     /// match payloads and `VALID MATCH SETTLE` statement
     ///
     /// Awaits until the transaction is confirmed on-chain
-    #[instrument(skip_all, err, fields(party0_blinder = %match_bundle.match_proof.statement.party0_modified_shares.blinder, party1_blinder = %match_bundle.match_proof.statement.party1_modified_shares.blinder))]
+    #[instrument(skip_all, err, fields(
+        tx_hash,
+        party0_blinder = %match_bundle.match_proof.statement.party0_modified_shares.blinder,
+        party1_blinder = %match_bundle.match_proof.statement.party1_modified_shares.blinder
+    ))]
     pub async fn process_match_settle(
         &self,
         party0_validity_proofs: &OrderValidityProofBundle,
@@ -213,7 +227,9 @@ impl ArbitrumClient {
         ))
         .await?;
 
-        info!("`process_match_settle` tx hash: {:#x}", receipt.transaction_hash);
+        let tx_hash = format!("{:#x}", receipt.transaction_hash);
+        tracing::Span::current().record("tx_hash", &tx_hash);
+        info!("`process_match_settle` tx hash: {}", tx_hash);
 
         Ok(())
     }

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -13,7 +13,7 @@ use ethers::{
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
-use tracing::error;
+use tracing::{error, instrument};
 
 use crate::{
     abi::{
@@ -35,6 +35,7 @@ impl ArbitrumClient {
     /// the given public blinder share
     ///
     /// Returns `None` if the public blinder share has not been used
+    #[instrument(skip_all, err, fields(public_blinder_share = %public_blinder_share))]
     pub async fn get_public_blinder_tx(
         &self,
         public_blinder_share: Scalar,
@@ -55,6 +56,7 @@ impl ArbitrumClient {
     /// Searches on-chain state for the insertion of the given wallet, then
     /// finds the most recent updates of the path's siblings and creates a
     /// Merkle authentication path
+    #[instrument(skip_all, err, fields(commitment = %commitment))]
     pub async fn find_merkle_authentication_path(
         &self,
         commitment: Scalar,
@@ -95,6 +97,7 @@ impl ArbitrumClient {
     }
 
     /// A helper to find a commitment's index in the Merkle tree
+    #[instrument(skip_all, err, fields(commitment = %commitment))]
     pub async fn find_commitment_in_state(
         &self,
         commitment: Scalar,
@@ -115,6 +118,7 @@ impl ArbitrumClient {
     /// Fetch and parse the public secret shares from the calldata of the
     /// transaction that updated the wallet with the given blinder
     // TODO: Add support for nested calls
+    #[instrument(skip_all, err, fields(public_blinder_share = %public_blinder_share))]
     pub async fn fetch_public_shares_for_blinder(
         &self,
         public_blinder_share: Scalar,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,4 +35,4 @@ task-driver = { path = "../workers/task-driver" }
 clap = { version = "3.2.8", features = ["derive"] }
 lazy_static = "1.4"
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,4 +35,4 @@ task-driver = { path = "../workers/task-driver" }
 clap = { version = "3.2.8", features = ["derive"] }
 lazy_static = "1.4"
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -365,7 +365,7 @@ fn configure_default_log_capture() {
     let filter_layer =
         EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy();
 
-    let fmt_layer = fmt::layer();
+    let fmt_layer = fmt::layer().pretty();
 
     tracing_subscriber::registry().with(filter_layer).with(fmt_layer).init();
 }

--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -35,6 +35,9 @@ RUN git clone \
 
 WORKDIR /sources/renegade-contracts
 
+# TODO: Remove this once Arbitrum client is updated
+RUN git checkout 86070446fe87a00c32b8ac50467030ec4ea68ff7
+
 # Build the `scripts` crate to cache it
 RUN cargo build -p scripts
 

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use matchit::Router as MatchRouter;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use state::State;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::error::{bad_request, not_found};
 
@@ -195,6 +195,7 @@ impl Router {
     }
 
     /// Route a request to a handler
+    #[instrument(skip_all, fields(method = %method, route = %route))]
     pub async fn handle_req(
         &self,
         method: Method,

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -210,7 +210,6 @@ impl Router {
             // If the request is an options request, handle it directly
             self.handle_options_req(&route)
         } else {
-
             // Get the full routable path
             let full_route = Self::create_full_route(&method, route.clone());
 
@@ -225,7 +224,9 @@ impl Router {
                     params_map.insert(key.to_string(), value.to_string());
                 }
 
-                if *auth_required && let Err(e) = self.check_wallet_auth(&params_map, &mut req).await {
+                if *auth_required
+                    && let Err(e) = self.check_wallet_auth(&params_map, &mut req).await
+                {
                     e.into()
                 } else {
                     handler.as_ref().handle(req, params_map).await

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -14,7 +14,7 @@ use system_bus::TopicReader;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::StreamMap;
 use tokio_tungstenite::{accept_async, WebSocketStream};
-use tracing::error;
+use tracing::{error, instrument};
 use tungstenite::Message;
 
 use crate::{
@@ -189,6 +189,7 @@ impl WebsocketServer {
     ///
     /// Manages subscriptions to internal channels and dispatches
     /// subscribe/unsubscribe requests
+    #[instrument(skip_all, err)]
     async fn handle_connection(&self, stream: TcpStream) -> Result<(), ApiServerError> {
         // Accept the websocket upgrade and split into read/write streams
         let websocket_stream = accept_async(stream)

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -16,7 +16,7 @@ use job_types::{
 };
 use renegade_crypto::fields::u256_to_scalar;
 use state::State;
-use tracing::{error, info, warn};
+use tracing::{error, info, instrument, warn};
 
 use super::error::OnChainEventListenerError;
 
@@ -123,6 +123,7 @@ impl OnChainEventListenerExecutor {
     }
 
     /// Handle an event from the contract
+    #[instrument(skip_all, err)]
     async fn handle_event(
         &self,
         event: DarkpoolContractEvents,

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -46,7 +46,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use system_bus::SystemBus;
-use tracing::info;
+use tracing::{error, info, info_span, Instrument};
 use util::err_str;
 use uuid::Uuid;
 
@@ -167,9 +167,9 @@ impl HandshakeExecutor {
                     let self_clone = self.clone();
                     tokio::task::spawn(async move {
                         if let Err(e) = self_clone.handle_handshake_job(job).await {
-                            info!("error executing handshake: {e}")
+                            error!("error executing handshake: {e}")
                         }
-                    });
+                    }.instrument(info_span!("handle_handshake_job")));
                 },
 
                 // Await cancellation by the coordinator

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::handshake::PriceVector;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};
 use lazy_static::lazy_static;
 use tokio::sync::oneshot;
-use tracing::{error, warn};
+use tracing::{error, instrument, warn};
 
 use super::{HandshakeExecutor, HandshakeManagerError};
 
@@ -113,6 +113,7 @@ lazy_static! {
 /// This will cause the price reporter to connect to exchanges and begin
 /// streaming, ahead of when we need prices
 #[allow(clippy::needless_pass_by_value)]
+#[instrument(skip_all, err)]
 pub fn init_price_streams(
     price_reporter_job_queue: PriceReporterQueue,
 ) -> Result<(), HandshakeManagerError> {

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -11,7 +11,7 @@ use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use std::{collections::HashMap, thread::JoinHandle};
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot::Sender as TokioSender;
-use tracing::{error, info, warn, info_span, Instrument};
+use tracing::{error, info, info_span, warn, Instrument};
 use util::err_str;
 
 use crate::errors::{ExchangeConnectionError, PriceReporterError};

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -11,7 +11,7 @@ use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use std::{collections::HashMap, thread::JoinHandle};
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot::Sender as TokioSender;
-use tracing::{error, info, warn};
+use tracing::{error, info, warn, info_span, Instrument};
 use util::err_str;
 
 use crate::errors::{ExchangeConnectionError, PriceReporterError};
@@ -80,7 +80,7 @@ impl PriceReporterExecutor {
                             if let Err(e) = self_clone.handle_job(job).await {
                                 error!("Error in PriceReporter execution loop: {e}");
                             }
-                        }
+                        }.instrument(info_span!("handle_job"))
                     });
                 },
 

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -25,7 +25,7 @@ use circuits::{
 use common::types::{proof_bundles::ProofBundle, CancelChannel};
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
 use rayon::ThreadPool;
-use tracing::{error, info};
+use tracing::{error, info, info_span, instrument};
 
 use super::error::ProofManagerError;
 
@@ -80,6 +80,7 @@ impl ProofManager {
                 .map_err(|err| ProofManagerError::JobQueueClosed(err.to_string()))?;
 
             thread_pool.spawn(move || {
+                let _span = info_span!("handle_proof_job").entered();
                 if let Err(e) = Self::handle_proof_job(job) {
                     error!("Error handling proof manager job: {}", e)
                 }
@@ -121,6 +122,7 @@ impl ProofManager {
     }
 
     /// Create a proof of `VALID WALLET CREATE`
+    #[instrument(skip_all, err)]
     fn prove_valid_wallet_create(
         witness: SizedValidWalletCreateWitness,
         statement: SizedValidWalletCreateStatement,
@@ -134,6 +136,7 @@ impl ProofManager {
     }
 
     /// Create a proof of `VALID REBLIND`
+    #[instrument(skip_all, err)]
     fn prove_valid_reblind(
         witness: SizedValidReblindWitness,
         statement: ValidReblindStatement,
@@ -147,6 +150,7 @@ impl ProofManager {
     }
 
     /// Create a proof of `VALID COMMITMENTS`
+    #[instrument(skip_all, err)]
     fn prove_valid_commitments(
         witness: SizedValidCommitmentsWitness,
         statement: ValidCommitmentsStatement,
@@ -160,6 +164,7 @@ impl ProofManager {
     }
 
     /// Create a proof of `VALID WALLET UPDATE`
+    #[instrument(skip_all, err)]
     fn prove_valid_wallet_update(
         witness: SizedValidWalletUpdateWitness,
         statement: SizedValidWalletUpdateStatement,
@@ -173,6 +178,7 @@ impl ProofManager {
     }
 
     /// Create a proof of `VALID MATCH SETTLE`
+    #[instrument(skip_all, err)]
     fn prove_valid_match_mpc(
         witness: SizedValidMatchSettleWitness,
         statement: SizedValidMatchSettleStatement,

--- a/workers/task-driver/Dockerfile
+++ b/workers/task-driver/Dockerfile
@@ -2,63 +2,39 @@
 # integration tests. We effectively copy all the sources and then remove the target
 # directory. This means that changes to `task-driver` sources will invalidate the
 # cache for this stage only, as the end state is the same
-FROM alpine AS sources
-COPY . .
-RUN rm -rf workers/task-driver
+FROM --platform=arm64 rust:latest AS chef
 
-# Rust build stage
-FROM rust:1.63-slim-buster AS builder
-
-# Install pkg-config, openssl
-RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev clang 
-
-# Build the rust toolchain before adding any dependencies; this is the slowest
-# step and we would like to cache it before anything else
-COPY ./rust-toolchain ./task-driver/rust-toolchain
-RUN cat task-driver/rust-toolchain | xargs rustup toolchain install
-
-# Create a build dir and add local dependencies
+# Build dir, use cargo chef to cache dependencies
 WORKDIR /build
-COPY --from=sources . .
+COPY ./rust-toolchain ./rust-toolchain
+RUN cat rust-toolchain | xargs rustup toolchain install
 
-# Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
-# transferring all workspace members to the docker image, and instead only transfer the
-# dependencies of the integration test. Every path dependency of the target crate is automatically
-# added to the workspace
-COPY ./Cargo.toml ./Cargo.toml
-RUN sed -i '/members = \[/,/\]/c\members = [ "workers/task-driver" ]' Cargo.toml
+# Install protoc, openssl, and pkg-config
+RUN apt-get update && \
+    apt-get install -y pkg-config && \
+    apt-get install -y protobuf-compiler && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y libclang-dev
 
-# Place a set of dummy sources in the path, build the dummy executable
-# to cache built dependencies, then bulid the full executable
-WORKDIR /build/workers/task-driver
-RUN mkdir src
-RUN touch src/dummy-lib.rs
+# Install chef and generate a recipe
+RUN cargo install cargo-chef
 
-RUN mkdir integration
-RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY workers/task-driver/Cargo.toml .
-
-# Modify the Cargo.toml to point to our dummy sources
-RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
-RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
-
-# Disable compiler warnings and enable backtraces for panic debugging
+# Disable compiler warnings and enable backtraces for panic
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --tests --features "integration" --recipe-path recipe.json
+
+# Copy back in the full sources and build the tests
+WORKDIR /build
+COPY . .
+
+WORKDIR /build/workers/task-driver
 RUN cargo build --quiet --test integration --features "integration"
 
-# Edit the Cargo.toml back to the original, build the full executable
-RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
-RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
-
-COPY workers/task-driver/src ./src
-COPY workers/task-driver/integration ./integration
-
-RUN cargo build --quiet --test integration --features "integration"
-
+# Copy in the deployments file from the sequencer
 COPY --from=sequencer /deployments.json /deployments.json
-
-CMD [ "cargo", "test" ]

--- a/workers/task-driver/Dockerfile
+++ b/workers/task-driver/Dockerfile
@@ -4,7 +4,7 @@
 # cache for this stage only, as the end state is the same
 FROM alpine AS sources
 COPY . .
-RUN rm -rf task-driver
+RUN rm -rf workers/task-driver
 
 # Rust build stage
 FROM rust:1.63-slim-buster AS builder
@@ -27,18 +27,18 @@ COPY --from=sources . .
 # dependencies of the integration test. Every path dependency of the target crate is automatically
 # added to the workspace
 COPY ./Cargo.toml ./Cargo.toml
-RUN sed -i '/members = \[/,/\]/c\members = [ "task-driver" ]' Cargo.toml
+RUN sed -i '/members = \[/,/\]/c\members = [ "workers/task-driver" ]' Cargo.toml
 
 # Place a set of dummy sources in the path, build the dummy executable
 # to cache built dependencies, then bulid the full executable
-WORKDIR /build/task-driver
+WORKDIR /build/workers/task-driver
 RUN mkdir src
 RUN touch src/dummy-lib.rs
 
 RUN mkdir integration
 RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
 
-COPY task-driver/Cargo.toml .
+COPY workers/task-driver/Cargo.toml .
 
 # Modify the Cargo.toml to point to our dummy sources
 RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
@@ -54,8 +54,8 @@ RUN cargo build --quiet --test integration --features "integration"
 RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
 RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
 
-COPY task-driver/src ./src
-COPY task-driver/integration ./integration
+COPY workers/task-driver/src ./src
+COPY workers/task-driver/integration ./integration
 
 RUN cargo build --quiet --test integration --features "integration"
 

--- a/workers/task-driver/docker-compose.yml
+++ b/workers/task-driver/docker-compose.yml
@@ -17,8 +17,8 @@ services:
   relayer:
     image: task-driver-integration-test:latest
     build:
-      context: ..
-      dockerfile: task-driver/Dockerfile
+      context: ../..
+      dockerfile: workers/task-driver/Dockerfile
     ports:
       - "8000:8000"
     command: >

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -192,7 +192,6 @@ impl TaskExecutor {
                         async move {
                             let res = fut.await;
                             if let Err(e) = res {
-                                // TODO: May be able to remove this log & instrumentation below
                                 error!("error running task: {e:?}");
                             }
                         }
@@ -285,7 +284,7 @@ impl TaskExecutor {
                 // Remove from the preemptive tasks list
                 preemptive_tasks.write().unwrap().remove(&task_id);
             }
-            .instrument(info_span!("immediate_task", task_id = %task_id)),
+            .instrument(info_span!("task", task_id = %task_id)),
         );
 
         Ok(())

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -23,6 +23,7 @@ use job_types::proof_manager::{ProofJob, ProofManagerQueue};
 use serde::Serialize;
 use state::error::StateError;
 use state::State;
+use tracing::instrument;
 
 use crate::driver::StateWrapper;
 use crate::helpers::enqueue_proof_job;
@@ -179,6 +180,8 @@ impl Task for NewWalletTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on the current state of the task
         match self.state() {

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -19,7 +19,7 @@ use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManage
 use renegade_crypto::hash::PoseidonCSPRNG;
 use serde::Serialize;
 use state::{error::StateError, State};
-use tracing::info;
+use tracing::{info, instrument};
 use uuid::Uuid;
 
 use crate::{
@@ -164,6 +164,8 @@ impl Task for LookupWalletTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on task state
         match self.task_state {

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -26,6 +26,7 @@ use job_types::proof_manager::ProofManagerQueue;
 use serde::Serialize;
 use state::error::StateError;
 use state::State;
+use tracing::instrument;
 
 use crate::driver::StateWrapper;
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
@@ -194,6 +195,8 @@ impl Task for SettleMatchTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on the current task state
         match self.state() {

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -28,6 +28,7 @@ use serde::Serialize;
 use state::error::StateError;
 use state::State;
 use tokio::task::JoinHandle as TokioJoinHandle;
+use tracing::instrument;
 use util::matching_engine::settle_match_into_wallets;
 
 // -------------
@@ -197,6 +198,8 @@ impl Task for SettleMatchInternalTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on the current task state
         match self.state() {

--- a/workers/task-driver/src/tasks/update_merkle_proof.rs
+++ b/workers/task-driver/src/tasks/update_merkle_proof.rs
@@ -13,6 +13,7 @@ use common::types::{tasks::UpdateMerkleProofTaskDescriptor, wallet::Wallet};
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
 use serde::Serialize;
 use state::{error::StateError, State};
+use tracing::instrument;
 
 use crate::{
     driver::StateWrapper,
@@ -155,6 +156,8 @@ impl Task for UpdateMerkleProofTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on the current transaction step
         match self.state() {

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -22,6 +22,7 @@ use job_types::proof_manager::{ProofJob, ProofManagerQueue};
 use serde::Serialize;
 use state::error::StateError;
 use state::State;
+use tracing::instrument;
 
 use crate::driver::StateWrapper;
 use crate::helpers::{enqueue_proof_job, find_merkle_path};
@@ -200,6 +201,8 @@ impl Task for UpdateWalletTask {
         })
     }
 
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
         // Dispatch based on the current transaction step
         match self.state() {


### PR DESCRIPTION
This PR adds some (basic, minimal) span structure to the relayer workers - though, for now, we don't do any tracing of the gossip and network manager workers, as they are fairly low-level and high-volume.

This includes a top-level span for each job of each worker, with some sub-spans per API request, per task step, per proof generated, and per Arbitrum client method.

Additionally, I've included in this the usage of `cargo chef` in the Arbitrum client and task driver integration tests, which I used to check on trace generation.