### PR TITLE
workers: price-reporter: stable quote price conversion in external executor

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -43,9 +43,9 @@ pub const USDT_TICKER: &str = "USDT";
 /// stream prices for it.
 pub const USD_TICKER: &str = "USD";
 
-/// The set of tickers of stablecoin quote assets for which price conversion may
-/// be invoked
-pub const STABLECOIN_QUOTE_TICKERS: &[&str] = &[USDC_TICKER, USDT_TICKER];
+/// The set of tickers of stablecoins for which price conversion may
+/// be invoked if they are the quote
+pub const STABLECOIN_TICKERS: &[&str] = &[USDC_TICKER, USDT_TICKER];
 
 // ---------------
 // | Base Tokens |
@@ -384,6 +384,11 @@ impl Token {
     /// Returns true if the Token has a Renegade-native ticker.
     pub fn is_named(&self) -> bool {
         self.get_ticker().is_some()
+    }
+
+    /// Returns true if the Token is a stablecoin.
+    pub fn is_stablecoin(&self) -> bool {
+        self.get_ticker().map_or(false, |ticker| STABLECOIN_TICKERS.contains(&ticker))
     }
 
     /// Returns the set of Exchanges that support this token.


### PR DESCRIPTION
This PR implements price conversion for stable-quoted assets in the external executor of the price reporter. This includes the following logic when a BASE<>NON-DEFAULT STABLE pair's price is requested:
1. Subscribe to price streams for BASE<>DEFAULT STABLE and NON-DEFAULT STABLE<>DEFAULT STABLE
2. Compute the converted price as (BASE/DEFAULT STABLE) / (NON-DEFAULT STABLE / DEFAULT STABLE)

I have asserted that this works ad-hoc, by running the relayer against the deployed price reporter and logging when price conversion occurs.

In the next PR, I will implement this for the native executor.