### PR TITLE
meta: Pin metrics to `0.22.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4638,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -6535,6 +6535,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
+ "uuid 1.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ itertools = "0.10"
 serde = { version = "1.0.139" }
 serde_json = "1.0.64"
 tracing = "0.1"
-metrics = "0.22"
+metrics = "0.22.1"


### PR DESCRIPTION
### Purpose
We observed that `ahash`, a transitive dependency through `metrics` had bumped its MSRV to 1.72.0. This broke proof submission though the cause is unknown. For now, we will pin metrics to a known working version.

### Testing
- Unit tests pass
- Tested submitting a match against the deployed sequencer. Was able to reproduce the problem before this fix, and was able to submit a match afterward.