### PR TITLE
circuits: mpc-circuits: settle: Compute & settle fees in MPC

### DIFF
--- a/arbitrum-client/Dockerfile
+++ b/arbitrum-client/Dockerfile
@@ -37,8 +37,4 @@ WORKDIR /build/arbitrum-client
 RUN cargo build --quiet --test integration --features "integration"
 
 # Copy in the deployments file from the sequencer
-<<<<<<< HEAD
 COPY --from=sequencer /deployments.json /deployments.json
-=======
-COPY --from=sequencer /deployments.json /deployments.json
->>>>>>> 8b6e28a1 (docker: sequencer: deploy new darkpool core & transfer executor contracts)

--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -347,6 +347,14 @@ impl From<AuthenticatedScalar> for AuthenticatedFixedPoint {
     }
 }
 
+impl Mul<&AuthenticatedScalar> for FixedPoint {
+    type Output = AuthenticatedFixedPoint;
+
+    fn mul(self, rhs: &AuthenticatedScalar) -> Self::Output {
+        AuthenticatedFixedPoint { repr: self.repr * rhs }
+    }
+}
+
 impl Mul<&AuthenticatedScalar> for &AuthenticatedFixedPoint {
     type Output = AuthenticatedFixedPoint;
 

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -83,6 +83,13 @@ impl FeeTake {
     }
 }
 
+impl AuthenticatedFeeTake {
+    /// Get the total fee
+    pub fn total(&self) -> AuthenticatedScalar {
+        &self.relayer_fee + &self.protocol_fee
+    }
+}
+
 /// The indices that specify where settlement logic should modify the wallet
 /// shares
 #[circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)]

--- a/circuits/benches/valid_wallet_update.rs
+++ b/circuits/benches/valid_wallet_update.rs
@@ -48,7 +48,12 @@ where
     let mut modified_wallet = original_wallet.clone();
     modified_wallet.orders[0] = Order::default();
 
-    construct_witness_statement(&original_wallet, &modified_wallet, ExternalTransfer::default())
+    construct_witness_statement(
+        &original_wallet,
+        &modified_wallet,
+        0, // transfer_idx
+        ExternalTransfer::default(),
+    )
 }
 
 /// Benchmark constraint generation for the circuit

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -58,10 +58,12 @@ macro_rules! print_mpc_wire {
         let x_eval = block_on($x.open());
         if $x.fabric().party_id() == 0 {
             info!("eval({}): {:?}", stringify!($x), scalar_to_biguint(&x_eval));
+        }
     }};
 }
 
 /// A debug macro used for printing wires in an MPC-ZK circuit during execution
+#[allow(unused)]
 macro_rules! print_multiprover_wire {
     ($x:expr, $cs:ident) => {{
         use circuit_types::traits::CircuitVarType;

--- a/circuits/src/mpc_gadgets/fixed_point.rs
+++ b/circuits/src/mpc_gadgets/fixed_point.rs
@@ -55,6 +55,5 @@ mod test {
 
         assert_eq!(res1, expected1);
         assert_eq!(res2, expected2);
-        panic!("test")
     }
 }

--- a/circuits/src/zk_circuits/valid_fee_redemption.rs
+++ b/circuits/src/zk_circuits/valid_fee_redemption.rs
@@ -466,7 +466,7 @@ mod test {
         statement: &ValidFeeRedemptionStatement<MAX_BALANCES, MAX_ORDERS>,
     ) -> bool {
         check_constraint_satisfaction::<ValidFeeRedemption<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>>(
-            &witness, &statement,
+            witness, statement,
         )
     }
 
@@ -494,7 +494,7 @@ mod test {
     fn recompute_note_opening_nullifier(
         note: &Note,
     ) -> (MerkleRoot, MerkleOpening<MERKLE_HEIGHT>, Nullifier) {
-        let note_comm = note_commitment(&note);
+        let note_comm = note_commitment(note);
         let (root, opening) = create_multi_opening(&[note_comm]);
         let nullifier = note_nullifier(note_comm, note.blinder);
 
@@ -688,6 +688,7 @@ mod test {
 
     /// Test the case in which a non-receive balance is modified
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn test_non_receive_balance_update() {
         let (wallet, note) = get_testing_wallet_and_note();
         let (original_statement, witness) = create_witness_and_statement(&wallet, &note);

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -543,7 +543,7 @@ mod tests {
         let (mut witness, statement) = dummy_witness_and_statement();
 
         // Modify the base amount
-        witness.match_res.base_amount = witness.match_res.base_amount - 1;
+        witness.match_res.base_amount -= 1;
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
 
@@ -553,7 +553,7 @@ mod tests {
         let (mut witness, statement) = dummy_witness_and_statement();
 
         // Modify the quote amount
-        witness.match_res.quote_amount = witness.match_res.quote_amount - 1;
+        witness.match_res.quote_amount -= 1;
         assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(&witness, &statement));
     }
 

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -331,7 +331,7 @@ mod test {
         let mut res = Scalar::zero();
 
         for bit in bits.into_iter() {
-            res = res * Scalar::from(2u8);
+            res *= Scalar::from(2u8);
             if bit {
                 res += Scalar::one();
             }

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -6,7 +6,7 @@ use circuit_types::{
     order::{Order, OrderSide},
     r#match::{FeeTake, MatchResult, OrderSettlementIndices},
     wallet::WalletShare,
-    Amount, Amount,
+    Amount,
 };
 use constants::Scalar;
 use renegade_crypto::fields::scalar_to_u128;


### PR DESCRIPTION
### Purpose
This PR adds fee computation and settlement to the `settle` MPC circuit. Single-sided fees are computed and then used to settle the match into the wallets. 

I also added a few fixes for clippy lints in `circuits` -- the repo is compiling enough locally for clippy lints to show up.

### Testing
- Updated settlement unit tests to account for fees
- Unit tests pass