### PR TITLE
task-driver: redeem-relayer-fee: Implement task logic

### DIFF
--- a/circuit-types/src/note.rs
+++ b/circuit-types/src/note.rs
@@ -53,6 +53,12 @@ impl Note {
         compute_poseidon_hash(&vals)
     }
 
+    /// Compute the nullifier for the note
+    pub fn nullifier(&self) -> Scalar {
+        let comm = self.commitment();
+        compute_poseidon_hash(&[comm, self.blinder])
+    }
+
     /// Get the elements of the note that are encrypted when the note is created
     pub fn plaintext_elements(&self) -> [Scalar; NOTE_CIPHERTEXT_SIZE] {
         [biguint_to_scalar(&self.mint), Scalar::from(self.amount), self.blinder]

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -43,6 +43,15 @@ impl State {
         Ok(keypair)
     }
 
+    /// Get the wallet ID that the local relayer owns
+    pub fn get_relayer_wallet_id(&self) -> Result<Option<WalletIdentifier>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let wallet_id = tx.get_local_node_wallet()?;
+        tx.commit()?;
+
+        Ok(Some(wallet_id))
+    }
+
     /// Get the wallet owned by the local relayer
     pub fn get_local_relayer_wallet(&self) -> Result<Option<Wallet>, StateError> {
         let tx = self.db.new_read_tx()?;

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -9,3 +9,10 @@ pub mod settle_match;
 pub mod settle_match_internal;
 pub mod update_merkle_proof;
 pub mod update_wallet;
+
+/// The error emitted when a wallet is missing from state
+pub(crate) const ERR_WALLET_MISSING: &str = "wallet not found in global state";
+/// The error emitted when a balance for a given mint is missing
+pub(crate) const ERR_BALANCE_MISSING: &str = "balance not found in wallet";
+/// The error message emitted when a Merkle proof is not found for a wallet
+pub(crate) const ERR_NO_MERKLE_PROOF: &str = "no merkle proof found for wallet";

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -27,15 +27,10 @@ use crate::driver::StateWrapper;
 use crate::helpers::{enqueue_proof_job, find_merkle_path, update_wallet_validity_proofs};
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
 
+use super::{ERR_BALANCE_MISSING, ERR_NO_MERKLE_PROOF, ERR_WALLET_MISSING};
+
 /// The name of the task
 const TASK_NAME: &str = "pay-relayer-fee";
-
-/// The error message emitted when the wallet is not found
-const WALLET_NOT_FOUND: &str = "wallet not found";
-/// The error message emitted when the balance is missing
-const ERR_BALANCE_MISSING: &str = "balance missing";
-/// The error message emitted when a Merkle proof is missing
-const ERR_NO_MERKLE_PROOF: &str = "Merkle proof missing";
 
 // --------------
 // | Task State |
@@ -165,10 +160,10 @@ impl Task for PayRelayerFeeTask {
         let state = &ctx.state;
         let sender_wallet = state
             .get_wallet(&descriptor.wallet_id)?
-            .ok_or_else(|| PayRelayerFeeTaskError::State(WALLET_NOT_FOUND.to_string()))?;
+            .ok_or_else(|| PayRelayerFeeTaskError::State(ERR_WALLET_MISSING.to_string()))?;
         let recipient_wallet = state
             .get_local_relayer_wallet()?
-            .ok_or_else(|| PayRelayerFeeTaskError::State(WALLET_NOT_FOUND.to_string()))?;
+            .ok_or_else(|| PayRelayerFeeTaskError::State(ERR_WALLET_MISSING.to_string()))?;
 
         let (new_sender_wallet, new_recipient_wallet) =
             Self::get_new_wallets(&descriptor.balance_mint, &sender_wallet, &recipient_wallet)?;

--- a/workers/task-driver/src/tasks/redeem_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_relayer_fee.rs
@@ -4,17 +4,31 @@ use std::{error::Error, fmt::Display};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use circuit_types::note::Note;
-use common::types::{proof_bundles::FeeRedemptionBundle, tasks::RedeemRelayerFeeTaskDescriptor};
-use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use circuit_types::{balance::Balance, note::Note};
+use circuits::zk_circuits::valid_fee_redemption::{
+    SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness,
+};
+use common::types::{
+    merkle::MerkleAuthenticationPath, proof_bundles::FeeRedemptionBundle,
+    tasks::RedeemRelayerFeeTaskDescriptor, wallet::Wallet,
+};
+use job_types::{
+    network_manager::NetworkManagerQueue,
+    proof_manager::{ProofJob, ProofManagerQueue},
+};
 use serde::Serialize;
 use state::{error::StateError, State};
 use tracing::instrument;
+use util::err_str;
 
 use crate::{
     driver::StateWrapper,
+    helpers::{enqueue_proof_job, find_merkle_path},
+    tasks::ERR_NO_MERKLE_PROOF,
     traits::{Task, TaskContext, TaskError, TaskState},
 };
+
+use super::lookup_wallet::ERR_WALLET_NOT_FOUND;
 
 /// The name of the task
 const TASK_NAME: &str = "redeem-relayer-fee";
@@ -73,6 +87,8 @@ pub enum RedeemRelayerFeeError {
     Arbitrum(String),
     /// An error generating a proof for fee payment
     ProofGeneration(String),
+    /// An error signing the commitment to the new wallet
+    Signature(String),
     /// An error interacting with the state
     State(String),
     /// An error updating validity proofs after the fees are settled
@@ -86,6 +102,7 @@ impl TaskError for RedeemRelayerFeeError {
             | RedeemRelayerFeeError::ProofGeneration(_)
             | RedeemRelayerFeeError::State(_)
             | RedeemRelayerFeeError::UpdateValidityProofs(_) => true,
+            RedeemRelayerFeeError::Signature(_) => false,
         }
     }
 }
@@ -112,6 +129,12 @@ impl From<StateError> for RedeemRelayerFeeError {
 pub struct RedeemRelayerFeeTask {
     /// The note to redeem
     pub note: Note,
+    /// The Merkle opening of the note
+    pub note_opening: Option<MerkleAuthenticationPath>,
+    /// The wallet before the note is settled
+    pub old_wallet: Wallet,
+    /// The wallet after the note is settled
+    pub new_wallet: Wallet,
     /// The proof of `VALID FEE REDEMPTION` used to pay the fee
     pub proof: Option<FeeRedemptionBundle>,
     /// The arbitrum client used for submitting transactions
@@ -133,8 +156,19 @@ impl Task for RedeemRelayerFeeTask {
     type Descriptor = RedeemRelayerFeeTaskDescriptor;
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        let state = &ctx.state;
+        let old_wallet = state
+            .get_wallet(&descriptor.wallet_id)
+            .map_err(err_str!(RedeemRelayerFeeError::State))?
+            .ok_or(RedeemRelayerFeeError::State(ERR_WALLET_NOT_FOUND.to_string()))?;
+
+        let new_wallet = Self::get_new_wallet(&descriptor.note, &old_wallet)?;
+
         Ok(Self {
             note: descriptor.note,
+            note_opening: None,
+            old_wallet,
+            new_wallet,
             proof: None,
             arbitrum_client: ctx.arbitrum_client,
             state: ctx.state,
@@ -147,7 +181,30 @@ impl Task for RedeemRelayerFeeTask {
     #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, err, fields(task = self.name(), state = %self.state()))]
     async fn step(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        match self.task_state {
+            RedeemRelayerFeeTaskState::Pending => {
+                self.task_state = RedeemRelayerFeeTaskState::FindingNoteOpening;
+            },
+            RedeemRelayerFeeTaskState::FindingNoteOpening => {
+                self.find_note_opening().await?;
+                self.task_state = RedeemRelayerFeeTaskState::ProvingRedemption;
+            },
+            RedeemRelayerFeeTaskState::ProvingRedemption => {
+                self.generate_proof().await?;
+                self.task_state = RedeemRelayerFeeTaskState::SubmittingRedemption;
+            },
+            RedeemRelayerFeeTaskState::SubmittingRedemption => {
+                self.submit_redemption().await?;
+                self.task_state = RedeemRelayerFeeTaskState::FindingWalletOpening;
+            },
+            RedeemRelayerFeeTaskState::FindingWalletOpening => {
+                self.find_wallet_opening().await?;
+                self.task_state = RedeemRelayerFeeTaskState::Completed;
+            },
+            RedeemRelayerFeeTaskState::Completed => panic!("step() called in `Completed` state"),
+        }
+
+        Ok(())
     }
 
     fn completed(&self) -> bool {
@@ -160,5 +217,130 @@ impl Task for RedeemRelayerFeeTask {
 
     fn name(&self) -> String {
         TASK_NAME.to_string()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl RedeemRelayerFeeTask {
+    /// Find the Merkle opening for the note
+    async fn find_note_opening(&mut self) -> Result<(), RedeemRelayerFeeError> {
+        let note_comm = self.note.commitment();
+        let opening = self
+            .arbitrum_client
+            .find_merkle_authentication_path(note_comm)
+            .await
+            .map_err(err_str!(RedeemRelayerFeeError::Arbitrum))?;
+
+        self.note_opening = Some(opening);
+        Ok(())
+    }
+
+    /// Generate a proof of `VALID RELAYER FEE REDEMPTION` for the relayer's
+    /// wallet
+    async fn generate_proof(&mut self) -> Result<(), RedeemRelayerFeeError> {
+        let (statement, witness) = self.get_witness_statement()?;
+        let job = ProofJob::ValidFeeRedemption { witness, statement };
+        let proof = enqueue_proof_job(job, &self.proof_queue)
+            .map_err(err_str!(RedeemRelayerFeeError::ProofGeneration))?;
+
+        // Await the proof
+        let bundle = proof.await.map_err(err_str!(RedeemRelayerFeeError::ProofGeneration))?;
+        self.proof = Some(bundle.proof.into());
+
+        Ok(())
+    }
+
+    /// Submit a `redeem_fee` transaction to the contract
+    async fn submit_redemption(&mut self) -> Result<(), RedeemRelayerFeeError> {
+        let proof = self.proof.as_ref().unwrap();
+
+        // Sign a commitment to the new wallet after redemption
+        let new_wallet_comm = self.new_wallet.get_wallet_share_commitment();
+        let sig = self
+            .old_wallet
+            .sign_commitment(new_wallet_comm)
+            .map_err(RedeemRelayerFeeError::Signature)?;
+
+        self.arbitrum_client
+            .redeem_fee(proof, sig.to_vec())
+            .await
+            .map_err(err_str!(RedeemRelayerFeeError::Arbitrum))
+    }
+
+    /// Find the opening for the relayer wallet
+    async fn find_wallet_opening(&mut self) -> Result<(), RedeemRelayerFeeError> {
+        let opening = find_merkle_path(&self.new_wallet, &self.arbitrum_client)
+            .await
+            .map_err(err_str!(RedeemRelayerFeeError::Arbitrum))?;
+        self.new_wallet.merkle_proof = Some(opening);
+
+        self.state.update_wallet(self.new_wallet.clone())?.await?;
+        Ok(())
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Get the new wallet after the note is settled
+    fn get_new_wallet(note: &Note, old_wallet: &Wallet) -> Result<Wallet, RedeemRelayerFeeError> {
+        let mut new_wallet = old_wallet.clone();
+        let bal = Balance::new_from_mint_and_amount(note.mint.clone(), note.amount);
+        new_wallet.add_balance(bal).map_err(err_str!(RedeemRelayerFeeError::State))?;
+        new_wallet.reblind_wallet();
+
+        Ok(new_wallet)
+    }
+
+    /// Get the witness and statement for the proof of `VALID FEE REDEMPTION`
+    fn get_witness_statement(
+        &self,
+    ) -> Result<
+        (SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness),
+        RedeemRelayerFeeError,
+    > {
+        let old_wallet = &self.old_wallet;
+        let new_wallet = &self.new_wallet;
+        let old_wallet_private_shares = old_wallet.private_shares.clone();
+        let old_wallet_public_shares = old_wallet.blinded_public_shares.clone();
+        let new_wallet_private_shares = new_wallet.private_shares.clone();
+        let new_wallet_public_shares = new_wallet.blinded_public_shares.clone();
+
+        let wallet_opening = self
+            .old_wallet
+            .merkle_proof
+            .clone()
+            .ok_or(RedeemRelayerFeeError::State(ERR_NO_MERKLE_PROOF.to_string()))?;
+        let note_opening = self.note_opening.clone().unwrap();
+
+        let recipient_key =
+            self.state.get_fee_decryption_key().map_err(err_str!(RedeemRelayerFeeError::State))?;
+        let receive_index = self.new_wallet.get_balance_index(&self.note.mint).unwrap();
+
+        let statement = SizedValidFeeRedemptionStatement {
+            wallet_root: wallet_opening.compute_root(),
+            note_root: note_opening.compute_root(),
+            wallet_nullifier: self.old_wallet.get_wallet_nullifier(),
+            note_nullifier: self.note.nullifier(),
+            new_wallet_commitment: self.new_wallet.get_private_share_commitment(),
+            new_wallet_public_shares,
+            recipient_root_key: self.old_wallet.key_chain.public_keys.pk_root.clone(),
+        };
+
+        let witness = SizedValidFeeRedemptionWitness {
+            old_wallet_private_shares,
+            old_wallet_public_shares,
+            new_wallet_private_shares,
+            wallet_opening: wallet_opening.into(),
+            note_opening: note_opening.into(),
+            note: self.note.clone(),
+            recipient_key,
+            receive_index,
+        };
+
+        Ok((statement, witness))
     }
 }


### PR DESCRIPTION
### Purpose
This PR implements the `redeem-realyer-fee` logic. Note that we don't need to update validity proofs because relayer wallets don't currently holds orders. 

We also automatically enqueue this task on the relayer's wallet when a relayer fee is settled offline.

Testing is deferred to a follow-up.

### Testing
- Workspace unit tests pass