### PR TITLE
workers: price-reporter: expose necessary items for standalone price reporter

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
 };
-use token_remaps::setup_token_remaps;
+pub use token_remaps::setup_token_remaps;
 use toml::{value::Map, Value};
 use util::arbitrum::{parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY};
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -30,6 +30,7 @@ use job_types::price_reporter::new_price_reporter_queue;
 use job_types::proof_manager::new_proof_manager_queue;
 use job_types::task_driver::new_task_driver_queue;
 use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
+use price_reporter::worker::ExchangeConnectionsConfig;
 use price_reporter::{manager::PriceReporter, worker::PriceReporterConfig};
 use proof_manager::{proof_manager::ProofManager, worker::ProofManagerConfig};
 use state::State;
@@ -257,9 +258,11 @@ async fn main() -> Result<(), CoordinatorError> {
         system_bus: system_bus.clone(),
         job_receiver: Some(price_reporter_worker_receiver).into(),
         cancel_channel: price_reporter_cancel_receiver,
-        coinbase_api_key: args.coinbase_api_key,
-        coinbase_api_secret: args.coinbase_api_secret,
-        eth_websocket_addr: args.eth_websocket_addr,
+        exchange_conn_config: ExchangeConnectionsConfig {
+            coinbase_api_key: args.coinbase_api_key,
+            coinbase_api_secret: args.coinbase_api_secret,
+            eth_websocket_addr: args.eth_websocket_addr,
+        },
         disabled: args.disable_price_reporter,
         disabled_exchanges: args.disabled_exchanges,
     })

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -45,7 +45,7 @@ use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
 use price_reporter::{
     manager::PriceReporter,
     mock::{setup_mock_token_remap, MockPriceReporter},
-    worker::PriceReporterConfig,
+    worker::{ExchangeConnectionsConfig, PriceReporterConfig},
 };
 use proof_manager::{
     mock::MockProofManager, proof_manager::ProofManager, worker::ProofManagerConfig,
@@ -397,9 +397,11 @@ impl MockNodeController {
         let system_bus = self.bus.clone();
 
         let conf = PriceReporterConfig {
-            coinbase_api_key: config.coinbase_api_key.clone(),
-            coinbase_api_secret: config.coinbase_api_secret.clone(),
-            eth_websocket_addr: config.eth_websocket_addr.clone(),
+            exchange_conn_config: ExchangeConnectionsConfig {
+                coinbase_api_key: config.coinbase_api_key.clone(),
+                coinbase_api_secret: config.coinbase_api_secret.clone(),
+                eth_websocket_addr: config.eth_websocket_addr.clone(),
+            },
             disabled: config.disable_price_reporter,
             disabled_exchanges: config.disabled_exchanges.clone(),
             job_receiver: default_option(job_receiver),

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -52,6 +52,7 @@ use util::err_str;
 use uuid::Uuid;
 
 pub(super) use price_agreement::init_price_streams;
+pub use price_agreement::DEFAULT_PAIRS;
 
 use self::{
     handshake::{ERR_NO_PROOF, ERR_NO_WALLET},

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -56,7 +56,7 @@ const AAVE_TICKER: &str = "AAVE";
 
 lazy_static! {
     /// The token pairs we want to keep price streams open for persistently
-    static ref DEFAULT_PAIRS: Vec<(Token, Token)> = {
+    pub static ref DEFAULT_PAIRS: Vec<(Token, Token)> = {
         // For now we only stream prices quoted in USDC
         vec![
             (

--- a/workers/price-reporter/src/exchange.rs
+++ b/workers/price-reporter/src/exchange.rs
@@ -16,7 +16,7 @@ use std::{
 
 use atomic_float::AtomicF64;
 use common::types::{exchange::Exchange, token::Token, Price};
-use connection::{get_current_time, ExchangeConnection};
+pub use connection::{get_current_time, ExchangeConnection};
 
 use futures_util::Stream;
 
@@ -25,13 +25,13 @@ use self::{
     okx::OkxConnection, uni_v3::UniswapV3Connection,
 };
 
-use super::{errors::ExchangeConnectionError, worker::PriceReporterConfig};
+use super::{errors::ExchangeConnectionError, worker::ExchangeConnectionsConfig};
 
 /// Construct a new websocket connection for the given exchange
 pub async fn connect_exchange(
     base_token: &Token,
     quote_token: &Token,
-    config: &PriceReporterConfig,
+    config: &ExchangeConnectionsConfig,
     exchange: Exchange,
 ) -> Result<Box<dyn ExchangeConnection>, ExchangeConnectionError> {
     let base_token = base_token.clone();
@@ -55,12 +55,12 @@ pub async fn connect_exchange(
 }
 
 /// The type that a price stream should return
-type PriceStreamType = Result<Price, ExchangeConnectionError>;
+pub type PriceStreamType = Result<Price, ExchangeConnectionError>;
 
 /// A helper struct that represents a stream of midpoint prices that may
 /// be initialized at construction
 #[derive(Debug)]
-struct InitializablePriceStream<T: Stream<Item = PriceStreamType> + Unpin> {
+pub struct InitializablePriceStream<T: Stream<Item = PriceStreamType> + Unpin> {
     /// The underlying stream
     stream: T,
     /// A buffered stream value, possibly used for initialization

--- a/workers/price-reporter/src/exchange/binance.rs
+++ b/workers/price-reporter/src/exchange/binance.rs
@@ -17,7 +17,7 @@ use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
-use crate::{errors::ExchangeConnectionError, worker::PriceReporterConfig};
+use crate::{errors::ExchangeConnectionError, worker::ExchangeConnectionsConfig};
 
 use super::{
     connection::{
@@ -139,7 +139,7 @@ impl ExchangeConnection for BinanceConnection {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        _config: &PriceReporterConfig,
+        _config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized,

--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -16,7 +16,7 @@ use tungstenite::{Error as WsError, Message};
 use url::Url;
 use util::get_current_time_seconds;
 
-use crate::{errors::ExchangeConnectionError, worker::PriceReporterConfig};
+use crate::{errors::ExchangeConnectionError, worker::ExchangeConnectionsConfig};
 
 use super::{
     connection::{
@@ -186,7 +186,7 @@ impl ExchangeConnection for CoinbaseConnection {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        config: &PriceReporterConfig,
+        config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError> {
         // Build the base websocket connection
         let url = Self::websocket_url();

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -18,7 +18,7 @@ use tracing::error;
 use tungstenite::Error as WsError;
 use url::Url;
 
-use crate::worker::PriceReporterConfig;
+use crate::worker::ExchangeConnectionsConfig;
 
 use super::{super::errors::ExchangeConnectionError, PriceStreamType};
 
@@ -139,7 +139,7 @@ pub trait ExchangeConnection: Stream<Item = PriceStreamType> + Unpin + Send {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        config: &PriceReporterConfig,
+        config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized;

--- a/workers/price-reporter/src/exchange/kraken.rs
+++ b/workers/price-reporter/src/exchange/kraken.rs
@@ -15,7 +15,7 @@ use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
-use crate::{errors::ExchangeConnectionError, worker::PriceReporterConfig};
+use crate::{errors::ExchangeConnectionError, worker::ExchangeConnectionsConfig};
 
 use super::{
     connection::{
@@ -110,7 +110,7 @@ impl ExchangeConnection for KrakenConnection {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        _config: &PriceReporterConfig,
+        _config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized,

--- a/workers/price-reporter/src/exchange/okx.rs
+++ b/workers/price-reporter/src/exchange/okx.rs
@@ -13,7 +13,7 @@ use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
 
-use crate::{errors::ExchangeConnectionError, worker::PriceReporterConfig};
+use crate::{errors::ExchangeConnectionError, worker::ExchangeConnectionsConfig};
 
 use super::{
     connection::{
@@ -110,7 +110,7 @@ impl ExchangeConnection for OkxConnection {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        _config: &PriceReporterConfig,
+        _config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized,

--- a/workers/price-reporter/src/exchange/uni_v3.rs
+++ b/workers/price-reporter/src/exchange/uni_v3.rs
@@ -22,7 +22,7 @@ use web3::{
     Web3,
 };
 
-use crate::worker::PriceReporterConfig;
+use crate::worker::ExchangeConnectionsConfig;
 
 use super::{
     super::errors::ExchangeConnectionError, ExchangeConnection, InitializablePriceStream,
@@ -318,7 +318,7 @@ impl ExchangeConnection for UniswapV3Connection {
     async fn connect(
         base_token: Token,
         quote_token: Token,
-        config: &PriceReporterConfig,
+        config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized,

--- a/workers/price-reporter/src/reporter.rs
+++ b/workers/price-reporter/src/reporter.rs
@@ -45,7 +45,7 @@ const MAX_DEVIATION: f64 = 0.02;
 
 /// The number of milliseconds to wait in between sending keepalive messages to
 /// the connections
-const KEEPALIVE_INTERVAL_MS: u64 = 15_000; // 15 seconds
+pub const KEEPALIVE_INTERVAL_MS: u64 = 15_000; // 15 seconds
 /// The number of milliseconds to wait in between retrying connections
 const CONN_RETRY_DELAY_MS: u64 = 2_000; // 2 seconds
 /// The number of milliseconds in which `MAX_CONN_RETRIES` failures will cause a
@@ -455,7 +455,7 @@ impl ConnectionMuxer {
             .map(|exchange| {
                 let base_token = self.base_token.clone();
                 let quote_token = self.quote_token.clone();
-                let config = self.config.clone();
+                let config = self.config.exchange_conn_config.clone();
 
                 async move { connect_exchange(&base_token, &quote_token, &config, *exchange).await }
             })
@@ -489,6 +489,12 @@ impl ConnectionMuxer {
 
         // Reconnect
         info!("Retrying connection to {exchange}");
-        connect_exchange(&self.base_token, &self.quote_token, &self.config, exchange).await
+        connect_exchange(
+            &self.base_token,
+            &self.quote_token,
+            &self.config.exchange_conn_config,
+            exchange,
+        )
+        .await
     }
 }

--- a/workers/price-reporter/src/worker.rs
+++ b/workers/price-reporter/src/worker.rs
@@ -26,12 +26,8 @@ pub struct PriceReporterConfig {
     pub system_bus: SystemBus<SystemBusMessage>,
     /// The receiver for jobs from other workers
     pub job_receiver: DefaultOption<PriceReporterReceiver>,
-    /// The coinbase API key that the price reporter may use
-    pub coinbase_api_key: Option<String>,
-    /// The coinbase API secret that the price reporter may use
-    pub coinbase_api_secret: Option<String>,
-    /// The ethereum RPC node websocket addresses for on-chain data
-    pub eth_websocket_addr: Option<String>,
+    /// Exchange connection config options
+    pub exchange_conn_config: ExchangeConnectionsConfig,
     /// Whether or not the worker is disabled
     pub disabled: bool,
     /// Exchanges that are explicitly disabled for price reporting
@@ -39,6 +35,17 @@ pub struct PriceReporterConfig {
     /// The channel on which the coordinator may mandate that the price reporter
     /// manager cancel its execution
     pub cancel_channel: CancelChannel,
+}
+
+/// The configuration options that may be used by exchange connections
+#[derive(Clone, Debug, Default)]
+pub struct ExchangeConnectionsConfig {
+    /// The coinbase API key that the price reporter may use
+    pub coinbase_api_key: Option<String>,
+    /// The coinbase API secret that the price reporter may use
+    pub coinbase_api_secret: Option<String>,
+    /// The ethereum RPC node websocket addresses for on-chain data
+    pub eth_websocket_addr: Option<String>,
 }
 
 impl PriceReporterConfig {
@@ -51,9 +58,10 @@ impl PriceReporterConfig {
         let disabled = self.disabled_exchanges.contains(&exchange);
         let configured = match exchange {
             Exchange::Coinbase => {
-                self.coinbase_api_key.is_some() && self.coinbase_api_secret.is_some()
+                self.exchange_conn_config.coinbase_api_key.is_some()
+                    && self.exchange_conn_config.coinbase_api_secret.is_some()
             },
-            Exchange::UniswapV3 => self.eth_websocket_addr.is_some(),
+            Exchange::UniswapV3 => self.exchange_conn_config.eth_websocket_addr.is_some(),
             _ => true,
         };
 


### PR DESCRIPTION
This PR exposes items from the `workers/price-reporter` crate needed by the standalone price reporter service. Notably, this included separating out an `ExchangeConnectionsConfig` struct that is more lightweight and can be used by the standalone price reporter instead of the entore `PriceReporterConfig`.