### PR TITLE
workers: price-reporter: per-exchange stream states

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -322,13 +322,13 @@ lazy_static! {
         exchange_tickers
     };
     /// The set of stablecoin quote assets
-    static ref STABLECOIN_QUOTES: HashSet<Token> = {
+    pub static ref STABLECOIN_QUOTES: HashSet<Token> = {
         let stablecoin_tickers = [USDC_TICKER, USDT_TICKER];
         stablecoin_tickers.iter().map(|ticker| Token::from_ticker(ticker)).collect()
     };
     /// The mapping between exchanges and the stablecoin quote asset on which they are generally
     /// the most liquid
-    static ref MOST_LIQ_STABLE: HashMap<Exchange, Token> = {
+    pub static ref MOST_LIQ_STABLE: HashMap<Exchange, Token> = {
         let mut most_liquid_stable = HashMap::<Exchange, Token>::new();
 
         // Most liquid stablecoin quote on Binance is generally USDT

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -28,6 +28,64 @@ use crate::biguint_to_str_addr;
 
 use super::exchange::{Exchange, ALL_EXCHANGES};
 
+// ----------------
+// | Quote Tokens |
+// ----------------
+
+/// USDC ticker
+pub const USDC_TICKER: &str = "USDC";
+/// USDT ticker
+pub const USDT_TICKER: &str = "USDT";
+/// USD ticker
+///
+/// We don't actually allow USD as a quote asset since it's not an ERC20,
+/// but it is used as a quote in some exchanges, so we must be able to
+/// stream prices for it.
+pub const USD_TICKER: &str = "USD";
+
+// ---------------
+// | Base Tokens |
+// ---------------
+
+/// WBTC ticker
+pub const WBTC_TICKER: &str = "WBTC";
+/// WETH ticker
+pub const WETH_TICKER: &str = "WETH";
+/// BNB ticker
+pub const BNB_TICKER: &str = "BNB";
+/// MATIC ticker
+pub const MATIC_TICKER: &str = "MATIC";
+/// LDO ticker
+pub const LDO_TICKER: &str = "LDO";
+/// LINK ticker
+pub const LINK_TICKER: &str = "LINK";
+/// UNI ticker
+pub const UNI_TICKER: &str = "UNI";
+/// CRV ticker
+pub const CRV_TICKER: &str = "CRV";
+/// DYDX ticker
+pub const DYDX_TICKER: &str = "DYDX";
+/// AAVE ticker
+pub const AAVE_TICKER: &str = "AAVE";
+/// SUSHI ticker
+pub const SUSHI_TICKER: &str = "SUSHI";
+/// 1INCH ticker
+pub const _1INCH_TICKER: &str = "1INCH";
+/// COMP ticker
+pub const COMP_TICKER: &str = "COMP";
+/// MKR ticker
+pub const MKR_TICKER: &str = "MKR";
+/// TORN ticker
+pub const TORN_TICKER: &str = "TORN";
+/// REN ticker
+pub const REN_TICKER: &str = "REN";
+/// SHIB ticker
+pub const SHIB_TICKER: &str = "SHIB";
+/// ENS ticker
+pub const ENS_TICKER: &str = "ENS";
+/// MANA ticker
+pub const MANA_TICKER: &str = "MANA";
+
 /// A helper enum to describe the state of each ticker on each Exchange. Same
 /// means that the ERC-20 and Exchange tickers are the same, Renamed means that
 /// the Exchange ticker is different from the underlying ERC-20, and Unsupported
@@ -42,13 +100,6 @@ pub enum ExchangeTicker {
     Unsupported,
 }
 
-// We populate three global heap-allocated structs for convenience and metadata
-// lookup. The first is a bidirectional map between the ERC-20 contract address
-// and the ERC-20 ticker. The second is a HashMap between the ERC-20 contract
-// address and the number of decimals (fixed-point offset). The third is a
-// HashMap between the ERC-20 ticker and each Exchange's expected name for each
-// ticker.
-
 /// The remapping of tickers between exchanges. The layout of `TICKER_NAMES` is
 /// (Renegade Ticker, Binance Ticker, Coinbase Ticker, Kraken Ticker, Okx
 /// Ticker), where "Renegade Ticker" denotes the ticker expected in the Renegade
@@ -62,84 +113,95 @@ pub static TICKER_NAMES: &[(
 )] = &[
     // L1
     (
-        "WBTC",
+        WBTC_TICKER,
         ExchangeTicker::Renamed("BTC"),
         ExchangeTicker::Renamed("BTC"),
         ExchangeTicker::Renamed("BTC"),
         ExchangeTicker::Renamed("BTC"),
     ),
     (
-        "WETH",
+        WETH_TICKER,
         ExchangeTicker::Renamed("ETH"),
         ExchangeTicker::Renamed("ETH"),
         ExchangeTicker::Renamed("ETH"),
         ExchangeTicker::Renamed("ETH"),
     ),
     (
-        "BNB",
+        BNB_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
         ExchangeTicker::Unsupported,
         ExchangeTicker::Same,
     ),
     (
-        "MATIC",
+        MATIC_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     // LSDs
-    ("LDO", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
+    (
+        LDO_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
     // Stables
     (
-        "USDC",
-        ExchangeTicker::Same,
-        ExchangeTicker::Renamed("USD"), // USDC has 1:1 peg with USD on Coinbase
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        "USDT",
+        USDC_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     (
-        "USD",
-        ExchangeTicker::Unsupported,
+        USDT_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
     ),
     // Oracles
     (
-        "LINK",
+        LINK_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     // DeFi Trading
-    ("UNI", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
-    ("CRV", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
     (
-        "DYDX",
+        UNI_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
+    (
+        CRV_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
+    (
+        DYDX_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     (
-        "SUSHI",
+        SUSHI_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     (
-        "1INCH",
+        _1INCH_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -147,41 +209,59 @@ pub static TICKER_NAMES: &[(
     ),
     // DeFi Lending
     (
-        "AAVE",
+        AAVE_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
     (
-        "COMP",
+        COMP_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
-    ("MKR", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
+    (
+        MKR_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
     // DeFi Other
     (
-        "TORN",
+        TORN_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Unsupported,
         ExchangeTicker::Unsupported,
         ExchangeTicker::Unsupported,
     ),
     // Bridges
-    ("REN", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
-    // Misc
     (
-        "SHIB",
+        REN_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),
-    ("ENS", ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same, ExchangeTicker::Same),
+    // Misc
     (
-        "MANA",
+        SHIB_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
+    (
+        ENS_TICKER,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+        ExchangeTicker::Same,
+    ),
+    (
+        MANA_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
@@ -194,10 +274,11 @@ pub static TICKER_NAMES: &[(
 pub static TOKEN_REMAPS: OnceLock<BiMap<String, String>> = OnceLock::new();
 
 /// The decimal mapping for the given environment, maps from the token address
-/// to the number of decimals the token uses
+/// to the number of decimals the token uses (fixed-point offset)
 pub static ADDR_DECIMALS_MAP: OnceLock<HashMap<String, u8>> = OnceLock::new();
 
 lazy_static! {
+    /// The mapping of ERC-20 ticker to the expected ticker names on each Exchange.
     static ref EXCHANGE_TICKERS: HashMap<Exchange, HashMap<String, String>> = {
         let mut exchange_tickers = HashMap::<Exchange, HashMap<String, String>>::new();
         for exchange in [Exchange::Binance, Exchange::Coinbase, Exchange::Kraken, Exchange::Okx] {
@@ -239,6 +320,29 @@ lazy_static! {
             }
         }
         exchange_tickers
+    };
+    /// The set of stablecoin quote assets
+    static ref STABLECOIN_QUOTES: HashSet<Token> = {
+        let stablecoin_tickers = [USDC_TICKER, USDT_TICKER];
+        stablecoin_tickers.iter().map(|ticker| Token::from_ticker(ticker)).collect()
+    };
+    /// The mapping between exchanges and the stablecoin quote asset on which they are generally
+    /// the most liquid
+    static ref MOST_LIQ_STABLE: HashMap<Exchange, Token> = {
+        let mut most_liquid_stable = HashMap::<Exchange, Token>::new();
+
+        // Most liquid stablecoin quote on Binance is generally USDT
+        most_liquid_stable.insert(Exchange::Binance, Token::from_ticker(USDT_TICKER));
+        // Most liquid stablecoin quote on Coinbase is generally USDC
+        most_liquid_stable.insert(Exchange::Coinbase, Token::from_ticker(USDC_TICKER));
+        // Most liquid "stablecoin" quote on Kraken is generally USD
+        most_liquid_stable.insert(Exchange::Kraken, Token::from_ticker(USD_TICKER));
+        // Most liquid stablecoin quote on Okx is generally USDT
+        most_liquid_stable.insert(Exchange::Okx, Token::from_ticker(USDT_TICKER));
+
+        // We currently omit UniswapV3 here, as it requires more involved routing logic
+
+        most_liquid_stable
     };
 }
 

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -43,6 +43,10 @@ pub const USDT_TICKER: &str = "USDT";
 /// stream prices for it.
 pub const USD_TICKER: &str = "USD";
 
+/// The set of tickers of stablecoin quote assets for which price conversion may
+/// be invoked
+pub const STABLECOIN_QUOTE_TICKERS: &[&str] = &[USDC_TICKER, USDT_TICKER];
+
 // ---------------
 // | Base Tokens |
 // ---------------
@@ -321,29 +325,6 @@ lazy_static! {
         }
         exchange_tickers
     };
-    /// The set of stablecoin quote assets
-    pub static ref STABLECOIN_QUOTES: HashSet<Token> = {
-        let stablecoin_tickers = [USDC_TICKER, USDT_TICKER];
-        stablecoin_tickers.iter().map(|ticker| Token::from_ticker(ticker)).collect()
-    };
-    /// The mapping between exchanges and the stablecoin quote asset on which they are generally
-    /// the most liquid
-    pub static ref MOST_LIQ_STABLE: HashMap<Exchange, Token> = {
-        let mut most_liquid_stable = HashMap::<Exchange, Token>::new();
-
-        // Most liquid stablecoin quote on Binance is generally USDT
-        most_liquid_stable.insert(Exchange::Binance, Token::from_ticker(USDT_TICKER));
-        // Most liquid stablecoin quote on Coinbase is generally USDC
-        most_liquid_stable.insert(Exchange::Coinbase, Token::from_ticker(USDC_TICKER));
-        // Most liquid "stablecoin" quote on Kraken is generally USD
-        most_liquid_stable.insert(Exchange::Kraken, Token::from_ticker(USD_TICKER));
-        // Most liquid stablecoin quote on Okx is generally USDT
-        most_liquid_stable.insert(Exchange::Okx, Token::from_ticker(USDT_TICKER));
-
-        // We currently omit UniswapV3 here, as it requires more involved routing logic
-
-        most_liquid_stable
-    };
 }
 
 /// The core Token abstraction, used for unambiguous definition of an ERC-20
@@ -468,4 +449,15 @@ impl Token {
 /// the pair should be supported on centralized exchanges.
 pub fn is_pair_named(base: &Token, quote: &Token) -> bool {
     base.is_named() && quote.is_named()
+}
+
+/// Returns the default stable quote asset for the given exchange.
+pub fn default_exchange_stable(exchange: &Exchange) -> Token {
+    match exchange {
+        Exchange::Binance => Token::from_ticker(USDT_TICKER),
+        Exchange::Coinbase => Token::from_ticker(USDC_TICKER),
+        Exchange::Kraken => Token::from_ticker(USD_TICKER),
+        Exchange::Okx => Token::from_ticker(USDT_TICKER),
+        _ => panic!("No default stable quote asset for exchange: {:?}", exchange),
+    }
 }

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -2,7 +2,15 @@
 
 use std::collections::HashMap;
 
-use common::types::{exchange::PriceReporterState, token::Token, wallet::OrderIdentifier, Price};
+use common::types::{
+    exchange::PriceReporterState,
+    token::{
+        Token, AAVE_TICKER, BNB_TICKER, CRV_TICKER, DYDX_TICKER, LDO_TICKER, LINK_TICKER,
+        MATIC_TICKER, UNI_TICKER, USDC_TICKER, WBTC_TICKER, WETH_TICKER,
+    },
+    wallet::OrderIdentifier,
+    Price,
+};
 use gossip_api::request_response::handshake::PriceVector;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};
 use lazy_static::lazy_static;
@@ -18,84 +26,50 @@ const MAX_PRICE_DEVIATION: f64 = 0.01;
 /// pair
 const ERR_NO_PRICE_STREAM: &str = "price report not available for token pair";
 
-// ----------------
-// | Quote Tokens |
-// ----------------
-
-/// USDT ticker
-///
-/// For now we only stream prices quoted in USDT
-const USDT_TICKER: &str = "USDT";
-
-// ---------------
-// | Base Tokens |
-// ---------------
-
-/// BTC ticker
-const BTC_TICKER: &str = "WBTC";
-/// ETH ticker
-const ETH_TICKER: &str = "WETH";
-/// BNB ticker
-const BNB_TICKER: &str = "BNB";
-/// MATIC ticker
-const MATIC_TICKER: &str = "MATIC";
-/// LDO ticker
-const LDO_TICKER: &str = "LDO";
-/// LINK ticker
-const LINK_TICKER: &str = "LINK";
-/// UNI ticker
-const UNI_TICKER: &str = "UNI";
-/// CRV ticker
-const CRV_TICKER: &str = "CRV";
-/// DYDX ticker
-const DYDX_TICKER: &str = "DYDX";
-/// AAVE ticker
-const AAVE_TICKER: &str = "AAVE";
-
 lazy_static! {
     /// The token pairs we want to keep price streams open for persistently
     pub static ref DEFAULT_PAIRS: Vec<(Token, Token)> = {
         // For now we only stream prices quoted in USDC
         vec![
             (
-                Token::from_ticker(BTC_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(WBTC_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
-                Token::from_ticker(ETH_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(WETH_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(BNB_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(MATIC_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(LDO_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(LINK_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(UNI_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(CRV_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(DYDX_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             ),
             (
                 Token::from_ticker(AAVE_TICKER),
-                Token::from_ticker(USDT_TICKER),
+                Token::from_ticker(USDC_TICKER),
             )
         ]
     };

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -139,6 +139,18 @@ pub fn get_supported_exchanges(
 
 /// Computes the state of the price reporter for the given token pair,
 /// checking against the provided exchange prices.
+
+// NOTE(@akirillo): This feels like the most sensible place to do stable-quote
+// price conversion. But, we need access to other pairs, e.g. base-liquid quote,
+// liquid quote-USDC. Can get this off of the price reporter structs, but this
+// method is generic over them. May be worth making a trait for this...
+// However, we also need to fetch alternate pair prices for each of the
+// exchanges. Let's start by writing this in `get_state` separately for each
+// executor, and re-abstract later. Though, I think the way this will play out
+// is a trait method that is an analogue of `get_state` for each exchange,
+// performing whatever conversions are necessary.
+// In fact, we can keep this method the same. The only thing that changes is the
+// prices that are passed in from each respective executor.
 pub fn compute_price_reporter_state(
     base_token: Token,
     quote_token: Token,

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -228,7 +228,7 @@ impl ExternalPriceReporterExecutor {
 
     /// Handler for the PeekPrice job
     async fn peek_price(
-        &mut self,
+        &self,
         base_token: Token,
         quote_token: Token,
         channel: TokioSender<PriceReporterState>,

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -270,6 +270,8 @@ impl ExternalPriceReporterExecutor {
     }
 
     /// Get the latest price for the given exchange and token pair
+    // TODO(@akirillo): HERE is where we will need to add the stable-quote price
+    // conversion logic for each exchange.
     async fn get_latest_price(
         &self,
         exchange: &Exchange,

--- a/workers/price-reporter/src/reporter.rs
+++ b/workers/price-reporter/src/reporter.rs
@@ -160,6 +160,8 @@ impl Reporter {
         }
 
         // Fetch the most recent price
+        // TODO(@akirillo): HERE, we will need to wrap around `read_price` to do stable
+        // quote conversion logic
         match self.exchange_info.read_price(&Exchange::Binance) {
             None => PriceReporterState::NotEnoughDataReported(0),
             Some((price, ts)) => {


### PR DESCRIPTION
This PR is introduces some preliminary changes to facilitate the implementation of stablecoin-quote price conversion. Primarily:
1. Adds a static set of stablecoin tokens, which are candidates for price conversion when they are a quote asset
2. Adds a static mapping from exchange -> most liquid stable quote asset for that exchange, this will be the pair through which price is converted when the pair in the order is quoted with a different stablecoin
3. Lifts the mapping from exchange -> atomic (price, timestamp) out of the `AtomicPriceStreamState`. This makes the subsequent implementation of kicking off price streams for potentially different pairs than what was requested, as well as computing the price via conversion through the most liquid stable quote asset, much smoother. For example, when requesting prices for UNI<>USDC, that will mean a UNI<>USDT price stream on Binance, and a UNI<>USD price stream on Kraken. Because of a potentially non-uniform quote on the underlying price streams with exchanges, it no longer makes sense to couple the price stream state for all exchanges under a single pair.

These changes are a work in progress, and will continue to take shape in subsequent PRs for price conversion. I wanted to get this PR up as I am fairly confident in this direction and wanted to split up review.