### PR TITLE
docker: sequencer: use custom devnet chain info

### DIFF
--- a/docker/sequencer/Dockerfile
+++ b/docker/sequencer/Dockerfile
@@ -53,6 +53,9 @@ RUN RUSTFLAGS="-Clink-arg=-zstack-size=131072 -Zlocation-detail=none -C opt-leve
     -Z build-std=std,panic_abort \
     -Z build-std-features=panic_immediate_abort
 
+# Copy over devnet chain info
+COPY ./devnet_chain_info.json /devnet_chain_info.json
+
 # Copy over the contract deployment script
 COPY ./deploy_contracts.sh /deploy_contracts.sh
 RUN chmod +x /deploy_contracts.sh
@@ -67,7 +70,8 @@ CMD ["--node.dangerous.no-l1-listener",\
     "--node.staker.enable=false",\
     "--init.dev-init",\
     "--init.empty=false",\
-    "--chain.id=412346",\
+    "--chain.id=473474",\
+    "--chain.info-files=/devnet_chain_info.json",\
     "--chain.dev-wallet.private-key=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659",\
     "--http.addr=0.0.0.0",\
     "--http.vhosts=*",\

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -14,7 +14,8 @@ nitro \
     --node.staker.enable=false \
     --init.dev-init \
     --init.empty=false \
-    --chain.id=412346 \
+    --chain.id=473474 \
+    --chain.info-files=/devnet_chain_info.json \
     --chain.dev-wallet.private-key=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
     --http.addr=0.0.0.0 \
     --http.vhosts=* \
@@ -132,7 +133,8 @@ cargo run \
     --rpc-url $DEVNET_RPC_URL \
     --deployments-path $DEPLOYMENTS_PATH \
     deploy-stylus \
-    --contract darkpool-test-contract
+    --contract darkpool-test-contract \
+    $no_verify_flag
 
 # Deploy the proxy contract
 cargo run \

--- a/docker/sequencer/devnet_chain_info.json
+++ b/docker/sequencer/devnet_chain_info.json
@@ -1,0 +1,34 @@
+[
+    {
+        "chain-name": "renegade-stylus-devnet",
+        "chain-config": {
+            "chainId": 473474,
+            "homesteadBlock": 0,
+            "daoForkBlock": null,
+            "daoForkSupport": true,
+            "eip150Block": 0,
+            "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "constantinopleBlock": 0,
+            "petersburgBlock": 0,
+            "istanbulBlock": 0,
+            "muirGlacierBlock": 0,
+            "berlinBlock": 0,
+            "londonBlock": 0,
+            "clique": {
+                "period": 0,
+                "epoch": 0
+            },
+            "arbitrum": {
+                "EnableArbOS": true,
+                "AllowDebugPrecompiles": true,
+                "DataAvailabilityCommittee": false,
+                "InitialArbOSVersion": 11,
+                "InitialChainOwner": "0x0000000000000000000000000000000000000000",
+                "GenesisBlockNum": 0
+            }
+        }
+    }
+]


### PR DESCRIPTION
This PR adds a custom chain configuration for the sequencer, allowing us to use the dedicated devnet chain ID defined in https://github.com/renegade-fi/renegade-contracts/pull/233.

This chain config is a copy of the one used for the [Arbitrum Stylus devnet](https://github.com/OffchainLabs/stylus/blob/stylus/cmd/chaininfo/arbitrum_chain_info.json#L148-L182), but with our own chain ID and chain name.

I ran the `arbitrum-client` integration tests with the new sequencer (against the `andrew/no-verify-guards` branch where these changes are reflected contract-side) and they pass, indicating that the verification guards are satisfied appropriately in the relayer integration tests and the chain IDs line up.