### PR TITLE
circuits: zk-circuits: valid-match-settle: singleprover circuit fees

### DIFF
--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -130,7 +130,6 @@ pub mod test_helpers {
                 amount: 1,
                 // No price limit by default
                 worst_case_price: FixedPoint::from_integer(100000),
-                timestamp: TIMESTAMP,
             },
             Order {
                 quote_mint: 1u8.into(),
@@ -139,14 +138,13 @@ pub mod test_helpers {
                 amount: 10,
                 // No price limit by default
                 worst_case_price: FixedPoint::from_integer(0),
-                timestamp: TIMESTAMP,
             }
         ];
         pub static ref INITIAL_WALLET: SizedWallet = Wallet {
             balances: INITIAL_BALANCES.clone(),
             orders: INITIAL_ORDERS.clone(),
             keys: PUBLIC_KEYS.clone(),
-            match_fee: FixedPoint::from_integer(0),
+            match_fee: FixedPoint::from_f64_round_down(0.002), // 20 bps
             managing_cluster: 0u8.into(),
             blinder: Scalar::from(42u64)
         };
@@ -160,8 +158,6 @@ pub mod test_helpers {
     pub const MAX_BALANCES: usize = 2;
     /// The maximum number of orders allowed in a wallet for tests
     pub const MAX_ORDERS: usize = 2;
-    /// The initial timestamp used in testing
-    pub const TIMESTAMP: u64 = 3; // dummy value
 
     pub type SizedWallet = Wallet<MAX_BALANCES, MAX_ORDERS>;
     pub type SizedWalletShare = WalletShare<MAX_BALANCES, MAX_ORDERS>;

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -91,40 +91,40 @@ where
 {
     /// The first party's order
     #[link_groups = "valid_commitments_match_settle0"]
-    pub order1: Order,
+    pub order0: Order,
     /// The first party's balance
     #[link_groups = "valid_commitments_match_settle0"]
-    pub balance1: Balance,
+    pub balance0: Balance,
     /// The first party's receive balance
     #[link_groups = "valid_commitments_match_settle0"]
-    pub balance_receive1: Balance,
+    pub balance_receive0: Balance,
     /// The first party's managing relayer fee
-    #[link_groups = "valid_commitments_match_settle1"]
-    pub relayer_fee1: FixedPoint,
+    #[link_groups = "valid_commitments_match_settle0"]
+    pub relayer_fee0: FixedPoint,
     /// The first party's fee obligations as a result of the match
     pub party0_fees: FeeTake,
     /// The price that the first party agreed to execute at for their asset
-    pub price1: FixedPoint,
+    pub price0: FixedPoint,
     /// The maximum amount that the first party may match
-    pub amount1: Scalar,
+    pub amount0: Scalar,
     /// The second party's order
     #[link_groups = "valid_commitments_match_settle1"]
-    pub order2: Order,
+    pub order1: Order,
     /// The second party's balance
     #[link_groups = "valid_commitments_match_settle1"]
-    pub balance2: Balance,
+    pub balance1: Balance,
     /// The second party's receive balance
     #[link_groups = "valid_commitments_match_settle1"]
-    pub balance_receive2: Balance,
+    pub balance_receive1: Balance,
     /// The second party's managing relayer fee
     #[link_groups = "valid_commitments_match_settle1"]
-    pub relayer_fee2: FixedPoint,
+    pub relayer_fee1: FixedPoint,
     /// The second party's fee obligations as a result of the match
     pub party1_fees: FeeTake,
     /// The price that the second party agreed to execute at for their asset
-    pub price2: FixedPoint,
+    pub price1: FixedPoint,
     /// The maximum amount that the second party may match
-    pub amount2: Scalar,
+    pub amount1: Scalar,
     /// The result of running a match MPC on the given orders
     ///
     /// We do not open this value before proving so that we can avoid leaking
@@ -302,25 +302,25 @@ pub mod test_helpers {
             o2.side,
         );
 
-        let amount1 = Scalar::from(o1.amount);
-        let amount2 = Scalar::from(o2.amount);
+        let amount0 = Scalar::from(o1.amount);
+        let amount1 = Scalar::from(o2.amount);
 
         (
             ValidMatchSettleWitness {
-                order1: o1,
-                balance1: wallet1.balances[party0_indices.balance_send].clone(),
-                balance_receive1: wallet1.balances[party0_indices.balance_receive].clone(),
-                relayer_fee1: wallet1.match_fee,
-                price1: price,
+                order0: o1,
+                balance0: wallet1.balances[party0_indices.balance_send].clone(),
+                balance_receive0: wallet1.balances[party0_indices.balance_receive].clone(),
+                relayer_fee0: wallet1.match_fee,
+                price0: price,
                 party0_fees,
-                amount1,
-                order2: o2,
-                balance2: wallet2.balances[party1_indices.balance_send].clone(),
-                balance_receive2: wallet2.balances[party1_indices.balance_receive].clone(),
-                relayer_fee2: wallet2.match_fee,
-                price2: price,
+                amount0,
+                order1: o2,
+                balance1: wallet2.balances[party1_indices.balance_send].clone(),
+                balance_receive1: wallet2.balances[party1_indices.balance_receive].clone(),
+                relayer_fee1: wallet2.match_fee,
+                price1: price,
                 party1_fees,
-                amount2,
+                amount1,
                 match_res,
                 party0_public_shares,
                 party1_public_shares,
@@ -477,14 +477,14 @@ mod tests {
 
         // One party switches the quote mint of their order
         let mut witness = original_witness.clone();
-        rand_branch!(witness.order1.quote_mint += 1u8, witness.order2.quote_mint += 1u8);
+        rand_branch!(witness.order0.quote_mint += 1u8, witness.order1.quote_mint += 1u8);
 
         // Validate that the constraints are not satisfied
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
 
         // Now test with base mint switched
         let mut witness = original_witness;
-        rand_branch!(witness.order1.base_mint += 1u8, witness.order2.base_mint += 1u8);
+        rand_branch!(witness.order0.base_mint += 1u8, witness.order1.base_mint += 1u8);
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
 
@@ -495,8 +495,8 @@ mod tests {
 
         // Swap the sides of one of the orders
         rand_branch!(
-            witness.order1.side = witness.order1.side.opposite(),
-            witness.order2.side = witness.order2.side.opposite()
+            witness.order0.side = witness.order0.side.opposite(),
+            witness.order1.side = witness.order1.side.opposite()
         );
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
@@ -519,7 +519,7 @@ mod tests {
 
         // Change the price of one of the orders
         let one = Scalar::one();
-        rand_branch!(witness.price1 = witness.price1 + one, witness.price2 = witness.price2 + one);
+        rand_branch!(witness.price0 = witness.price0 + one, witness.price1 = witness.price1 + one);
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
 
@@ -531,8 +531,8 @@ mod tests {
 
         // Set the amount to be greater than the maximum
         rand_branch!(
-            witness.amount1 = max_amount_scalar() + Scalar::one(),
-            witness.amount2 = max_amount_scalar() + Scalar::one()
+            witness.amount0 = max_amount_scalar() + Scalar::one(),
+            witness.amount1 = max_amount_scalar() + Scalar::one()
         );
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
@@ -564,7 +564,7 @@ mod tests {
         let (mut witness, statement) = dummy_witness_and_statement();
 
         // Reduce the balance to be less than the amount matched
-        rand_branch!(witness.balance1.amount = 1, witness.balance2.amount = 1);
+        rand_branch!(witness.balance0.amount = 1, witness.balance1.amount = 1);
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
 
@@ -576,8 +576,8 @@ mod tests {
 
         // Place one party's order amount below the min amount
         rand_branch!(
-            witness.order1.amount = witness.match_res.base_amount - 1,
-            witness.order2.amount = witness.match_res.base_amount - 1
+            witness.order0.amount = witness.match_res.base_amount - 1,
+            witness.order1.amount = witness.match_res.base_amount - 1
         );
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
@@ -604,10 +604,10 @@ mod tests {
 
         // Move the worst case price of the buy side order down
         let new_price = FixedPoint::from_f64_round_down(execution_price - 1.);
-        if witness.order1.side.is_buy() {
-            witness.order1.worst_case_price = new_price;
+        if witness.order0.side.is_buy() {
+            witness.order0.worst_case_price = new_price;
         } else {
-            witness.order2.worst_case_price = new_price;
+            witness.order1.worst_case_price = new_price;
         }
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
@@ -623,10 +623,10 @@ mod tests {
 
         // Move the worst case price of the sell side order up
         let new_price = FixedPoint::from_f64_round_down(execution_price + 1.);
-        if witness.order1.side.is_sell() {
-            witness.order1.worst_case_price = new_price;
+        if witness.order0.side.is_sell() {
+            witness.order0.worst_case_price = new_price;
         } else {
-            witness.order2.worst_case_price = new_price;
+            witness.order1.worst_case_price = new_price;
         }
 
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
@@ -645,8 +645,8 @@ mod tests {
         // Set the balance to be the maximum
         let initial_bal = scalar_to_u128(&max_amount_scalar());
         rand_branch!(
-            witness.balance_receive1.amount = initial_bal,
-            witness.balance_receive2.amount = initial_bal
+            witness.balance_receive0.amount = initial_bal,
+            witness.balance_receive1.amount = initial_bal
         );
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
@@ -659,8 +659,8 @@ mod tests {
         // Set the relayer fee balance to be the maximum
         let initial_bal = scalar_to_u128(&max_amount_scalar());
         rand_branch!(
-            witness.balance_receive1.relayer_fee_balance = initial_bal,
-            witness.balance_receive2.relayer_fee_balance = initial_bal
+            witness.balance_receive0.relayer_fee_balance = initial_bal,
+            witness.balance_receive1.relayer_fee_balance = initial_bal
         );
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
@@ -673,8 +673,8 @@ mod tests {
         // Set the protocol fee balance to be the maximum
         let initial_bal = scalar_to_u128(&max_amount_scalar());
         rand_branch!(
-            witness.balance_receive1.protocol_fee_balance = initial_bal,
-            witness.balance_receive2.protocol_fee_balance = initial_bal
+            witness.balance_receive0.protocol_fee_balance = initial_bal,
+            witness.balance_receive1.protocol_fee_balance = initial_bal
         );
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }

--- a/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
@@ -5,7 +5,7 @@ use circuit_types::{
     balance::BalanceVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::{MatchResultVar, OrderSettlementIndicesVar},
+    r#match::{FeeTakeVar, MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     Fabric, MpcPlonkCircuit, AMOUNT_BITS, PRICE_BITS,
 };
@@ -14,12 +14,10 @@ use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
 use super::{ValidMatchSettle, ValidMatchSettleStatementVar, ValidMatchSettleWitnessVar};
 use crate::zk_gadgets::{
-    comparators::{
-        EqGadget, MultiproverEqGadget, MultiproverGreaterThanEqGadget,
-        MultiproverGreaterThanEqZeroGadget,
-    },
+    comparators::{EqGadget, MultiproverEqGadget, MultiproverGreaterThanEqGadget},
     fixed_point::MultiproverFixedPointGadget,
     select::{CondSelectGadget, CondSelectVectorGadget},
+    wallet_operations::{MultiproverAmountGadget, MultiproverPriceGadget},
 };
 
 // --- Matching Engine --- //
@@ -41,31 +39,93 @@ where
         let zero_var = cs.zero();
         let one_var = cs.one();
 
-        // --- Match Engine Input Validity --- //
+        // --- Order Crossing Constraints --- //
         // Check that both orders are for the matched asset pair
+        cs.enforce_equal(witness.order0.quote_mint, witness.match_res.quote_mint)?;
+        cs.enforce_equal(witness.order0.base_mint, witness.match_res.base_mint)?;
         cs.enforce_equal(witness.order1.quote_mint, witness.match_res.quote_mint)?;
         cs.enforce_equal(witness.order1.base_mint, witness.match_res.base_mint)?;
-        cs.enforce_equal(witness.order2.quote_mint, witness.match_res.quote_mint)?;
-        cs.enforce_equal(witness.order2.base_mint, witness.match_res.base_mint)?;
 
         // Check that the prices supplied by the parties are equal, these should be
         // agreed upon outside of the circuit
-        EqGadget::constrain_eq(&witness.price1, &witness.price2, cs)?;
+        EqGadget::constrain_eq(&witness.price0, &witness.price1, cs)?;
+        // Validate that the price is valid, i.e. representable in a small enough number
+        // of bits to avoid overflow
+        MultiproverPriceGadget::constrain_valid_price(witness.price0, fabric, cs)?;
 
-        // Check that the balances supplied are for the correct mints; i.e. for the mint
-        // that each party sells in the settlement
-        let selected_mints = CondSelectGadget::select(
-            &[witness.match_res.base_mint, witness.match_res.quote_mint],
-            &[witness.match_res.quote_mint, witness.match_res.base_mint],
-            witness.match_res.direction,
+        // The orders must be on opposite sides of the market
+        // i.e. one must be a buy order and the other a sell order
+        //     o1.side + o2.side == 1
+        //
+        // Note that the orders are constrained binary by their allocation as a
+        // `BoolVar`
+        cs.lc_gate(
+            &[witness.order0.side.into(), witness.order1.side.into(), zero_var, zero_var, one_var],
+            &[one, one, zero, zero],
+        )?;
+
+        // Check that the direction of the match is the same as the first party's
+        // direction
+        cs.enforce_equal(witness.match_res.direction.into(), witness.order0.side.into())?;
+
+        // --- Match Volume Constraints --- //
+        // Constrain that the pledged amount of each party is a valid amount
+        MultiproverAmountGadget::constrain_valid_amount(witness.amount0, fabric, cs)?;
+        MultiproverAmountGadget::constrain_valid_amount(witness.amount1, fabric, cs)?;
+
+        let max_minus_min1 = cs.sub(witness.amount0, witness.amount1)?;
+        let max_minus_min2 = cs.sub(witness.amount1, witness.amount0)?;
+        let max_minus_min_amount = CondSelectGadget::select(
+            &max_minus_min1,
+            &max_minus_min2,
+            witness.match_res.min_amount_order_index,
             cs,
         )?;
 
-        cs.enforce_equal(witness.balance1.mint, selected_mints[0])?;
-        cs.enforce_equal(witness.balance2.mint, selected_mints[1])?;
+        // Constrain the `max_minus_min_amount` value to be in [0,
+        // 2^AMOUNT_BITS] This effectively constrains this value to be
+        // correctly computed. As if instead it were min(a, b) - max(a,
+        // b), then this value would be negative.
+        //
+        // This constraint then also implicitly constrains the
+        // `min_amount_order_index` value to be correct. This value is
+        // separately constrained to be 0 or 1, as it is a `BoolVar`
+        MultiproverAmountGadget::constrain_valid_amount(max_minus_min_amount, fabric, cs)?;
+
+        // Validate that the swapped amounts correctly reflect the minimum order amount
+        // Order amounts are specified in the base asset, so the swapped base amount
+        // should be the minimum of the two order amounts
+        let min_amount = CondSelectGadget::select(
+            &witness.amount1,
+            &witness.amount0,
+            witness.match_res.min_amount_order_index,
+            cs,
+        )?;
+        cs.enforce_equal(witness.match_res.base_amount, min_amount)?;
+
+        // The quote amount swapped should equal the price multiplied by the base amount
+        // Here we round down to the nearest integer
+        let expected_quote_amount =
+            witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
+        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_quote_amount,
+            witness.match_res.quote_amount,
+            fabric,
+            cs,
+        )?;
+
+        // --- Order & Balance Volume Constraints --- //
 
         // Check that the max amount match supplied by both parties is covered by the
-        // balance no greater than the amount specified in the order
+        // balance and no greater than the amount specified in the order
+        Self::validate_volume_constraints(
+            &witness.match_res,
+            &witness.balance0,
+            &witness.order0,
+            fabric,
+            cs,
+        )?;
+
         Self::validate_volume_constraints(
             &witness.match_res,
             &witness.balance1,
@@ -74,95 +134,10 @@ where
             cs,
         )?;
 
-        Self::validate_volume_constraints(
-            &witness.match_res,
-            &witness.balance2,
-            &witness.order2,
-            fabric,
-            cs,
-        )?;
-
-        // --- Match Engine Execution Validity --- //
-        // Check that the direction of the match is the same as the first party's
-        // direction
-        cs.enforce_equal(witness.match_res.direction.into(), witness.order1.side.into())?;
-
-        // Check that the orders are on opposite sides of the market. It is assumed that
-        // order sides are already constrained to be binary when they are
-        // submitted. More broadly it is assumed that orders are well formed,
-        // checking this amounts to checking their inclusion in the state tree,
-        // which is done in `input_consistency_check`
-        cs.lc_gate(
-            &[
-                witness.order1.side.into(),
-                witness.order2.side.into(),
-                one_var,
-                one_var,
-                zero_var, // out wire
-            ],
-            &[one, one, -one, zero],
-        )?;
-
-        // Check that the amount of base currency exchanged is equal to the minimum of
-        // the two order's amounts
-
-        // 1. Constrain the max_minus_min_amount to be correctly computed with respect
-        //    to the argmin
-        // witness variable min_amount_order_index
-        let max_minus_min1 = cs.sub(witness.amount1, witness.amount2)?;
-        let max_minus_min2 = cs.sub(witness.amount2, witness.amount1)?;
-        cs.mux_gate(
-            witness.match_res.min_amount_order_index,
-            max_minus_min1,
-            max_minus_min2,
-            witness.match_res.max_minus_min_amount, // out wire
-        )?;
-
-        // 2. Constrain the max_minus_min_amount value to be positive
-        // This, along with the previous check, constrain `max_minus_min_amount` to be
-        // computed correctly. I.e. the above constraint forces
-        // `max_minus_min_amount` to be either max(amounts) - min(amounts)
-        // or min(amounts) - max(amounts).
-        // Constraining the value to be positive forces it to be equal to max(amounts) -
-        // min(amounts)
-        MultiproverGreaterThanEqZeroGadget::<AMOUNT_BITS>::constrain_greater_than_zero(
-            witness.match_res.max_minus_min_amount,
-            fabric,
-            cs,
-        )?;
-
-        // 3. Constrain the executed base amount to be the minimum of the two order
-        //    amounts
-        // We use the identity
-        //      min(a, b) = 1/2 * (a + b - [max(a, b) - min(a, b)])
-        // Above we are given max(a, b) - min(a, b), so we can enforce the constraint
-        //      2 * executed_amount = amount1 + amount2 - max_minus_min_amount
-        let two = ScalarField::from(2u64);
-        cs.lc_gate(
-            &[
-                witness.match_res.base_amount,
-                witness.amount1,
-                witness.amount2,
-                witness.match_res.max_minus_min_amount,
-                zero_var, // out wire
-            ],
-            &[two, -one, -one, one],
-        )?;
-
-        // The quote amount should then equal the price multiplied by the base amount
-        let expected_quote_amount =
-            witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
-
-        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
-            expected_quote_amount,
-            witness.match_res.quote_amount,
-            fabric,
-            cs,
-        )?;
-
         // --- Price Protection --- //
-        Self::verify_price_protection(&witness.price1, &witness.order1, fabric, cs)?;
-        Self::verify_price_protection(&witness.price2, &witness.order2, fabric, cs)
+        // Check that the execution price is within the user-defined limits
+        Self::verify_price_protection(&witness.price0, &witness.order0, fabric, cs)?;
+        Self::verify_price_protection(&witness.price1, &witness.order1, fabric, cs)
     }
 
     /// Check that a balance covers the advertised amount at a given price, and
@@ -196,12 +171,9 @@ where
             order.side,
             cs,
         )?;
-        MultiproverGreaterThanEqGadget::<AMOUNT_BITS>::constrain_greater_than_eq(
-            balance.amount,
-            amount_sold,
-            fabric,
-            cs,
-        )
+
+        let new_balance = cs.sub(balance.amount, amount_sold)?;
+        MultiproverAmountGadget::constrain_valid_amount(new_balance, fabric, cs)
     }
 
     /// Verify the price protection on the orders; i.e. that the executed price
@@ -257,10 +229,22 @@ where
         let party0_received_amount = party0_party1_received[0];
         let party1_received_amount = party0_party1_received[1];
 
+        // Validate the first party's fee take
+        Self::validate_fee_take(
+            party0_received_amount,
+            witness.relayer_fee0,
+            statement.protocol_fee,
+            &witness.party0_fees,
+            fabric,
+            cs,
+        )?;
+
         // Constrain the wallet updates to party0's shares
         Self::validate_balance_updates(
             party1_received_amount,
             party0_received_amount,
+            &witness.balance_receive0,
+            &witness.party0_fees,
             &statement.party0_indices,
             &witness.party0_public_shares,
             &statement.party0_modified_shares,
@@ -283,10 +267,22 @@ where
             cs,
         )?;
 
+        // Validate the second party's fee take
+        Self::validate_fee_take(
+            party1_received_amount,
+            witness.relayer_fee1,
+            statement.protocol_fee,
+            &witness.party1_fees,
+            fabric,
+            cs,
+        )?;
+
         // Constrain the wallet update to party1's shares
         Self::validate_balance_updates(
             party0_received_amount,
             party1_received_amount,
+            &witness.balance_receive1,
+            &witness.party1_fees,
             &statement.party1_indices,
             &witness.party1_public_shares,
             &statement.party1_modified_shares,
@@ -310,14 +306,44 @@ where
         )
     }
 
+    /// Validate a fee take for a given relayer fee and protocol fee
+    fn validate_fee_take(
+        received_amount: Variable,
+        relayer_fee: FixedPointVar,
+        protocol_fee: FixedPointVar,
+        fee_take: &FeeTakeVar,
+        fabric: &Fabric,
+        cs: &mut MpcPlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let expected_relayer_fee = relayer_fee.mul_integer(received_amount, cs)?;
+        let expected_protocol_fee = protocol_fee.mul_integer(received_amount, cs)?;
+
+        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_relayer_fee,
+            fee_take.relayer_fee,
+            fabric,
+            cs,
+        )?;
+
+        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_protocol_fee,
+            fee_take.protocol_fee,
+            fabric,
+            cs,
+        )
+    }
+
     /// Verify that the balance updates to a wallet are valid
     ///
     /// That is, all balances in the settled wallet are the same as in the
     /// pre-settle wallet except for the balance sent and the balance
     /// received, which have the correct amounts applied from the match
+    #[allow(clippy::too_many_arguments)]
     fn validate_balance_updates(
         send_amount: Variable,
         received_amount: Variable,
+        receive_balance: &BalanceVar,
+        fees: &FeeTakeVar,
         indices: &OrderSettlementIndicesVar,
         pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
@@ -325,6 +351,17 @@ where
         cs: &mut MpcPlonkCircuit,
     ) -> Result<(), CircuitError> {
         let one = ScalarField::one();
+        let zero = ScalarField::zero();
+        let zero_var = cs.zero();
+
+        // Compute the trader's take net of their fee obligations
+        let trader_take = cs.lc(
+            &[received_amount, fees.relayer_fee, fees.protocol_fee, zero_var],
+            &[one, -one, -one, zero],
+        )?;
+
+        // Check that no overflow occurs in the receive balance
+        Self::validate_no_receive_overflow(trader_take, receive_balance, fees, fabric, cs)?;
 
         let mut curr_index = cs.zero();
         for (pre_update_balance, post_update_balance) in pre_update_shares
@@ -341,13 +378,23 @@ where
             // Mask the receive term
             let receive_term_index_mask =
                 MultiproverEqGadget::eq_public(&indices.balance_receive, &curr_index, fabric, cs)?;
-            let masked_receive = cs.mul(receive_term_index_mask.into(), received_amount)?;
+            let masked_receive = cs.mul(receive_term_index_mask.into(), trader_take)?;
+            let masked_relayer_fee = cs.mul(receive_term_index_mask.into(), fees.relayer_fee)?;
+            let masked_protocol_fee = cs.mul(receive_term_index_mask.into(), fees.protocol_fee)?;
 
             // Add the terms together to get the expected update
             let expected_balance_amount =
                 cs.sum(&[pre_update_balance.amount, masked_send, masked_receive])?;
+            let expected_balance_relayer_fee =
+                cs.add(pre_update_balance.relayer_fee_balance, masked_relayer_fee)?;
+            let expected_balance_protocol_fee =
+                cs.add(pre_update_balance.protocol_fee_balance, masked_protocol_fee)?;
+
+            // Ensure that the post-update balance is equal to the expected balance
             let mut expected_balance_shares = pre_update_balance.clone();
             expected_balance_shares.amount = expected_balance_amount;
+            expected_balance_shares.relayer_fee_balance = expected_balance_relayer_fee;
+            expected_balance_shares.protocol_fee_balance = expected_balance_protocol_fee;
 
             EqGadget::constrain_eq(&expected_balance_shares, &post_update_balance, cs)?;
 
@@ -356,6 +403,25 @@ where
         }
 
         Ok(())
+    }
+
+    /// Validate that the receive balance amounts after update do not overflow
+    fn validate_no_receive_overflow(
+        trader_take: Variable,
+        receive_balance: &BalanceVar,
+        fees: &FeeTakeVar,
+        fabric: &Fabric,
+        cs: &mut MpcPlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let post_update_amount = cs.add(receive_balance.amount, trader_take)?;
+        let post_update_relayer_fee =
+            cs.add(receive_balance.relayer_fee_balance, fees.relayer_fee)?;
+        let post_update_protocol_fee =
+            cs.add(receive_balance.protocol_fee_balance, fees.protocol_fee)?;
+
+        MultiproverAmountGadget::constrain_valid_amount(post_update_amount, fabric, cs)?;
+        MultiproverAmountGadget::constrain_valid_amount(post_update_relayer_fee, fabric, cs)?;
+        MultiproverAmountGadget::constrain_valid_amount(post_update_protocol_fee, fabric, cs)
     }
 
     /// Verify that order updates to a wallet are valid
@@ -407,6 +473,12 @@ where
         post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         cs: &mut MpcPlonkCircuit,
     ) -> Result<(), CircuitError> {
+        EqGadget::constrain_eq(
+            &pre_update_shares.managing_cluster,
+            &post_update_shares.managing_cluster,
+            cs,
+        )?;
+        EqGadget::constrain_eq(&pre_update_shares.match_fee, &post_update_shares.match_fee, cs)?;
         EqGadget::constrain_eq(&pre_update_shares.keys, &post_update_shares.keys, cs)?;
         EqGadget::constrain_eq(&pre_update_shares.blinder, &post_update_shares.blinder, cs)
     }

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -5,7 +5,7 @@ use circuit_types::{
     balance::BalanceVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::{MatchResultVar, OrderSettlementIndicesVar},
+    r#match::{FeeTakeVar, MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     PlonkCircuit, AMOUNT_BITS, PRICE_BITS,
 };
@@ -13,9 +13,10 @@ use constants::ScalarField;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
 use crate::zk_gadgets::{
-    comparators::{EqGadget, GreaterThanEqGadget, GreaterThanEqZeroGadget},
+    comparators::{EqGadget, GreaterThanEqGadget},
     fixed_point::FixedPointGadget,
     select::{CondSelectGadget, CondSelectVectorGadget},
+    wallet_operations::{AmountGadget, PriceGadget},
 };
 
 use super::{ValidMatchSettle, ValidMatchSettleStatementVar, ValidMatchSettleWitnessVar};
@@ -39,7 +40,7 @@ where
         let zero_var = cs.zero();
         let one_var = cs.one();
 
-        // --- Match Engine Input Validity --- //
+        // --- Order Crossing Constraints --- //
         // Check that both orders are for the matched asset pair
         cs.enforce_equal(witness.order1.quote_mint, witness.match_res.quote_mint)?;
         cs.enforce_equal(witness.order1.base_mint, witness.match_res.base_mint)?;
@@ -49,21 +50,74 @@ where
         // Check that the prices supplied by the parties are equal, these should be
         // agreed upon outside of the circuit
         EqGadget::constrain_eq(&witness.price1, &witness.price2, cs)?;
+        // Validate that the price is valid, i.e. representable in a small enough number
+        // of bits to avoid overflow
+        PriceGadget::constrain_valid_price(witness.price1, cs)?;
 
-        // Check that the balances supplied are for the correct mints; i.e. for the mint
-        // that each party sells in the settlement
-        let mut selected_mints = CondSelectVectorGadget::select(
-            &[witness.match_res.base_mint, witness.match_res.quote_mint],
-            &[witness.match_res.quote_mint, witness.match_res.base_mint],
-            witness.match_res.direction,
+        // The orders must be on opposite sides of the market
+        // i.e. one must be a buy order and the other a sell order
+        //     o1.side + o2.side == 1
+        //
+        // Note that the orders are constrained binary by their allocation as a
+        // `BoolVar`
+        cs.lc_gate(
+            &[witness.order1.side.into(), witness.order2.side.into(), zero_var, zero_var, one_var],
+            &[one, one, zero, zero],
+        )?;
+
+        // Check that the direction of the match is the same as the first party's
+        // direction
+        cs.enforce_equal(witness.match_res.direction.into(), witness.order1.side.into())?;
+
+        // --- Match Volume Constraints --- //
+        // Constrain that the pledged amount of each party is a valid amount
+        AmountGadget::constrain_valid_amount(witness.amount1, cs)?;
+        AmountGadget::constrain_valid_amount(witness.amount2, cs)?;
+
+        let max_minus_min1 = cs.sub(witness.amount1, witness.amount2)?;
+        let max_minus_min2 = cs.sub(witness.amount2, witness.amount1)?;
+        let max_minus_min_amount = CondSelectGadget::select(
+            &max_minus_min1,
+            &max_minus_min2,
+            witness.match_res.min_amount_order_index,
             cs,
         )?;
 
-        cs.enforce_equal(witness.balance1.mint, selected_mints.remove(0))?;
-        cs.enforce_equal(witness.balance2.mint, selected_mints.remove(0))?;
+        // Constrain the `max_minus_min_amount` value to be in [0, 2^AMOUNT_BITS]
+        // This effectively constrains this value to be correctly computed. As if
+        // instead it were min(a, b) - max(a, b), then this value would be
+        // negative.
+        //
+        // This constraint then also implicitly constrains the `min_amount_order_index`
+        // value to be correct. This value is separately constrained to be 0 or
+        // 1, as it is a `BoolVar`
+        AmountGadget::constrain_valid_amount(max_minus_min_amount, cs)?;
+
+        // Validate that the swapped amounts correctly reflect the minimum order amount
+        // Order amounts are specified in the base asset, so the swapped base amount
+        // should be the minimum of the two order amounts
+        let min_amount = CondSelectGadget::select(
+            &witness.amount2,
+            &witness.amount1,
+            witness.match_res.min_amount_order_index,
+            cs,
+        )?;
+        cs.enforce_equal(witness.match_res.base_amount, min_amount)?;
+
+        // The quote amount swapped should equal the price multiplied by the base amount
+        // Here we round down to the nearest integer
+        let expected_quote_amount =
+            witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
+        FixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_quote_amount,
+            witness.match_res.quote_amount,
+            cs,
+        )?;
+
+        // --- Order & Balance Volume Constraints --- //
 
         // Check that the max amount match supplied by both parties is covered by the
-        // balance no greater than the amount specified in the order
+        // balance and no greater than the amount specified in the order
         Self::validate_volume_constraints_single_prover(
             &witness.match_res,
             &witness.balance1,
@@ -78,77 +132,8 @@ where
             cs,
         )?;
 
-        // --- Match Engine Execution Validity --- //
-        // Check that the direction of the match is the same as the first party's
-        // direction
-        cs.enforce_equal(witness.match_res.direction.into(), witness.order1.side.into())?;
-
-        // Check that the orders are on opposite sides of the market. It is assumed that
-        // order sides are already constrained to be binary when they are
-        // submitted. More broadly it is assumed that orders are well formed,
-        // checking this amounts to checking their inclusion in the state tree,
-        // which is done in `input_consistency_check`
-        cs.lc_gate(
-            &[witness.order1.side.into(), witness.order2.side.into(), one_var, one_var, zero_var],
-            &[one, one, -one, zero],
-        )?;
-
-        // Check that the amount of base currency exchanged is equal to the minimum of
-        // the two order's amounts
-
-        // 1. Constrain the max_minus_min_amount to be correctly computed with respect
-        //    to the argmin
-        // witness variable min_amount_order_index
-        let max_minus_min1 = cs.sub(witness.amount1, witness.amount2)?;
-        let max_minus_min2 = cs.sub(witness.amount2, witness.amount1)?;
-        cs.mux_gate(
-            witness.match_res.min_amount_order_index,
-            max_minus_min1,
-            max_minus_min2,
-            witness.match_res.max_minus_min_amount, // out wire
-        )?;
-
-        // 2. Constrain the max_minus_min_amount value to be positive
-        // This, along with the previous check, constrain `max_minus_min_amount` to be
-        // computed correctly. I.e. the above constraint forces
-        // `max_minus_min_amount` to be either max(amounts) - min(amounts)
-        // or min(amounts) - max(amounts).
-        // Constraining the value to be positive forces it to be equal to max(amounts) -
-        // min(amounts)
-        GreaterThanEqZeroGadget::<AMOUNT_BITS>::constrain_greater_than_zero(
-            witness.match_res.max_minus_min_amount,
-            cs,
-        )?;
-
-        // 3. Constrain the executed base amount to be the minimum of the two order
-        //    amounts
-        // We use the identity
-        //      min(a, b) = 1/2 * (a + b - [max(a, b) - min(a, b)])
-        // Above we are given max(a, b) - min(a, b), so we can enforce the constraint
-        //      2 * executed_amount = amount1 + amount2 - max_minus_min_amount
-
-        let two = ScalarField::from(2u64);
-        cs.lc_gate(
-            &[
-                witness.match_res.base_amount,
-                witness.amount1,
-                witness.amount2,
-                witness.match_res.max_minus_min_amount,
-                zero_var, // output
-            ],
-            &[two, -one, -one, one],
-        )?;
-
-        // The quote amount should then equal the price multiplied by the base amount
-        let expected_quote_amount =
-            witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(
-            expected_quote_amount,
-            witness.match_res.quote_amount,
-            cs,
-        )?;
-
         // --- Price Protection --- //
+        // Check that the execution price is within the user-defined limits
         Self::verify_price_protection_single_prover(&witness.price1, &witness.order1, cs)?;
         Self::verify_price_protection_single_prover(&witness.price2, &witness.order2, cs)
     }
@@ -183,11 +168,8 @@ where
             cs,
         )?;
 
-        GreaterThanEqGadget::<AMOUNT_BITS>::constrain_greater_than_eq(
-            balance.amount,
-            amount_sold,
-            cs,
-        )
+        let new_balance = cs.sub(balance.amount, amount_sold)?;
+        AmountGadget::constrain_valid_amount(new_balance, cs)
     }
 
     /// Verify the price protection on the orders; i.e. that the executed price
@@ -239,10 +221,21 @@ where
         let party0_received_amount = party0_party1_received[0];
         let party1_received_amount = party0_party1_received[1];
 
+        // Validate the first party's fee take
+        Self::validate_fee_take_singleprover(
+            party0_received_amount,
+            witness.relayer_fee1,
+            statement.protocol_fee,
+            &witness.party0_fees,
+            cs,
+        )?;
+
         // Constrain the wallet updates to party0's shares
         Self::validate_balance_updates_singleprover(
             party1_received_amount,
             party0_received_amount,
+            &witness.balance_receive1,
+            &witness.party0_fees,
             &statement.party0_indices,
             &witness.party0_public_shares,
             &statement.party0_modified_shares,
@@ -263,10 +256,21 @@ where
             cs,
         )?;
 
+        // Validate the second party's fee take
+        Self::validate_fee_take_singleprover(
+            party1_received_amount,
+            witness.relayer_fee2,
+            statement.protocol_fee,
+            &witness.party1_fees,
+            cs,
+        )?;
+
         // Constrain the wallet update to party1's shares
         Self::validate_balance_updates_singleprover(
             party0_received_amount,
             party1_received_amount,
+            &witness.balance_receive2,
+            &witness.party1_fees,
             &statement.party1_indices,
             &witness.party1_public_shares,
             &statement.party1_modified_shares,
@@ -288,21 +292,60 @@ where
         )
     }
 
+    /// Validate a fee take for a given relayer fee and protocol fee
+    fn validate_fee_take_singleprover(
+        received_amount: Variable,
+        relayer_fee: FixedPointVar,
+        protocol_fee: FixedPointVar,
+        fee_take: &FeeTakeVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let expected_relayer_fee = relayer_fee.mul_integer(received_amount, cs)?;
+        let expected_protocol_fee = protocol_fee.mul_integer(received_amount, cs)?;
+
+        FixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_relayer_fee,
+            fee_take.relayer_fee,
+            cs,
+        )?;
+
+        FixedPointGadget::constrain_equal_integer_ignore_fraction(
+            expected_protocol_fee,
+            fee_take.protocol_fee,
+            cs,
+        )
+    }
+
     /// Verify that the balance updates to a wallet are valid
     ///
     /// That is, all balances in the settled wallet are the same as in the
     /// pre-settle wallet except for the balance sent and the balance
     /// received, which have the correct amounts applied from the match
+    #[allow(clippy::too_many_arguments)]
     fn validate_balance_updates_singleprover(
         send_amount: Variable,
         received_amount: Variable,
+        receive_balance: &BalanceVar,
+        fees: &FeeTakeVar,
         indices: &OrderSettlementIndicesVar,
         pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
         let one = ScalarField::one();
+        let zero = ScalarField::zero();
+        let zero_var = cs.zero();
 
+        // Compute the trader's take net of their fee obligations
+        let trader_take = cs.lc(
+            &[received_amount, fees.relayer_fee, fees.protocol_fee, zero_var],
+            &[one, -one, -one, zero],
+        )?;
+
+        // Check that no overflow occurs in the receive balance
+        Self::validate_no_receive_overflow(trader_take, receive_balance, fees, cs)?;
+
+        // Check that the balances are updated correctly
         let mut curr_index = cs.zero();
         for (pre_update_balance, post_update_balance) in pre_update_shares
             .balances
@@ -314,15 +357,25 @@ where
             let send_term_index_mask = EqGadget::eq(&indices.balance_send, &curr_index, cs)?;
             let masked_send = cs.mul_with_coeff(send_term_index_mask.into(), send_amount, &-one)?;
 
-            // Mask the receive term
+            // Mask the receive term, this includes the fee takes of the match
             let receive_term_index_mask = EqGadget::eq(&indices.balance_receive, &curr_index, cs)?;
-            let masked_receive = cs.mul(receive_term_index_mask.into(), received_amount)?;
+            let masked_receive = cs.mul(receive_term_index_mask.into(), trader_take)?;
+            let masked_relayer_fee = cs.mul(receive_term_index_mask.into(), fees.relayer_fee)?;
+            let masked_protocol_fee = cs.mul(receive_term_index_mask.into(), fees.protocol_fee)?;
 
-            // Add the terms together to get the expected update
+            // Add in masked update terms to the pre-update balance
             let expected_balance_amount =
                 cs.sum(&[pre_update_balance.amount, masked_send, masked_receive])?;
+            let expected_balance_relayer_fee =
+                cs.add(pre_update_balance.relayer_fee_balance, masked_relayer_fee)?;
+            let expected_balance_protocol_fee =
+                cs.add(pre_update_balance.protocol_fee_balance, masked_protocol_fee)?;
+
+            // Ensure that the post-update balance is equal to the expected balance
             let mut expected_balance_shares = pre_update_balance.clone();
             expected_balance_shares.amount = expected_balance_amount;
+            expected_balance_shares.relayer_fee_balance = expected_balance_relayer_fee;
+            expected_balance_shares.protocol_fee_balance = expected_balance_protocol_fee;
 
             EqGadget::constrain_eq(&expected_balance_shares, &post_update_balance, cs)?;
 
@@ -331,6 +384,24 @@ where
         }
 
         Ok(())
+    }
+
+    /// Validate that the receive balance amounts after update do not overflow
+    fn validate_no_receive_overflow(
+        trader_take: Variable,
+        receive_balance: &BalanceVar,
+        fees: &FeeTakeVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let post_update_amount = cs.add(receive_balance.amount, trader_take)?;
+        let post_update_relayer_fee =
+            cs.add(receive_balance.relayer_fee_balance, fees.relayer_fee)?;
+        let post_update_protocol_fee =
+            cs.add(receive_balance.protocol_fee_balance, fees.protocol_fee)?;
+
+        AmountGadget::constrain_valid_amount(post_update_amount, cs)?;
+        AmountGadget::constrain_valid_amount(post_update_relayer_fee, cs)?;
+        AmountGadget::constrain_valid_amount(post_update_protocol_fee, cs)
     }
 
     /// Verify that order updates to a wallet are valid
@@ -373,13 +444,17 @@ where
 
     /// Validate that fees, keys, and blinders remain the same in the pre and
     /// post wallet shares
-    ///
-    /// TODO: Also validate other fields in the fee impl
     fn validate_fees_keys_blinder_updates_singleprover(
         pre_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         post_update_shares: &WalletShareVar<MAX_BALANCES, MAX_ORDERS>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
+        EqGadget::constrain_eq(
+            &pre_update_shares.managing_cluster,
+            &post_update_shares.managing_cluster,
+            cs,
+        )?;
+        EqGadget::constrain_eq(&pre_update_shares.match_fee, &post_update_shares.match_fee, cs)?;
         EqGadget::constrain_eq(&pre_update_shares.keys, &post_update_shares.keys, cs)?;
         EqGadget::constrain_eq(&pre_update_shares.blinder, &post_update_shares.blinder, cs)
     }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -29,6 +29,9 @@ pub const MERKLE_HEIGHT: usize = 32;
 /// The number of historical roots the contract stores as being valid
 pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 
+/// The fee that the protocol takes on each trade
+pub const PROTOCOL_FEE: f64 = 0.0006; // 6 bps
+
 // ------------------------------------
 // | System Specific Type Definitions |
 // ------------------------------------


### PR DESCRIPTION
### Purpose
This PR adds fees, extra range constraints, and tests to the single-prover `VALID MATCH SETTLE` circuit. The MPC circuits and the multiprover circuit are deferred for a follow up.

### Testing
- All unit tests pass except multiprover tests