### PR TITLE
arbitrum-client: `settle_online_relayer_fee`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8145,8 +8145,6 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "util"
 version = "0.1.0"
 dependencies = [
- "ark-ec",
- "ark-serialize 0.4.2",
  "circuit-types",
  "constants",
  "eyre",

--- a/arbitrum-client/integration/contract_interaction.rs
+++ b/arbitrum-client/integration/contract_interaction.rs
@@ -3,8 +3,8 @@
 use circuit_types::transfers::ExternalTransfer;
 use common::types::proof_bundles::{
     mocks::{
-        dummy_link_proof, dummy_valid_match_settle_bundle, dummy_valid_wallet_update_bundle,
-        dummy_validity_proof_bundle,
+        dummy_link_proof, dummy_relayer_fee_settlement_bundle, dummy_valid_match_settle_bundle,
+        dummy_valid_wallet_update_bundle, dummy_validity_proof_bundle,
     },
     MatchBundle,
 };
@@ -104,3 +104,41 @@ async fn test_process_match_settle(test_args: IntegrationTestArgs) -> Result<()>
     assert_eq_result!(party_1_new_shares, recovered_party_1_shares)
 }
 integration_test_async!(test_process_match_settle);
+
+/// Test settling the relayer fee and then recovering the shares of the sender
+/// and recipient wallets
+async fn test_settle_online_relayer_fee(test_args: IntegrationTestArgs) -> Result<()> {
+    let client = &test_args.client;
+
+    // Generate a dummy proof bundle for the relayer fee settlement
+    let mut valid_relayer_fee_settlement_bundle = dummy_relayer_fee_settlement_bundle();
+    let new_sender_shares = random_wallet_shares();
+    let new_recipient_shares = random_wallet_shares();
+    valid_relayer_fee_settlement_bundle.statement.sender_updated_public_shares =
+        new_sender_shares.clone();
+    valid_relayer_fee_settlement_bundle.statement.recipient_updated_public_shares =
+        new_recipient_shares.clone();
+
+    // Settle the relayer fee
+    client
+        .settle_online_relayer_fee(
+            &valid_relayer_fee_settlement_bundle,
+            vec![], // relayer_wallet_commitment_signature
+        )
+        .await?;
+
+    let recovered_sender_shares =
+        client.fetch_public_shares_for_blinder(new_sender_shares.blinder).await?;
+
+    // Check that the recovered sender public shares are the same as the original
+    // ones
+    assert_eq_result!(new_sender_shares, recovered_sender_shares)?;
+
+    let recovered_recipient_shares =
+        client.fetch_public_shares_for_blinder(new_recipient_shares.blinder).await?;
+
+    // Check that the recovered recipient public shares are the same as the original
+    // ones
+    assert_eq_result!(new_recipient_shares, recovered_recipient_shares)
+}
+integration_test_async!(test_settle_online_relayer_fee);

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -17,6 +17,9 @@ abigen!(
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
+        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
+        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
@@ -38,6 +41,9 @@ abigen!(
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
+        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
+        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -57,4 +57,7 @@ sol! {
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
+    function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
+    function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
+    function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
 }

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -17,14 +17,14 @@ use tracing::{error, instrument};
 
 use crate::{
     abi::{
-        newWalletCall, processMatchSettleCall, updateWalletCall, NodeChangedFilter,
-        WalletUpdatedFilter,
+        newWalletCall, processMatchSettleCall, settleOnlineRelayerFeeCall, updateWalletCall,
+        NodeChangedFilter, WalletUpdatedFilter,
     },
     constants::{DEFAULT_AUTHENTICATION_PATH, SELECTOR_LEN},
     errors::ArbitrumClientError,
     helpers::{
         parse_shares_from_new_wallet, parse_shares_from_process_match_settle,
-        parse_shares_from_update_wallet,
+        parse_shares_from_settle_online_relayer_fee, parse_shares_from_update_wallet,
     },
 };
 
@@ -152,6 +152,9 @@ impl ArbitrumClient {
             <updateWalletCall as SolCall>::SELECTOR => parse_shares_from_update_wallet(&calldata),
             <processMatchSettleCall as SolCall>::SELECTOR => {
                 parse_shares_from_process_match_settle(&calldata, public_blinder_share)
+            },
+            <settleOnlineRelayerFeeCall as SolCall>::SELECTOR => {
+                parse_shares_from_settle_online_relayer_fee(&calldata, public_blinder_share)
             },
             sel => {
                 error!("invalid selector when parsing public shares: {sel:?}");

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -6,12 +6,7 @@ use std::{
 };
 
 use circuit_types::{
-    elgamal::DecryptionKey,
-    fixed_point::FixedPoint,
-    keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey, SecretSigningKey},
-    order::{Order, OrderSide},
-    traits::BaseType,
-    Amount, SizedWalletShare,
+    elgamal::DecryptionKey, fixed_point::FixedPoint, keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey, SecretSigningKey}, order::{Order, OrderSide}, traits::BaseType, Amount, SizedWalletShare
 };
 use constants::{Scalar, MERKLE_HEIGHT};
 use k256::ecdsa::SigningKey as K256SigningKey;

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -6,7 +6,12 @@ use std::{
 };
 
 use circuit_types::{
-    elgamal::DecryptionKey, fixed_point::FixedPoint, keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey, SecretSigningKey}, order::{Order, OrderSide}, traits::BaseType, Amount, SizedWalletShare
+    elgamal::DecryptionKey,
+    fixed_point::FixedPoint,
+    keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey, SecretSigningKey},
+    order::{Order, OrderSide},
+    traits::BaseType,
+    Amount, SizedWalletShare,
 };
 use constants::{Scalar, MERKLE_HEIGHT};
 use k256::ecdsa::SigningKey as K256SigningKey;


### PR DESCRIPTION
This PR adds a method to the Arbitrum client for calling the `settle_online_relayer_fee` method on the Darkpool. This includes the necessary conversion & event parsing methods.

I've also added an integration test asserting that the method does not revert, and that the correct public shares can be recovered from calldata.

All `arbitrum-client` integration tests pass.