### PR TITLE
workers: price-reporter: Do not fail on invalid pair

### DIFF
--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -89,6 +89,8 @@ pub enum PriceReporterState {
     /// holding off until prices stabilize. Includes the current deviation
     /// as a fraction.
     TooMuchDeviation(PriceReport, f64),
+    /// No reporter state, price pair is unsupported
+    UnsupportedPair(Token, Token),
 }
 
 /// The state of an ExchangeConnection. Note that the ExchangeConnection itself

--- a/workers/price-reporter/src/errors.rs
+++ b/workers/price-reporter/src/errors.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::fmt::{self, Display};
 
-use common::types::exchange::Exchange;
+use common::types::{exchange::Exchange, token::Token};
 
 /// The core error type used by the ExchangeConnection. All thrown errors are
 /// handled by the PriceReporter, either for restarts or panics upon too many
@@ -19,6 +19,8 @@ pub enum ExchangeConnectionError {
     /// The maximum retry count was exceeded while trying to re-establish
     /// an exchange connection
     MaxRetries(Exchange),
+    /// No exchanges support the given token pair
+    NoSupportedExchanges(Token, Token),
     /// Error sending on the `write` end of the websocket
     SendError(String),
 }
@@ -42,9 +44,8 @@ pub enum PriceReporterError {
     /// Tried to query information from a PriceReporter that does not exist.
     /// Callers should send a StartPriceReporter job first
     PriceReporterNotCreated(String),
-    /// In one of the PriceReporters, one of the ExchangeConnections failed too
-    /// many times in a row.
-    _TooManyFailures(ExchangeConnectionError),
+    /// Unsupported pair for the reporter
+    UnsupportedPair(Token, Token),
 }
 
 impl Error for PriceReporterError {}

--- a/workers/price-reporter/src/reporter.rs
+++ b/workers/price-reporter/src/reporter.rs
@@ -128,8 +128,13 @@ impl Reporter {
         quote_token: Token,
         config: PriceReporterConfig,
     ) -> Result<Self, ExchangeConnectionError> {
+        // Get the supported exchanges for the token pair
         let supported_exchanges =
             Self::compute_supported_exchanges_for_pair(&base_token, &quote_token, &config);
+        if supported_exchanges.is_empty() {
+            warn!("No supported exchanges for {base_token}-{quote_token}");
+            return Err(ExchangeConnectionError::NoSupportedExchanges(base_token, quote_token));
+        }
 
         // Create shared memory that the `ConnectionMuxer` will use to communicate with
         // the `Reporter`


### PR DESCRIPTION
### Purpose
This PR changes the price reporter to not fail on invalid asset pairs, i.e. if no exchange supports the pair. In this case the `Unsupported` message is returned to the caller. 

I tested this through the API to verify that this unsupported information makes its way back to the client.

### Testing
- All unit tests pass