### PR TITLE
external-api: task: Add descriptor to `TaskStateResponse`

### DIFF
--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -10,7 +10,7 @@ use common::types::{
 };
 use serde::Serialize;
 
-use crate::types::ApiWallet;
+use crate::{http::task::ApiTaskStatus, types::ApiWallet};
 
 // ----------------------------
 // | System Bus Message Types |
@@ -97,10 +97,8 @@ pub enum SystemBusMessage {
     // -- Tasks -- //
     /// A message indicating that a task has
     TaskStatusUpdate {
-        /// The ID of the task
-        task_id: TaskIdentifier,
-        /// The new state of the task
-        state: String,
+        /// The updated status of the task
+        status: ApiTaskStatus,
     },
 
     // -- Wallet Updates -- //

--- a/external-api/src/http/task.rs
+++ b/external-api/src/http/task.rs
@@ -1,6 +1,6 @@
 //! Defines API types for task status introspection
 
-use common::types::tasks::{QueuedTask, QueuedTaskState, TaskIdentifier};
+use common::types::tasks::{QueuedTask, TaskIdentifier};
 use serde::{Deserialize, Serialize};
 
 // ---------------
@@ -16,32 +16,33 @@ pub const GET_TASK_QUEUE_ROUTE: &str = "/v0/task_queue/:wallet_id";
 // | API Types |
 // -------------
 
-/// The response type for a request to fetch task status
+/// The task status for a given task
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetTaskStatusResponse {
-    /// The status of the requested task
-    pub status: String,
-}
-
-/// A type encapsulating status information for a task
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TaskStatus {
+pub struct ApiTaskStatus {
     /// The ID of the task
     pub id: TaskIdentifier,
+    /// The description of the task
+    pub description: String,
     /// The status of the task
-    pub status: String,
+    pub state: String,
     /// Whether or not the task has already committed
     pub committed: bool,
 }
 
-impl From<QueuedTask> for TaskStatus {
-    fn from(task: QueuedTask) -> Self {
-        let (status, committed) = match task.state {
-            QueuedTaskState::Queued => ("queued".to_string(), false),
-            QueuedTaskState::Running { state, committed } => (state, committed),
-        };
+/// The response type for a request to fetch task status
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetTaskStatusResponse {
+    /// The status of the requested task
+    pub status: ApiTaskStatus,
+}
 
-        TaskStatus { id: task.id, status, committed }
+impl From<QueuedTask> for ApiTaskStatus {
+    fn from(task: QueuedTask) -> Self {
+        let state = task.state.display_description();
+        let committed = task.state.is_committed();
+        let description = task.descriptor.display_description();
+
+        ApiTaskStatus { id: task.id, description, state, committed }
     }
 }
 
@@ -49,5 +50,5 @@ impl From<QueuedTask> for TaskStatus {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskQueueListResponse {
     /// The list of tasks on a wallet
-    pub tasks: Vec<TaskStatus>,
+    pub tasks: Vec<ApiTaskStatus>,
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -328,7 +328,8 @@ impl TypedHandler for CreateOrderHandler {
         new_wallet.reblind_wallet();
 
         let task = UpdateWalletTaskDescriptor::new(
-            None, // transfer
+            "Create Order".to_string(), // description
+            None,                       // transfer
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -388,7 +389,8 @@ impl TypedHandler for UpdateOrderHandler {
         new_wallet.reblind_wallet();
 
         let task = UpdateWalletTaskDescriptor::new(
-            None, // transfer
+            "Update Order".to_string(), // description
+            None,                       // transfer
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -439,7 +441,8 @@ impl TypedHandler for CancelOrderHandler {
         new_wallet.reblind_wallet();
 
         let task = UpdateWalletTaskDescriptor::new(
-            None, // transfer
+            "Cancel Order".to_string(), // description
+            None,                       // transfer
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -582,6 +585,7 @@ impl TypedHandler for DepositBalanceHandler {
         );
 
         let task = UpdateWalletTaskDescriptor::new(
+            "Deposit".to_string(), // description
             Some(deposit_with_auth),
             old_wallet,
             new_wallet,
@@ -647,6 +651,7 @@ impl TypedHandler for WithdrawBalanceHandler {
         );
 
         let task = UpdateWalletTaskDescriptor::new(
+            "Withdraw".to_string(), // description
             Some(withdrawal_with_auth),
             old_wallet,
             new_wallet,

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -68,8 +68,14 @@ pub(crate) async fn execute_wallet_update(
     let sig = gen_wallet_update_sig(&new_wallet, key);
 
     let id = new_wallet.wallet_id;
-    let task =
-        UpdateWalletTaskDescriptor::new(transfer_with_auth, old_wallet, new_wallet, sig).unwrap();
+    let task = UpdateWalletTaskDescriptor::new(
+        "test".to_string(),
+        transfer_with_auth,
+        old_wallet,
+        new_wallet,
+        sig,
+    )
+    .unwrap();
 
     await_task(task.into(), &test_args).await?;
 

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -528,8 +528,8 @@ impl Display for StateWrapper {
 impl From<StateWrapper> for QueuedTaskState {
     fn from(value: StateWrapper) -> Self {
         // Serialize the state into a string
-        let state = serde_json::to_string(&value).expect("error serializing state");
+        let description = value.to_string();
         let committed = value.committed();
-        QueuedTaskState::Running { state, committed }
+        QueuedTaskState::Running { state: description, committed }
     }
 }

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -70,10 +70,11 @@ impl TaskState for NewWalletTaskState {
 impl Display for NewWalletTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            NewWalletTaskState::SubmittingTx { .. } => {
-                write!(f, "SubmittingTx")
-            },
-            _ => write!(f, "{self:?}"),
+            NewWalletTaskState::Pending => write!(f, "Pending"),
+            NewWalletTaskState::Proving => write!(f, "Proving"),
+            NewWalletTaskState::SubmittingTx => write!(f, "Submitting Tx"),
+            NewWalletTaskState::FindingMerkleOpening => write!(f, "Finding Opening"),
+            NewWalletTaskState::Completed => write!(f, "Completed"),
         }
     }
 }

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -63,7 +63,12 @@ impl TaskState for LookupWalletTaskState {
 
 impl Display for LookupWalletTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{self:?}")
+        match self {
+            LookupWalletTaskState::Pending => write!(f, "Pending"),
+            LookupWalletTaskState::FindingWallet => write!(f, "Finding Wallet"),
+            LookupWalletTaskState::CreatingValidityProofs => write!(f, "Creating Validity Proofs"),
+            LookupWalletTaskState::Completed => write!(f, "Completed"),
+        }
     }
 }
 

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -72,7 +72,14 @@ impl TaskState for PayOfflineFeeTaskState {
 
 impl Display for PayOfflineFeeTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{self:?}")
+        match self {
+            PayOfflineFeeTaskState::Pending => write!(f, "Pending"),
+            PayOfflineFeeTaskState::ProvingPayment => write!(f, "Proving Payment"),
+            PayOfflineFeeTaskState::SubmittingPayment => write!(f, "Submitting Payment"),
+            PayOfflineFeeTaskState::FindingOpening => write!(f, "Finding Opening"),
+            PayOfflineFeeTaskState::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
+            PayOfflineFeeTaskState::Completed => write!(f, "Completed"),
+        }
     }
 }
 

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -65,7 +65,14 @@ impl TaskState for PayRelayerFeeTaskState {
 
 impl Display for PayRelayerFeeTaskState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            PayRelayerFeeTaskState::Pending => write!(f, "Pending"),
+            PayRelayerFeeTaskState::ProvingPayment => write!(f, "Proving Payment"),
+            PayRelayerFeeTaskState::SubmittingPayment => write!(f, "Submitting Payment"),
+            PayRelayerFeeTaskState::FindingOpening => write!(f, "Finding Opening"),
+            PayRelayerFeeTaskState::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
+            PayRelayerFeeTaskState::Completed => write!(f, "Completed"),
+        }
     }
 }
 

--- a/workers/task-driver/src/tasks/redeem_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_relayer_fee.rs
@@ -66,7 +66,14 @@ impl TaskState for RedeemRelayerFeeTaskState {
 
 impl Display for RedeemRelayerFeeTaskState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            RedeemRelayerFeeTaskState::Pending => write!(f, "Pending"),
+            RedeemRelayerFeeTaskState::FindingNoteOpening => write!(f, "Finding Note Opening"),
+            RedeemRelayerFeeTaskState::ProvingRedemption => write!(f, "Proving Redemption"),
+            RedeemRelayerFeeTaskState::SubmittingRedemption => write!(f, "Submitting Redemption"),
+            RedeemRelayerFeeTaskState::FindingWalletOpening => write!(f, "Finding Opening"),
+            RedeemRelayerFeeTaskState::Completed => write!(f, "Completed"),
+        }
     }
 }
 

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -86,8 +86,11 @@ impl From<SettleMatchTaskState> for StateWrapper {
 impl Display for SettleMatchTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            SettleMatchTaskState::SubmittingMatch { .. } => write!(f, "SubmittingMatch"),
-            _ => write!(f, "{self:?}"),
+            SettleMatchTaskState::Pending => write!(f, "Pending"),
+            SettleMatchTaskState::SubmittingMatch => write!(f, "Submitting Match"),
+            SettleMatchTaskState::UpdatingState => write!(f, "Updating State"),
+            SettleMatchTaskState::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
+            SettleMatchTaskState::Completed => write!(f, "Completed"),
         }
     }
 }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -89,7 +89,14 @@ impl From<SettleMatchInternalTaskState> for StateWrapper {
 
 impl Display for SettleMatchInternalTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{self:?}")
+        match self {
+            Self::Pending => write!(f, "Pending"),
+            Self::ProvingMatchSettle => write!(f, "Proving Match Settle"),
+            Self::SubmittingMatch => write!(f, "Submitting Match"),
+            Self::UpdatingState => write!(f, "Updating State"),
+            Self::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
+            Self::Completed => write!(f, "Completed"),
+        }
     }
 }
 

--- a/workers/task-driver/src/tasks/update_merkle_proof.rs
+++ b/workers/task-driver/src/tasks/update_merkle_proof.rs
@@ -56,8 +56,8 @@ impl Display for UpdateMerkleProofTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::Pending => write!(f, "Pending"),
-            Self::FindingOpening => write!(f, "FindingOpening"),
-            Self::UpdatingValidityProofs => write!(f, "UpdatingValidityProofs"),
+            Self::FindingOpening => write!(f, "Finding Opening"),
+            Self::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
             Self::Completed => write!(f, "Completed"),
         }
     }

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -76,8 +76,12 @@ impl TaskState for UpdateWalletTaskState {
 impl Display for UpdateWalletTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::SubmittingTx { .. } => write!(f, "SubmittingTx"),
-            _ => write!(f, "{self:?}"),
+            Self::Pending => write!(f, "Pending"),
+            Self::Proving => write!(f, "Proving"),
+            Self::SubmittingTx => write!(f, "Submitting Tx"),
+            Self::FindingOpening => write!(f, "Finding Opening"),
+            Self::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
+            Self::Completed => write!(f, "Completed"),
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the API format of the task status to give a cleaner interface to the client. As well, for update wallet tasks we name the tasks by the update they perform.

### Testing
- Unit tests pass
- Tested the create + cancel order flows
- Opened a websocket on one of the tasks, verified the shape of the JSON