### PR TITLE
external-api: Publish HTTP routes on crate interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,6 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.8.0",
 ]
 
 [[package]]

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -7,7 +7,7 @@ use mpc_relation::{traits::Circuit, BoolVar, Variable};
 use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};
-use std::ops::Add;
+use std::{fmt::Display, ops::Add};
 
 use crate::{
     biguint_from_hex_string, biguint_to_hex_string,
@@ -98,6 +98,15 @@ pub enum OrderSide {
     Buy = 0,
     /// Sell side
     Sell,
+}
+
+impl Display for OrderSide {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrderSide::Buy => write!(f, "Buy"),
+            OrderSide::Sell => write!(f, "Sell"),
+        }
+    }
 }
 
 impl OrderSide {

--- a/external-api/src/http/network.rs
+++ b/external-api/src/http/network.rs
@@ -4,6 +4,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{Cluster, Network, Peer};
 
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Returns the full network topology known to the local node
+pub const GET_NETWORK_TOPOLOGY_ROUTE: &str = "/v0/network";
+/// Returns the cluster information for the specified cluster
+pub const GET_CLUSTER_INFO_ROUTE: &str = "/v0/network/clusters/:cluster_id";
+/// Returns the peer info for a given peer
+pub const GET_PEER_INFO_ROUTE: &str = "/v0/network/peers/:peer_id";
+
+// -------------
+// | API Types |
+// -------------
+
 /// The response type to fetch the entire known network topology
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkTopologyResponse {

--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -4,6 +4,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ApiNetworkOrder;
 
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Returns all known network orders
+pub const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
+/// Returns the network order information of the specified order
+pub const GET_NETWORK_ORDER_BY_ID_ROUTE: &str = "/v0/order_book/orders/:order_id";
+
+// -------------
+// | API Types |
+// -------------
+
 /// The response type to fetch all the known orders in the network
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkOrdersResponse {

--- a/external-api/src/http/price_report.rs
+++ b/external-api/src/http/price_report.rs
@@ -8,6 +8,17 @@ use common::types::{
 };
 use serde::{Deserialize, Serialize};
 
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Exchange health check route
+pub const EXCHANGE_HEALTH_ROUTE: &str = "/v0/exchange/health_check";
+
+// -------------
+// | API Types |
+// -------------
+
 /// A request to get the health of each exchange for a given token pair
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetExchangeHealthStatesRequest {

--- a/external-api/src/http/task.rs
+++ b/external-api/src/http/task.rs
@@ -1,17 +1,30 @@
 //! Defines API types for task status introspection
 
 use common::types::tasks::{QueuedTask, QueuedTaskState, TaskIdentifier};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Get the status of a task
+pub const GET_TASK_STATUS_ROUTE: &str = "/v0/tasks/:task_id";
+/// Get the task queue of a given wallet
+pub const GET_TASK_QUEUE_ROUTE: &str = "/v0/task_queue/:wallet_id";
+
+// -------------
+// | API Types |
+// -------------
 
 /// The response type for a request to fetch task status
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetTaskStatusResponse {
     /// The status of the requested task
     pub status: String,
 }
 
 /// A type encapsulating status information for a task
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskStatus {
     /// The ID of the task
     pub id: TaskIdentifier,
@@ -33,7 +46,7 @@ impl From<QueuedTask> for TaskStatus {
 }
 
 /// The response type for a request to fetch all tasks on a wallet
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskQueueListResponse {
     /// The list of tasks on a wallet
     pub tasks: Vec<TaskStatus>,

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -11,6 +11,33 @@ use crate::{
     types::{ApiKeychain, ApiOrder, ApiWallet},
 };
 
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Create a new wallet
+pub const CREATE_WALLET_ROUTE: &str = "/v0/wallet";
+/// Find a wallet in contract storage
+pub const FIND_WALLET_ROUTE: &str = "/v0/wallet/lookup";
+/// Returns the wallet information for the given id
+pub const GET_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
+/// Route to the orders of a given wallet
+pub const WALLET_ORDERS_ROUTE: &str = "/v0/wallet/:wallet_id/orders";
+/// Returns a single order by the given identifier
+pub const GET_ORDER_BY_ID_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id";
+/// Updates a given order
+pub const UPDATE_ORDER_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id/update";
+/// Cancels a given order
+pub const CANCEL_ORDER_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id/cancel";
+/// Returns the balances within a given wallet
+pub const GET_BALANCES_ROUTE: &str = "/v0/wallet/:wallet_id/balances";
+/// Returns the balance associated with the given mint
+pub const GET_BALANCE_BY_MINT_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint";
+/// Deposits an ERC-20 token into the darkpool
+pub const DEPOSIT_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/deposit";
+/// Withdraws an ERC-20 token from the darkpool
+pub const WITHDRAW_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint/withdraw";
+
 // --------------------
 // | Wallet API Types |
 // --------------------

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -12,6 +12,11 @@ pub mod http;
 pub mod types;
 pub mod websocket;
 
+/// Header name for the HTTP auth signature
+pub const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
+/// Header name for the expiration timestamp of a signature
+pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
+
 /// An empty request/response type
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmptyRequestResponse {}

--- a/workers/api-server/src/auth.rs
+++ b/workers/api-server/src/auth.rs
@@ -4,15 +4,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::engine::{general_purpose as b64_general_purpose, Engine};
 use circuit_types::keychain::PublicSigningKey;
+use external_api::{RENEGADE_AUTH_HEADER_NAME, RENEGADE_SIG_EXPIRATION_HEADER_NAME};
 use hyper::HeaderMap;
 use k256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
 
 use crate::error::{bad_request, unauthorized, ApiServerError};
-
-/// Header name for the HTTP auth signature
-const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
-/// Header name for the expiration timestamp of a signature
-const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
 
 /// Error displayed when the signature format is invalid
 const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
@@ -98,13 +94,12 @@ fn validate_expiring_signature(
 #[cfg(test)]
 mod test {
     use base64::engine::{general_purpose as b64_general_purpose, Engine};
+    use external_api::{RENEGADE_AUTH_HEADER_NAME, RENEGADE_SIG_EXPIRATION_HEADER_NAME};
     use hyper::{header::HeaderValue, HeaderMap};
     use k256::ecdsa::{signature::Signer, Signature, SigningKey};
     use rand::thread_rng;
 
-    use super::{
-        authenticate_wallet_request, RENEGADE_AUTH_HEADER_NAME, RENEGADE_SIG_EXPIRATION_HEADER_NAME,
-    };
+    use super::authenticate_wallet_request;
 
     /// A message to sign for testing
     const MSG: &[u8] = b"dummy";

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -5,7 +5,21 @@ use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     tasks::TaskIdentifier,
 };
-use external_api::{http::PingResponse, EmptyRequestResponse};
+use external_api::{
+    http::{
+        network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
+        order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
+        price_report::EXCHANGE_HEALTH_ROUTE,
+        task::{GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
+        wallet::{
+            CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE,
+            GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+            UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
+        },
+        PingResponse,
+    },
+    EmptyRequestResponse,
+};
 use hyper::{
     server::conn::AddrStream,
     service::{make_service_fn, service_fn},
@@ -25,25 +39,14 @@ use uuid::Uuid;
 use crate::error::{bad_request, not_found};
 
 use self::{
-    network::{
-        GetClusterInfoHandler, GetNetworkTopologyHandler, GetPeerInfoHandler,
-        GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE,
-    },
-    order_book::{
-        GetNetworkOrderByIdHandler, GetNetworkOrdersHandler, GET_NETWORK_ORDERS_ROUTE,
-        GET_NETWORK_ORDER_BY_ID_ROUTE,
-    },
-    price_report::{ExchangeHealthStatesHandler, EXCHANGE_HEALTH_ROUTE},
-    task::{
-        GetTaskQueueHandler, GetTaskStatusHandler, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE,
-    },
+    network::{GetClusterInfoHandler, GetNetworkTopologyHandler, GetPeerInfoHandler},
+    order_book::{GetNetworkOrderByIdHandler, GetNetworkOrdersHandler},
+    price_report::ExchangeHealthStatesHandler,
+    task::{GetTaskQueueHandler, GetTaskStatusHandler},
     wallet::{
         CancelOrderHandler, CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler,
         FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler, GetOrderByIdHandler,
         GetOrdersHandler, GetWalletHandler, UpdateOrderHandler, WithdrawBalanceHandler,
-        CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE,
-        GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
-        UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
     },
 };
 

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -26,17 +26,6 @@ use super::{parse_cluster_id_from_params, parse_peer_id_from_params};
 /// Error displayed when a requested peer could not be found in the peer index
 const ERR_PEER_NOT_FOUND: &str = "could not find peer in index";
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Returns the full network topology known to the local node
-pub(super) const GET_NETWORK_TOPOLOGY_ROUTE: &str = "/v0/network";
-/// Returns the cluster information for the specified cluster
-pub(super) const GET_CLUSTER_INFO_ROUTE: &str = "/v0/network/clusters/:cluster_id";
-/// Returns the peer info for a given peer
-pub(super) const GET_PEER_INFO_ROUTE: &str = "/v0/network/peers/:peer_id";
-
 // ------------------
 // | Route Handlers |
 // ------------------

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -1,9 +1,5 @@
 //! Groups routes and handlers for order book API operations
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
 use async_trait::async_trait;
 use external_api::{
     http::order_book::{GetNetworkOrderByIdResponse, GetNetworkOrdersResponse},
@@ -26,15 +22,6 @@ use super::parse_order_id_from_params;
 
 /// Error displayed when an order cannot be found in the network order book
 const ERR_ORDER_NOT_FOUND: &str = "order not found in network order book";
-
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Returns all known network orders
-pub(super) const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
-/// Returns the network order information of the specified order
-pub(super) const GET_NETWORK_ORDER_BY_ID_ROUTE: &str = "/v0/order_book/orders/:order_id";
 
 // ----------------------
 // | Order Book Routers |

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -14,13 +14,6 @@ use crate::{
     worker::ApiServerConfig,
 };
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Exchange health check route
-pub(super) const EXCHANGE_HEALTH_ROUTE: &str = "/v0/exchange/health_check";
-
 // ------------------
 // | Route Handlers |
 // ------------------

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -20,11 +20,6 @@ use crate::{
 
 use super::{parse_task_id_from_params, parse_wallet_id_from_params};
 
-/// Get the status of a task
-pub const GET_TASK_STATUS_ROUTE: &str = "/v0/tasks/:task_id";
-/// Get the task queue of a given wallet
-pub const GET_TASK_QUEUE_ROUTE: &str = "/v0/task_queue/:wallet_id";
-
 // ------------------
 // | Error Messages |
 // ------------------

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -63,33 +63,6 @@ async fn append_task_and_await(
     Ok(task_id)
 }
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Create a new wallet
-pub(super) const CREATE_WALLET_ROUTE: &str = "/v0/wallet";
-/// Find a wallet in contract storage
-pub(super) const FIND_WALLET_ROUTE: &str = "/v0/wallet/lookup";
-/// Returns the wallet information for the given id
-pub(super) const GET_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
-/// Route to the orders of a given wallet
-pub(super) const WALLET_ORDERS_ROUTE: &str = "/v0/wallet/:wallet_id/orders";
-/// Returns a single order by the given identifier
-pub(super) const GET_ORDER_BY_ID_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id";
-/// Updates a given order
-pub(super) const UPDATE_ORDER_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id/update";
-/// Cancels a given order
-pub(super) const CANCEL_ORDER_ROUTE: &str = "/v0/wallet/:wallet_id/orders/:order_id/cancel";
-/// Returns the balances within a given wallet
-pub(super) const GET_BALANCES_ROUTE: &str = "/v0/wallet/:wallet_id/balances";
-/// Returns the balance associated with the given mint
-pub(super) const GET_BALANCE_BY_MINT_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint";
-/// Deposits an ERC-20 token into the darkpool
-pub(super) const DEPOSIT_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/deposit";
-/// Withdraws an ERC-20 token from the darkpool
-pub(super) const WITHDRAW_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint/withdraw";
-
 // ------------------
 // | Error Messages |
 // ------------------


### PR DESCRIPTION
### Purpose
This PR publishes the HTTP routes offered by the relayer in the `external-api` crate. This is nice for building rust-based clients that may inherit these types directly.

### Testing
- Unit tests pass
- Tested a few endpoints on the relayer