### PR TITLE
state: applicator: Run internal matching engine when wallet job commits

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -108,6 +108,20 @@ impl TaskDescriptor {
             TaskDescriptor::UpdateWallet(task) => task.old_wallet.wallet_id,
         }
     }
+
+    /// Returns whether the task is a wallet task
+    ///
+    /// Currently all tasks are wallet tasks
+    pub fn is_wallet_task(&self) -> bool {
+        match self {
+            TaskDescriptor::NewWallet(_)
+            | TaskDescriptor::LookupWallet(_)
+            | TaskDescriptor::UpdateWallet(_)
+            | TaskDescriptor::SettleMatch(_)
+            | TaskDescriptor::SettleMatchInternal(_)
+            | TaskDescriptor::UpdateMerkleProof(_) => true,
+        }
+    }
 }
 
 // ---------------
@@ -180,8 +194,12 @@ pub struct SettleMatchInternalTaskDescriptor {
     pub execution_price: FixedPoint,
     /// The identifier of the first order
     pub order_id1: OrderIdentifier,
+    /// The identifier of the first order's wallet
+    pub wallet_id1: WalletIdentifier,
     /// The identifier of the second order
     pub order_id2: OrderIdentifier,
+    /// The identifier of the second order's wallet
+    pub wallet_id2: WalletIdentifier,
     /// The validity proofs for the first order
     pub order1_proof: OrderValidityProofBundle,
     /// The validity proof witness for the first order
@@ -200,7 +218,9 @@ impl SettleMatchInternalTaskDescriptor {
     pub fn new(
         execution_price: FixedPoint,
         order_id1: OrderIdentifier,
+        wallet_id1: WalletIdentifier,
         order_id2: OrderIdentifier,
+        wallet_id2: WalletIdentifier,
         order1_proof: OrderValidityProofBundle,
         order1_validity_witness: OrderValidityWitnessBundle,
         order2_proof: OrderValidityProofBundle,
@@ -210,7 +230,9 @@ impl SettleMatchInternalTaskDescriptor {
         Ok(SettleMatchInternalTaskDescriptor {
             execution_price,
             order_id1,
+            wallet_id1,
             order_id2,
+            wallet_id2,
             order1_proof,
             order1_validity_witness,
             order2_proof,

--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error, fmt::Display};
 
-use common::types::wallet::WalletIdentifier;
+use common::types::{tasks::TaskQueueKey, wallet::WalletIdentifier};
 
 use crate::storage::error::StorageError;
 
@@ -15,6 +15,8 @@ pub enum StateApplicatorError {
     MissingEntry(String),
     /// An error interacting with storage
     Storage(StorageError),
+    /// A task queue is empty when it should not be
+    TaskQueueEmpty(TaskQueueKey),
     /// An error parsing a message separately from proto errors
     Parse(String),
     /// An error trying to preempt a committed task

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -301,7 +301,9 @@ async fn test_settle_internal_match(test_args: IntegrationTestArgs) -> Result<()
     let task = SettleMatchInternalTaskDescriptor::new(
         FixedPoint::from_f64_round_down(EXECUTION_PRICE),
         buy_wallet.orders.first().unwrap().0,
+        buy_wallet.wallet_id,
         sell_wallet.orders.first().unwrap().0,
+        sell_wallet.wallet_id,
         get_first_order_proofs(&buy_wallet, state)?,
         get_first_order_witness(&buy_wallet, state)?,
         get_first_order_proofs(&sell_wallet, state)?,


### PR DESCRIPTION
### Purpose
This PR changes how we run the internal matching engine. Previously, we enqueued an internal matching engine job when the state received an order validity bundle. This is, however, done _during_ execution of other tasks, after their commit point, so the handshake manager would:
1. Find a match
2. Attempt to pause the wallet's task queue to settle the match
3. Fail, because the running task had already reached its commit point

Now, we instead run the internal matching engine on all wallet orders when the wallet task completes

### Testing
- All unit tests pass
- All `task-driver` integration tests pass