### PR TITLE
workers: task-driver: Fix integration tests after fees changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,12 +4021,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4556,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -5030,9 +5030,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-fastrlp"
@@ -5334,9 +5334,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5517,7 +5517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
  "universal-hash",
 ]
 
@@ -6783,7 +6783,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -6807,7 +6807,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -6843,7 +6843,7 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -7473,7 +7473,6 @@ dependencies = [
  "circuit-types",
  "common",
  "constants",
- "contracts-common",
  "dns-lookup",
  "ethers",
  "eyre",
@@ -8195,9 +8194,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -50,6 +50,8 @@ const TASK_DRIVER_N_THREADS: usize = 5;
 const TASK_DRIVER_THREAD_NAME: &str = "renegade-task-driver";
 /// The number of times to retry a step in a task before propagating the error
 const TASK_DRIVER_N_RETRIES: usize = 5;
+/// The stack size to allocate for task driver threads
+const DRIVER_THREAD_STACK_SIZE: usize = 5_000_000; // 5MB
 
 /// Error message sent on a notification when a task is not found
 const TASK_NOT_FOUND_ERROR: &str = "task not found";
@@ -117,6 +119,7 @@ impl TaskExecutor {
         let runtime = TokioRuntimeBuilder::new_multi_thread()
             .enable_all()
             .worker_threads(TASK_DRIVER_N_THREADS)
+            .thread_stack_size(DRIVER_THREAD_STACK_SIZE)
             .thread_name(TASK_DRIVER_THREAD_NAME)
             .build()
             .expect("error building task driver runtime");

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -383,8 +383,8 @@ impl UpdateWalletTask {
         if let Some(transfer) = self.transfer.as_ref().map(|t| &t.external_transfer) {
             let mint = &transfer.mint;
             let idx = match transfer.direction {
-                ExternalTransferDirection::Deposit => self.old_wallet.get_balance_index(mint),
-                ExternalTransferDirection::Withdrawal => self.new_wallet.get_balance_index(mint),
+                ExternalTransferDirection::Deposit => self.new_wallet.get_balance_index(mint),
+                ExternalTransferDirection::Withdrawal => self.old_wallet.get_balance_index(mint),
             };
 
             idx.expect("transfer mint {mint:x} not found")


### PR DESCRIPTION
### Purpose
This PR fixes up two bugs discovered when integration testing the `task-driver` changes:
1. The logic to find an external transfer index was swapped
2. Stack overflows allocating `tokio::oneshot` channels; I increased the stack size available to 5Mb

### Testing
- Unit tests pass
- `task-driver` integration tests pass