### PR TITLE
task-driver: tasks: pay-relayer-fee: Implement relayer fee skeleton

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -80,8 +80,10 @@ pub enum TaskDescriptor {
     NewWallet(NewWalletTaskDescriptor),
     /// The task descriptor for the `LookupWallet` task
     LookupWallet(LookupWalletTaskDescriptor),
-    /// The task descriptor for the `PayFees` task
+    /// The task descriptor for the `PayProtocolFee` task
     ProtocolFee(PayProtocolFeeTaskDescriptor),
+    /// The task descriptor for the `PayRelayerFee` task
+    RelayerFee(PayRelayerFeeTaskDescriptor),
     /// The task descriptor for the `SettleMatchInternal` task
     SettleMatchInternal(SettleMatchInternalTaskDescriptor),
     /// The task descriptor for the `SettleMatch` task
@@ -99,6 +101,7 @@ impl TaskDescriptor {
             TaskDescriptor::NewWallet(task) => task.wallet.wallet_id,
             TaskDescriptor::LookupWallet(task) => task.wallet_id,
             TaskDescriptor::ProtocolFee(task) => task.wallet_id,
+            TaskDescriptor::RelayerFee(task) => task.wallet_id,
             TaskDescriptor::SettleMatch(_) => {
                 unimplemented!("SettleMatch should preempt queue, no key needed")
             },
@@ -118,6 +121,7 @@ impl TaskDescriptor {
             TaskDescriptor::NewWallet(_)
             | TaskDescriptor::LookupWallet(_)
             | TaskDescriptor::ProtocolFee(_)
+            | TaskDescriptor::RelayerFee(_)
             | TaskDescriptor::UpdateWallet(_)
             | TaskDescriptor::SettleMatch(_)
             | TaskDescriptor::SettleMatchInternal(_)
@@ -361,7 +365,7 @@ impl From<UpdateWalletTaskDescriptor> for TaskDescriptor {
     }
 }
 
-/// The task descriptor for the fee payment task
+/// The task descriptor for the protocol fee payment task
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PayProtocolFeeTaskDescriptor {
     /// The wallet to pay fees for
@@ -380,6 +384,28 @@ impl PayProtocolFeeTaskDescriptor {
 impl From<PayProtocolFeeTaskDescriptor> for TaskDescriptor {
     fn from(descriptor: PayProtocolFeeTaskDescriptor) -> Self {
         TaskDescriptor::ProtocolFee(descriptor)
+    }
+}
+
+/// The task descriptor for the relayer fee payment task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PayRelayerFeeTaskDescriptor {
+    /// The wallet to pay fees for
+    pub wallet_id: WalletIdentifier,
+    /// The balance to pay fees for
+    pub balance_mint: BigUint,
+}
+
+impl PayRelayerFeeTaskDescriptor {
+    /// Constructor
+    pub fn new(wallet_id: WalletIdentifier, balance_mint: BigUint) -> Self {
+        PayRelayerFeeTaskDescriptor { wallet_id, balance_mint }
+    }
+}
+
+impl From<PayRelayerFeeTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: PayRelayerFeeTaskDescriptor) -> Self {
+        TaskDescriptor::RelayerFee(descriptor)
     }
 }
 

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -702,8 +702,8 @@ impl Token {
             })
     }
 
-    /// Converts the amount of the token as an f64, accounting for the associated
-    /// number of decimals.
+    /// Converts the amount of the token as an f64, accounting for the
+    /// associated number of decimals.
     ///
     /// Note that due to conversion to f64, the result may lose precision.
     pub fn convert_to_decimal(&self, amount: u128) -> f64 {

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -30,6 +30,7 @@ use crate::{
         create_new_wallet::{NewWalletTask, NewWalletTaskState},
         lookup_wallet::{LookupWalletTask, LookupWalletTaskState},
         pay_protocol_fee::{PayProtocolFeeTask, PayProtocolFeeTaskState},
+        pay_relayer_fee::{PayRelayerFeeTask, PayRelayerFeeTaskState},
         settle_match::{SettleMatchTask, SettleMatchTaskState},
         settle_match_internal::{SettleMatchInternalTask, SettleMatchInternalTaskState},
         update_merkle_proof::{UpdateMerkleProofTask, UpdateMerkleProofTaskState},
@@ -338,6 +339,10 @@ impl TaskExecutor {
                 Self::start_task_helper::<PayProtocolFeeTask>(immediate, id, desc, ctx, args, notif)
                     .await
             },
+            TaskDescriptor::RelayerFee(desc) => {
+                Self::start_task_helper::<PayRelayerFeeTask>(immediate, id, desc, ctx, args, notif)
+                    .await
+            },
             TaskDescriptor::UpdateWallet(desc) => {
                 Self::start_task_helper::<UpdateWalletTask>(immediate, id, desc, ctx, args, notif)
                     .await
@@ -443,6 +448,8 @@ pub enum StateWrapper {
     NewWallet(NewWalletTaskState),
     /// The state object for the pay protocol fee task
     PayProtocolFee(PayProtocolFeeTaskState),
+    /// The state object for the pay relayer fee task
+    PayRelayerFee(PayRelayerFeeTaskState),
     /// The state object for the settle match task
     SettleMatch(SettleMatchTaskState),
     /// The state object for the settle match internal task
@@ -460,6 +467,7 @@ impl StateWrapper {
             StateWrapper::LookupWallet(state) => state.committed(),
             StateWrapper::NewWallet(state) => state.committed(),
             StateWrapper::PayProtocolFee(state) => state.committed(),
+            StateWrapper::PayRelayerFee(state) => state.committed(),
             StateWrapper::SettleMatch(state) => state.committed(),
             StateWrapper::SettleMatchInternal(state) => state.committed(),
             StateWrapper::UpdateWallet(state) => state.committed(),
@@ -476,6 +484,7 @@ impl StateWrapper {
             StateWrapper::PayProtocolFee(state) => {
                 state == &PayProtocolFeeTaskState::commit_point()
             },
+            StateWrapper::PayRelayerFee(state) => state == &PayRelayerFeeTaskState::commit_point(),
             StateWrapper::SettleMatch(state) => state == &SettleMatchTaskState::commit_point(),
             StateWrapper::SettleMatchInternal(state) => {
                 state == &SettleMatchInternalTaskState::commit_point()
@@ -494,6 +503,7 @@ impl Display for StateWrapper {
             StateWrapper::LookupWallet(state) => state.to_string(),
             StateWrapper::NewWallet(state) => state.to_string(),
             StateWrapper::PayProtocolFee(state) => state.to_string(),
+            StateWrapper::PayRelayerFee(state) => state.to_string(),
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
             StateWrapper::UpdateWallet(state) => state.to_string(),

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -3,6 +3,7 @@
 pub mod create_new_wallet;
 pub mod lookup_wallet;
 pub mod pay_protocol_fee;
+pub mod pay_relayer_fee;
 pub mod settle_match;
 pub mod settle_match_internal;
 pub mod update_merkle_proof;

--- a/workers/task-driver/src/tasks/pay_protocol_fee.rs
+++ b/workers/task-driver/src/tasks/pay_protocol_fee.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 /// The name of the task
-const TASK_NAME: &str = "pay-fees";
+const TASK_NAME: &str = "pay-protocol-fee";
 /// The error emitted when a wallet is missing from state
 const ERR_WALLET_MISSING: &str = "wallet not found in global state";
 /// The error emitted when a balance for a given mint is missing

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -1,0 +1,211 @@
+//! Pay a relayer fee for a balance
+
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
+use circuit_types::Amount;
+use common::types::proof_bundles::RelayerFeeSettlementBundle;
+use common::types::tasks::PayRelayerFeeTaskDescriptor;
+use common::types::wallet::Wallet;
+use job_types::network_manager::NetworkManagerQueue;
+use job_types::proof_manager::ProofManagerQueue;
+use num_bigint::BigUint;
+use serde::Serialize;
+use state::error::StateError;
+use state::State;
+use tracing::instrument;
+
+use crate::driver::StateWrapper;
+use crate::traits::{Task, TaskContext, TaskError, TaskState};
+
+/// The name of the task
+const TASK_NAME: &str = "pay-relayer-fee";
+
+/// The error message emitted when the wallet is not found
+const WALLET_NOT_FOUND: &str = "wallet not found";
+/// The error message emitted when the balance is missing
+const ERR_BALANCE_MISSING: &str = "balance missing";
+
+// --------------
+// | Task State |
+// --------------
+
+/// Defines the state of the relayer fee payment task
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum PayRelayerFeeTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is proving fee payment for the balance
+    ProvingPayment,
+    /// The task is submitting a fee payment transaction
+    SubmittingPayment,
+    /// The task is finding the new Merkle opening for the wallet
+    FindingOpening,
+    /// The task is updating validity proofs for the wallet
+    UpdatingValidityProofs,
+    /// The task has finished
+    Completed,
+}
+
+impl TaskState for PayRelayerFeeTaskState {
+    fn commit_point() -> Self {
+        PayRelayerFeeTaskState::SubmittingPayment
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, PayRelayerFeeTaskState::Completed)
+    }
+}
+
+impl Display for PayRelayerFeeTaskState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl From<PayRelayerFeeTaskState> for StateWrapper {
+    fn from(value: PayRelayerFeeTaskState) -> Self {
+        StateWrapper::PayRelayerFee(value)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type for the pay fees task
+#[derive(Clone, Debug)]
+pub enum PayRelayerFeeTaskError {
+    /// An error interacting with Arbitrum
+    Arbitrum(String),
+    /// An error generating a proof for fee payment
+    ProofGeneration(String),
+    /// An error interacting with the state
+    State(String),
+    /// An error updating validity proofs after the fees are settled
+    UpdateValidityProofs(String),
+}
+
+impl TaskError for PayRelayerFeeTaskError {
+    fn retryable(&self) -> bool {
+        match self {
+            PayRelayerFeeTaskError::Arbitrum(_)
+            | PayRelayerFeeTaskError::ProofGeneration(_)
+            | PayRelayerFeeTaskError::State(_)
+            | PayRelayerFeeTaskError::UpdateValidityProofs(_) => true,
+        }
+    }
+}
+
+impl Display for PayRelayerFeeTaskError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for PayRelayerFeeTaskError {}
+
+impl From<StateError> for PayRelayerFeeTaskError {
+    fn from(err: StateError) -> Self {
+        PayRelayerFeeTaskError::State(err.to_string())
+    }
+}
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Defines the pay fees task
+pub struct PayRelayerFeeTask {
+    /// The balance to pay fees for
+    pub mint: BigUint,
+    /// The wallet that this task pays fees for
+    pub old_wallet: Wallet,
+    /// The new wallet after fees have been paid
+    pub new_wallet: Wallet,
+    /// The proof of `VALID RELAYER FEE SETTLEMENT` used to pay the protocol fee
+    pub protocol_proof: Option<RelayerFeeSettlementBundle>,
+    /// The arbitrum client used for submitting transactions
+    pub arbitrum_client: ArbitrumClient,
+    /// A hand to the global state
+    pub state: State,
+    /// The work queue for the proof manager
+    pub proof_queue: ProofManagerQueue,
+    /// A sender to the network manager's queue
+    pub network_sender: NetworkManagerQueue,
+    /// The current state of the task
+    pub task_state: PayRelayerFeeTaskState,
+}
+
+#[async_trait]
+impl Task for PayRelayerFeeTask {
+    type State = PayRelayerFeeTaskState;
+    type Error = PayRelayerFeeTaskError;
+    type Descriptor = PayRelayerFeeTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        let old_wallet = ctx
+            .state
+            .get_wallet(&descriptor.wallet_id)?
+            .ok_or_else(|| PayRelayerFeeTaskError::State(WALLET_NOT_FOUND.to_string()))?;
+        let new_wallet = Self::get_new_wallet(&descriptor.balance_mint, &old_wallet)?;
+
+        Ok(Self {
+            mint: descriptor.balance_mint,
+            old_wallet,
+            new_wallet,
+            protocol_proof: None,
+            arbitrum_client: ctx.arbitrum_client,
+            state: ctx.state,
+            proof_queue: ctx.proof_queue,
+            network_sender: ctx.network_queue,
+            task_state: PayRelayerFeeTaskState::Pending,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn completed(&self) -> bool {
+        self.task_state.completed()
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    fn name(&self) -> String {
+        TASK_NAME.to_string()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl PayRelayerFeeTask {
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Clone the old wallet and update it to reflect the fee payment
+    fn get_new_wallet(
+        mint: &BigUint,
+        old_wallet: &Wallet,
+    ) -> Result<Wallet, PayRelayerFeeTaskError> {
+        let mut new_wallet = old_wallet.clone();
+        let balance = new_wallet
+            .get_balance_mut(mint)
+            .ok_or_else(|| PayRelayerFeeTaskError::State(ERR_BALANCE_MISSING.to_string()))?;
+
+        balance.relayer_fee_balance = Amount::from(0u8);
+        new_wallet.reblind_wallet();
+
+        Ok(new_wallet)
+    }
+}


### PR DESCRIPTION
### Purpose
This PR builds the skeleton of the `pay-relayer-fee` task. This task will hold logic for paying relayer fees settled during a match.

Implementation is deferred to a follow-up

### Testing
- Unit tests pass