### PR TITLE
circuits: zk-gadgets: arithmetic: Prevent wraparound in `DivRem` gadget

### DIFF
--- a/circuits/src/zk_gadgets/fixed_point.rs
+++ b/circuits/src/zk_gadgets/fixed_point.rs
@@ -91,7 +91,8 @@ impl FixedPointGadget {
     pub fn floor(val: FixedPointVar, cs: &mut PlonkCircuit) -> Result<Variable, CircuitError> {
         // Floor div by the scaling factor
         let divisor = cs.mul_constant(cs.one(), &*TWO_TO_M_SCALAR).unwrap();
-        let (div, _) = DivRemGadget::<DEFAULT_FP_PRECISION>::div_rem(val.repr, divisor, cs)?;
+        let (div, _) =
+            DivRemGadget::<{ DEFAULT_FP_PRECISION + 1 }>::div_rem(val.repr, divisor, cs)?;
 
         Ok(div)
     }

--- a/circuits/src/zk_gadgets/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/wallet_operations.rs
@@ -13,7 +13,7 @@ use constants::ScalarField;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 
 use super::{
-    bits::{MultiproverToBitsGadget, ToBitsGadget},
+    bits::{BitRangeGadget, MultiproverBitRangeGadget},
     merkle::PoseidonMerkleHashGadget,
     poseidon::{PoseidonCSPRNGGadget, PoseidonHashGadget},
     select::CondSelectGadget,
@@ -208,10 +208,7 @@ impl AmountGadget {
         amount: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Decompose into `AMOUNT_BITS` bits, this checks that the reconstruction is
-        // correct, so this will also force the value to be within the range [0,
-        // 2^AMOUNT_BITS-1]
-        ToBitsGadget::<AMOUNT_BITS>::to_bits(amount, cs).map(|_| ())
+        BitRangeGadget::<AMOUNT_BITS>::constrain_bit_range(amount, cs)
     }
 }
 
@@ -224,10 +221,7 @@ impl MultiproverAmountGadget {
         fabric: &Fabric,
         cs: &mut MpcPlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Decompose into `AMOUNT_BITS` bits, this checks that the reconstruction is
-        // correct, so this will also force the value to be within the range [0,
-        // 2^AMOUNT_BITS-1]
-        MultiproverToBitsGadget::<AMOUNT_BITS>::to_bits(amount, fabric, cs).map(|_| ())
+        MultiproverBitRangeGadget::<AMOUNT_BITS>::constrain_bit_range(amount, fabric, cs)
     }
 }
 
@@ -241,10 +235,7 @@ impl FeeGadget {
         fee: FixedPointVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Decompose into `FEE_BITS` bits, this checks that the reconstruction is
-        // correct, so this will also force the value to be within the range [0,
-        // 2^FEE_BITS-1]
-        ToBitsGadget::<FEE_BITS>::to_bits(fee.repr, cs).map(|_| ())
+        BitRangeGadget::<FEE_BITS>::constrain_bit_range(fee.repr, cs)
     }
 }
 
@@ -257,10 +248,7 @@ impl PriceGadget {
         price: FixedPointVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Decompose into `PRICE_BITS` bits, this checks that the reconstruction is
-        // correct, so this will also force the value to be within the range [0,
-        // 2^PRICE_BITS-1]
-        ToBitsGadget::<PRICE_BITS>::to_bits(price.repr, cs).map(|_| ())
+        BitRangeGadget::<PRICE_BITS>::constrain_bit_range(price.repr, cs)
     }
 }
 
@@ -273,10 +261,7 @@ impl MultiproverPriceGadget {
         fabric: &Fabric,
         cs: &mut MpcPlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Decompose into `PRICE_BITS` bits, this checks that the reconstruction is
-        // correct, so this will also force the value to be within the range [0,
-        // 2^PRICE_BITS-1]
-        MultiproverToBitsGadget::<PRICE_BITS>::to_bits(price.repr, fabric, cs).map(|_| ())
+        MultiproverBitRangeGadget::<PRICE_BITS>::constrain_bit_range(price.repr, fabric, cs)
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR makes a fix to the `DivRem` gadget to avoid wraparound. Specifically, we constrain each of `b`, `q`, and `r` to be of bitlength at most `D`. We also disallow `D` from being large enough that `2D` would wrap around the field.

### Testing
- Unit tests pass