### PR TITLE
circuits: valid-match-settle: Implement fees for multiprover circuit

### DIFF
--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -393,7 +393,6 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     #![allow(non_snake_case)]
-    use ark_mpc::PARTY0;
     use circuit_types::{fixed_point::FixedPoint, traits::MpcBaseType, AMOUNT_BITS};
 
     use constants::Scalar;

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -343,7 +343,7 @@ where
         )?;
 
         // Check that no overflow occurs in the receive balance
-        Self::validate_no_receive_overflow(trader_take, receive_balance, fees, cs)?;
+        Self::validate_no_receive_overflow_singleprover(trader_take, receive_balance, fees, cs)?;
 
         // Check that the balances are updated correctly
         let mut curr_index = cs.zero();
@@ -387,7 +387,7 @@ where
     }
 
     /// Validate that the receive balance amounts after update do not overflow
-    fn validate_no_receive_overflow(
+    fn validate_no_receive_overflow_singleprover(
         trader_take: Variable,
         receive_balance: &BalanceVar,
         fees: &FeeTakeVar,


### PR DESCRIPTION
### Purpose
This PR adds multiprover changes to the `VALID MATCH SETTLE` circuit including fees and the updated bounds checks in the single prover case. We test verification against the single prover verifier, which implies that the circuits have the same topology.

### Testing
- Unit tests pass