### PR TITLE
core: setup: Set `local-wallet-id` metadata entry at startup

### DIFF
--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -52,7 +52,9 @@ async fn setup_relayer_wallet(
     let keychain =
         derive_wallet_keychain(key, chain_id).map_err(err_str!(CoordinatorError::Setup))?;
 
+    // Set the node metadata entry for the relayer's wallet
     let wallet_id = derive_wallet_id(key).map_err(err_str!(CoordinatorError::Setup))?;
+    state.set_local_relayer_wallet_id(wallet_id).map_err(err_str!(CoordinatorError::Setup))?;
 
     // Attempt to find the wallet on-chain
     if find_wallet_onchain(


### PR DESCRIPTION
### Purpose
This PR fixed a bug wherein the relayer's wallet ID is never setup in the node metadata table. This prevents the relayer from redeeming fees after a match.

### Testing
- Unit tests pass
- Integration tests pass
- @sehyunc Please check that your flows work with this fix