### PR TITLE
arbitrum-client, util: Lookup protocol fee and key from contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -111,10 +111,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
 dependencies = [
  "dunce",
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "api-server"
@@ -241,7 +241,7 @@ dependencies = [
  "tracing",
  "tungstenite 0.18.0",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "common",
  "constants",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "ark-bls12-377"
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "ark-mpc"
 version = "0.1.2"
-source = "git+https://github.com/renegade-fi/ark-mpc#cc650a59b1f882b55153a92b4db4b1e34b8f1b38"
+source = "git+https://github.com/renegade-fi/ark-mpc#316750a99cce76e2b83243cd62f4d671a90412eb"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -725,13 +725,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -792,7 +792,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -940,7 +940,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -966,9 +966,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -1091,9 +1091,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.8",
  "tinyvec",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bus"
@@ -1130,9 +1130,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -1225,10 +1225,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1291,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1394,7 +1395,7 @@ dependencies = [
  "bitvec 1.0.1",
  "circuit-macros",
  "circuit-types",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "constants",
  "criterion",
@@ -1451,19 +1452,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.0",
+ "clap_derive 4.5.3",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1477,7 +1478,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1486,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1523,7 +1524,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
 dependencies = [
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "coins-core",
  "digest 0.10.7",
  "hmac",
@@ -1557,7 +1558,7 @@ checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
  "base64 0.21.7",
  "bech32",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "digest 0.10.7",
  "generic-array 0.14.7",
  "hex 0.4.3",
@@ -1623,7 +1624,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -1643,7 +1644,7 @@ dependencies = [
  "base64 0.13.1",
  "bimap",
  "circuit-types",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "common",
  "ed25519-dalek 1.0.1",
@@ -1662,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbd12d49ab0eaf8193ba9175e45f56bbc2e4b27d57b8cfe62aa47942a46b9a9"
+checksum = "5ba00838774b4ab0233e355d26710fbfc8327a05c017f6dc4873f876d1f79f78"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1704,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "contracts-common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts.git#fe444929a6a594347f17cc9ecedeb16f740ea3e9"
+source = "git+https://github.com/renegade-fi/renegade-contracts.git#99de3d16c9e60fe565c45a54ce02e9e8d78e71a7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1790,7 +1791,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.1",
+ "clap 4.5.3",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1903,7 +1904,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -2020,7 +2021,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2044,7 +2045,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2055,7 +2056,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2222,7 +2223,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2388,9 +2389,9 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enr"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2410,7 +2411,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2551,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7cd562832e2ff584fa844cd2f6e5d4f35bbe11b28c7c9b8df957b2e1d0c701"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2567,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35dc9a249c066d17e8947ff52a4116406163cf92c7f0763cb8c001760b26403f"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2579,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43304317c7f776876e47f2f637859f6d0701c1ec7930a150f169d5fbe7d76f5a"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -2598,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f96502317bf34f6d71a3e3d270defaa9485d754d789e15a8e04a84161c95eb"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2615,16 +2616,16 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.52",
- "toml 0.8.10",
+ "syn 2.0.53",
+ "toml 0.8.12",
  "walkdir",
 ]
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452ff6b0a64507ce8d67ffd48b1da3b42f03680dcf5382244e9c93822cbbf5de"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2633,14 +2634,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "ethers-core"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2659,7 +2660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.52",
+ "syn 2.0.53",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2668,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d45b981f5fa769e1d0343ebc2a44cfa88c9bc312eb681b676318b40cef6fb1"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -2684,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145211f34342487ef83a597c1e69f0d3e01512217a7c72cc8a25931854c7dca0"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2711,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6b15393996e3b8a78ef1332d6483c11d839042c17be58decc92fa8b1c3508a"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2748,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b125a103b56aef008af5d5fb48191984aa326b50bfd2557d231dc499833de3"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2767,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -2832,7 +2833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -3033,9 +3034,9 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3059,7 +3060,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3212,7 +3213,7 @@ dependencies = [
  "raft",
  "serde",
  "serde_json",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -3262,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -3321,7 +3322,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "common",
  "constants",
@@ -3350,7 +3351,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -3361,7 +3362,7 @@ dependencies = [
  "ark-mpc",
  "base64 0.13.1",
  "circuit-types",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "common",
  "config",
@@ -3379,7 +3380,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -3408,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e57fa0ae458eb99874f54c09f4f9174f8b45fb87e854536a4e608696247f0c23"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -3468,6 +3469,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3545,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -3799,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
  "serde",
 ]
 
@@ -3955,14 +3962,23 @@ dependencies = [
  "libp2p",
  "libp2p-core",
  "tokio",
- "uuid 1.7.0",
+ "uuid 1.8.0",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4076,7 +4092,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
 ]
 
 [[package]]
@@ -4102,9 +4118,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.4",
@@ -4122,7 +4138,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f0bee397dc9a7003e7bd34fffc1dc2d4c4fdc96530a0c439a5f98c9402bc7bf"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "derive_more",
  "indexmap 1.9.3",
@@ -4426,7 +4442,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "quote",
  "syn 1.0.109",
 ]
@@ -4472,7 +4488,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -4526,7 +4542,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
 ]
 
 [[package]]
@@ -4622,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -4660,14 +4676,14 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece71ab046dcf45604e573329966ec1db5ff4b81cfa170a924ff4c959ab5451a"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
  "indexmap 2.2.5",
  "metrics",
  "num_cpus",
@@ -5007,14 +5023,14 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
 name = "new_debug_unreachable"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nibble_vec"
@@ -5142,7 +5158,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5218,7 +5234,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5235,7 +5251,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5665,7 +5681,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5688,22 +5704,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5845,7 +5861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5961,9 +5977,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5988,7 +6004,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6017,7 +6033,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -6332,7 +6348,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -6422,7 +6438,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -6437,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6523,9 +6539,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -6674,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b1d9521f889713d1221270fdd63370feca7e5c71a18745343402fa86e4f04f"
+checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6753,7 +6769,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6879,9 +6895,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
+checksum = "2ef2175c2907e7c8bc0a9c3f86aeb5ec1f3b275300ad58a44d0c3ae379a5e52e"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -6891,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
+checksum = "634d9b8eb8fd61c5cdd3390d9b2132300a7e7618955b98b8416f118c1b4e144f"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -7058,7 +7074,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7095,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -7113,14 +7129,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7414,7 +7430,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7536,7 +7552,7 @@ dependencies = [
  "tui",
  "tui-logger",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -7585,24 +7601,24 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7644,9 +7660,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7662,7 +7678,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7764,7 +7780,7 @@ dependencies = [
  "async-trait",
  "circuit-types",
  "circuits",
- "clap 4.5.1",
+ "clap 4.5.3",
  "colored",
  "common",
  "constants",
@@ -7793,7 +7809,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.7.0",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -7865,22 +7881,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7995,7 +8011,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8020,9 +8036,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8098,14 +8114,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -8141,9 +8157,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -8232,7 +8248,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8634,9 +8650,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
@@ -8708,9 +8724,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "serde",
@@ -8720,24 +8736,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8747,9 +8763,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8757,22 +8773,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-timer"
@@ -8791,9 +8807,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9249,7 +9265,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -9269,7 +9285,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -12,6 +12,8 @@ abigen!(
     r#"[
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
         function getRoot() external view returns (uint256)
+        function getFee() external view returns (uint256)
+        function getPubkey() external view returns (uint256[2])
         function rootInHistory(uint256 memory root) external view returns (bool)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
@@ -36,6 +38,8 @@ abigen!(
     r#"[
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
         function getRoot() external view returns (uint256)
+        function getFee() external view returns (uint256)
+        function getPubkey() external view returns (uint256[2])
         function rootInHistory(uint256 memory root) external view returns (bool)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external

--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -7,7 +7,7 @@ use std::ops::{Add, Mul, Neg, Sub};
 use ark_ff::{BigInteger, Field, PrimeField};
 use bigdecimal::{BigDecimal, ToPrimitive};
 use circuit_macros::circuit_type;
-use constants::{AuthenticatedScalar, Scalar, ScalarField, PROTOCOL_FEE};
+use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use lazy_static::lazy_static;
 use mpc_relation::{errors::CircuitError, traits::Circuit, Variable};
 use num_bigint::BigUint;
@@ -39,9 +39,6 @@ lazy_static! {
     /// Compute the constant 2^-M (mod p), so that we may conveniently reduce after
     /// multiplications
     pub static ref TWO_TO_NEG_M: ScalarField = TWO_TO_M_SCALAR.inverse().unwrap();
-
-    /// A fixed point representation of the global protocol fee
-    pub static ref PROTOCOL_FEE_FP: FixedPoint = FixedPoint::from_f64_round_down(PROTOCOL_FEE);
 }
 
 // -----------
@@ -86,6 +83,11 @@ impl FixedPoint {
         } else {
             *self
         }
+    }
+
+    /// Construct a fixed point value from its `Scalar` representation
+    pub fn from_repr(repr: Scalar) -> Self {
+        Self { repr }
     }
 
     /// Create a new fixed point representation of the given u64

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test_helpers = ["dep:tracing-subscriber", "dep:ctor", "dep:util"]
+test_helpers = ["dep:tracing-subscriber", "dep:ctor", "util/mocks"]
 large_benchmarks = []
 large_tests = []
 stats = ["ark-mpc/stats"]
@@ -82,7 +82,7 @@ circuit-macros = { path = "../circuit-macros" }
 circuit-types = { path = "../circuit-types" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
-util = { path = "../util", optional = true }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 bitvec = "1.0"
@@ -113,4 +113,4 @@ rand = "0.8"
 serde_json = "1.0"
 test-helpers = { path = "../test-helpers" }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
-util = { path = "../util" }
+util = { path = "../util", feaures = ["mocks"] }

--- a/circuits/integration/mpc_circuits/match_settle.rs
+++ b/circuits/integration/mpc_circuits/match_settle.rs
@@ -4,7 +4,7 @@ use ark_mpc::PARTY0;
 use circuit_types::Amount;
 use circuit_types::{
     balance::Balance,
-    fixed_point::{FixedPoint, PROTOCOL_FEE_FP},
+    fixed_point::FixedPoint,
     order::OrderSide,
     r#match::OrderSettlementIndices,
     traits::{BaseType, MpcBaseType, MpcType, MultiProverCircuit, MultiproverCircuitBaseType},
@@ -28,6 +28,7 @@ use mpc_relation::{proof_linking::LinkableCircuit, traits::Circuit};
 use rand::{thread_rng, RngCore};
 use renegade_crypto::fields::scalar_to_u128;
 use test_helpers::{assert_true_result, integration_test_async};
+use util::arbitrum::get_protocol_fee;
 use util::matching_engine::compute_max_amount;
 
 use crate::{types::create_wallet_shares, IntegrationTestArgs};
@@ -184,7 +185,7 @@ fn run_match_settle_with_amounts(
             party1_indices: ind1.allocate(PARTY0, fabric),
             party0_modified_shares,
             party1_modified_shares,
-            protocol_fee: (*PROTOCOL_FEE_FP).allocate(PARTY0, fabric),
+            protocol_fee: get_protocol_fee().allocate(PARTY0, fabric),
         },
         SizedValidMatchSettleWitness {
             order0,

--- a/circuits/src/mpc_circuits/settle.rs
+++ b/circuits/src/mpc_circuits/settle.rs
@@ -1,12 +1,13 @@
 //! Settles a match into secret shared wallets
 
 use circuit_types::{
-    fixed_point::{AuthenticatedFixedPoint, PROTOCOL_FEE_FP},
+    fixed_point::AuthenticatedFixedPoint,
     r#match::{AuthenticatedFeeTake, AuthenticatedMatchResult, OrderSettlementIndices},
     wallet::AuthenticatedWalletShare,
     Fabric,
 };
 use constants::AuthenticatedScalar;
+use util::arbitrum::get_protocol_fee;
 
 use crate::mpc_gadgets::{comparators::cond_select_vec, fixed_point::FixedPointMpcGadget};
 
@@ -98,7 +99,7 @@ fn compute_settlement_fees(
     let party1_relayer_fee = FixedPointMpcGadget::as_integer(&party1_relayer_fee_fp, fabric);
 
     // Protocol fees
-    let protocol_fee = *PROTOCOL_FEE_FP;
+    let protocol_fee = get_protocol_fee();
     let party0_protocol_fee_fp = protocol_fee * party0_buy_amount;
     let party0_protocol_fee = FixedPointMpcGadget::as_integer(&party0_protocol_fee_fp, fabric);
     let party1_protocol_fee_fp = protocol_fee * party1_buy_amount;

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -244,13 +244,15 @@ where
 pub mod test_helpers {
     use circuit_types::{
         balance::Balance,
-        fixed_point::PROTOCOL_FEE_FP,
         order::{Order, OrderSide},
         r#match::{MatchResult, OrderSettlementIndices},
     };
     use constants::Scalar;
     use rand::{distributions::uniform::SampleRange, thread_rng, RngCore};
-    use util::matching_engine::{apply_match_to_shares, compute_fee_obligation};
+    use util::{
+        arbitrum::get_protocol_fee,
+        matching_engine::{apply_match_to_shares, compute_fee_obligation},
+    };
 
     use crate::{
         test_helpers::random_orders_and_match,
@@ -330,7 +332,7 @@ pub mod test_helpers {
                 party1_indices,
                 party0_modified_shares,
                 party1_modified_shares,
-                protocol_fee: *PROTOCOL_FEE_FP,
+                protocol_fee: get_protocol_fee(),
             },
         )
     }

--- a/common/src/types/wallet/keychain.rs
+++ b/common/src/types/wallet/keychain.rs
@@ -1,8 +1,12 @@
 //! Keychain helpers for the wallet
 
 use constants::Scalar;
-use ethers::{signers::Wallet as EthersWallet, types::Signature, utils::keccak256};
-use k256::ecdsa::SigningKey;
+use ethers::{
+    core::k256::ecdsa::SigningKey as EthersSigningKey,
+    types::{Signature, U256},
+    utils::keccak256,
+};
+use util::raw_err_str;
 
 use super::Wallet;
 
@@ -11,17 +15,26 @@ const ERR_NO_SK_ROOT: &str = "wallet does not have an `sk_root` value";
 
 impl Wallet {
     /// Sign a wallet transition commitment with the wallet's keychain
+    ///
+    /// The contracts expect a recoverable signature with the recover ID set to
+    /// 0/1; we use ethers `sign_prehash_recoverable` to generate this signature
     pub fn sign_commitment(&self, commitment: Scalar) -> Result<Signature, String> {
         // Fetch the `sk_root` key
         let root_key = self.key_chain.secret_keys.sk_root.as_ref().ok_or(ERR_NO_SK_ROOT)?;
-        let key = SigningKey::try_from(root_key)?;
-        let wallet = EthersWallet::from(key);
+        let key = EthersSigningKey::try_from(root_key)?;
 
+        // Hash the message and sign it
         let comm_bytes = commitment.to_biguint().to_bytes_be();
         let digest = keccak256(comm_bytes);
+        let (sig, recovery_id) = key
+            .sign_prehash_recoverable(&digest)
+            .map_err(raw_err_str!("failed to sign commitment: {}"))?;
 
-        // Sign the commitment
-        wallet.sign_hash(digest.into()).map_err(|e| e.to_string())
+        Ok(Signature {
+            r: U256::from_big_endian(&sig.r().to_bytes()),
+            s: U256::from_big_endian(&sig.s().to_bytes()),
+            v: recovery_id.to_byte() as u64,
+        })
     }
 }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -64,7 +64,7 @@ struct Cli {
     #[clap(long, value_parser, default_value = "testnet")]
     pub chain_id: Chain,
     /// The address of the darkpool contract, defaults to the internal testnet deployment
-    #[clap(long, value_parser, default_value = "0xe1080224b632a93951a7cfa33eeea9fd81558b5e")]
+    #[clap(long, value_parser, default_value = "0x84bc75bc4fb943d5576545fb4724c5cab781a61e")]
     pub contract_address: String,
     /// The path to the file containing deployments info for the darkpool contract
     #[clap(long, value_parser)]

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -36,16 +36,6 @@ pub const MERKLE_HEIGHT: usize = 32;
 /// The number of historical roots the contract stores as being valid
 pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 
-/// The fee that the protocol takes on each trade
-pub const PROTOCOL_FEE: f64 = 0.0006; // 6 bps
-
-/// The encryption key used by the protocol to collect fees
-///
-/// TODO: This is a dummy key, replace with real encryption key when it is
-/// created
-pub const PROTOCOL_ENCRYPTION_KEY: &str =
-    "0x238605ef44e283ca92d1e2a373a8bb7885bddeff0be47d39d6016f270a9b900c79db2b3fe50110a1f9bcec1e924de82042be3351a0fb625d3f02042c28c3991e";
-
 // ------------------------------------
 // | System Specific Type Definitions |
 // ------------------------------------

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -185,7 +185,14 @@ async fn main() -> Result<(), CoordinatorError> {
     // snapshots, state sync, etc
     let chain_id =
         arbitrum_client.chain_id().await.map_err(err_str!(CoordinatorError::Arbitrum))?;
-    node_setup(&args.arbitrum_private_key, chain_id, task_sender.clone(), &global_state).await?;
+    node_setup(
+        &args.arbitrum_private_key,
+        chain_id,
+        task_sender.clone(),
+        &arbitrum_client,
+        &global_state,
+    )
+    .await?;
 
     // --- Workers Setup Phase --- //
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,6 +3,9 @@ name = "util"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+mocks = []
+
 [dependencies]
 # === Arithmetic === #
 ark-ec = "0.4"
@@ -26,6 +29,7 @@ renegade-crypto = { path = "../renegade-crypto" }
 eyre = { workspace = true }
 hex = "0.4"
 json = "0.12"
+rand = "0.8"
 
 # === Logs / Traces === #
 chrono = "0.4"
@@ -33,11 +37,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-serde = "0.1"
-tracing-subscriber = { vesion = "0.3", features = ["env-filter", "json"]}
+tracing-subscriber = { vesion = "0.3", features = ["env-filter", "json"] }
 tracing-opentelemetry = "0.22"
 opentelemetry_sdk = { version = "0.21", features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = "0.14"
-opentelemetry = { version = "0.21", default-features = false, features = ["trace"]}
+opentelemetry = { version = "0.21", default-features = false, features = [
+    "trace",
+] }
 opentelemetry-semantic-conventions = "0.13"
 opentelemetry-datadog = "0.9"
 
@@ -49,4 +55,3 @@ metrics-tracing-context = "0.15"
 
 [dev-dependencies]
 lazy_static = "1.4"
-rand = "0.8"

--- a/util/src/arbitrum.rs
+++ b/util/src/arbitrum.rs
@@ -54,8 +54,6 @@ pub fn get_protocol_fee() -> FixedPoint {
 ///
 /// Panics if the protocol encryption key has not been set
 pub fn get_protocol_pubkey() -> EncryptionKey {
-    let key = PROTOCOL_PUBKEY.get();
-
     // If the mocks feature is enabled we unwrap to a default
     #[cfg(feature = "mocks")]
     {
@@ -63,11 +61,11 @@ pub fn get_protocol_pubkey() -> EncryptionKey {
         use rand::thread_rng;
 
         let mut rng = thread_rng();
-        *key.unwrap_or(&DecryptionKey::random(&mut rng).public_key())
+        *PROTOCOL_PUBKEY.get_or_init(|| DecryptionKey::random(&mut rng).public_key())
     }
 
     #[cfg(not(feature = "mocks"))]
     {
-        *key.expect("Protocol pubkey has not been set")
+        *PROTOCOL_PUBKEY.get().expect("Protocol pubkey has not been set")
     }
 }

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -2,7 +2,7 @@
 
 use circuit_types::{
     balance::Balance,
-    fixed_point::{FixedPoint, PROTOCOL_FEE_FP},
+    fixed_point::FixedPoint,
     order::{Order, OrderSide},
     r#match::{FeeTake, MatchResult, OrderSettlementIndices},
     wallet::WalletShare,
@@ -10,6 +10,8 @@ use circuit_types::{
 };
 use constants::Scalar;
 use renegade_crypto::fields::scalar_to_u128;
+
+use crate::arbitrum::get_protocol_fee;
 
 // ------------
 // | Matching |
@@ -165,7 +167,7 @@ pub fn compute_fee_obligation(
     let receive_amount = Scalar::from(receive_amount);
 
     let relayer_take = (relayer_fee * receive_amount).floor();
-    let protocol_take = (*PROTOCOL_FEE_FP * receive_amount).floor();
+    let protocol_take = (get_protocol_fee() * receive_amount).floor();
 
     FeeTake {
         relayer_fee: scalar_to_u128(&relayer_take),

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use ark_mpc::{network::QuicTwoPartyNet, MpcFabric, PARTY0, PARTY1};
 use circuit_types::{
     balance::Balance,
-    fixed_point::{FixedPoint, PROTOCOL_FEE_FP},
+    fixed_point::FixedPoint,
     order::Order,
     r#match::{MatchResult, OrderSettlementIndices},
     traits::{MpcBaseType, MpcType},
@@ -35,7 +35,7 @@ use constants::SystemCurveGroup;
 use crossbeam::channel::{bounded, Receiver};
 use test_helpers::mpc_network::mocks::PartyIDBeaverSource;
 use tracing::info;
-use util::matching_engine::compute_max_amount;
+use util::{arbitrum::get_protocol_fee, matching_engine::compute_max_amount};
 use uuid::Uuid;
 
 use crate::error::HandshakeManagerError;
@@ -214,7 +214,7 @@ impl HandshakeExecutor {
         let amount1 = my_amount.allocate(PARTY1, fabric);
         let party1_public_shares = my_public_shares.allocate(PARTY1, fabric);
 
-        let protocol_fee = (*PROTOCOL_FEE_FP).allocate(PARTY0, fabric);
+        let protocol_fee = get_protocol_fee().allocate(PARTY0, fabric);
 
         // Match the orders
         //

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-integration = ["state/mocks", "common/mocks", "arbitrum-client/integration"]
+integration = [
+    "state/mocks",
+    "common/mocks",
+    "arbitrum-client/integration",
+    "util/mocks",
+]
 
 [[test]]
 name = "integration"

--- a/workers/task-driver/integration/tests/pay_offline_fee.rs
+++ b/workers/task-driver/integration/tests/pay_offline_fee.rs
@@ -9,7 +9,9 @@ use renegade_crypto::fields::scalar_to_biguint;
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{
-    helpers::{await_task, lookup_wallet_and_check_result, setup_initial_wallet},
+    helpers::{
+        await_task, lookup_wallet_and_check_result, setup_initial_wallet, setup_relayer_wallet,
+    },
     IntegrationTestArgs,
 };
 
@@ -36,6 +38,7 @@ fn random_balance_with_fees() -> Balance {
 async fn test_pay_offline_fees(test_args: IntegrationTestArgs) -> Result<()> {
     let mut rng = thread_rng();
     let state = &test_args.state;
+    setup_relayer_wallet(&test_args).await?;
 
     // Create a wallet in the darkpool with a non-zero fee
     let mut wallet = mock_empty_wallet();

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use circuit_types::{
     balance::Balance,
-    fixed_point::{FixedPoint, PROTOCOL_FEE_FP},
+    fixed_point::FixedPoint,
     order::{Order, OrderSide},
     r#match::{MatchResult, OrderSettlementIndices},
     Amount, SizedWallet,
@@ -35,6 +35,7 @@ use state::State;
 use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
 use tokio::sync::oneshot::channel;
 use util::{
+    arbitrum::get_protocol_fee,
     hex::biguint_from_hex_string,
     matching_engine::{
         compute_fee_obligation, compute_max_amount, match_orders, settle_match_into_wallets,
@@ -257,7 +258,7 @@ async fn dummy_match_bundle(
                 party1_indices,
                 party0_modified_shares,
                 party1_modified_shares,
-                protocol_fee: *PROTOCOL_FEE_FP,
+                protocol_fee: get_protocol_fee(),
             },
         },
         response_channel: send,

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -23,7 +23,7 @@ use num_bigint::BigUint;
 use serde::Serialize;
 use state::{error::StateError, State};
 use tracing::instrument;
-use util::{arbitrum::get_protocol_encryption_key, err_str};
+use util::{arbitrum::get_protocol_pubkey, err_str};
 
 use crate::{
     driver::StateWrapper,
@@ -308,7 +308,7 @@ impl PayOfflineFeeTask {
             .get_balance_mut(mint)
             .ok_or_else(|| PayOfflineFeeTaskError::State(ERR_BALANCE_MISSING.to_string()))?;
         let note = if is_protocol {
-            balance.create_protocol_note(get_protocol_encryption_key())
+            balance.create_protocol_note(get_protocol_pubkey())
         } else {
             balance.create_relayer_note(old_wallet.managing_cluster)
         };
@@ -338,7 +338,7 @@ impl PayOfflineFeeTask {
         let send_index = wallet.get_balance_index(&self.mint).unwrap();
 
         // Encrypt the note
-        let protocol_key = get_protocol_encryption_key();
+        let protocol_key = get_protocol_pubkey();
         let key = if self.is_protocol_fee { protocol_key } else { wallet.managing_cluster };
         let note_commitment = note.commitment();
 

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -12,7 +12,6 @@ use crate::{driver::StateWrapper, helpers::find_merkle_path};
 use arbitrum_client::client::ArbitrumClient;
 use ark_mpc::{PARTY0, PARTY1};
 use async_trait::async_trait;
-use circuit_types::fixed_point::PROTOCOL_FEE_FP;
 use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
 use circuits::zk_circuits::proof_linking::link_sized_commitments_match_settle;
 use circuits::zk_circuits::valid_match_settle::{
@@ -34,6 +33,7 @@ use state::error::StateError;
 use state::State;
 use tokio::task::JoinHandle as TokioJoinHandle;
 use tracing::instrument;
+use util::arbitrum::get_protocol_fee;
 use util::matching_engine::{
     compute_fee_obligation, compute_max_amount, settle_match_into_wallets,
 };
@@ -475,7 +475,7 @@ impl SettleMatchInternalTask {
             party0_modified_shares,
             party1_indices,
             party1_modified_shares,
-            protocol_fee: *PROTOCOL_FEE_FP,
+            protocol_fee: get_protocol_fee(),
         };
 
         (witness, statement)


### PR DESCRIPTION
### Purpose
This PR fetches the protocol's encryption key and take rate from the contract at startup and stores them in a `OnceCell`. To make testing simpler, if the `mocks` feature flag is enabled, the implementation of the `OnceCell` getter methods will fall back to a default.

### Testing
- Unit tests pass
- Ran a relayer, verified that it fetched the fee and encryption key