### PR TITLE
arbitrum-client, workers: task-driver, api-server: add `TransferAuxData` to wallet updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek 1.0.1",
  "ethers",
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "itertools 0.10.5",
  "jf-primitives",
  "k256",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "contracts-common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts.git#feba22caa30e8d0835c059619be1ca34040aeb2f"
+source = "git+https://github.com/renegade-fi/renegade-contracts.git#9a9b03e48db903d3fbd94e4ff06cba7d76dbd1b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3215,7 +3215,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3723,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -5379,7 +5379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
 ]
 
 [[package]]
@@ -6778,7 +6778,7 @@ dependencies = [
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7775,7 +7775,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7786,7 +7786,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7797,7 +7797,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.4",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -37,6 +37,7 @@ circuit-types = { path = "../circuit-types" }
 circuits = { path = "../circuits" }
 common = { path = "../common" }
 renegade-crypto = { path = "../renegade-crypto" }
+util = { path = "../util" }
 
 # === Serde === #
 serde = { workspace = true }

--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -47,6 +47,7 @@ async fn test_update_wallet(test_args: IntegrationTestArgs) -> Result<()> {
         .update_wallet(
             &valid_wallet_update_bundle,
             vec![], // statement_signature
+            None,   // transfer_aux_data
         )
         .await?;
 

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -36,7 +36,7 @@ abigen!(
         function rootInHistory(uint256 memory root) external view returns (bool)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory public_inputs_signature) external
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -8,7 +8,7 @@ use common::types::{
         MatchBundle, OrderValidityProofBundle, SizedValidWalletCreateBundle,
         SizedValidWalletUpdateBundle,
     },
-    transfer::TransferAuxData,
+    transfer_aux_data::TransferAuxData,
 };
 use constants::Scalar;
 use contracts_common::types::MatchPayload;
@@ -129,7 +129,7 @@ impl ArbitrumClient {
         let contract_statement = to_contract_valid_wallet_update_statement(statement)?;
         let valid_wallet_update_statement_calldata = serialize_calldata(&contract_statement)?;
 
-        let contract_transfer_aux_data = to_contract_transfer_aux_data(&transfer_aux_data);
+        let contract_transfer_aux_data = to_contract_transfer_aux_data(&transfer_aux_data)?;
         let transfer_aux_data_calldata = serialize_calldata(&contract_transfer_aux_data)?;
 
         let receipt = send_tx(self.darkpool_contract.update_wallet(

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -129,7 +129,8 @@ impl ArbitrumClient {
         let contract_statement = to_contract_valid_wallet_update_statement(statement)?;
         let valid_wallet_update_statement_calldata = serialize_calldata(&contract_statement)?;
 
-        let contract_transfer_aux_data = to_contract_transfer_aux_data(&transfer_aux_data)?;
+        let contract_transfer_aux_data =
+            transfer_aux_data.map(to_contract_transfer_aux_data).transpose()?.unwrap_or_default();
         let transfer_aux_data_calldata = serialize_calldata(&contract_transfer_aux_data)?;
 
         let receipt = send_tx(self.darkpool_contract.update_wallet(

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -150,39 +150,28 @@ pub fn to_contract_valid_wallet_update_statement(
 
 /// Convert a [`TransferAuxData`] to its corresponding smart contract type
 pub fn to_contract_transfer_aux_data(
-    data: &Option<TransferAuxData>,
+    data: TransferAuxData,
 ) -> Result<ContractTransferAuxData, ConversionError> {
-    let res = if let Some(data) = data {
-        match data {
-            TransferAuxData::Deposit(deposit) => ContractTransferAuxData {
-                permit_nonce: Some(
-                    AlloyU256::from_str(&biguint_to_hex_string(&deposit.permit_nonce))
-                        .map_err(|_| ConversionError::InvalidUint)?,
-                ),
-                permit_deadline: Some(
-                    AlloyU256::from_str(&biguint_to_hex_string(&deposit.permit_deadline))
-                        .map_err(|_| ConversionError::InvalidUint)?,
-                ),
-                permit_signature: Some(deposit.permit_signature.clone()),
-                transfer_signature: None,
-            },
-            TransferAuxData::Withdrawal(withdrawal) => ContractTransferAuxData {
-                permit_nonce: None,
-                permit_deadline: None,
-                permit_signature: None,
-                transfer_signature: Some(withdrawal.external_transfer_signature.clone()),
-            },
-        }
-    } else {
-        ContractTransferAuxData {
+    Ok(match data {
+        TransferAuxData::Deposit(deposit) => ContractTransferAuxData {
+            permit_nonce: Some(
+                AlloyU256::from_str(&biguint_to_hex_string(&deposit.permit_nonce))
+                    .map_err(|_| ConversionError::InvalidUint)?,
+            ),
+            permit_deadline: Some(
+                AlloyU256::from_str(&biguint_to_hex_string(&deposit.permit_deadline))
+                    .map_err(|_| ConversionError::InvalidUint)?,
+            ),
+            permit_signature: Some(deposit.permit_signature.clone()),
+            transfer_signature: None,
+        },
+        TransferAuxData::Withdrawal(withdrawal) => ContractTransferAuxData {
             permit_nonce: None,
             permit_deadline: None,
             permit_signature: None,
-            transfer_signature: None,
-        }
-    };
-
-    Ok(res)
+            transfer_signature: Some(withdrawal.external_transfer_signature.clone()),
+        },
+    })
 }
 
 /// Convert a [`ValidReblindStatement`] to its corresponding smart contract type

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -16,7 +16,7 @@ use circuits::zk_circuits::{
     valid_wallet_create::SizedValidWalletCreateStatement,
     valid_wallet_update::SizedValidWalletUpdateStatement,
 };
-use common::types::proof_bundles::{MatchBundle, OrderValidityProofBundle};
+use common::types::{proof_bundles::{MatchBundle, OrderValidityProofBundle}, transfer::TransferAuxData};
 use constants::{Scalar, ScalarField};
 use contracts_common::types::{
     ExternalTransfer as ContractExternalTransfer, LinkingProof as ContractLinkingProof,
@@ -27,6 +27,7 @@ use contracts_common::types::{
     ValidReblindStatement as ContractValidReblindStatement,
     ValidWalletCreateStatement as ContractValidWalletCreateStatement,
     ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
+    TransferAuxData as ContractTransferAuxData,
 };
 use ruint::aliases::{U160, U256};
 
@@ -139,6 +140,24 @@ pub fn to_contract_valid_wallet_update_statement(
         old_pk_root,
         timestamp: statement.timestamp,
     })
+}
+
+/// Convert a [`TransferAuxData`] to its corresponding smart contract type
+pub fn to_contract_transfer_aux_data(data: &TransferAuxData) -> ContractTransferAuxData {
+    match data {
+            TransferAuxData::Deposit(deposit) => ContractsTransferAuxData {
+                permit_nonce: Some(biguint_to_u256(&deposit.permit_nonce)),
+                permit_deadline: Some(biguint_to_u256(&deposit.permit_deadline)),
+                permit_signature: Some(deposit.permit_signature),
+                transfer_signature: None,
+            },
+            TransferAuxData::Withdrawal(withdrawal) => ContractsTransferAuxData {
+                permit_nonce: None,
+                permit_deadline: None,
+                permit_signature: None,
+                transfer_signature: Some(withdrawal.external_transfer_signature),
+            },
+        }
 }
 
 /// Convert a [`ValidReblindStatement`] to its corresponding smart contract type

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -7,6 +7,7 @@ pub mod network_order;
 pub mod proof_bundles;
 pub mod tasks;
 pub mod token;
+pub mod transfer;
 pub mod wallet;
 
 // Re-export the mock types

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -7,7 +7,7 @@ pub mod network_order;
 pub mod proof_bundles;
 pub mod tasks;
 pub mod token;
-pub mod transfer;
+pub mod transfer_aux_data;
 pub mod wallet;
 
 // Re-export the mock types

--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -16,7 +16,7 @@ use super::{
     gossip::WrappedPeerId,
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
-    transfer::TransferAuxData,
+    transfer_aux_data::TransferAuxData,
     wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
 };
 

--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -16,6 +16,7 @@ use super::{
     gossip::WrappedPeerId,
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
+    transfer::TransferAuxData,
     wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
 };
 
@@ -319,6 +320,8 @@ pub struct UpdateWalletTaskDescriptor {
     pub timestamp_received: u64,
     /// The external transfer, if one exists
     pub external_transfer: Option<ExternalTransfer>,
+    /// The auxiliary data for the external transfer, if one exists
+    pub transfer_aux_data: Option<TransferAuxData>,
     /// The old wallet before update
     pub old_wallet: Wallet,
     /// The new wallet after update
@@ -333,6 +336,7 @@ impl UpdateWalletTaskDescriptor {
     pub fn new(
         timestamp_received: u64,
         external_transfer: Option<ExternalTransfer>,
+        transfer_aux_data: Option<TransferAuxData>,
         old_wallet: Wallet,
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
@@ -350,6 +354,7 @@ impl UpdateWalletTaskDescriptor {
         Ok(UpdateWalletTaskDescriptor {
             timestamp_received,
             external_transfer,
+            transfer_aux_data,
             old_wallet,
             new_wallet,
             wallet_update_signature,
@@ -475,6 +480,7 @@ mod test {
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
             None, // transfer
+            None, // transfer_aux_data
             wallet.clone(),
             wallet,
             vec![],
@@ -492,6 +498,7 @@ mod test {
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
             None, // transfer
+            None, // transfer_aux_data
             wallet.clone(),
             wallet,
             sig,
@@ -510,6 +517,7 @@ mod test {
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
             None, // transfer
+            None, // transfer_aux_data
             wallet.clone(),
             wallet,
             sig,

--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -1,9 +1,6 @@
 //! Defines task related types
 
-use circuit_types::{
-    fixed_point::FixedPoint, keychain::PublicSigningKey, r#match::MatchResult,
-    transfers::ExternalTransfer,
-};
+use circuit_types::{fixed_point::FixedPoint, keychain::PublicSigningKey, r#match::MatchResult};
 use constants::Scalar;
 use ethers::core::types::Signature;
 use ethers::core::utils::keccak256;
@@ -16,7 +13,7 @@ use super::{
     gossip::WrappedPeerId,
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
-    transfer_aux_data::TransferAuxData,
+    transfer_aux_data::ExternalTransferWithAuxData,
     wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
 };
 
@@ -318,10 +315,8 @@ impl From<UpdateMerkleProofTaskDescriptor> for TaskDescriptor {
 pub struct UpdateWalletTaskDescriptor {
     /// The timestamp at which the task was initiated, used to timestamp orders
     pub timestamp_received: u64,
-    /// The external transfer, if one exists
-    pub external_transfer: Option<ExternalTransfer>,
-    /// The auxiliary data for the external transfer, if one exists
-    pub transfer_aux_data: Option<TransferAuxData>,
+    /// The external transfer & auxiliary data, if one exists
+    pub external_transfer_with_aux_data: Option<ExternalTransferWithAuxData>,
     /// The old wallet before update
     pub old_wallet: Wallet,
     /// The new wallet after update
@@ -335,8 +330,7 @@ impl UpdateWalletTaskDescriptor {
     /// Constructor
     pub fn new(
         timestamp_received: u64,
-        external_transfer: Option<ExternalTransfer>,
-        transfer_aux_data: Option<TransferAuxData>,
+        external_transfer_with_aux_data: Option<ExternalTransferWithAuxData>,
         old_wallet: Wallet,
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
@@ -353,8 +347,7 @@ impl UpdateWalletTaskDescriptor {
 
         Ok(UpdateWalletTaskDescriptor {
             timestamp_received,
-            external_transfer,
-            transfer_aux_data,
+            external_transfer_with_aux_data,
             old_wallet,
             new_wallet,
             wallet_update_signature,
@@ -479,8 +472,7 @@ mod test {
 
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
-            None, // transfer
-            None, // transfer_aux_data
+            None, // external_transfer_with_aux_data
             wallet.clone(),
             wallet,
             vec![],
@@ -497,8 +489,7 @@ mod test {
 
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
-            None, // transfer
-            None, // transfer_aux_data
+            None, // external_transfer_with_aux_data
             wallet.clone(),
             wallet,
             sig,
@@ -516,8 +507,7 @@ mod test {
 
         UpdateWalletTaskDescriptor::new(
             0,    // timestamp
-            None, // transfer
-            None, // transfer_aux_data
+            None, // external_transfer_with_aux_data
             wallet.clone(),
             wallet,
             sig,

--- a/common/src/types/transfer.rs
+++ b/common/src/types/transfer.rs
@@ -1,0 +1,32 @@
+//! Type definitions for auxiliary data passed along from the client to the
+//! contract to authorizing / authenticating ERC20 transfers
+
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+/// Auxiliary data for validating a deposit, namely a [Permit2 permitTransferFrom](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permittransferfrom)
+/// signature, and the signed fields that cannot be extracted from the external
+/// transfer.
+#[derive(Serialize, Deserialize)]
+pub struct DepositAuxData {
+    /// The nonce used in the permit
+    pub permit_nonce: BigUint,
+    /// The deadline used in the permit
+    pub permit_deadline: BigUint,
+    /// The signature of the permit
+    pub permit_signature: Vec<u8>,
+}
+
+/// Auxiliary data for validating a withdrawal, namely a signature
+/// over the external transfer.
+#[derive(Serialize, Deserialize)]
+pub struct WithdrawalAuxData {
+    /// The signature over the external transfer
+    pub external_transfer_signature: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum TransferAuxData {
+    Deposit(DepositAuxData),
+    Withdrawal(WithdrawalAuxData),
+}

--- a/common/src/types/transfer_aux_data.rs
+++ b/common/src/types/transfer_aux_data.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Auxiliary data for validating a deposit, namely a [Permit2 permitTransferFrom](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#single-permittransferfrom)
 /// signature, and the signed fields that cannot be extracted from the external
 /// transfer.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DepositAuxData {
     /// The nonce used in the permit
     pub permit_nonce: BigUint,
@@ -19,14 +19,18 @@ pub struct DepositAuxData {
 
 /// Auxiliary data for validating a withdrawal, namely a signature
 /// over the external transfer.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WithdrawalAuxData {
     /// The signature over the external transfer
     pub external_transfer_signature: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize)]
+/// Auxiliary data for validating a transfer, which can be either a deposit or a
+/// withdrawal
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TransferAuxData {
+    /// Auxiliary data for validating a deposit
     Deposit(DepositAuxData),
+    /// Auxiliary data for validating a withdrawal
     Withdrawal(WithdrawalAuxData),
 }

--- a/common/src/types/transfer_aux_data.rs
+++ b/common/src/types/transfer_aux_data.rs
@@ -1,6 +1,10 @@
 //! Type definitions for auxiliary data passed along from the client to the
 //! contract to authorizing / authenticating ERC20 transfers
 
+use circuit_types::{
+    transfers::{ExternalTransfer, ExternalTransferDirection},
+    Amount,
+};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -33,4 +37,52 @@ pub enum TransferAuxData {
     Deposit(DepositAuxData),
     /// Auxiliary data for validating a withdrawal
     Withdrawal(WithdrawalAuxData),
+}
+
+/// An external transfer packed together with the necessary auxiliary data to
+/// validate it
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalTransferWithAuxData {
+    /// The external transfer
+    external_transfer: ExternalTransfer,
+    /// The auxiliary data to validate the external transfer
+    aux_data: TransferAuxData,
+}
+
+impl ExternalTransferWithAuxData {
+    /// Create a new external transfer with auxiliary data for a deposit
+    pub fn deposit(
+        account_addr: BigUint,
+        mint: BigUint,
+        amount: Amount,
+        aux_data: DepositAuxData,
+    ) -> Self {
+        Self {
+            external_transfer: ExternalTransfer {
+                account_addr,
+                mint,
+                amount,
+                direction: ExternalTransferDirection::Deposit,
+            },
+            aux_data: TransferAuxData::Deposit(aux_data),
+        }
+    }
+
+    /// Create a new external transfer with auxiliary data for a withdrawal
+    pub fn withdrawal(
+        account_addr: BigUint,
+        mint: BigUint,
+        amount: Amount,
+        aux_data: WithdrawalAuxData,
+    ) -> Self {
+        Self {
+            external_transfer: ExternalTransfer {
+                account_addr,
+                mint,
+                amount,
+                direction: ExternalTransferDirection::Withdrawal,
+            },
+            aux_data: TransferAuxData::Withdrawal(aux_data),
+        }
+    }
 }

--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -31,13 +31,9 @@ RUN cargo install wasm-opt --locked
 ADD https://api.github.com/repos/renegade-fi/renegade-contracts/git/refs/heads/main /renegade-contracts-version.json
 WORKDIR /sources
 RUN git clone \
-    -b andrew/gen-random-protocol-key \
     https://github.com/renegade-fi/renegade-contracts.git
 
 WORKDIR /sources/renegade-contracts
-
-# TODO: Remove this once Arbitrum client is updated
-RUN git checkout 86070446fe87a00c32b8ac50467030ec4ea68ff7
 
 # Build the `scripts` crate to cache it
 RUN cargo build -p scripts

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -168,13 +168,21 @@ pub struct DepositBalanceRequest {
     pub mint: BigUint,
     /// The amount of the token to deposit
     pub amount: BigUint,
-    /// A signature of the circuit statement used in the proof of
+    /// A signature of the wallet commitment used in the proof of
     /// VALID WALLET UPDATE by `sk_root`. This allows the contract
     /// to guarantee that the wallet updates are properly authorized
     ///
     /// TODO: For now this is just a blob, we will add this feature in
     /// a follow up
-    pub statement_sig: Vec<u8>,
+    pub wallet_commitment_sig: Vec<u8>,
+    /// The nonce used in the associated Permit2 permit
+    pub permit_nonce: BigUint,
+    /// The deadline used in the associated Permit2 permit
+    pub permit_deadline: BigUint,
+    /// The signature over the associated Permit2 permit, allowing
+    /// the contract to guarantee that the deposit is sourced from
+    /// the correct account
+    pub permit_signature: Vec<u8>,
 }
 
 /// The response type to a request to deposit into the darkpool
@@ -196,13 +204,17 @@ pub struct WithdrawBalanceRequest {
     pub destination_addr: BigUint,
     /// The amount of the token to withdraw
     pub amount: BigUint,
-    /// A signature of the circuit statement used in the proof of
+    /// A signature of the wallet commitment used in the proof of
     /// VALID WALLET UPDATE by `sk_root`. This allows the contract
     /// to guarantee that the wallet updates are properly authorized
     ///
     /// TODO: For now this is just a blob, we will add this feature in
     /// a follow up
-    pub statement_sig: Vec<u8>,
+    pub wallet_commitment_sig: Vec<u8>,
+    /// A signature over the external transfer, allowing the contract
+    /// to guarantee that the withdrawal is directed at the correct
+    /// recipient
+    pub external_transfer_sig: Vec<u8>,
 }
 
 /// The response type to a request to withdraw a balance

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -386,6 +386,7 @@ impl TypedHandler for CreateOrderHandler {
         let task = UpdateWalletTaskDescriptor::new(
             timestamp,
             None, // transfer
+            None, // transfer_aux_data
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -449,6 +450,7 @@ impl TypedHandler for UpdateOrderHandler {
         let task = UpdateWalletTaskDescriptor::new(
             timestamp,
             None, // transfer
+            None, // transfer_aux_data
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -502,6 +504,7 @@ impl TypedHandler for CancelOrderHandler {
         let task = UpdateWalletTaskDescriptor::new(
             get_current_timestamp(),
             None, // transfer
+            None, // transfer_aux_data
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -637,6 +640,8 @@ impl TypedHandler for DepositBalanceHandler {
             .map_err(bad_request)?;
         new_wallet.reblind_wallet();
 
+        // TODO: Construct transfer aux data
+
         let task = UpdateWalletTaskDescriptor::new(
             get_current_timestamp(),
             Some(ExternalTransfer {
@@ -700,6 +705,8 @@ impl TypedHandler for WithdrawBalanceHandler {
             return Err(bad_request(ERR_INSUFFICIENT_BALANCE.to_string()));
         }
         new_wallet.reblind_wallet();
+
+        // TODO: Construct transfe aux data
 
         let task = UpdateWalletTaskDescriptor::new(
             get_current_timestamp(),
@@ -808,6 +815,7 @@ impl TypedHandler for AddFeeHandler {
         let task = UpdateWalletTaskDescriptor::new(
             get_current_timestamp(),
             None, // transfer
+            None, // transfer_aux_data
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -863,7 +871,8 @@ impl TypedHandler for RemoveFeeHandler {
         // Start a task to submit this update to the contract
         let task = UpdateWalletTaskDescriptor::new(
             get_current_timestamp(),
-            None,
+            None, // transfer
+            None, // transfer_aux_data
             old_wallet,
             new_wallet,
             req.statement_sig,

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -15,6 +15,7 @@ use circuit_types::{
 use circuits::zk_circuits::valid_wallet_update::{
     SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
 };
+use common::types::transfer_aux_data::ExternalTransferWithAuxData;
 use common::types::{proof_bundles::ValidWalletUpdateBundle, wallet::Wallet};
 use common::types::{tasks::UpdateWalletTaskDescriptor, transfer_aux_data::TransferAuxData};
 use job_types::network_manager::NetworkManagerQueue;
@@ -153,10 +154,8 @@ impl From<StateError> for UpdateWalletTaskError {
 pub struct UpdateWalletTask {
     /// The timestamp at which the task was initiated, used to timestamp orders
     pub timestamp_received: u64,
-    /// The external transfer, if one exists
-    pub external_transfer: Option<ExternalTransfer>,
-    /// The auxiliary data for the external transfer, if one exists
-    pub transfer_aux_data: Option<TransferAuxData>,
+    /// The external transfer & auxiliary data, if one exists
+    pub external_transfer_with_aux_data: Option<ExternalTransferWithAuxData>,
     /// The old wallet before update
     pub old_wallet: Wallet,
     /// The new wallet after update
@@ -190,8 +189,7 @@ impl Task for UpdateWalletTask {
 
         Ok(Self {
             timestamp_received: descriptor.timestamp_received,
-            external_transfer: descriptor.external_transfer,
-            transfer_aux_data: descriptor.transfer_aux_data,
+            external_transfer_with_aux_data: descriptor.external_transfer_with_aux_data,
             old_wallet: descriptor.old_wallet,
             new_wallet: descriptor.new_wallet,
             wallet_update_signature: descriptor.wallet_update_signature,

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -16,7 +16,7 @@ use circuits::zk_circuits::valid_wallet_update::{
     SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
 };
 use common::types::{proof_bundles::ValidWalletUpdateBundle, wallet::Wallet};
-use common::types::{tasks::UpdateWalletTaskDescriptor, transfer::TransferAuxData};
+use common::types::{tasks::UpdateWalletTaskDescriptor, transfer_aux_data::TransferAuxData};
 use job_types::network_manager::NetworkManagerQueue;
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
 use serde::Serialize;


### PR DESCRIPTION
This PR introduces a `TransferAuxData` type analogous to the one present in the contracts repo which encapsulates auxiliary data needed to validate an external transfer. The type is used in the `update_wallet` `ArbitrumClient` method and throughout the task driver and API server as appropriate (i.e., we now expect this struct to be submitted alongside deposit/withdrawal API requests).

When patching the rest of the repo to compile, everything builds, but updates to the existing Arbitrum client and task driver integration test are deferred for the next PR as there are a lot of helpers to be ported over from the contracts repo.