### PR TITLE
task-driver: tasks: pay-fees: Define initial `pay-fees` task

### DIFF
--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -29,6 +29,7 @@ use crate::{
     tasks::{
         create_new_wallet::{NewWalletTask, NewWalletTaskState},
         lookup_wallet::{LookupWalletTask, LookupWalletTaskState},
+        pay_fees::{PayFeesTask, PayFeesTaskState},
         settle_match::{SettleMatchTask, SettleMatchTaskState},
         settle_match_internal::{SettleMatchInternalTask, SettleMatchInternalTaskState},
         update_merkle_proof::{UpdateMerkleProofTask, UpdateMerkleProofTaskState},
@@ -333,6 +334,9 @@ impl TaskExecutor {
                 Self::start_task_helper::<LookupWalletTask>(immediate, id, desc, ctx, args, notif)
                     .await
             },
+            TaskDescriptor::PayFees(desc) => {
+                Self::start_task_helper::<PayFeesTask>(immediate, id, desc, ctx, args, notif).await
+            },
             TaskDescriptor::UpdateWallet(desc) => {
                 Self::start_task_helper::<UpdateWalletTask>(immediate, id, desc, ctx, args, notif)
                     .await
@@ -436,6 +440,8 @@ pub enum StateWrapper {
     LookupWallet(LookupWalletTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
+    /// The state object for the pay fees task
+    PayFees(PayFeesTaskState),
     /// The state object for the settle match task
     SettleMatch(SettleMatchTaskState),
     /// The state object for the settle match internal task
@@ -452,6 +458,7 @@ impl StateWrapper {
         match self {
             StateWrapper::LookupWallet(state) => state.committed(),
             StateWrapper::NewWallet(state) => state.committed(),
+            StateWrapper::PayFees(state) => state.committed(),
             StateWrapper::SettleMatch(state) => state.committed(),
             StateWrapper::SettleMatchInternal(state) => state.committed(),
             StateWrapper::UpdateWallet(state) => state.committed(),
@@ -465,6 +472,7 @@ impl StateWrapper {
         match self {
             StateWrapper::LookupWallet(state) => state == &LookupWalletTaskState::commit_point(),
             StateWrapper::NewWallet(state) => state == &NewWalletTaskState::commit_point(),
+            StateWrapper::PayFees(state) => state == &PayFeesTaskState::commit_point(),
             StateWrapper::SettleMatch(state) => state == &SettleMatchTaskState::commit_point(),
             StateWrapper::SettleMatchInternal(state) => {
                 state == &SettleMatchInternalTaskState::commit_point()
@@ -482,6 +490,7 @@ impl Display for StateWrapper {
         let out = match self {
             StateWrapper::LookupWallet(state) => state.to_string(),
             StateWrapper::NewWallet(state) => state.to_string(),
+            StateWrapper::PayFees(state) => state.to_string(),
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
             StateWrapper::UpdateWallet(state) => state.to_string(),

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod create_new_wallet;
 pub mod lookup_wallet;
+pub mod pay_fees;
 pub mod settle_match;
 pub mod settle_match_internal;
 pub mod update_merkle_proof;

--- a/workers/task-driver/src/tasks/pay_fees.rs
+++ b/workers/task-driver/src/tasks/pay_fees.rs
@@ -1,0 +1,195 @@
+//! The `PayFees` task is responsible for settling the fees due for a given
+//! wallet
+
+// TODO: Remove this lint allowance
+#![allow(unused)]
+
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
+use common::types::{tasks::PayFeesTaskDescriptor, wallet::WalletIdentifier};
+use job_types::proof_manager::ProofManagerQueue;
+use num_bigint::BigUint;
+use serde::Serialize;
+use state::{error::StateError, State};
+use tracing::instrument;
+
+use crate::{
+    driver::StateWrapper,
+    traits::{Task, TaskContext, TaskError, TaskState},
+};
+
+/// The name of the task
+const TASK_NAME: &str = "pay-fees";
+
+// --------------
+// | Task State |
+// --------------
+
+/// Defines the state of the fee payment task
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum PayFeesTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is proving relayer fee payment for the ith balance
+    ProvingRelayerPayment,
+    /// The task is submitting a fee payment transaction for the ith balance
+    SubmittingPayment,
+    /// The task is proving protocol fee payment for the ith balance
+    ProvingProtocolPayment,
+    /// The task is submitting a fee payment transaction for the ith balance
+    SubmittingProtocolPayment,
+    /// The task is updating the validity proofs for the wallet
+    UpdatingValidityProofs,
+    /// The task has finished
+    Completed,
+}
+
+impl TaskState for PayFeesTaskState {
+    fn commit_point() -> Self {
+        PayFeesTaskState::ProvingRelayerPayment
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, PayFeesTaskState::Completed)
+    }
+}
+
+impl Display for PayFeesTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+
+impl From<PayFeesTaskState> for StateWrapper {
+    fn from(value: PayFeesTaskState) -> Self {
+        StateWrapper::PayFees(value)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type for the pay fees task
+#[derive(Clone, Debug)]
+pub enum PayFeesTaskError {
+    /// An error interacting with Arbitrum
+    Arbitrum(String),
+    /// An error interacting with the state
+    State(String),
+}
+
+impl TaskError for PayFeesTaskError {
+    fn retryable(&self) -> bool {
+        match self {
+            PayFeesTaskError::Arbitrum(_) | PayFeesTaskError::State(_) => true,
+        }
+    }
+}
+
+impl Display for PayFeesTaskError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for PayFeesTaskError {}
+
+impl From<StateError> for PayFeesTaskError {
+    fn from(error: StateError) -> Self {
+        PayFeesTaskError::State(error.to_string())
+    }
+}
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Defines the pay fees task flow
+pub struct PayFeesTask {
+    /// The wallet to pay fees for
+    pub wallet_id: WalletIdentifier,
+    /// The balance to pay fees for
+    pub mint: BigUint,
+    /// The arbitrum client used for submitting transactions
+    pub arbitrum_client: ArbitrumClient,
+    /// A hand to the global state
+    pub state: State,
+    /// The work queue for the proof manager
+    pub proof_queue: ProofManagerQueue,
+    /// The current state of the task
+    pub task_state: PayFeesTaskState,
+}
+
+#[async_trait]
+impl Task for PayFeesTask {
+    type State = PayFeesTaskState;
+    type Error = PayFeesTaskError;
+    type Descriptor = PayFeesTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        Ok(Self {
+            wallet_id: descriptor.wallet_id,
+            mint: descriptor.balance_mint,
+            arbitrum_client: ctx.arbitrum_client,
+            state: ctx.state,
+            proof_queue: ctx.proof_queue,
+            task_state: PayFeesTaskState::Pending,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn completed(&self) -> bool {
+        self.task_state.completed()
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    fn name(&self) -> String {
+        TASK_NAME.to_string()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl PayFeesTask {
+    /// Generate a proof of `VALID RELAYER FEE SETTLEMENT` for the given balance
+    async fn generate_relayer_proof(&mut self) -> Result<(), PayFeesTaskError> {
+        todo!()
+    }
+
+    /// Submit the `settle_relayer_fee` transaction for the balance
+    async fn submit_relayer_payment(&mut self) -> Result<(), PayFeesTaskError> {
+        todo!()
+    }
+
+    /// Generate a proof of `VALID PROTOCOL FEE SETTLEMENT` for the given
+    /// balance
+    async fn generate_protocol_proof(&mut self) -> Result<(), PayFeesTaskError> {
+        todo!()
+    }
+
+    /// Submit the `settle_protocol_fee` transaction for the balance
+    async fn submit_protocol_payment(&mut self) -> Result<(), PayFeesTaskError> {
+        todo!()
+    }
+
+    /// Update the validity proofs for the wallet after fee payment
+    async fn update_validity_proofs(&mut self) -> Result<(), PayFeesTaskError> {
+        todo!()
+    }
+}

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -43,7 +43,6 @@ const ERR_NO_MERKLE_PROOF: &str = "merkle proof for wallet not found";
 
 /// Defines the state of the deposit update wallet task
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(clippy::large_enum_variant)]
 pub enum UpdateWalletTaskState {
     /// The task is awaiting scheduling
     Pending,


### PR DESCRIPTION
### Purpose
This PR defines the skeleton of the `PayFees` task, which will settle the relayer and protocol fee for a given balance in a given wallet. Implementation is deferred to a follow-up

### Testing
- Unit tests pass