### PR TITLE
api-server: http: wallet: Overwrite managing cluster & take rate

### DIFF
--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -1,6 +1,6 @@
 //! Stores state information relating to the node's configuration
 
-use circuit_types::elgamal::DecryptionKey;
+use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use common::types::{
     gossip::{ClusterId, PeerInfo, WrappedPeerId},
     wallet::{Wallet, WalletIdentifier},
@@ -62,6 +62,15 @@ impl State {
         Ok(key)
     }
 
+    /// Get the local relayer's match take rate
+    pub fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let rate = tx.get_relayer_take_rate()?;
+        tx.commit()?;
+
+        Ok(rate)
+    }
+
     // -----------
     // | Setters |
     // -----------
@@ -108,6 +117,7 @@ impl State {
         tx.set_cluster_id(&config.cluster_id)?;
         tx.set_node_keypair(&config.p2p_key)?;
         tx.set_fee_decryption_key(&config.fee_decryption_key)?;
+        tx.set_relayer_take_rate(&config.match_take_rate)?;
 
         tx.commit()?;
         Ok(())

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -1,6 +1,6 @@
 //! Storage access methods for the local node's metadata
 
-use circuit_types::elgamal::DecryptionKey;
+use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     wallet::WalletIdentifier,
@@ -30,7 +30,9 @@ const LOCAL_ADDR_KEY: &str = "local-addr";
 const LOCAL_WALLET_ID_KEY: &str = "local-wallet-id";
 /// The key for the local relayer's fee decryption key in the node metadata
 /// table
-const LOCAL_RELAYER_FEE_KEY: &str = "local-relayer-fee";
+const LOCAL_RELAYER_DECRYPTION_KEY: &str = "local-relayer-decryption-key";
+/// The key for the local relayer's match take rate in the node metadata table
+const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
 
 // -----------
 // | Helpers |
@@ -92,8 +94,15 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Get the local relayer's fee decryption key
     pub fn get_fee_decryption_key(&self) -> Result<DecryptionKey, StorageError> {
         self.inner()
-            .read(NODE_METADATA_TABLE, &LOCAL_RELAYER_FEE_KEY.to_string())?
-            .ok_or_else(|| err_not_found(LOCAL_RELAYER_FEE_KEY))
+            .read(NODE_METADATA_TABLE, &LOCAL_RELAYER_DECRYPTION_KEY.to_string())?
+            .ok_or_else(|| err_not_found(LOCAL_RELAYER_DECRYPTION_KEY))
+    }
+
+    /// Get the local relayer's match take rate
+    pub fn get_relayer_take_rate(&self) -> Result<FixedPoint, StorageError> {
+        self.inner()
+            .read(NODE_METADATA_TABLE, &RELAYER_TAKE_RATE_KEY.to_string())?
+            .ok_or_else(|| err_not_found(RELAYER_TAKE_RATE_KEY))
     }
 }
 
@@ -130,6 +139,11 @@ impl<'db> StateTxn<'db, RW> {
 
     /// Set the local relayer's fee decryption key
     pub fn set_fee_decryption_key(&self, fee_key: &DecryptionKey) -> Result<(), StorageError> {
-        self.inner().write(NODE_METADATA_TABLE, &LOCAL_RELAYER_FEE_KEY.to_string(), fee_key)
+        self.inner().write(NODE_METADATA_TABLE, &LOCAL_RELAYER_DECRYPTION_KEY.to_string(), fee_key)
+    }
+
+    /// Set the local relayer's match take rate
+    pub fn set_relayer_take_rate(&self, take_rate: &FixedPoint) -> Result<(), StorageError> {
+        self.inner().write(NODE_METADATA_TABLE, &RELAYER_TAKE_RATE_KEY.to_string(), take_rate)
     }
 }


### PR DESCRIPTION
### Purpose
This PR overwrites a wallet's `managing_cluster` and `match_fee` with the relayer's configured values when a wallet is created. The client will be updated of the wallet after the creation flow finishes, at which point it will be able to abandon the wallet if either field is set unexpectedly.

### Testing
- Unit tests pass 