### PR TITLE
common: wallet: balances, orders: Make order/balance append consistent

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -17,7 +17,7 @@ use super::{
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
+    wallet::{KeyChain, Wallet, WalletIdentifier},
 };
 
 /// The error message returned when a wallet's shares are invalid
@@ -227,12 +227,8 @@ impl From<LookupWalletTaskDescriptor> for TaskDescriptor {
 pub struct SettleMatchInternalTaskDescriptor {
     /// The price at which the match was executed
     pub execution_price: FixedPoint,
-    /// The identifier of the first order
-    pub order_id1: OrderIdentifier,
     /// The identifier of the first order's wallet
     pub wallet_id1: WalletIdentifier,
-    /// The identifier of the second order
-    pub order_id2: OrderIdentifier,
     /// The identifier of the second order's wallet
     pub wallet_id2: WalletIdentifier,
     /// The validity proofs for the first order
@@ -252,9 +248,7 @@ impl SettleMatchInternalTaskDescriptor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         execution_price: FixedPoint,
-        order_id1: OrderIdentifier,
         wallet_id1: WalletIdentifier,
-        order_id2: OrderIdentifier,
         wallet_id2: WalletIdentifier,
         order1_proof: OrderValidityProofBundle,
         order1_validity_witness: OrderValidityWitnessBundle,
@@ -264,9 +258,7 @@ impl SettleMatchInternalTaskDescriptor {
     ) -> Result<Self, String> {
         Ok(SettleMatchInternalTaskDescriptor {
             execution_price,
-            order_id1,
             wallet_id1,
-            order_id2,
             wallet_id2,
             order1_proof,
             order1_validity_witness,

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -64,8 +64,8 @@ impl Wallet {
     /// wallet is full
     pub fn add_order(&mut self, id: OrderIdentifier, order: Order) -> Result<(), String> {
         // Append if the orders are not full
-        if let Some(index) = self.find_first_default_order() {
-            self.orders.insert_at_index(index, id, order);
+        if let Some(index) = self.find_first_replaceable_order() {
+            self.orders.replace_at_index(index, id, order);
         } else if self.orders.len() < MAX_ORDERS {
             self.orders.append(id, order)
         } else {
@@ -76,8 +76,8 @@ impl Wallet {
     }
 
     /// Find the first default order in the wallet
-    fn find_first_default_order(&self) -> Option<usize> {
-        self.orders.iter().position(|(_, order)| order.is_default())
+    fn find_first_replaceable_order(&self) -> Option<usize> {
+        self.orders.iter().position(|(_, order)| order.is_zero())
     }
 
     /// Remove an order from the wallet, replacing it with a default order

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -95,8 +95,6 @@ impl HandshakeExecutor {
                 .try_match_and_settle(
                     my_order.clone(),
                     order2,
-                    network_order.id,
-                    order_id,
                     wallet.wallet_id,
                     other_wallet_id,
                     price,
@@ -130,8 +128,6 @@ impl HandshakeExecutor {
         &self,
         o1: Order,
         o2: Order,
-        order_id1: OrderIdentifier,
-        order_id2: OrderIdentifier,
         wallet_id1: WalletIdentifier,
         wallet_id2: WalletIdentifier,
         price: FixedPoint,
@@ -151,9 +147,7 @@ impl HandshakeExecutor {
         // Submit the match to the task driver
         let task: TaskDescriptor = SettleMatchInternalTaskDescriptor::new(
             price,
-            order_id1,
             wallet_id1,
-            order_id2,
             wallet_id2,
             validity_proof1,
             validity_witness1,


### PR DESCRIPTION
### Purpose
This PR modifies the logic for balance and order updates to make them mutually consistent:
- Orders are now overwritten if they are zero'd (amount is zero)
- Balances are now overwritten if they are zero'd (amount and fees are zero)
- Balances are added to the wallet in the same fashion orders are, i.e:
    - Overwriting the first zero'd balance if it exists
    - Appending if possible
    - Erroring otherwise

### Testing
- Unit tests pass