### PR TITLE
common: wallet: orders: Remove orders entirely from `KeyedList`

### DIFF
--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -115,32 +115,6 @@ mod test {
         assert_eq!(wallet.orders.index_of(&id2), Some(1));
     }
 
-    /// Tests adding an order that overwrites a default order
-    #[test]
-    fn test_add_order_overwrite() {
-        let mut wallet = mock_empty_wallet();
-
-        // Fill the orders with default orders
-        for _ in 0..MAX_ORDERS {
-            let id = Uuid::new_v4();
-            let order = mock_order();
-            wallet.add_order(id, order).unwrap();
-        }
-
-        // Zero a random order
-        let mut rng = thread_rng();
-        let idx = (0..MAX_ORDERS).sample_single(&mut rng);
-        wallet.orders.get_index_mut(idx).unwrap().amount = 0;
-
-        // Add a new order
-        let id = Uuid::new_v4();
-        let order = mock_order();
-        wallet.add_order(id, order).unwrap();
-
-        // Check that the order overrode the correct idx
-        assert_eq!(wallet.orders.index_of(&id), Some(idx));
-    }
-
     /// Tests adding an order when the wallet is full
     #[test]
     #[should_panic(expected = "orders full")]

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -64,28 +64,16 @@ impl Wallet {
     /// wallet is full
     pub fn add_order(&mut self, id: OrderIdentifier, order: Order) -> Result<(), String> {
         // Append if the orders are not full
-        if self.orders.len() < MAX_ORDERS {
-            self.orders.insert(id, order);
-            return Ok(());
+        if self.orders.len() >= MAX_ORDERS {
+            return Err(ERR_ORDERS_FULL.to_string());
         }
 
-        // Otherwise try to find an order to overwrite
-        let idx = self
-            .orders
-            .iter()
-            .enumerate()
-            .find_map(|(i, (_, order))| order.is_zero().then_some(i))
-            .ok_or_else(|| ERR_ORDERS_FULL.to_string())?;
-        self.orders.replace_at_index(idx, id, order);
-
+        self.orders.append(id, order);
         Ok(())
     }
 
     /// Remove an order from the wallet, replacing it with a default order
     pub fn remove_order(&mut self, id: &OrderIdentifier) -> Option<Order> {
-        let order = self.get_order_mut(id)?;
-        *order = Order::default();
-
-        Some(order.clone())
+        self.orders.remove(id)
     }
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -434,8 +434,7 @@ impl TypedHandler for CancelOrderHandler {
         // Remove the order from the new wallet
         let mut new_wallet = old_wallet.clone();
         let order = new_wallet
-            .orders
-            .remove(&order_id)
+            .remove_order(&order_id)
             .ok_or_else(|| not_found(ERR_ORDER_NOT_FOUND.to_string()))?;
         new_wallet.reblind_wallet();
 


### PR DESCRIPTION
### Purpose
This PR updates the way in which we remove orders from a wallet. Specifically, we no longer replace the order with a default but have the order list behave more like an append-centric vector. This makes for a more sensible API client-side.

This comes as a result of circuit changes that allow for more flexibility in updating orders.

### Testing
- Used the changes to create and cancel orders in the `renegade-cli` and verified its functionality
- Unit tests pass