### PR TITLE
common, external-api: wallet: Do not filter default elements

### DIFF
--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -64,12 +64,20 @@ impl Wallet {
     /// wallet is full
     pub fn add_order(&mut self, id: OrderIdentifier, order: Order) -> Result<(), String> {
         // Append if the orders are not full
-        if self.orders.len() >= MAX_ORDERS {
+        if let Some(index) = self.find_first_default_order() {
+            self.orders.insert_at_index(index, id, order);
+        } else if self.orders.len() < MAX_ORDERS {
+            self.orders.append(id, order)
+        } else {
             return Err(ERR_ORDERS_FULL.to_string());
         }
 
-        self.orders.append(id, order);
         Ok(())
+    }
+
+    /// Find the first default order in the wallet
+    fn find_first_default_order(&self) -> Option<usize> {
+        self.orders.iter().position(|(_, order)| order.is_default())
     }
 
     /// Remove an order from the wallet, replacing it with a default order

--- a/external-api/src/types.rs
+++ b/external-api/src/types.rs
@@ -64,12 +64,7 @@ pub struct ApiWallet {
 /// Conversion from a wallet that has been indexed in the global state to the
 /// API type
 impl From<Wallet> for ApiWallet {
-    fn from(mut wallet: Wallet) -> Self {
-        // Remove all default orders and balances from the wallet
-        // These are used to pad the wallet to the size of the circuit, and are
-        // not relevant to the client
-        wallet.remove_default_elements();
-
+    fn from(wallet: Wallet) -> Self {
         // Build API types from the indexed wallet
         let orders = wallet.orders.into_iter().map(|order| order.into()).collect_vec();
         let balances = wallet.balances.into_values().collect_vec();


### PR DESCRIPTION
### Purpose
This PR makes a few changes to the API and the serialization we impose on it:
- We do not remove default elements from the wallet when delivering a wallet to the API. These, importantly, should remain in place when a wallet is updated (unless they are overridden) so removing them from the API response makes it difficult or impossible for a client to correctly construct a wallet update.
- We serialize and deserialize fixed point values by the decimal string of their `repr` field.
- I also simplified some of the withdrawal logic in the balance API

### Testing
- Unit tests pass
- Tested the API through our CLI