### PR TITLE
docker: sequencer: deploy new darkpool core & transfer executor contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -114,7 +114,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -154,9 +154,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -510,19 +510,15 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "async-trait",
- "bitvec 1.0.1",
  "bytes",
  "crossbeam",
- "dashmap",
  "digest 0.10.7",
  "futures",
- "identity-hash",
  "itertools 0.10.5",
  "kanal",
  "num-bigint",
  "quinn",
  "rand 0.8.5",
- "rayon",
  "rcgen 0.9.3",
  "rustc-hash",
  "rustls 0.20.9",
@@ -828,7 +824,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -889,13 +885,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -995,7 +991,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1287,9 +1283,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 dependencies = [
  "libc",
 ]
@@ -1468,6 +1464,7 @@ dependencies = [
  "futures",
  "inventory",
  "itertools 0.10.5",
+ "jf-primitives",
  "lazy_static",
  "mpc-plonk",
  "mpc-relation",
@@ -1555,7 +1552,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1711,7 +1708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
 dependencies = [
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1747,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d59688ad0945eaf6b84cb44fedbe93484c81b48970e98f09db8a22832d7961"
+checksum = "efbd12d49ab0eaf8193ba9175e45f56bbc2e4b27d57b8cfe62aa47942a46b9a9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1789,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "contracts-common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts.git#14a6b7db0c22c6ac320cc98c3f56fd5ede970f50"
+source = "git+https://github.com/renegade-fi/renegade-contracts.git#feba22caa30e8d0835c059619be1ca34040aeb2f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1925,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2117,7 +2114,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2141,7 +2138,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2152,20 +2149,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.50",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.9",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2348,7 +2332,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2389,9 +2373,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -2862,7 +2846,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.50",
+ "syn 2.0.51",
  "toml 0.8.10",
  "walkdir",
 ]
@@ -2880,7 +2864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2906,7 +2890,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.50",
+ "syn 2.0.51",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3560,7 +3544,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -3780,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3977,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
 name = "hex"
@@ -4170,12 +4154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "identity-hash"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4339,7 +4317,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.8",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4368,7 +4346,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.8",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4400,7 +4378,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e3253cbbbb4b6e842d1ec37a4902db4d788af59b"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4444,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e3253cbbbb4b6e842d1ec37a4902db4d788af59b"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -5225,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e3253cbbbb4b6e842d1ec37a4902db4d788af59b"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5259,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#e3253cbbbb4b6e842d1ec37a4902db4d788af59b"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5620,7 +5598,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.8",
  "libc",
 ]
 
@@ -5663,7 +5641,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -5756,7 +5734,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -6067,7 +6045,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -6105,7 +6083,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -6288,7 +6266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -6431,7 +6409,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -6729,9 +6707,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -7039,9 +7017,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+checksum = "49b1d9521f889713d1221270fdd63370feca7e5c71a18745343402fa86e4f04f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -7063,9 +7041,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
 
 [[package]]
 name = "rustc-demangle"
@@ -7451,7 +7429,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -7558,7 +7536,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -8044,7 +8022,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -8086,9 +8064,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8104,7 +8082,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -8237,9 +8215,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
@@ -8315,7 +8293,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -8420,7 +8398,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -8586,7 +8564,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.2",
+ "winnow 0.6.3",
 ]
 
 [[package]]
@@ -8615,7 +8593,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -9063,7 +9041,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
  "wasm-bindgen-shared",
 ]
 
@@ -9097,7 +9075,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9472,9 +9450,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
+checksum = "44e19b97e00a4d3db3cdb9b53c8c5f87151b5689b82cc86c2848cbdcccb2689b"
 dependencies = [
  "memchr",
 ]
@@ -9573,7 +9551,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -9593,7 +9571,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]

--- a/arbitrum-client/Dockerfile
+++ b/arbitrum-client/Dockerfile
@@ -2,63 +2,39 @@
 # integration tests. We effectively copy all the sources and then remove the target
 # directory. This means that changes to `arbitrum-client` sources will invalidate the
 # cache for this stage only, as the end state is the same
-FROM alpine AS sources
-COPY . .
-RUN rm -rf arbitrum-client
+FROM --platform=arm64 rust:latest AS chef
 
-# Rust build stage
-FROM rust:1.63-slim-buster AS builder
+# Build dir, use cargo chef to cache dependencies
+WORKDIR /build
+COPY ./rust-toolchain ./rust-toolchain
+RUN cat rust-toolchain | xargs rustup toolchain install
 
-# Install pkg-config, openssl
+# Install protoc, openssl, and pkg-config
 RUN apt-get update && \
     apt-get install -y pkg-config && \
-    apt-get install -y libssl-dev 
+    apt-get install -y protobuf-compiler && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y libclang-dev
 
-# Build the rust toolchain before adding any dependencies; this is the slowest
-# step and we would like to cache it before anything else
-COPY ./rust-toolchain ./arbitrum-client/rust-toolchain
-RUN cat arbitrum-client/rust-toolchain | xargs rustup toolchain install
+# Install chef and generate a recipe
+RUN cargo install cargo-chef
 
-# Create a build dir and add local dependencies
-WORKDIR /build
-COPY --from=sources . .
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Copy in the workspace Cargo.toml and modify the members field, this allows us to skip
-# transferring all workspace members to the docker image, and instead only transfer the
-# dependencies of the integration test. Every path dependency of the target crate is automatically
-# added to the workspace
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-RUN sed -i '/members = \[/,/\]/c\members = [ "arbitrum-client" ]' Cargo.toml
-
-# Place a set of dummy sources in the path, build the dummy executable
-# to cache built dependencies, then bulid the full executable
-WORKDIR /build/arbitrum-client
-RUN mkdir src
-RUN touch src/dummy-lib.rs
-
-RUN mkdir integration
-RUN echo 'fn main() { println!("dummy main!") }' >> integration/dummy-main.rs
-
-COPY arbitrum-client/Cargo.toml .
-
-# Modify the Cargo.toml to point to our dummy sources
-RUN sed -i 's/lib.rs/dummy-lib.rs/g' Cargo.toml
-RUN sed -i 's/main.rs/dummy-main.rs/g' Cargo.toml
-
-# Disable compiler warnings and enable backtraces for panic debugging
+# Disable compiler warnings and enable backtraces for panic
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --tests --features "integration" --recipe-path recipe.json
+
+# Copy back in the full sources and build the tests
+WORKDIR /build
+COPY . .
+
+WORKDIR /build/arbitrum-client
 RUN cargo build --quiet --test integration --features "integration"
 
-# Edit the Cargo.toml back to the original, build the full executable
-RUN sed -i 's/dummy-lib.rs/lib.rs/g' Cargo.toml
-RUN sed -i 's/dummy-main.rs/main.rs/g' Cargo.toml
-
-COPY arbitrum-client/src ./src
-COPY arbitrum-client/integration ./integration
-
-RUN cargo build --quiet --test integration --features "integration"
-
+# Copy in the deployments file from the sequencer
 COPY --from=sequencer /deployments.json /deployments.json

--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -31,6 +31,7 @@ RUN cargo install wasm-opt --locked
 ADD https://api.github.com/repos/renegade-fi/renegade-contracts/git/refs/heads/main /renegade-contracts-version.json
 WORKDIR /sources
 RUN git clone \
+    -b andrew/gen-random-protocol-key \
     https://github.com/renegade-fi/renegade-contracts.git
 
 WORKDIR /sources/renegade-contracts
@@ -38,17 +39,17 @@ WORKDIR /sources/renegade-contracts
 # Build the `scripts` crate to cache it
 RUN cargo build -p scripts
 
-# Build the darkpool contract with the same flags as the deploy scripts
-# to cache the dependencies.
+# Build the darkpool-core contract with the same flags as the first
+# contracts in the deploy scripts to cache as many dependencies as possible.
 # The actual deploy script will rebuild & deploy this contract, along with
 # the others.
-RUN RUSTFLAGS="-C opt-level=3" \
+RUN RUSTFLAGS="-Clink-arg=-zstack-size=131072 -Zlocation-detail=none -C opt-level=3" \
     cargo \
     +nightly \
     build \
     -r \
     -p contracts-stylus \
-    --features darkpool \
+    --features darkpool-core \
     --target wasm32-unknown-unknown \
     -Z build-std=std,panic_abort \
     -Z build-std-features=panic_immediate_abort


### PR DESCRIPTION
This PR updates the sequencer Dockerfile & contract deployment script to deploy the newly-introduced darkpool core & transfer executor contracts, as well as a Permit2 contract.

Note: the Dockerfile assumes that https://github.com/renegade-fi/renegade-contracts/pull/229 has been merged into `renegade-contracts/main`, so we should not merge this until that is the case.

The sequencer image builds successfully, but I am not yet able to run the existing integration tests (which should not need any changes) due to compilation errors elsewhere in the repo.

@joeykraut I can fix try fixing these errors, but I'm sure you have more context and were already planning on doing so, so I don't want to duplicate work. I can press onward with implementing new functionality / tests and run them when compilation errors are resolved.