### PR TITLE
workers: price-reporter: reorganize price reporter modules for external executor

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -712,3 +712,13 @@ impl Token {
         amount as f64 / decimal_adjustment as f64
     }
 }
+
+// -----------
+// | HELPERS |
+// -----------
+
+/// Returns true if the given pair of Tokens is named, indicating that
+/// the pair should be supported on centralized exchanges.
+pub fn is_pair_named(base: &Token, quote: &Token) -> bool {
+    base.is_named() && quote.is_named()
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -44,6 +44,10 @@ struct Cli {
     /// An auth config file to read from
     #[clap(long, value_parser)]
     pub config_file: Option<String>,
+    /// The price reporter from which to stream prices.
+    /// If unset, the relayer will connect to exchanges directly.
+    #[clap(long, value_parser, conflicts_with_all = &["coinbase_api_key", "coinbase_api_secret", "eth_websocket_addr"])]
+    pub price_reporter_url: Option<String>,
 
     // -----------------------------
     // | Application Level Configs |
@@ -198,6 +202,9 @@ pub struct RelayerConfig {
     /// The take rate of this relayer on a managed match, i.e. the amount of the
     /// received asset that the relayer takes as a fee
     pub match_take_rate: FixedPoint,
+    /// The price reporter from which to stream prices.
+    /// If unset, the relayer will connect to exchanges directly.
+    pub price_reporter_url: Option<String>,
 
     // -----------------------
     // | Environment Configs |
@@ -299,6 +306,7 @@ impl Clone for RelayerConfig {
     fn clone(&self) -> Self {
         Self {
             match_take_rate: self.match_take_rate,
+            price_reporter_url: self.price_reporter_url.clone(),
             chain_id: self.chain_id,
             contract_address: self.contract_address.clone(),
             bootstrap_servers: self.bootstrap_servers.clone(),
@@ -415,6 +423,7 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
 
     let mut config = RelayerConfig {
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
+        price_reporter_url: cli_args.price_reporter_url,
         chain_id: cli_args.chain_id,
         contract_address: cli_args.contract_address,
         bootstrap_servers: parsed_bootstrap_addrs,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -270,6 +270,7 @@ async fn main() -> Result<(), CoordinatorError> {
             coinbase_api_secret: args.coinbase_api_secret,
             eth_websocket_addr: args.eth_websocket_addr,
         },
+        price_reporter_url: args.price_reporter_url,
         disabled: args.disable_price_reporter,
         disabled_exchanges: args.disabled_exchanges,
     })

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -402,6 +402,7 @@ impl MockNodeController {
                 coinbase_api_secret: config.coinbase_api_secret.clone(),
                 eth_websocket_addr: config.eth_websocket_addr.clone(),
             },
+            price_reporter_url: config.price_reporter_url.clone(),
             disabled: config.disable_price_reporter,
             disabled_exchanges: config.disabled_exchanges.clone(),
             job_receiver: default_option(job_receiver),

--- a/workers/api-server/src/websocket/price_report.rs
+++ b/workers/api-server/src/websocket/price_report.rs
@@ -87,7 +87,7 @@ impl WebsocketTopicHandler for PriceReporterHandler {
 
         // Start a price reporting stream in the manager
         self.price_reporter_work_queue
-            .send(PriceReporterJob::StartPriceReporter {
+            .send(PriceReporterJob::StreamPrice {
                 base_token: base.clone(),
                 quote_token: quote.clone(),
             })

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -119,7 +119,7 @@ pub fn init_price_streams(
 ) -> Result<(), HandshakeManagerError> {
     for (base, quote) in DEFAULT_PAIRS.iter() {
         price_reporter_job_queue
-            .send(PriceReporterJob::StartPriceReporter {
+            .send(PriceReporterJob::StreamPrice {
                 base_token: base.clone(),
                 quote_token: quote.clone(),
             })

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -19,7 +19,12 @@ pub fn new_price_reporter_queue() -> (PriceReporterQueue, PriceReporterReceiver)
 /// All possible jobs that the PriceReporter accepts.
 #[derive(Debug)]
 pub enum PriceReporterJob {
-    /// Create and start a new PriceReporter for a given token pair.
+    /// Stream prices for the given token pair.
+    ///
+    /// If using the external executor, this will send a subscription request
+    /// for the pair across all exchanges.
+    ///
+    /// If using the native executor, this will create and start a new PriceReporter for the pair.
     ///
     /// If the PriceReporter does not yet exist, spawn it and begin publication
     /// to the global system bus. If the PriceReporter already exists and id
@@ -30,7 +35,7 @@ pub enum PriceReporterJob {
     /// subscribers on the system bus stop listening. Cleanup is done via
     /// DropListenerID, and callees are responsible for dropping all
     /// listener IDs.
-    StartPriceReporter {
+    StreamPrice {
         /// The base Token
         base_token: Token,
         /// The quote Token

--- a/workers/price-reporter/src/errors.rs
+++ b/workers/price-reporter/src/errors.rs
@@ -46,6 +46,8 @@ pub enum PriceReporterError {
     PriceReporterNotCreated(String),
     /// Unsupported pair for the reporter
     UnsupportedPair(Token, Token),
+    /// Error thrown by an individual exchange connection
+    ExchangeConnectionError(ExchangeConnectionError),
 }
 
 impl Error for PriceReporterError {}

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -38,7 +38,7 @@ const CLOUDFLARE_RESET_MESSAGE: &str = "CloudFlare WebSocket proxy restarting";
 // -----------
 
 /// Build a websocket connection to the given endpoint
-pub(super) async fn ws_connect(
+pub(crate) async fn ws_connect(
     url: Url,
 ) -> Result<
     (

--- a/workers/price-reporter/src/manager/native_executor.rs
+++ b/workers/price-reporter/src/manager/native_executor.rs
@@ -1,0 +1,188 @@
+//! Defines the PriceReporterExecutor, a handler that is responsible
+//! for executing individual PriceReporterJobs. This is used when the
+//! relayer opts for natively streaming price data from exchanges.
+
+use common::default_wrapper::{DefaultOption, DefaultWrapper};
+use common::types::exchange::PriceReporterState;
+use common::types::token::Token;
+use common::types::CancelChannel;
+use common::{new_async_shared, AsyncShared};
+use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
+use std::collections::HashMap;
+use tokio::sync::oneshot::Sender as TokioSender;
+use tracing::{error, info, info_span, warn, Instrument};
+use util::err_str;
+
+use crate::{
+    errors::{ExchangeConnectionError, PriceReporterError},
+    reporter::Reporter,
+    worker::PriceReporterConfig,
+};
+
+/// The actual executor that handles incoming jobs, to create and destroy
+/// PriceReporters, and peek at PriceReports.
+#[derive(Clone)]
+pub struct PriceReporterExecutor {
+    /// The map between base/quote token pairs and the instantiated
+    /// PriceReporter
+    active_price_reporters: AsyncShared<HashMap<(Token, Token), Reporter>>,
+    /// The manager config
+    config: PriceReporterConfig,
+    /// The channel along which jobs are passed to the price reporter
+    job_receiver: DefaultOption<PriceReporterReceiver>,
+    /// The channel on which the coordinator may cancel execution
+    cancel_channel: DefaultOption<CancelChannel>,
+}
+
+impl PriceReporterExecutor {
+    /// Creates the executor for the PriceReporter worker.
+    pub(crate) fn new(
+        job_receiver: PriceReporterReceiver,
+        config: PriceReporterConfig,
+        cancel_channel: CancelChannel,
+    ) -> Self {
+        Self {
+            job_receiver: DefaultWrapper::new(Some(job_receiver)),
+            cancel_channel: DefaultWrapper::new(Some(cancel_channel)),
+            active_price_reporters: new_async_shared(HashMap::new()),
+            config,
+        }
+    }
+
+    /// The execution loop for the price reporter
+    pub(crate) async fn execution_loop(mut self) -> Result<(), PriceReporterError> {
+        let mut job_receiver = self.job_receiver.take().unwrap();
+        let mut cancel_channel = self.cancel_channel.take().unwrap();
+
+        loop {
+            tokio::select! {
+                // Dequeue the next job from elsewhere in the local node
+                Some(job) = job_receiver.recv() => {
+                    if self.config.disabled {
+                        warn!("PriceReporter received job while disabled, ignoring...");
+                        continue;
+                    }
+
+                    tokio::spawn({
+                        let mut self_clone = self.clone();
+                        async move {
+                            if let Err(e) = self_clone.handle_job(job).await {
+                                error!("Error in PriceReporter execution loop: {e}");
+                            }
+                        }.instrument(info_span!("handle_job"))
+                    });
+                },
+
+                // Await cancellation by the coordinator
+                _ = cancel_channel.changed() => {
+                    info!("PriceReporter cancelled, shutting down...");
+                    return Err(PriceReporterError::Cancelled("received cancel signal".to_string()));
+                }
+            }
+        }
+    }
+
+    /// Handles a job for the PriceReporter worker.
+    pub(super) async fn handle_job(
+        &mut self,
+        job: PriceReporterJob,
+    ) -> Result<(), PriceReporterError> {
+        match job {
+            PriceReporterJob::StreamPrice { base_token, quote_token } => {
+                self.start_price_reporter(base_token, quote_token).await
+            },
+
+            PriceReporterJob::PeekPrice { base_token, quote_token, channel } => {
+                self.peek_price(base_token, quote_token, channel).await
+            },
+        }
+    }
+
+    // ----------------
+    // | Job Handlers |
+    // ----------------
+
+    /// Handler for StartPriceReporter job
+    async fn start_price_reporter(
+        &mut self,
+        base_token: Token,
+        quote_token: Token,
+    ) -> Result<(), PriceReporterError> {
+        let mut locked_reporters = self.active_price_reporters.write().await;
+        if locked_reporters.contains_key(&(base_token.clone(), quote_token.clone())) {
+            return Ok(());
+        }
+
+        // Create the price reporter
+        let reporter =
+            match Reporter::new(base_token.clone(), quote_token.clone(), self.config.clone()) {
+                Ok(reporter) => reporter,
+                Err(ExchangeConnectionError::NoSupportedExchanges(base, quote)) => {
+                    return Err(PriceReporterError::UnsupportedPair(base, quote));
+                },
+                Err(e) => {
+                    return Err(e).map_err(err_str!(PriceReporterError::PriceReporterCreation))
+                },
+            };
+
+        locked_reporters.insert((base_token.clone(), quote_token.clone()), reporter);
+
+        Ok(())
+    }
+
+    /// Handler for PeekPrice job
+    async fn peek_price(
+        &mut self,
+        base_token: Token,
+        quote_token: Token,
+        channel: TokioSender<PriceReporterState>,
+    ) -> Result<(), PriceReporterError> {
+        match self.get_price_reporter_or_create(base_token, quote_token).await {
+            Ok(reporter) => channel.send(reporter.peek_price()).unwrap(),
+            Err(PriceReporterError::UnsupportedPair(base, quote)) => {
+                channel.send(PriceReporterState::UnsupportedPair(base, quote)).unwrap()
+            },
+            Err(e) => return Err(e),
+        };
+
+        Ok(())
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Internal helper function to get a (base_token, quote_token)
+    /// PriceReporter
+    async fn get_price_reporter(
+        &self,
+        base_token: Token,
+        quote_token: Token,
+    ) -> Result<Reporter, PriceReporterError> {
+        let locked_reporters = self.active_price_reporters.read().await;
+        locked_reporters.get(&(base_token.clone(), quote_token.clone())).cloned().ok_or_else(|| {
+            PriceReporterError::PriceReporterNotCreated(format!("{:?}", (base_token, quote_token)))
+        })
+    }
+
+    /// Internal helper function to get a (base_token, quote_token)
+    /// PriceReporter. If the PriceReporter does not already exist, first
+    /// creates it.
+    async fn get_price_reporter_or_create(
+        &mut self,
+        base_token: Token,
+        quote_token: Token,
+    ) -> Result<Reporter, PriceReporterError> {
+        let reporter_exists = {
+            self.active_price_reporters
+                .read()
+                .await
+                .contains_key(&(base_token.clone(), quote_token.clone()))
+        };
+
+        if !reporter_exists {
+            self.start_price_reporter(base_token.clone(), quote_token.clone()).await?;
+        }
+        self.get_price_reporter(base_token, quote_token).await
+    }
+}

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -68,7 +68,7 @@ impl MockPriceReporter {
     /// Handle a job
     fn handle_job(&self, job: PriceReporterJob) -> Result<(), PriceReporterError> {
         match job {
-            PriceReporterJob::StartPriceReporter { .. } => {
+            PriceReporterJob::StreamPrice { .. } => {
                 debug!("mock price reporter got `StartPriceReporter` job");
                 Ok(())
             },


### PR DESCRIPTION
This PR introduces some reorganization of the `manager` module in the price reporter worker ahead of the implementation of the `ExternalPriceReporterExecutor`, which will be used to manage the worker in the case that the relayer opts to connect to an external price reporting service.

This mostly consists of moving the existing `PriceReporterExecutor` into the `native_executor` module, while keeping some utilities which will be shared in the `manager` module.

The next PR will have the implementation of the `ExternalPriceReporterExecutor`.