### PR TITLE
workers: price-reporter: add external price reporter executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "tempfile",
  "toml 0.5.11",
  "tracing",
+ "url",
  "util",
 ]
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 toml = "0.5.9"
+url = "2.4"
 
 [dev-dependencies]
 tempfile = "3.9"

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
 };
 pub use token_remaps::setup_token_remaps;
 use toml::{value::Map, Value};
+use url::Url;
 use util::arbitrum::{parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY};
 
 /// The dummy message used for checking elliptic curve key pairs
@@ -204,7 +205,7 @@ pub struct RelayerConfig {
     pub match_take_rate: FixedPoint,
     /// The price reporter from which to stream prices.
     /// If unset, the relayer will connect to exchanges directly.
-    pub price_reporter_url: Option<String>,
+    pub price_reporter_url: Option<Url>,
 
     // -----------------------
     // | Environment Configs |
@@ -421,9 +422,14 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 
+    // Parse the price reporter URL, if ther is one
+    let price_reporter_url = cli_args
+        .price_reporter_url
+        .map(|url| Url::parse(&url).expect("Invalid price reporter URL"));
+
     let mut config = RelayerConfig {
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
-        price_reporter_url: cli_args.price_reporter_url,
+        price_reporter_url,
         chain_id: cli_args.chain_id,
         contract_address: cli_args.contract_address,
         bootstrap_servers: parsed_bootstrap_addrs,

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -16,6 +16,7 @@ use common::types::{
     token::Token,
     Price,
 };
+use itertools::Itertools;
 use statrs::statistics::{Data, Median};
 use util::get_current_time_seconds;
 
@@ -118,6 +119,23 @@ impl AtomicPriceStreamState {
 // -----------
 // | HELPERS |
 // -----------
+
+/// Returns the set of supported exchanges on the pair
+pub fn compute_supported_exchanges_for_pair(
+    base_token: &Token,
+    quote_token: &Token,
+    config: &PriceReporterConfig,
+) -> Vec<Exchange> {
+    // Compute the intersection of the supported exchanges for each of the assets
+    // in the pair, filtering for those not configured
+    let base_token_supported_exchanges = base_token.supported_exchanges();
+    let quote_token_supported_exchanges = quote_token.supported_exchanges();
+    base_token_supported_exchanges
+        .intersection(&quote_token_supported_exchanges)
+        .copied()
+        .filter(|exchange| config.exchange_configured(*exchange))
+        .collect_vec()
+}
 
 /// Computes the state of the price reporter for the given token pair,
 /// checking against the provided exchange prices.

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -21,7 +21,7 @@ use util::get_current_time_seconds;
 
 use crate::{errors::PriceReporterError, worker::PriceReporterConfig};
 
-// pub mod external_executor;
+pub mod external_executor;
 pub mod native_executor;
 
 // -------------

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -121,7 +121,7 @@ impl AtomicPriceStreamState {
 // -----------
 
 /// Returns the set of supported exchanges on the pair
-pub fn compute_supported_exchanges_for_pair(
+pub fn get_supported_exchanges(
     base_token: &Token,
     quote_token: &Token,
     config: &PriceReporterConfig,

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -1,0 +1,444 @@
+//! Defines the ExternalPriceReporterExecutor, a handler that is responsible for
+//! executing individual PriceReporterJobs. This is used when the relayer opts
+//! for streaming prices from an external price reporter service.
+
+use std::{collections::HashMap, str::FromStr, time::Duration};
+
+use common::{
+    default_wrapper::DefaultOption,
+    new_async_shared,
+    types::{
+        exchange::{Exchange, PriceReporterState, ALL_EXCHANGES},
+        token::{is_pair_named, Token},
+        CancelChannel, Price,
+    },
+    AsyncShared,
+};
+use external_api::{
+    bus_message::{price_report_topic_name, SystemBusMessage},
+    websocket::{SubscriptionResponse, WebsocketMessage},
+};
+use futures::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    net::TcpStream,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        oneshot::Sender as TokioSender,
+    },
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tracing::{error, info, info_span, warn, Instrument};
+use tungstenite::Message;
+use url::Url;
+use util::{err_str, get_current_time_seconds};
+
+use crate::{
+    errors::{ExchangeConnectionError, PriceReporterError},
+    exchange::connection::ws_connect,
+    manager::CONN_RETRY_DELAY_MS,
+    worker::PriceReporterConfig,
+};
+
+use super::{compute_price_reporter_state, AtomicPriceStreamState, PRICE_REPORT_INTERVAL_MS};
+
+/// A type alias for the shared state of the price streams
+type SubscriptionStates = AsyncShared<HashMap<(Token, Token), AtomicPriceStreamState>>;
+
+/// A type alias for the write end of the websocket connection
+type WsWriteStream = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+
+/// A type alias for the read end of the websocket connection
+type WsReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
+
+/// A message that is sent by the price reporter to the client indicating
+/// a price udpate for the given topic
+///
+/// Ported over from https://github.com/renegade-fi/renegade-price-reporter/blob/main/src/utils.rs
+#[derive(Serialize, Deserialize)]
+pub struct PriceMessage {
+    /// The topic for which the price update is being sent
+    pub topic: String,
+    /// The new price
+    pub price: Price,
+}
+
+/// The actual executor that handles incoming jobs, to subscribe to
+/// price streams, and peek at PriceReports.
+#[derive(Clone)]
+pub struct ExternalPriceReporterExecutor {
+    /// The map between (base, quote) pairs and the latest
+    /// timestamped prices for those pairs across the exchanges
+    subscription_states: SubscriptionStates,
+    /// The manager config
+    config: PriceReporterConfig,
+    /// The channel along which jobs are passed to the price reporter
+    job_receiver: DefaultOption<PriceReporterReceiver>,
+    /// The channel on which the coordinator may cancel execution
+    cancel_channel: DefaultOption<CancelChannel>,
+}
+
+impl ExternalPriceReporterExecutor {
+    /// Creates the executor for the PriceReporter worker.
+    pub(super) fn new(
+        job_receiver: PriceReporterReceiver,
+        config: PriceReporterConfig,
+        cancel_channel: CancelChannel,
+    ) -> Self {
+        Self {
+            subscription_states: new_async_shared(HashMap::new()),
+            config,
+            job_receiver: DefaultOption::new(Some(job_receiver)),
+            cancel_channel: DefaultOption::new(Some(cancel_channel)),
+        }
+    }
+
+    /// The execution loop for the price reporter
+    pub(super) async fn execution_loop(mut self) -> Result<(), PriceReporterError> {
+        let mut job_receiver = self.job_receiver.take().unwrap();
+        let mut cancel_channel = self.cancel_channel.take().unwrap();
+
+        // Spawn WS handler loop, which forwards reads/writes over channels
+        let (msg_out_tx, mut msg_in_rx) = self.spawn_ws_handler_loop();
+
+        loop {
+            tokio::select! {
+                // Process price update from external price reporter
+                Some(price_message) = msg_in_rx.recv() => {
+                    self.handle_price_update(price_message).await.map_err(PriceReporterError::ExchangeConnectionError)?;
+                }
+
+                // Dequeue the next job from elsewhere in the local node
+                Some(job) = job_receiver.recv() => {
+                    if self.config.disabled {
+                        warn!("ExternalPriceReporter received job while disabled, ignoring...");
+                        continue;
+                    }
+
+                    tokio::spawn({
+                        let mut self_clone = self.clone();
+                        let msg_out_tx = msg_out_tx.clone();
+                        async move {
+                            if let Err(e) = self_clone.handle_job(job, msg_out_tx).await {
+                                error!("Error in ExternalPriceReporter execution loop: {e}");
+                            }
+                        }.instrument(info_span!("handle_job"))
+                    });
+                },
+
+                // Await cancellation by the coordinator
+                _ = cancel_channel.changed() => {
+                    info!("ExternalPriceReporter cancelled, shutting down...");
+                    return Err(PriceReporterError::Cancelled("received cancel signal".to_string()));
+                }
+            }
+        }
+    }
+
+    /// Spawns the task responsible for handling the websocket connection
+    /// with the external price reporter
+    fn spawn_ws_handler_loop(
+        &self,
+    ) -> (UnboundedSender<WebsocketMessage>, UnboundedReceiver<PriceMessage>) {
+        let price_reporter_url: Url = self
+            .config
+            .price_reporter_url
+            .clone()
+            .unwrap()
+            .parse()
+            .expect("Invalid price reporter URL");
+
+        let (msg_out_tx, msg_out_rx) = unbounded_channel();
+        let (msg_in_tx, msg_in_rx) = unbounded_channel();
+
+        let subscription_states = self.subscription_states.clone();
+
+        tokio::spawn(ws_handler_loop(
+            price_reporter_url,
+            subscription_states,
+            msg_out_rx,
+            msg_in_tx,
+        ));
+
+        (msg_out_tx, msg_in_rx)
+    }
+
+    /// Spawns the price streamer loop, which periodically publishes price
+    /// reports to the system bus for the given token pair
+    fn spawn_price_streamer_loop(self, base: Token, quote: Token) {
+        tokio::spawn(async move {
+            let topic_name = price_report_topic_name(&base, &quote);
+
+            loop {
+                if self.config.system_bus.has_listeners(&topic_name) {
+                    if let PriceReporterState::Nominal(report) =
+                        self.get_state(base.clone(), quote.clone()).await
+                    {
+                        self.config
+                            .system_bus
+                            .publish(topic_name.clone(), SystemBusMessage::PriceReport(report));
+                    }
+                }
+
+                tokio::time::sleep(Duration::from_millis(PRICE_REPORT_INTERVAL_MS)).await;
+            }
+        });
+    }
+
+    /// Handles a price update from the external price reporter
+    async fn handle_price_update(
+        &self,
+        price_message: PriceMessage,
+    ) -> Result<(), ExchangeConnectionError> {
+        let price = price_message.price;
+
+        // Do not update if the price is default, simply let the price age
+        if price == Price::default() {
+            return Ok(());
+        }
+
+        let (exchange, base_token, quote_token) = parse_topic(&price_message.topic)
+            .map_err(err_str!(ExchangeConnectionError::InvalidMessage))?;
+        let ts = get_current_time_seconds();
+
+        let mut subscriptions = self.subscription_states.write().await;
+        subscriptions
+            .entry((base_token, quote_token))
+            .or_insert_with(|| AtomicPriceStreamState::new_from_exchanges(ALL_EXCHANGES))
+            .new_price(exchange, price, ts);
+
+        Ok(())
+    }
+
+    /// Handles a job for the PriceReporter worker.
+    pub(super) async fn handle_job(
+        &mut self,
+        job: PriceReporterJob,
+        msg_out_tx: UnboundedSender<WebsocketMessage>,
+    ) -> Result<(), PriceReporterError> {
+        match job {
+            PriceReporterJob::StreamPrice { base_token, quote_token } => self
+                .subscribe_to_price_stream(base_token, quote_token, msg_out_tx)
+                .await
+                .map_err(PriceReporterError::ExchangeConnectionError),
+            PriceReporterJob::PeekPrice { base_token, quote_token, channel } => {
+                self.peek_price(base_token, quote_token, channel).await
+            },
+        }
+    }
+
+    /// Handler for the StreamPrice job
+    async fn subscribe_to_price_stream(
+        &mut self,
+        base_token: Token,
+        quote_token: Token,
+        msg_out_tx: UnboundedSender<WebsocketMessage>,
+    ) -> Result<(), ExchangeConnectionError> {
+        {
+            let mut subscriptions = self.subscription_states.write().await;
+            if subscriptions.contains_key(&(base_token.clone(), quote_token.clone())) {
+                return Ok(());
+            }
+
+            // Send subscription messages to WS connection
+            for exchange in ALL_EXCHANGES {
+                let topic = format_topic(exchange, &base_token, &quote_token);
+                let message = WebsocketMessage::Subscribe { topic };
+                msg_out_tx.send(message).map_err(err_str!(ExchangeConnectionError::SendError))?;
+            }
+
+            // Insert the new subscription state
+            subscriptions.insert(
+                (base_token.clone(), quote_token.clone()),
+                AtomicPriceStreamState::new_from_exchanges(ALL_EXCHANGES),
+            );
+        }
+
+        // Spawn a price streamer loop associated with the pair
+        self.clone().spawn_price_streamer_loop(base_token, quote_token);
+
+        Ok(())
+    }
+
+    /// Handler for the PeekPrice job
+    async fn peek_price(
+        &mut self,
+        base_token: Token,
+        quote_token: Token,
+        channel: TokioSender<PriceReporterState>,
+    ) -> Result<(), PriceReporterError> {
+        // TODO: Get-or-create price stream subscription
+        let state = self.get_state(base_token, quote_token).await;
+        channel.send(state).unwrap();
+
+        Ok(())
+    }
+
+    /// Get the state of the price reporter for the given token pair
+    async fn get_state(&self, base_token: Token, quote_token: Token) -> PriceReporterState {
+        // We don't currently support unnamed pairs
+        if !is_pair_named(&base_token, &quote_token) {
+            return PriceReporterState::UnsupportedPair(base_token, quote_token);
+        }
+
+        // Fetch the most recent Binance price
+        match self.get_latest_price(&Exchange::Binance, &base_token, &quote_token).await {
+            None => PriceReporterState::NotEnoughDataReported(0),
+            Some((price, ts)) => {
+                // Fetch the most recent prices from all other exchanges
+                let mut exchange_prices = Vec::new();
+                for exchange in ALL_EXCHANGES {
+                    if let Some((price, ts)) =
+                        self.get_latest_price(exchange, &base_token, &quote_token).await
+                    {
+                        exchange_prices.push((*exchange, (price, ts)));
+                    }
+                }
+
+                // Compute the state of the price reporter
+                compute_price_reporter_state(base_token, quote_token, price, ts, &exchange_prices)
+            },
+        }
+    }
+
+    /// Get the latest price for the given exchange and token pair
+    async fn get_latest_price(
+        &self,
+        exchange: &Exchange,
+        base_token: &Token,
+        quote_token: &Token,
+    ) -> Option<(Price, u64)> {
+        self.subscription_states
+            .read()
+            .await
+            .get(&(base_token.clone(), quote_token.clone()))
+            .and_then(|state| state.read_price(&exchange))
+    }
+}
+
+/// The main loop for the websocket handler, responsible for forwarding
+/// messages between the external price reporter and the executor, and
+/// re-establishing connections indefinitely in case of failure
+async fn ws_handler_loop(
+    price_reporter_url: Url,
+    subscription_states: SubscriptionStates,
+    mut msg_out_rx: UnboundedReceiver<WebsocketMessage>,
+    msg_in_tx: UnboundedSender<PriceMessage>,
+) -> Result<(), PriceReporterError> {
+    // Outer loop handles retrying the websocket connection to the external price
+    // reporter in case of some failure
+    loop {
+        let (mut ws_write, mut ws_read) = connect_with_retries(price_reporter_url.clone()).await;
+
+        // Inner loop handles the actual communication over the websocket
+        loop {
+            tokio::select! {
+                // Forward incoming messages from the external price reporter
+                // to the executor
+                Some(res) = ws_read.next() => {
+                    match res {
+                        Ok(msg) => {
+                            if let Message::Text(text) = msg {
+                                // If receiving a subscription response from the price reporter,
+                                // log the subscribed topics (exchange, base, quote)
+                                if let Ok(subscription_response) =
+                                    serde_json::from_str::<SubscriptionResponse>(&text)
+                                {
+                                    if log_subscribed_exchanges(&subscription_response, &subscription_states).await.is_err() {
+                                        break;
+                                    }
+                                }
+
+                                if let Ok(price_message) = serde_json::from_str::<PriceMessage>(&text) {
+                                    // If receiving a price update from the external price reporter, forward to the executor
+                                    if msg_in_tx.send(price_message).is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        Err(_) => break,
+                    }
+                }
+
+                // Forward outgoing messages from the executor to the external price reporter
+                Some(message) = msg_out_rx.recv() => {
+                    if ws_write.send(Message::Text(serde_json::to_string(&message).unwrap())).await.is_err() {
+                        break;
+                    }
+                },
+            }
+        }
+
+        // We only break out of the inner loop in case of an error
+        error!("Error communicating with external price reporter, restarting connection...");
+    }
+}
+
+/// Attempt to reconnect to the external price reporter,
+/// retrying indefinitely until a successful connection is made
+async fn connect_with_retries(price_reporter_url: Url) -> (WsWriteStream, WsReadStream) {
+    loop {
+        match ws_connect(price_reporter_url.clone()).await {
+            Ok((write, read)) => return (write, read),
+            Err(e) => {
+                error!("Error connecting to external price reporter: {e}, retrying...");
+                tokio::time::sleep(Duration::from_millis(CONN_RETRY_DELAY_MS)).await;
+            },
+        }
+    }
+}
+
+/// Format the topic for the given exchange and token pair
+fn format_topic(exchange: &Exchange, base_token: &Token, quote_token: &Token) -> String {
+    format!("{}-{}-{}", exchange, base_token, quote_token)
+}
+
+/// Parse the exchange & pair from a given topic
+fn parse_topic(topic: &str) -> Result<(Exchange, Token, Token), ExchangeConnectionError> {
+    let parts: Vec<&str> = topic.split('-').collect();
+    let exchange =
+        Exchange::from_str(parts[0]).map_err(err_str!(ExchangeConnectionError::InvalidMessage))?;
+    let base = Token::from_addr(parts[1]);
+    let quote = Token::from_addr(parts[2]);
+
+    Ok((exchange, base, quote))
+}
+
+/// Log the exchanges that the price reporter has subscribed to
+async fn log_subscribed_exchanges(
+    subscription_response: &SubscriptionResponse,
+    subscription_states: &AsyncShared<HashMap<(Token, Token), AtomicPriceStreamState>>,
+) -> Result<(), ExchangeConnectionError> {
+    // Iterate over the subscriptions, parse the topic, and filter for those
+    // which are not already present in the subscription states
+
+    let subscriptions = subscription_response
+        .subscriptions
+        .iter()
+        .map(|t| parse_topic(t))
+        .collect::<Result<Vec<(Exchange, Token, Token)>, ExchangeConnectionError>>()?;
+
+    let current_subscriptions = subscription_states.read().await;
+    for (exchange, base, quote) in subscriptions {
+        if !current_subscriptions.contains_key(&(base.clone(), quote.clone()))
+            || current_subscriptions
+                .get(&(base.clone(), quote.clone()))
+                .unwrap()
+                .read_price(&exchange)
+                .is_none()
+        {
+            info!(
+                "Now subscribed to {}-{} pair on {} from external price reporter",
+                base, quote, exchange
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/workers/price-reporter/src/reporter.rs
+++ b/workers/price-reporter/src/reporter.rs
@@ -20,7 +20,7 @@ use util::get_current_time_seconds;
 use crate::exchange::connect_exchange;
 use crate::exchange::connection::ExchangeConnection;
 use crate::manager::{
-    compute_price_reporter_state, compute_supported_exchanges_for_pair, AtomicPriceStreamState,
+    compute_price_reporter_state, get_supported_exchanges, AtomicPriceStreamState,
     CONN_RETRY_DELAY_MS, KEEPALIVE_INTERVAL_MS, MAX_CONN_RETRIES, MAX_CONN_RETRY_WINDOW_MS,
     PRICE_REPORT_INTERVAL_MS,
 };
@@ -52,8 +52,7 @@ impl Reporter {
         config: PriceReporterConfig,
     ) -> Result<Self, ExchangeConnectionError> {
         // Get the supported exchanges for the token pair
-        let supported_exchanges =
-            compute_supported_exchanges_for_pair(&base_token, &quote_token, &config);
+        let supported_exchanges = get_supported_exchanges(&base_token, &quote_token, &config);
         if supported_exchanges.is_empty() {
             warn!("No supported exchanges for {base_token}-{quote_token}");
             return Err(ExchangeConnectionError::NoSupportedExchanges(base_token, quote_token));

--- a/workers/price-reporter/src/worker.rs
+++ b/workers/price-reporter/src/worker.rs
@@ -11,6 +11,7 @@ use job_types::price_reporter::PriceReporterReceiver;
 use std::thread::{self, JoinHandle};
 use system_bus::SystemBus;
 use tokio::runtime::Builder as TokioBuilder;
+use url::Url;
 
 use crate::manager::external_executor::ExternalPriceReporterExecutor;
 
@@ -32,7 +33,7 @@ pub struct PriceReporterConfig {
     /// Exchange connection config options
     pub exchange_conn_config: ExchangeConnectionsConfig,
     /// The URL of an external price reporter service
-    pub price_reporter_url: Option<String>,
+    pub price_reporter_url: Option<Url>,
     /// Whether or not the worker is disabled
     pub disabled: bool,
     /// Exchanges that are explicitly disabled for price reporting


### PR DESCRIPTION
This PR implements a secondary executor for the price reporter worker which connects to an external price reporter service, subscribing to all price updates over a single websocket connection. It spawns a separate task which manages the websocket connection and forwards incoming/outgoing messages between it and the executor over a pair of channels.

I have tested running the relayer ad-hoc with both the native and external executor, ensuring that it starts smoothly and that websocket subscriptions are established.