### PR TITLE
workers: external-price-reporter: scaffold external price reporter worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "external-price-reporter"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "external-api",
+ "job-types",
+ "system-bus",
+ "tokio",
+ "util",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6504,6 +6516,7 @@ dependencies = [
  "crossbeam",
  "ethers",
  "external-api",
+ "external-price-reporter",
  "gossip-api",
  "gossip-server",
  "handshake-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
 	"workers/proof-manager",
 	"workers/task-driver",
 	"renegade-metrics",
+	"workers/external-price-reporter",
 ]
 
 [profile.bench]

--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -69,10 +69,10 @@ pub struct PriceReport {
 
 /// The state of the PriceReporter. The Nominal state means that enough
 /// ExchangeConnections are reporting recent prices, so it is OK to proceed with
-/// MPCs at the given median price.
+/// MPCs at the given price.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PriceReporterState {
-    /// Enough reporters are correctly reporting to construct a median price.
+    /// Enough reporters are correctly reporting to construct a price.
     Nominal(PriceReport),
     /// Not enough data has yet to be reported from the ExchangeConnections.
     /// Includes the number of ExchangeConnection reporters.

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -55,6 +55,10 @@ struct Cli {
     /// Defaults to 20 basis points
     #[clap(long, value_parser, default_value = "0.002")]
     pub match_take_rate: f64,
+    /// The price reporter from which to stream prices.
+    /// If unset, the relayer will connect to exchanges directly.
+    #[clap(long, value_parser, conflicts_with_all = &["coinbase_api_key", "coinbase_api_secret", "eth_websocket_addr"])]
+    pub price_reporter_url: Option<String>,
 
     // -----------------------
     // | Environment Configs |
@@ -198,6 +202,9 @@ pub struct RelayerConfig {
     /// The take rate of this relayer on a managed match, i.e. the amount of the
     /// received asset that the relayer takes as a fee
     pub match_take_rate: FixedPoint,
+    /// The price reporter from which to stream prices.
+    /// If unset, the relayer will connect to exchanges directly.
+    pub price_reporter_url: Option<String>,
 
     // -----------------------
     // | Environment Configs |
@@ -299,6 +306,7 @@ impl Clone for RelayerConfig {
     fn clone(&self) -> Self {
         Self {
             match_take_rate: self.match_take_rate,
+            price_reporter_url: self.price_reporter_url.clone(),
             chain_id: self.chain_id,
             contract_address: self.contract_address.clone(),
             bootstrap_servers: self.bootstrap_servers.clone(),
@@ -415,6 +423,7 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
 
     let mut config = RelayerConfig {
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
+        price_reporter_url: cli_args.price_reporter_url,
         chain_id: cli_args.chain_id,
         contract_address: cli_args.contract_address,
         bootstrap_servers: parsed_bootstrap_addrs,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ handshake-manager = { path = "../workers/handshake-manager" }
 job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
 price-reporter = { path = "../workers/price-reporter" }
+external-price-reporter = { path = "../workers/external-price-reporter" }
 proof-manager = { path = "../workers/proof-manager" }
 state = { path = "../state", features = ["mocks"] }
 system-bus = { path = "../system-bus" }

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -33,8 +33,8 @@ pub fn task_topic_name(task_id: &TaskIdentifier) -> String {
 }
 
 /// Get the topic name for a price report
-pub fn price_report_topic_name(source: &str, base: &Token, quote: &Token) -> String {
-    format!("{}-price-report-{}-{}", source, base.get_addr(), quote.get_addr())
+pub fn price_report_topic_name(base: &Token, quote: &Token) -> String {
+    format!("price-report-{}-{}", base.get_addr(), quote.get_addr())
 }
 
 /// A message type for generic system bus messages, broadcast to all modules
@@ -88,11 +88,8 @@ pub enum SystemBusMessage {
     },
 
     // -- Price Report -- //
-    /// A message indicating that a new median PriceReport has been published
-    PriceReportMedian(PriceReport),
-    /// A message indicating that a new individual exchange PriceReport has been
-    /// published
-    PriceReportExchange(PriceReport),
+    /// A message indicating that a new PriceReport has been published
+    PriceReport(PriceReport),
 
     // -- Tasks -- //
     /// A message indicating that a task has

--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod network;
 pub mod order_book;
-pub mod price_report;
+pub mod price_report; // TODO: REMOVE AFTER FE INTEGRATION W/ STANDALONE PRICE REPORTER
 pub mod task;
 pub mod wallet;
 

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -33,6 +33,7 @@ use self::{
         GetNetworkOrderByIdHandler, GetNetworkOrdersHandler, GET_NETWORK_ORDERS_ROUTE,
         GET_NETWORK_ORDER_BY_ID_ROUTE,
     },
+    price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
     task::{
         GetTaskQueueHandler, GetTaskStatusHandler, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE,
     },
@@ -54,6 +55,7 @@ use super::{
 
 mod network;
 mod order_book;
+mod price_report; // TODO: REMOVE AFTER FE INTEGRATION W/ STANDALONE PRICE REPORTER
 mod task;
 mod wallet;
 
@@ -173,14 +175,22 @@ impl HttpServer {
     /// Create a new http server
     pub(super) fn new(config: ApiServerConfig, global_state: State) -> Self {
         // Build the router, server, and register routes
-        let router = Self::build_router(global_state);
+        let router = Self::build_router(&config, global_state);
         Self { router: Arc::new(router), config }
     }
 
     /// Build a router and register routes on it
-    fn build_router(global_state: State) -> Router {
+    fn build_router(config: &ApiServerConfig, global_state: State) -> Router {
         // Build the router and register its routes
         let mut router = Router::new(global_state.clone());
+
+        // The "/exchangeHealthStates" route
+        router.add_route(
+            &Method::POST,
+            EXCHANGE_HEALTH_ROUTE.to_string(),
+            false, // auth_required
+            ExchangeHealthStatesHandler::new(config.clone()),
+        );
 
         // The "/ping" route
         router.add_route(

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -1,0 +1,71 @@
+//! Groups price reporting API handlers and types
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use external_api::http::price_report::{
+    GetExchangeHealthStatesRequest, GetExchangeHealthStatesResponse,
+};
+use hyper::HeaderMap;
+use job_types::price_reporter::PriceReporterJob;
+use tokio::sync::oneshot::channel;
+
+use crate::{
+    error::ApiServerError,
+    router::{TypedHandler, UrlParams},
+    worker::ApiServerConfig,
+};
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Exchange health check route
+pub(super) const EXCHANGE_HEALTH_ROUTE: &str = "/v0/exchange/health_check";
+
+// ------------------
+// | Route Handlers |
+// ------------------
+
+/// Handler for the / route, returns the health report for each individual
+/// exchange and the aggregate median
+#[derive(Clone)]
+pub(crate) struct ExchangeHealthStatesHandler {
+    /// The config for the API server
+    config: ApiServerConfig,
+}
+
+impl ExchangeHealthStatesHandler {
+    /// Create a new handler for "/exchange/health"
+    pub fn new(config: ApiServerConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for ExchangeHealthStatesHandler {
+    type Request = GetExchangeHealthStatesRequest;
+    type Response = GetExchangeHealthStatesResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        req: Self::Request,
+        _params: UrlParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let (price_reporter_state_sender, price_reporter_state_receiver) = channel();
+        self.config
+            .price_reporter_work_queue
+            .send(PriceReporterJob::PeekPrice {
+                base_token: req.base_token.clone(),
+                quote_token: req.quote_token.clone(),
+                channel: price_reporter_state_sender,
+            })
+            .unwrap();
+        let all_exchanges = HashMap::new();
+        Ok(GetExchangeHealthStatesResponse {
+            median: price_reporter_state_receiver.await.unwrap(),
+            all_exchanges,
+        })
+    }
+}

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -46,7 +46,7 @@ pub struct ApiServerConfig {
     /// A sender to the network manager's work queue
     pub network_sender: NetworkManagerQueue,
     /// The worker job queue for the PriceReporter
-    pub price_reporter_work_queue: PriceReporterQueue,
+    pub price_reporter_work_queue: PriceReporterQueue, // TODO: REMOVE AFTER FE INTEGRATION W/ STANDALONE PRICE REPORTER
     /// The worker job queue for the ProofGenerationManager
     pub proof_generation_work_queue: ProofManagerQueue,
     /// The relayer-global state

--- a/workers/external-price-reporter/Cargo.toml
+++ b/workers/external-price-reporter/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "external-price-reporter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+# === Async + Runtime === #
+tokio = { workspace = true }
+
+# === Workspace Dependencies === #
+common = { path = "../../common" }
+external-api = { path = "../../external-api" }
+job-types = { path = "../job-types" }
+system-bus = { path = "../../system-bus" }
+util = { path = "../../util" }

--- a/workers/external-price-reporter/src/errors.rs
+++ b/workers/external-price-reporter/src/errors.rs
@@ -1,0 +1,21 @@
+//! Defines the error type for the ExternalPriceReporter.
+
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
+
+/// The core error type thrown by the ExternalPriceReporter worker.
+#[derive(Clone, Debug)]
+pub enum ExternalPriceReporterError {
+    /// The spawning of the initial ExternalPriceReporter execution thread
+    /// failed
+    ManagerSetup(String),
+}
+
+impl Display for ExternalPriceReporterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for ExternalPriceReporterError {}

--- a/workers/external-price-reporter/src/lib.rs
+++ b/workers/external-price-reporter/src/lib.rs
@@ -1,0 +1,17 @@
+//! The external price reporter module manages a connection to an external
+//! standalone price reporter service, streaming in exchange prices
+//! from it to compute PriceReports.
+//!
+//! Much of the types and logic employed by this worker are shared with the
+//! native PriceReporter worker
+
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![allow(incomplete_features)]
+#![feature(let_chains)]
+#![feature(generic_const_exprs)]
+
+pub mod errors;
+pub mod manager;
+pub mod worker;

--- a/workers/external-price-reporter/src/manager.rs
+++ b/workers/external-price-reporter/src/manager.rs
@@ -1,0 +1,60 @@
+//! Defines the ExternalPriceReporterExecutor, the handler that is responsible
+//! for executing individual ExternalPriceReporterJobs.
+
+use std::{collections::HashSet, thread::JoinHandle};
+
+use common::{
+    default_wrapper::{DefaultOption, DefaultWrapper},
+    new_async_shared,
+    types::CancelChannel,
+    AsyncShared,
+};
+use job_types::price_reporter::PriceReporterReceiver;
+
+use crate::{errors::ExternalPriceReporterError, worker::ExternalPriceReporterConfig};
+
+/// The ExternalPriceReporter worker is a wrapper around the
+/// ExternalPriceReporterExecutor, handling and dispatching jobs to the executor
+/// for subscription to price streams and peeking at price reports.
+pub struct ExternalPriceReporter {
+    /// The config for the ExternalPriceReporter
+    pub(super) config: ExternalPriceReporterConfig,
+    /// The single thread that joins all individual PriceReporter threads
+    pub(super) manager_executor_handle: Option<JoinHandle<ExternalPriceReporterError>>,
+}
+
+/// The actual executor that handles incoming jobs, to subscribe to price
+/// streams and peek at PriceReports
+#[derive(Clone)]
+pub struct ExternalPriceReporterExecutor {
+    /// The manager config
+    config: ExternalPriceReporterConfig,
+    /// The set of topics that the executor is subscribed to
+    /// on the external price reporter service
+    subscriptions: AsyncShared<HashSet<String>>,
+    /// The channel along which jobs are passed to the price reporter
+    job_receiver: DefaultOption<PriceReporterReceiver>,
+    /// The channel on which the coordinator may cancel execution
+    cancel_channel: DefaultOption<CancelChannel>,
+}
+
+impl ExternalPriceReporterExecutor {
+    /// Creates the executor for the ExternalPriceReporter worker.
+    pub(super) fn new(
+        job_receiver: PriceReporterReceiver,
+        config: ExternalPriceReporterConfig,
+        cancel_channel: CancelChannel,
+    ) -> Self {
+        Self {
+            job_receiver: DefaultWrapper::new(Some(job_receiver)),
+            cancel_channel: DefaultWrapper::new(Some(cancel_channel)),
+            subscriptions: new_async_shared(HashSet::new()),
+            config,
+        }
+    }
+
+    /// The execution loop for the external price reporter
+    pub(super) async fn execution_loop(mut self) -> Result<(), ExternalPriceReporterError> {
+        todo!()
+    }
+}

--- a/workers/external-price-reporter/src/worker.rs
+++ b/workers/external-price-reporter/src/worker.rs
@@ -1,7 +1,7 @@
 //! Defines the Worker logic for the ExtenalPriceReporterManager, which simply
 //! dispatches jobs to the ExternalPriceReporterExecutor.
 
-use std::thread::{JoinHandle, Builder as ThreadBuilder};
+use std::thread::{Builder as ThreadBuilder, JoinHandle};
 
 use common::{
     default_wrapper::DefaultOption,

--- a/workers/external-price-reporter/src/worker.rs
+++ b/workers/external-price-reporter/src/worker.rs
@@ -1,0 +1,94 @@
+//! Defines the Worker logic for the ExtenalPriceReporterManager, which simply
+//! dispatches jobs to the ExternalPriceReporterExecutor.
+
+use std::thread::{JoinHandle, Builder as ThreadBuilder};
+
+use common::{
+    default_wrapper::DefaultOption,
+    types::{exchange::Exchange, CancelChannel},
+    worker::Worker,
+};
+use external_api::bus_message::SystemBusMessage;
+use job_types::price_reporter::PriceReporterReceiver;
+use system_bus::SystemBus;
+use tokio::runtime::Builder as TokioBuilder;
+use util::err_str;
+
+use crate::{
+    errors::ExternalPriceReporterError,
+    manager::{ExternalPriceReporter, ExternalPriceReporterExecutor},
+};
+
+/// The number of threads backing the external price reporter manager
+const EXTERNAL_PRICE_REPORTER_MANAGER_NUM_THREADS: usize = 2;
+
+/// The config passed from the coordinator to the ExternalPriceReporter
+#[derive(Clone, Debug)]
+pub struct ExternalPriceReporterConfig {
+    /// The global system bus
+    pub system_bus: SystemBus<SystemBusMessage>,
+    /// The receiver for jobs from other workers
+    pub job_receiver: DefaultOption<PriceReporterReceiver>,
+    /// The WS URL of the external price reporter service
+    pub price_reporter_url: String,
+    /// Whether or not the worker is disabled
+    pub disabled: bool,
+    /// Exchanges that are explicitly disabled for price reporting
+    pub disabled_exchanges: Vec<Exchange>,
+    /// The channel on which the coordinator may mandate that the price reporter
+    /// manager cancel its execution
+    pub cancel_channel: CancelChannel,
+}
+
+impl Worker for ExternalPriceReporter {
+    type WorkerConfig = ExternalPriceReporterConfig;
+    type Error = ExternalPriceReporterError;
+
+    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+        Ok(Self { config, manager_executor_handle: None })
+    }
+
+    fn is_recoverable(&self) -> bool {
+        false
+    }
+
+    fn name(&self) -> String {
+        "external-price-reporter-manager-main".to_string()
+    }
+
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        vec![self.manager_executor_handle.take().unwrap()]
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        // Start the loop that dispatches incoming jobs to the executor
+        let manager_executor = ExternalPriceReporterExecutor::new(
+            self.config.job_receiver.take().unwrap(),
+            self.config.clone(),
+            self.config.cancel_channel.clone(),
+        );
+
+        let manager_executor_handle = {
+            ThreadBuilder::new()
+                .name("external-price-reporter-manager-executor".to_string())
+                .spawn(move || {
+                    // Build a tokio runtime to drive the price reporter
+                    let runtime = TokioBuilder::new_multi_thread()
+                        .worker_threads(EXTERNAL_PRICE_REPORTER_MANAGER_NUM_THREADS)
+                        .enable_all()
+                        .build()
+                        .unwrap();
+
+                    runtime.block_on(manager_executor.execution_loop()).err().unwrap()
+                })
+                .map_err(err_str!(ExternalPriceReporterError::ManagerSetup))
+        }?;
+
+        self.manager_executor_handle = Some(manager_executor_handle);
+        Ok(())
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -137,7 +137,7 @@ impl HandshakeExecutor {
         for (base, quote) in DEFAULT_PAIRS.iter().cloned() {
             let (sender, receiver) = oneshot::channel();
             self.price_reporter_job_queue
-                .send(PriceReporterJob::PeekMedian {
+                .send(PriceReporterJob::PeekPrice {
                     base_token: base,
                     quote_token: quote,
                     channel: sender,

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -20,10 +20,10 @@ pub fn new_price_reporter_queue() -> (PriceReporterQueue, PriceReporterReceiver)
 #[derive(Debug)]
 pub enum PriceReporterJob {
     /// Start streaming prices for the given token pair.
-    /// 
+    ///
     /// If using the ExternalPriceReporter, this will subscribe to the pair's
     /// price stream on the external price reporter service.
-    /// 
+    ///
     /// If using the native PriceReporter:
     ///
     /// If the PriceReporter does not yet exist, spawn it and begin publication

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -36,8 +36,8 @@ pub enum PriceReporterJob {
         /// The quote Token
         quote_token: Token,
     },
-    /// Peek at the median price report
-    PeekMedian {
+    /// Peek at the price report
+    PeekPrice {
         /// The base Token
         base_token: Token,
         /// The quote Token

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -16,10 +16,15 @@ pub fn new_price_reporter_queue() -> (PriceReporterQueue, PriceReporterReceiver)
     unbounded_channel()
 }
 
-/// All possible jobs that the PriceReporter accepts.
+/// All possible jobs that the PriceReporter and ExternalPriceReporter accept.
 #[derive(Debug)]
 pub enum PriceReporterJob {
-    /// Create and start a new PriceReporter for a given token pair.
+    /// Start streaming prices for the given token pair.
+    /// 
+    /// If using the ExternalPriceReporter, this will subscribe to the pair's
+    /// price stream on the external price reporter service.
+    /// 
+    /// If using the native PriceReporter:
     ///
     /// If the PriceReporter does not yet exist, spawn it and begin publication
     /// to the global system bus. If the PriceReporter already exists and id

--- a/workers/price-reporter/src/lib.rs
+++ b/workers/price-reporter/src/lib.rs
@@ -1,7 +1,6 @@
 //! The price reporter module manages all external price feeds, including
 //! PriceReporter spin-up and tear-down, websocket connections to all exchanges
-//! (both centralized and decentralized), and aggregation of individual
-//! PriceReports into medians.
+//! (both centralized and decentralized), and computing PriceReports.
 
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
@@ -17,6 +16,3 @@ pub mod manager;
 pub mod mock;
 pub mod reporter;
 pub mod worker;
-
-/// The pubsub topic source name for median price reports
-pub const MEDIAN_SOURCE_NAME: &str = "median";

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -101,8 +101,8 @@ impl PriceReporterExecutor {
                 self.start_price_reporter(base_token, quote_token).await
             },
 
-            PriceReporterJob::PeekMedian { base_token, quote_token, channel } => {
-                self.peek_median(base_token, quote_token, channel).await
+            PriceReporterJob::PeekPrice { base_token, quote_token, channel } => {
+                self.peek_price(base_token, quote_token, channel).await
             },
         }
     }
@@ -139,15 +139,15 @@ impl PriceReporterExecutor {
         Ok(())
     }
 
-    /// Handler for PeekMedian job
-    async fn peek_median(
+    /// Handler for PeekPrice job
+    async fn peek_price(
         &mut self,
         base_token: Token,
         quote_token: Token,
         channel: TokioSender<PriceReporterState>,
     ) -> Result<(), PriceReporterError> {
         match self.get_price_reporter_or_create(base_token, quote_token).await {
-            Ok(reporter) => channel.send(reporter.peek_median()).unwrap(),
+            Ok(reporter) => channel.send(reporter.peek_price()).unwrap(),
             Err(PriceReporterError::UnsupportedPair(base, quote)) => {
                 channel.send(PriceReporterState::UnsupportedPair(base, quote)).unwrap()
             },

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -72,14 +72,14 @@ impl MockPriceReporter {
                 debug!("mock price reporter got `StartPriceReporter` job");
                 Ok(())
             },
-            PriceReporterJob::PeekMedian { base_token, quote_token, channel } => {
-                self.handle_peek_median(base_token, quote_token, channel)
+            PriceReporterJob::PeekPrice { base_token, quote_token, channel } => {
+                self.handle_peek_price(base_token, quote_token, channel)
             },
         }
     }
 
-    /// Handle a peek median job
-    fn handle_peek_median(
+    /// Handle a peek price job
+    fn handle_peek_price(
         &self,
         base_token: Token,
         quote_token: Token,
@@ -110,9 +110,9 @@ mod test {
 
     use crate::mock::{setup_mock_token_remap, MockPriceReporter};
 
-    /// Test the median price reporter from the mock
+    /// Test the price reporter from the mock
     #[tokio::test]
-    async fn test_peek_median() {
+    async fn test_peek_price() {
         const PRICE: f64 = 100.9;
         setup_mock_token_remap();
 
@@ -122,9 +122,9 @@ mod test {
         let reporter = MockPriceReporter::new(PRICE, price_recv);
         reporter.run();
 
-        // Request a median price
+        // Request a price
         let (resp_send, resp_recv) = channel();
-        let job = PriceReporterJob::PeekMedian {
+        let job = PriceReporterJob::PeekPrice {
             base_token: Token::from_ticker("WETH"),
             quote_token: Token::from_ticker("USDC"),
             channel: resp_send,

--- a/workers/price-reporter/src/worker.rs
+++ b/workers/price-reporter/src/worker.rs
@@ -93,6 +93,7 @@ impl Worker for PriceReporter {
 
     fn start(&mut self) -> Result<(), Self::Error> {
         // Spawn a tokio thread pool to run the manager in
+        // NOTE(@akirillo): Do we need this?
         let tokio_runtime = TokioBuilder::new_multi_thread()
             .worker_threads(PRICE_REPORTER_MANAGER_NUM_THREADS)
             .enable_io()


### PR DESCRIPTION
This PR adds the necessary scaffolding for a separate worker responsible for driving the connection to the external price reporter service. This worker is spawned instead of the native price reporter worker if the associated config option is set. It will be sharing some types/functionality (e.g. in this PR, the `PriceReporterJob`) as appropriate with the native price reporter.

I will fill in the implementation of the external price reporter worker stemming from its execution loop in the following PR.