### PR TITLE
config: add tracing/logging config options

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -153,6 +153,27 @@ struct Cli {
     /// should manage
     #[clap(short, long, value_parser)]
     pub wallet_file: Option<String>,
+
+    // -------------
+    // | Telemetry |
+    // -------------
+
+    /// Whether or not to enable OTLP tracing
+    #[clap(long = "otlp", value_parser)]
+    pub otlp_enabled: bool,
+
+    /// The deployment environment w/ which
+    /// to tag OTLP traces
+    #[clap(long, value_parser)]
+    pub otlp_env: Option<String>,
+
+    /// The OTLP collector endpoint to send traces to
+    #[clap(long, value_parser, default_value = "http://localhost:4317")]
+    pub otlp_collector_url: String,
+
+    /// Whether or not to enable Datadog-formatted logs
+    #[clap(long = "datadog", value_parser)]
+    pub datadog_enabled: bool,
 }
 
 // ----------
@@ -234,6 +255,19 @@ pub struct RelayerConfig {
     pub arbitrum_private_key: String,
     /// The Ethereum RPC node websocket address to dial for on-chain data
     pub eth_websocket_addr: Option<String>,
+
+    // -------------
+    // | Telemetry |
+    // -------------
+    /// Whether or not to enable OTLP tracing
+    pub otlp_enabled: bool,
+    /// The deployment environment w/ which to tag OTLP traces
+    pub otlp_env: Option<String>,
+    /// The OTLP collector endpoint to send traces to
+    pub otlp_collector_url: String,
+
+    /// Whether or not to enable Datadog-formatted logs
+    pub datadog_enabled: bool,
 }
 
 impl Default for RelayerConfig {
@@ -274,6 +308,10 @@ impl Clone for RelayerConfig {
             arbitrum_private_key: self.arbitrum_private_key.clone(),
             eth_websocket_addr: self.eth_websocket_addr.clone(),
             debug: self.debug,
+            otlp_enabled: self.otlp_enabled,
+            otlp_env: self.otlp_env.clone(),
+            otlp_collector_url: self.otlp_collector_url.clone(),
+            datadog_enabled: self.datadog_enabled,
         }
     }
 }
@@ -380,6 +418,10 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         arbitrum_private_key: cli_args.arbitrum_private_key,
         eth_websocket_addr: cli_args.eth_websocket_addr,
         debug: cli_args.debug,
+        otlp_enabled: cli_args.otlp_enabled,
+        otlp_env: cli_args.otlp_env,
+        otlp_collector_url: cli_args.otlp_collector_url,
+        datadog_enabled: cli_args.datadog_enabled,
     };
 
     set_contract_from_file(&mut config, cli_args.deployments_file)?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,9 +6,6 @@ default-run = "renegade-relayer"
 
 [features]
 debug-tui = []
-trace-otlp = ["util/trace-otlp"]
-metrics = []
-datadog = ["util/datadog", "trace-otlp", "metrics"]
 
 [dependencies]
 # === Runtime + Async === #

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -119,7 +119,13 @@ async fn main() -> Result<(), CoordinatorError> {
             exit(0);
         });
     } else {
-        configure_telemetry().map_err(err_str!(CoordinatorError::Telemetry))?;
+        configure_telemetry(
+            args.datadog_enabled,
+            args.otlp_enabled,
+            args.otlp_env,
+            args.otlp_collector_url,
+        )
+        .map_err(err_str!(CoordinatorError::Telemetry))?;
     }
 
     // Construct an arbitrum client that workers will use for submitting txs
@@ -352,8 +358,9 @@ async fn main() -> Result<(), CoordinatorError> {
     thread::sleep(Duration::from_millis(TERMINATION_TIMEOUT_MS));
     info!("Terminating...");
 
-    #[cfg(feature = "trace-otlp")]
-    opentelemetry::global::shutdown_tracer_provider();
+    if args.otlp_enabled {
+        opentelemetry::global::shutdown_tracer_provider();
+    }
     Err(err)
 }
 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -32,11 +32,11 @@ ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
 # Build only the dependencies to cache them in this layer
-RUN cargo chef cook --release --features "datadog" --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build the relayer
 COPY . .
-RUN cargo build --release --features "datadog"
+RUN cargo build --release
 
 # Release stage
 FROM --platform=arm64 debian:bookworm-slim

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,10 +3,6 @@ name = "util"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-trace-otlp = []
-datadog = ["trace-otlp"]
-
 [dependencies]
 # === Arithmetic === #
 num-bigint = "0.4"


### PR DESCRIPTION
This PR removes the usage of compiler flags and environment variables for configuring telemetry with CLI / config file options. This centralizes relayer configuration and makes it more straightforward. I tested these changes ad-hoc by running the relayer locally and setting the values appropriately in a config file, confirming that traces / logs show up in Datadog as expected.