### PR TITLE
circuits, renegade-crypto: Increment `next_index` in Poseidon squeeze

### DIFF
--- a/renegade-crypto/src/hash/poseidon2.rs
+++ b/renegade-crypto/src/hash/poseidon2.rs
@@ -69,6 +69,7 @@ impl Poseidon2Sponge {
         }
 
         let entry = self.next_index + CAPACITY;
+        self.next_index += 1;
         self.state[entry]
     }
 


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the Poseidon2 sponge implementations in which we were not incrementing `next_index` within the `squeeze` method. This bug is fixed in both the native and circuit definitions, and I added a test for implementation coherence.

### Testing
- All unit tests pass