### PR TITLE
task-driver: integration: redeem-relayer-fee: Add integration tests

### DIFF
--- a/workers/task-driver/integration/tests/mod.rs
+++ b/workers/task-driver/integration/tests/mod.rs
@@ -4,5 +4,6 @@ pub mod create_new_wallet;
 pub mod lookup_wallet;
 pub mod pay_offline_fee;
 pub mod pay_relayer_fee;
+pub mod redeem_relayer_fee;
 pub mod settle_match;
 pub mod update_wallet;

--- a/workers/task-driver/integration/tests/redeem_relayer_fee.rs
+++ b/workers/task-driver/integration/tests/redeem_relayer_fee.rs
@@ -1,0 +1,85 @@
+//! Integration tests for redeeming relayer fees
+
+use circuit_types::balance::Balance;
+use circuits::test_helpers::random_wallet_amount;
+use common::types::{
+    tasks::PayOfflineFeeTaskDescriptor, wallet::Wallet, wallet_mocks::mock_empty_wallet,
+};
+use constants::Scalar;
+use eyre::{eyre, Result};
+use rand::thread_rng;
+use renegade_crypto::fields::scalar_to_biguint;
+use test_helpers::{assert_eq_result, integration_test_async};
+
+use crate::{
+    helpers::{
+        await_task, await_wallet_task_queue_flush, setup_initial_wallet, setup_relayer_wallet,
+    },
+    IntegrationTestArgs,
+};
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Get a random balance with a relayer fee
+fn random_balance() -> Balance {
+    let mut rng = thread_rng();
+    let mint = scalar_to_biguint(&Scalar::random(&mut rng));
+    let amount = random_wallet_amount();
+    let relayer_fee_balance = random_wallet_amount();
+    let protocol_fee_balance = 0;
+
+    Balance { mint, amount, relayer_fee_balance, protocol_fee_balance }
+}
+
+/// Setup the trader's wallet
+///
+/// Returns the wallet and the balance that was added to it
+async fn setup_trader_wallet(test_args: &IntegrationTestArgs) -> Result<(Balance, Wallet)> {
+    let mut rng = thread_rng();
+    let blinder_seed = Scalar::random(&mut rng);
+    let share_seed = Scalar::random(&mut rng);
+
+    let mut wallet = mock_empty_wallet();
+    let bal = random_balance();
+    wallet.add_balance(bal.clone()).unwrap();
+
+    // Set the managing cluster of the wallet to the local relayer
+    let key = test_args.state.get_fee_decryption_key().unwrap().public_key();
+    wallet.managing_cluster = key;
+
+    setup_initial_wallet(blinder_seed, share_seed, &mut wallet, test_args).await?;
+    Ok((bal, wallet))
+}
+
+// ---------
+// | Tests |
+// ---------
+
+/// Settle a relayer fee from a trader's wallet, and await automatic redemption
+/// by the relayer
+async fn test_auto_redeem_relayer_fee(test_args: IntegrationTestArgs) -> Result<()> {
+    setup_relayer_wallet(&test_args).await?;
+    let state = &test_args.state;
+
+    // Setup the trader's wallet in the darkpool with a non-zero relayer fee
+    let (bal, wallet) = setup_trader_wallet(&test_args).await?;
+
+    // Pay the relayer fee for the balance
+    let descriptor =
+        PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet.wallet_id, bal.mint.clone()).unwrap();
+    await_task(descriptor.into(), &test_args).await?;
+
+    // Await for the relayer's queue to flush
+    let relayer_wallet_id = state.get_relayer_wallet_id()?.unwrap();
+    await_wallet_task_queue_flush(relayer_wallet_id, &test_args).await?;
+
+    // Check that the relayer has redeemed the fee
+    let wallet = state.get_wallet(&relayer_wallet_id)?.unwrap();
+    let new_bal = wallet.get_balance(&bal.mint).ok_or(eyre!("redeem balance not found"))?.clone();
+
+    let expected_balance = Balance::new_from_mint_and_amount(bal.mint, bal.relayer_fee_balance);
+    assert_eq_result!(new_bal, expected_balance)
+}
+integration_test_async!(test_auto_redeem_relayer_fee);

--- a/workers/task-driver/src/tasks/redeem_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_relayer_fee.rs
@@ -4,6 +4,7 @@ use std::{error::Error, fmt::Display};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
+<<<<<<< HEAD
 use circuit_types::{balance::Balance, note::Note};
 use circuits::zk_circuits::valid_fee_redemption::{
     SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness,
@@ -30,6 +31,20 @@ use crate::{
 
 use super::lookup_wallet::ERR_WALLET_NOT_FOUND;
 
+=======
+use circuit_types::note::Note;
+use common::types::{proof_bundles::FeeRedemptionBundle, tasks::RedeemRelayerFeeTaskDescriptor};
+use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use serde::Serialize;
+use state::{error::StateError, State};
+use tracing::instrument;
+
+use crate::{
+    driver::StateWrapper,
+    traits::{Task, TaskContext, TaskError, TaskState},
+};
+
+>>>>>>> e133c441 (task-driver: redeem-realyer-fee: Define task skeleton)
 /// The name of the task
 const TASK_NAME: &str = "redeem-relayer-fee";
 
@@ -87,8 +102,11 @@ pub enum RedeemRelayerFeeError {
     Arbitrum(String),
     /// An error generating a proof for fee payment
     ProofGeneration(String),
+<<<<<<< HEAD
     /// An error signing the commitment to the new wallet
     Signature(String),
+=======
+>>>>>>> e133c441 (task-driver: redeem-realyer-fee: Define task skeleton)
     /// An error interacting with the state
     State(String),
     /// An error updating validity proofs after the fees are settled
@@ -102,7 +120,10 @@ impl TaskError for RedeemRelayerFeeError {
             | RedeemRelayerFeeError::ProofGeneration(_)
             | RedeemRelayerFeeError::State(_)
             | RedeemRelayerFeeError::UpdateValidityProofs(_) => true,
+<<<<<<< HEAD
             RedeemRelayerFeeError::Signature(_) => false,
+=======
+>>>>>>> e133c441 (task-driver: redeem-realyer-fee: Define task skeleton)
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds integration tests for the relayer fee redemption path. Specifically, we pay a relayer fee from a trader's wallet and verify that the relayer automatically redeems the fee into its own wallet.

### Testing
- Unit tests pass workspace wide
- All integration tests pass