### PR TITLE
workers: price-reporter: add PeekBinance job & use in price agreement

### DIFF
--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -81,7 +81,10 @@ pub enum PriceReporterState {
     Nominal(PriceReport),
     /// Not enough data has yet to be reported from the ExchangeConnections.
     /// Includes the number of ExchangeConnection reporters.
+    // NOTE(@akirillo): We will probably remove this since we're no longer computing medians
     NotEnoughDataReported(usize),
+    /// No data has been reported as of yet
+    NoDataReported,
     /// At least one of the ExchangeConnection has not reported a recent enough
     /// report. Includes the current time_diff in milliseconds.
     DataTooStale(PriceReport, u64),

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -107,6 +107,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
+    // TODO: Update, this is now supported (w/ USDT pair)
     (
         "0x6810e776880c02933d47db1b9fc05908e5386b96",
         18,
@@ -117,6 +118,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Unsupported,
     ),
     // LSDs
+    // TODO: Remove b/c unsupported by Binance
     (
         "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
         18,
@@ -154,6 +156,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
+    // TODO: Remove b/c being deprecated
     (
         "0x4fabb145d64652a948d72533023f6e7a623c7c53",
         18,
@@ -320,6 +323,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     // DeFi Lending Undercollateralized
+    // TODO: Update, this is now supported (w/ USDT pair)
     (
         "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
         8,
@@ -329,6 +333,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
     ),
+    // TODO: Remove b/c unsupported by Binance
     (
         "0x33349b282065b0284d756f0577fb39c158f935e6",
         18,
@@ -348,6 +353,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
+    // TODO: Remove b/c unsupported by Binance
     (
         "0x221657776846890989a759ba2973e427dff5c9bb",
         18,
@@ -404,6 +410,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
+    // TODO: Remove b/c unsupported by Binance
     (
         "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
         18,

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -40,6 +40,7 @@ impl ExchangeHealthStatesHandler {
     }
 }
 
+// NOTE(@akirillo): We'll remove this route / file
 #[async_trait]
 impl TypedHandler for ExchangeHealthStatesHandler {
     type Request = GetExchangeHealthStatesRequest;

--- a/workers/api-server/src/websocket/price_report.rs
+++ b/workers/api-server/src/websocket/price_report.rs
@@ -80,6 +80,7 @@ impl PriceReporterHandler {
     }
 }
 
+// NOTE(@akirillo): Remove this route / file
 #[async_trait]
 impl WebsocketTopicHandler for PriceReporterHandler {
     /// Handle a subscription to a price report

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -137,7 +137,7 @@ impl HandshakeExecutor {
         for (base, quote) in DEFAULT_PAIRS.iter().cloned() {
             let (sender, receiver) = oneshot::channel();
             self.price_reporter_job_queue
-                .send(PriceReporterJob::PeekMedian {
+                .send(PriceReporterJob::PeekBinance {
                     base_token: base,
                     quote_token: quote,
                     channel: sender,
@@ -168,6 +168,7 @@ impl HandshakeExecutor {
                 // TODO: We may want to re-evaluate whether we want to accept price reports
                 // with large deviation. This largely happens because of Uniswap, and we could
                 // implement a more complex deviation calculation that ignores DEXs
+                // NOTE(@akirillo): We're going to remove Uniswap anyway, lol
                 PriceReporterState::TooMuchDeviation(report, _) => {
                     midpoint_prices.push((
                         report.base_token,

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -40,6 +40,15 @@ pub enum PriceReporterJob {
         /// The quote Token
         quote_token: Token,
     },
+    /// Peek at the Binance price report
+    PeekBinance {
+        /// The base Token
+        base_token: Token,
+        /// The quote Token
+        quote_token: Token,
+        /// The return channel for the price report
+        channel: TokioSender<PriceReporterState>,
+    },
     /// Peek at the median price report
     PeekMedian {
         /// The base Token


### PR DESCRIPTION
This PR adds a `PeekBinance` job type to the price reporter, makes the associated handler methods for it, and replaces the invocation of the `PeekMedian` job with it in the price agreement.

I've also left notes/todos for myself throughout the codebase indicating the necessary changes for removing the `PeekMedian` job and any reliance on median prices, which will be done in the next PR.

All unit tests (other than `test_delay`, which seems wholly unrelated) pass. Integration tests for the task driver and handshake manager are failing, but the same tests are failing on main. This is a problem, but seemingly not with this PR.

EDIT: Per our discussion, this is due to a bug in running the whole integration testing suite