### PR TITLE
common: types: token: clean up token statics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -114,7 +114,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -222,7 +222,7 @@ dependencies = [
  "futures",
  "futures-util",
  "gossip-api",
- "hyper",
+ "hyper 0.14.28",
  "itertools 0.11.0",
  "job-types",
  "k256",
@@ -264,7 +264,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "common",
  "constants",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ark-bls12-377"
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "ark-mpc"
 version = "0.1.2"
-source = "git+https://github.com/renegade-fi/ark-mpc#316750a99cce76e2b83243cd62f4d671a90412eb"
+source = "git+https://github.com/renegade-fi/ark-mpc#a1836fb2719eb83a3bc3db98a44b9b618d242c49"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -725,13 +725,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -792,14 +792,14 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
@@ -812,9 +812,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -838,8 +838,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -940,7 +940,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1142,9 +1142,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472b6b55bd7e5410178ecd5d544b0bd6d6af926a960fae4048b570923dffdb08"
+checksum = "7611a627d6f459659e63e007fb6a01733a4dca558779fe019f66579068779d79"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -1190,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -1395,7 +1395,7 @@ dependencies = [
  "bitvec 1.0.1",
  "circuit-macros",
  "circuit-types",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "constants",
  "criterion",
@@ -1452,12 +1452,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.3",
+ "clap_derive 4.5.4",
 ]
 
 [[package]]
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1603,7 +1603,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek 1.0.1",
  "ethers",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "jf-primitives",
  "k256",
@@ -1644,7 +1644,7 @@ dependencies = [
  "base64 0.13.1",
  "bimap",
  "circuit-types",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "common",
  "ed25519-dalek 1.0.1",
@@ -1652,7 +1652,7 @@ dependencies = [
  "json",
  "libp2p",
  "rand_core 0.5.1",
- "reqwest",
+ "reqwest 0.12.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -1792,7 +1792,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.3",
+ "clap 4.5.4",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2022,7 +2022,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2046,7 +2046,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2057,7 +2057,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2224,7 +2224,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2614,10 +2614,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.53",
+ "syn 2.0.55",
  "toml 0.8.12",
  "walkdir",
 ]
@@ -2635,7 +2635,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2661,7 +2661,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.53",
+ "syn 2.0.55",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2676,7 +2676,7 @@ checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -2701,7 +2701,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -2728,12 +2728,12 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.12",
  "instant",
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fastrlp"
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "fixed-hash"
@@ -3061,7 +3061,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3273,8 +3273,27 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.2.5",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3323,7 +3342,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "circuit-types",
  "circuits",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "common",
  "constants",
@@ -3363,7 +3382,7 @@ dependencies = [
  "ark-mpc",
  "base64 0.13.1",
  "circuit-types",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "common",
  "config",
@@ -3410,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fa0ae458eb99874f54c09f4f9174f8b45fb87e854536a4e608696247f0c23"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -3436,7 +3455,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -3448,7 +3467,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -3563,13 +3582,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -3595,9 +3648,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -3610,14 +3663,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.3",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls",
@@ -3629,7 +3702,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -3642,10 +3715,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2 0.5.6",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3802,12 +3911,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.4",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3884,14 +3993,14 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#1eac22f69e6524dae3be26eb2273d63096690238"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3935,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#1eac22f69e6524dae3be26eb2273d63096690238"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -4079,7 +4188,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4543,7 +4652,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.4",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -4664,7 +4773,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -4684,8 +4793,8 @@ dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.14.4",
- "indexmap 2.2.5",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -4748,7 +4857,7 @@ dependencies = [
  "network-manager",
  "price-reporter",
  "proof-manager",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "state",
@@ -4761,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#1eac22f69e6524dae3be26eb2273d63096690238"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4795,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#38d13e58377e90fd212547a70b07e64e14399d9a"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#1eac22f69e6524dae3be26eb2273d63096690238"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5159,7 +5268,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5252,7 +5361,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5281,7 +5390,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -5296,8 +5405,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
 dependencies = [
  "futures-core",
- "http",
- "indexmap 2.2.5",
+ "http 0.2.12",
+ "indexmap 2.2.6",
  "itertools 0.11.0",
  "once_cell",
  "opentelemetry",
@@ -5317,7 +5426,7 @@ checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.12",
  "opentelemetry",
 ]
 
@@ -5329,7 +5438,7 @@ checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -5639,7 +5748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -5682,7 +5791,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5720,7 +5829,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5787,12 +5896,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi 0.3.9",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -5857,12 +5967,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5882,7 +5992,7 @@ dependencies = [
  "itertools 0.11.0",
  "job-types",
  "lazy_static",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "statrs",
@@ -6005,7 +6115,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6040,7 +6150,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6360,9 +6470,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -6433,14 +6543,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -6460,7 +6570,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -6471,9 +6581,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "renegade-crypto"
@@ -6549,12 +6659,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -6579,6 +6689,49 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.3",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "winreg",
 ]
 
@@ -6766,9 +6919,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -6896,9 +7049,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2175c2907e7c8bc0a9c3f86aeb5ec1f3b275300ad58a44d0c3ae379a5e52e"
+checksum = "788745a868b0e751750388f4e6546eb921ef714a4317fa6954f7cde114eb2eb7"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -6908,9 +7061,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b8eb8fd61c5cdd3390d9b2132300a7e7618955b98b8416f118c1b4e144f"
+checksum = "7dc2f4e8bc344b9fc3d5f74f72c2e55bfc38d28dc2ebc69c194a3df424e4d9ac"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -7075,14 +7228,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -7120,7 +7273,7 @@ dependencies = [
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7137,7 +7290,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -7410,9 +7563,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
@@ -7619,7 +7772,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -7638,7 +7791,7 @@ dependencies = [
  "fs2",
  "hex 0.4.3",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -7661,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7679,7 +7832,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -7781,7 +7934,7 @@ dependencies = [
  "async-trait",
  "circuit-types",
  "circuits",
- "clap 4.5.3",
+ "clap 4.5.4",
  "colored",
  "common",
  "constants",
@@ -7867,7 +8020,7 @@ dependencies = [
  "num-bigint",
  "rand 0.8.5",
  "renegade-crypto",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tokio",
@@ -7897,7 +8050,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -8012,7 +8165,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -8122,7 +8275,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -8140,7 +8293,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -8151,18 +8304,18 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8181,10 +8334,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -8249,7 +8402,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -8441,7 +8594,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "native-tls",
@@ -8461,7 +8614,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -8746,7 +8899,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -8780,7 +8933,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8848,7 +9001,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "rlp",
  "secp256k1",
  "serde",
@@ -9266,7 +9419,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -9286,7 +9439,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -49,12 +49,11 @@ pub enum ExchangeTicker {
 // HashMap between the ERC-20 ticker and each Exchange's expected name for each
 // ticker.
 
-/// The raw ERC-20 data to be parsed as heap-allocated global structs. The
-/// layout of ERC20_DATA is (ERC-20 Address, Decimals, ERC-20 Ticker, Binance
-/// Ticker, Coinbase Ticker, Kraken Ticker, Okx Ticker).
-pub static ERC20_DATA: &[(
-    &str,
-    u8,
+/// The remapping of tickers between exchanges. The layout of `TICKER_NAMES` is
+/// (Renegade Ticker, Binance Ticker, Coinbase Ticker, Kraken Ticker, Okx
+/// Ticker), where "Renegade Ticker" denotes the ticker expected in the Renegade
+/// token remapping used.
+pub static TICKER_NAMES: &[(
     &str,
     ExchangeTicker,
     ExchangeTicker,
@@ -63,8 +62,6 @@ pub static ERC20_DATA: &[(
 )] = &[
     // L1
     (
-        "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-        8,
         "WBTC",
         ExchangeTicker::Renamed("BTC"),
         ExchangeTicker::Renamed("BTC"),
@@ -72,8 +69,6 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Renamed("BTC"),
     ),
     (
-        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        18,
         "WETH",
         ExchangeTicker::Renamed("ETH"),
         ExchangeTicker::Renamed("ETH"),
@@ -81,8 +76,6 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Renamed("ETH"),
     ),
     (
-        "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
-        18,
         "BNB",
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
@@ -90,64 +83,23 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     (
-        "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-        18,
         "MATIC",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
-    (
-        "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
-        18,
-        "FTM",
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x6810e776880c02933d47db1b9fc05908e5386b96",
-        18,
-        "GNO",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
     // LSDs
-    (
-        "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
-        18,
-        "CBETH",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
-        18,
-        "LDO",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
+    ("LDO", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     // Stables
     (
-        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        6,
         "USDC",
-        ExchangeTicker::Renamed("BUSD"),
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Renamed("USDT"),
+        ExchangeTicker::Same,
+        ExchangeTicker::Renamed("USD"), // USDC has 1:1 peg with USD on Coinbase
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
     ),
     (
-        "0xdac17f958d2ee523a2206206994597c13d831ec7",
-        6,
         "USDT",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -155,27 +107,14 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     (
-        "0x4fabb145d64652a948d72533023f6e7a623c7c53",
-        18,
-        "BUSD",
+        "USD",
+        ExchangeTicker::Unsupported,
         ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
+        ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
     ),
     // Oracles
     (
-        "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
-        18,
-        "BAND",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x514910771af9ca656af840dff83e8264ecf986ca",
-        18,
         "LINK",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -183,27 +122,9 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     // DeFi Trading
+    ("UNI", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
+    ("CRV", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     (
-        "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
-        18,
-        "UNI",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xd533a949740bb3306d119cc777fa900ba034cd52",
-        18,
-        "CRV",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x92d6c1e31e14520e676a687f0a93788b716beff5",
-        18,
         "DYDX",
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
@@ -211,8 +132,6 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     (
-        "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
-        18,
         "SUSHI",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -220,54 +139,7 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     (
-        "0x111111111117dc0aa78b770fa6a738034120c302",
-        18,
         "1INCH",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xba100000625a3754423978a60c9317c58a424e3d",
-        18,
-        "BAL",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
-        18,
-        "HFT",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0xbc396689893d065f41bc2c6ecbee5e0085233447",
-        18,
-        "PERP",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
-        18,
-        "WOO",
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xe41d2489571d322189246dafa5ebde1f4699f498",
-        18,
-        "ZRX",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -275,8 +147,6 @@ pub static ERC20_DATA: &[(
     ),
     // DeFi Lending
     (
-        "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-        18,
         "AAVE",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -284,82 +154,15 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Same,
     ),
     (
-        "0xc00e94cb662c3520282e6f5717214004a7f26888",
-        18,
         "COMP",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
-    (
-        "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
-        18,
-        "MKR",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
-        18,
-        "YFI",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x090185f2135308bad17527004364ebcc2d37e5f6",
-        18,
-        "SPELL",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // DeFi Lending Undercollateralized
-    (
-        "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
-        8,
-        "TRU",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0x33349b282065b0284d756f0577fb39c158f935e6",
-        18,
-        "MPL",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-    ),
+    ("MKR", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     // DeFi Other
     (
-        "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
-        18,
-        "SNX",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x221657776846890989a759ba2973e427dff5c9bb",
-        18,
-        "REP",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x77777feddddffc19ff86db637967013e6c6a116c",
-        18,
         "TORN",
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
@@ -367,175 +170,18 @@ pub static ERC20_DATA: &[(
         ExchangeTicker::Unsupported,
     ),
     // Bridges
-    (
-        "0x408e41876cccdc0f92210600ef50372656052a38",
-        18,
-        "REN",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
-        18,
-        "STG",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0x4a220e6096b25eadb88358cb44068a3248254675",
-        18,
-        "QNT",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    // L2s
-    (
-        "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
-        18,
-        "LRC",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
-        18,
-        "BOBA",
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    // NFTs
-    (
-        "0x4d224452801aced8b2f0aebe155379bb5d594381",
-        18,
-        "APE",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
-        18,
-        "AXS",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
-        18,
-        "ENJ",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xba5bde662c17e2adff1075610382b9b691296350",
-        18,
-        "RARE",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
+    ("REN", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     // Misc
     (
-        "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-        18,
         "SHIB",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
+    ("ENS", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     (
-        "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
-        18,
-        "PEOPLE",
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
-        18,
-        "OMG",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
-        18,
-        "GRT",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
-        18,
-        "ENS",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
-        18,
         "MANA",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-        8,
-        "GALA",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
-        18,
-        "RAD",
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0x18aaa7115705e8be94bffebde57af9bfc265b998",
-        18,
-        "AUDIO",
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
-        18,
-        "BAT",
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -547,21 +193,18 @@ pub static ERC20_DATA: &[(
 /// to the ticker of the token
 pub static TOKEN_REMAPS: OnceLock<BiMap<String, String>> = OnceLock::new();
 
+/// The decimal mapping for the given environment, maps from the token address
+/// to the number of decimals the token uses
+pub static ADDR_DECIMALS_MAP: OnceLock<HashMap<String, u8>> = OnceLock::new();
+
 lazy_static! {
-    static ref ADDR_DECIMALS_MAP: HashMap<String, u8> = {
-        let mut addr_decimals_map = HashMap::<String, u8>::new();
-        for (addr, decimals, _, _, _, _, _) in ERC20_DATA.iter() {
-            addr_decimals_map.insert(String::from(*addr), *decimals);
-        }
-        addr_decimals_map
-    };
     static ref EXCHANGE_TICKERS: HashMap<Exchange, HashMap<String, String>> = {
         let mut exchange_tickers = HashMap::<Exchange, HashMap<String, String>>::new();
         for exchange in [Exchange::Binance, Exchange::Coinbase, Exchange::Kraken, Exchange::Okx] {
             exchange_tickers.insert(exchange, HashMap::<String, String>::new());
         }
-        for (_, _, erc20_ticker, binance_ticker, coinbase_ticker, kraken_ticker, okx_ticker) in
-            ERC20_DATA.iter()
+        for (erc20_ticker, binance_ticker, coinbase_ticker, kraken_ticker, okx_ticker) in
+            TICKER_NAMES.iter()
         {
             let process_ticker = move |ticker: ExchangeTicker| -> Option<&'static str> {
                 match ticker {
@@ -650,7 +293,7 @@ impl Token {
 
     /// Returns the ERC-20 `decimals` field, if available.
     pub fn get_decimals(&self) -> Option<u8> {
-        ADDR_DECIMALS_MAP.get(self.get_addr()).copied()
+        ADDR_DECIMALS_MAP.get().unwrap().get(self.get_addr()).copied()
     }
 
     /// Returns true if the Token has a Renegade-native ticker.

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -22,7 +22,7 @@ ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 ethers = { workspace = true }
 json = "0.12"
 rand_core = "0.5"
-reqwest = { verison = "0.11", features = ["blocking"] }
+reqwest = { verison = "0.11", features = ["blocking", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/config/src/token_remaps.rs
+++ b/config/src/token_remaps.rs
@@ -46,6 +46,7 @@ impl TokenRemap {
 }
 
 /// Setup token remaps in the global `OnceCell`
+// TODO(@akirillo): populate `ADDR_DECIMALS_MAP` with the decimals from the remap
 pub fn setup_token_remaps(remap_file: Option<String>, chain: Chain) -> Result<(), String> {
     // If the remap file is not provided, fetch the Renegade maintained remap file
     // from the default location

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -184,7 +184,7 @@ impl HttpServer {
         // Build the router and register its routes
         let mut router = Router::new(global_state.clone());
 
-        // The "/exchangeHealthStates" route
+        // The "/price_report" route
         router.add_route(
             &Method::POST,
             PRICE_REPORT_ROUTE.to_string(),

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -22,9 +22,9 @@ const ERR_NO_PRICE_STREAM: &str = "price report not available for token pair";
 // | Quote Tokens |
 // ----------------
 
-/// USDC ticker
+/// USDT ticker
 ///
-/// For now we only stream prices quoted in USDC
+/// For now we only stream prices quoted in USDT
 const USDT_TICKER: &str = "USDT";
 
 // ---------------

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -25,7 +25,7 @@ const ERR_NO_PRICE_STREAM: &str = "price report not available for token pair";
 /// USDC ticker
 ///
 /// For now we only stream prices quoted in USDC
-const USDC_TICKER: &str = "USDC";
+const USDT_TICKER: &str = "USDT";
 
 // ---------------
 // | Base Tokens |
@@ -41,8 +41,6 @@ const BNB_TICKER: &str = "BNB";
 const MATIC_TICKER: &str = "MATIC";
 /// LDO ticker
 const LDO_TICKER: &str = "LDO";
-/// CBETH ticker
-const CBETH_TICKER: &str = "CBETH";
 /// LINK ticker
 const LINK_TICKER: &str = "LINK";
 /// UNI ticker
@@ -61,47 +59,43 @@ lazy_static! {
         vec![
             (
                 Token::from_ticker(BTC_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(ETH_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(BNB_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(MATIC_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(LDO_TICKER),
-                Token::from_ticker(USDC_TICKER),
-            ),
-            (
-                Token::from_ticker(CBETH_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(LINK_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(UNI_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(CRV_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(DYDX_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             ),
             (
                 Token::from_ticker(AAVE_TICKER),
-                Token::from_ticker(USDC_TICKER),
+                Token::from_ticker(USDT_TICKER),
             )
         ]
     };

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use bimap::BiMap;
 use common::types::exchange::{PriceReport, PriceReporterState};
-use common::types::token::{Token, ERC20_DATA, TOKEN_REMAPS};
+use common::types::token::{Token, TICKER_NAMES, TOKEN_REMAPS};
 use common::types::Price;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
@@ -19,9 +19,9 @@ use crate::errors::PriceReporterError;
 pub fn setup_mock_token_remap() {
     // Setup the mock token map
     let mut token_map = BiMap::new();
-    for (i, token_data) in ERC20_DATA.iter().enumerate() {
-        // Pull the ticker, the index 2 field
-        let ticker = token_data.2.to_string();
+    for (i, token_data) in TICKER_NAMES.iter().enumerate() {
+        // Pull the ticker, the index 0 field
+        let ticker = token_data.0.to_string();
         let addr = format!("{i:x}");
 
         token_map.insert(addr, ticker);


### PR DESCRIPTION
This PR accomplishes the following:
1. Pares down any token metadata hardcoded in the relayer to contain only those tokens which are supported by Binance, and are currently on the hosted token remap in Github. This latter condition is temporary, I'll hammer out canonical token list w/ @ChrisBender tomorrow & update hosted token remap accordingly.
2. Simplifies the `ERC20_DATA` static to only contain ticker renaming information across exchanges, deferring the token address & decimals to the remap used by the relayer as the source of truth.

Also, this PR temporarily switches the quote asset for the default pairs from USDC to USDT. This is because many assets do not have a USDC pair on Binance. When stablecoin price conversion is implemented, we can go back to default USDC quotes w/ price conversion beneath the hood. But for now, this allows the relayer to run against the deployed price reporter w/o issue and with effectively identical prices to what will be implemented, unblocking testing of the frontend.

Using this, the relayer successfully returns a price report over http both when using the native and external executor for the price reporter worker. For the external executor, I ran a price reporter locally over VPN that made use of the changes in this PR. I have also deployed a staging price reporter that imports the changes in this PR and tested the relayer locally against it, confirming that it can return price reports.

When this PR is merged, the `andrew/external-price-reporting-clean` branch will be ready for merge with `main`, ahead of the stablecoin price conversion logic.