### PR TITLE
util: telemetry: expose telemetry builder & add metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1163,6 +1163,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "cadence"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472b6b55bd7e5410178ecd5d544b0bd6d6af926a960fae4048b570923dffdb08"
+dependencies = [
+ "crossbeam-channel",
 ]
 
 [[package]]
@@ -2377,6 +2386,12 @@ checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enr"
@@ -4514,6 +4529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69c0481fc2424cb55795de7da41add33372ea75a94f9b6588ab6a2826dfebc"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,6 +4647,63 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "metrics"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-statsd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82bd7bb16e431f15d56a61b18ee34881cd9d427da7b4450d1a588c911c1d9ac3"
+dependencies = [
+ "cadence",
+ "metrics",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-tracing-context"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
+dependencies = [
+ "indexmap 2.2.3",
+ "itoa",
+ "lockfree-object-pool",
+ "metrics",
+ "metrics-util",
+ "once_cell",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece71ab046dcf45604e573329966ec1db5ff4b81cfa170a924ff4c959ab5451a"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.3",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -4966,6 +5044,15 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -5766,6 +5853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6049,6 +6142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6146,6 +6254,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "raft"
@@ -6265,6 +6383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -7231,6 +7358,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -8511,6 +8644,10 @@ dependencies = [
  "json",
  "lazy_static",
  "libp2p",
+ "metrics",
+ "metrics-exporter-statsd",
+ "metrics-tracing-context",
+ "metrics-util",
  "num-bigint",
  "num-traits",
  "opentelemetry",

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -159,21 +159,28 @@ struct Cli {
     // -------------
 
     /// Whether or not to enable OTLP tracing
-    #[clap(long = "otlp", value_parser)]
+    #[clap(long = "enable-otlp", value_parser)]
     pub otlp_enabled: bool,
-
     /// The deployment environment w/ which
     /// to tag OTLP traces
     #[clap(long, value_parser)]
     pub otlp_env: Option<String>,
-
     /// The OTLP collector endpoint to send traces to
     #[clap(long, value_parser, default_value = "http://localhost:4317")]
     pub otlp_collector_url: String,
-
     /// Whether or not to enable Datadog-formatted logs
-    #[clap(long = "datadog", value_parser)]
+    #[clap(long = "enable-datadog", value_parser)]
     pub datadog_enabled: bool,
+    /// Whether or not to enable metrics collection
+    #[clap(long = "enable-metrics", value_parser)]
+    pub metrics_enabled: bool,
+    /// The StatsD recorder host to send metrics to
+    #[clap(long, value_parser, default_value = "127.0.0.1")]
+    pub statsd_host: String,
+
+    /// The StatsD recorder port to send metrics to
+    #[clap(long, value_parser, default_value = "8125")]
+    pub statsd_port: u16,
 }
 
 // ----------
@@ -265,9 +272,14 @@ pub struct RelayerConfig {
     pub otlp_env: Option<String>,
     /// The OTLP collector endpoint to send traces to
     pub otlp_collector_url: String,
-
     /// Whether or not to enable Datadog-formatted logs
     pub datadog_enabled: bool,
+    /// Whether or not to enable metrics collection
+    pub metrics_enabled: bool,
+    /// The StatsD recorder host to send metrics to
+    pub statsd_host: String,
+    /// The StatsD recorder port to send metrics to
+    pub statsd_port: u16,
 }
 
 impl Default for RelayerConfig {
@@ -312,6 +324,9 @@ impl Clone for RelayerConfig {
             otlp_env: self.otlp_env.clone(),
             otlp_collector_url: self.otlp_collector_url.clone(),
             datadog_enabled: self.datadog_enabled,
+            metrics_enabled: self.metrics_enabled,
+            statsd_host: self.statsd_host.clone(),
+            statsd_port: self.statsd_port,
         }
     }
 }
@@ -422,6 +437,9 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         otlp_env: cli_args.otlp_env,
         otlp_collector_url: cli_args.otlp_collector_url,
         datadog_enabled: cli_args.datadog_enabled,
+        metrics_enabled: cli_args.metrics_enabled,
+        statsd_host: cli_args.statsd_host,
+        statsd_port: cli_args.statsd_port,
     };
 
     set_contract_from_file(&mut config, cli_args.deployments_file)?;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -122,8 +122,11 @@ async fn main() -> Result<(), CoordinatorError> {
         configure_telemetry(
             args.datadog_enabled,
             args.otlp_enabled,
+            args.metrics_enabled,
             args.otlp_env,
             args.otlp_collector_url,
+            &args.statsd_host,
+            args.statsd_port,
         )
         .map_err(err_str!(CoordinatorError::Telemetry))?;
     }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -24,6 +24,8 @@ renegade-crypto = { path = "../renegade-crypto" }
 eyre = { workspace = true }
 hex = "0.4"
 json = "0.12"
+
+# === Logs / Traces === #
 chrono = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,6 +38,12 @@ opentelemetry-otlp = "0.14"
 opentelemetry = { version = "0.21", default-features = false, features = ["trace"]}
 opentelemetry-semantic-conventions = "0.13"
 opentelemetry-datadog = "0.9"
+
+# === Metrics === #
+metrics = "0.22"
+metrics-util = "0.16"
+metrics-exporter-statsd = "0.7"
+metrics-tracing-context = "0.15"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/util/src/telemetry/metrics.rs
+++ b/util/src/telemetry/metrics.rs
@@ -1,0 +1,23 @@
+//! Configures a metrics recorder to send metrics to a statsd server
+
+use metrics_exporter_statsd::{StatsdBuilder, StatsdError};
+use metrics_tracing_context::TracingContextLayer;
+use metrics_util::layers::Layer;
+
+use super::RELAYER_SERVICE_NAME;
+
+/// Configures a statsd metrics recorder
+pub fn configure_metrics_statsd_recorder(
+    statsd_host: &str,
+    statsd_port: u16,
+) -> Result<(), StatsdError> {
+    let recorder = TracingContextLayer::all().layer(
+        StatsdBuilder::from(statsd_host, statsd_port)
+            .with_buffer_size(0)
+            .build(Some(RELAYER_SERVICE_NAME))?,
+    );
+
+    metrics::set_global_recorder(recorder).unwrap();
+
+    Ok(())
+}

--- a/util/src/telemetry/mod.rs
+++ b/util/src/telemetry/mod.rs
@@ -2,12 +2,19 @@
 
 use std::{error::Error, fmt::Display};
 pub use tracing_subscriber::{filter::LevelFilter, fmt::format::Format};
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+use tracing_subscriber::{
+    fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer, Registry,
+};
 
 use crate::err_str;
 
 pub mod formatter;
+pub mod metrics;
 pub mod otlp_tracer;
+
+/// The [OTLP service name](https://opentelemetry.io/docs/specs/semconv/resource/#service)
+/// for the relayer
+pub const RELAYER_SERVICE_NAME: &str = "renegade_relayer";
 
 /// Possible errors that occur when setting up telemetry
 /// for the relayer
@@ -20,6 +27,8 @@ pub enum TelemetrySetupError {
     DeploymentEnvUnset,
     /// Error emitted when the OTLP collector endpoint is not provided
     CollectorEndpointUnset,
+    /// Error emitted when setting up the statsd metrics recorder
+    Metrics(String),
 }
 
 impl Error for TelemetrySetupError {}
@@ -34,39 +43,89 @@ pub fn setup_system_logger(level: LevelFilter) {
     tracing_subscriber::fmt().event_format(Format::default().pretty()).with_max_level(level).init();
 }
 
+/// A builder for configuring telemetry for the relayer
+#[derive(Default)]
+pub struct TelemetryBuilder {
+    /// The subscriber layers to add to the telemetry stack
+    layers: Vec<Box<dyn Layer<Registry> + Send + Sync + 'static>>,
+}
+
+impl TelemetryBuilder {
+    /// Add a subscriber layer to the telemetry builder
+    fn with_layer<L: Layer<Registry> + Send + Sync>(mut self, layer: L) -> Self {
+        self.layers.push(layer.boxed());
+        self
+    }
+
+    /// Configure logging for the relayer
+    pub fn with_logging(self, datadog_enabled: bool) -> Self {
+        if datadog_enabled {
+            opentelemetry::global::set_text_map_propagator(
+                opentelemetry_datadog::DatadogPropagator::new(),
+            );
+
+            self.with_layer(fmt::layer().json().event_format(formatter::DatadogFormatter))
+        } else {
+            self.with_layer(fmt::layer().pretty())
+        }
+    }
+
+    /// Configure OTLP tracing for the relayer
+    pub fn with_tracing(
+        self,
+        deployment_env: Option<String>,
+        collector_endpoint: String,
+    ) -> Result<Self, TelemetrySetupError> {
+        let otlp_tracer = otlp_tracer::configure_otlp_tracer(deployment_env, collector_endpoint)
+            .map_err(err_str!(TelemetrySetupError::Tracer))?;
+        let otlp_trace_layer = tracing_opentelemetry::layer().with_tracer(otlp_tracer);
+
+        Ok(self.with_layer(otlp_trace_layer))
+    }
+
+    /// Configure StatsD metrics for the relayer
+    pub fn with_metrics(
+        self,
+        statsd_host: &str,
+        statsd_port: u16,
+    ) -> Result<Self, TelemetrySetupError> {
+        metrics::configure_metrics_statsd_recorder(statsd_host, statsd_port)
+            .map_err(err_str!(TelemetrySetupError::Metrics))?;
+
+        Ok(self.with_layer(metrics_tracing_context::MetricsLayer::new()))
+    }
+
+    /// Initialize the global subscriber with the configured telemetry layers
+    pub fn build(self) {
+        let layers = self.layers.with_filter(
+            EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy(),
+        );
+        tracing_subscriber::registry().with(layers).init()
+    }
+}
+
 /// Configures logging, tracing, and metrics for the relayer
 /// based on the compilation features enabled
 pub fn configure_telemetry(
     datadog_enabled: bool,
     otlp_enabled: bool,
+    metrics_enabled: bool,
     deployment_env: Option<String>,
     collector_endpoint: String,
+    statsd_host: &str,
+    statsd_port: u16,
 ) -> Result<(), TelemetrySetupError> {
-    let mut layers = Vec::new();
-
-    if datadog_enabled {
-        layers.push(fmt::layer().json().event_format(formatter::DatadogFormatter).boxed());
-
-        opentelemetry::global::set_text_map_propagator(
-            opentelemetry_datadog::DatadogPropagator::new(),
-        );
-    } else {
-        layers.push(fmt::layer().pretty().boxed());
-    }
+    let mut telemetry = TelemetryBuilder::default().with_logging(datadog_enabled);
 
     if otlp_enabled {
-        let otlp_tracer = otlp_tracer::configure_otlp_tracer(deployment_env, collector_endpoint)
-            .map_err(err_str!(TelemetrySetupError::Tracer))?;
-        let otlp_trace_layer = tracing_opentelemetry::layer().with_tracer(otlp_tracer);
-        layers.push(otlp_trace_layer.boxed());
+        telemetry = telemetry.with_tracing(deployment_env, collector_endpoint)?;
     }
 
-    tracing_subscriber::registry()
-        .with(
-            EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy(),
-        )
-        .with(layers)
-        .init();
+    if metrics_enabled {
+        telemetry = telemetry.with_metrics(statsd_host, statsd_port)?;
+    }
+
+    telemetry.build();
 
     Ok(())
 }

--- a/util/src/telemetry/otlp_tracer.rs
+++ b/util/src/telemetry/otlp_tracer.rs
@@ -14,9 +14,7 @@ use opentelemetry_semantic_conventions::{
     SCHEMA_URL,
 };
 
-/// The [OTLP service name](https://opentelemetry.io/docs/specs/semconv/resource/#service)
-/// for the relayer
-const RELAYER_SERVICE_NAME: &str = "renegade_relayer";
+use super::RELAYER_SERVICE_NAME;
 
 /// Constructs the resource tags for OTLP traces
 fn otlp_resource(deployment_env: Option<String>) -> Resource {


### PR DESCRIPTION
This PR refactors the `telemetry` module to use a builder pattern so that configuration for the various telemetry services is more discoverable and easily configurable as we add functionality.

We use this pattern to introduce a metrics layer that exports metrics to a StatsD endpoint, and additionally leverages the [`metrics_tracing_context`](https://docs.rs/metrics-tracing-context/latest/metrics_tracing_context/) crate to inject span fields as metric labels.

I've tested this ad-hoc by running the relayer with the desired config options + a local Datadog agent and have confirmed that metrics are recorded.