### PR TITLE
workers: price-reporter: manager: properly compute price reports upon price update

### DIFF
--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -59,7 +59,7 @@ const HANDSHAKE_ROUTE: &str = "/v0/handshake";
 /// The wallet topic, events about wallet updates are streamed here
 const WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
 /// The price report topic, events about price updates are streamed
-const PRICE_REPORT_ROUTE: &str = "/v0/price_report/:source/:base/:quote";
+const PRICE_REPORT_ROUTE: &str = "/v0/price_report/:base/:quote";
 /// The order book topic, streams events about known network orders
 const ORDER_BOOK_ROUTE: &str = "/v0/order_book";
 /// The network topic, streams events about network peers
@@ -114,7 +114,7 @@ impl WebsocketServer {
             )
             .unwrap();
 
-        // The "/v0/price_report/:source/:base/:quote" route
+        // The "/v0/price_report/:base/:quote" route
         router
             .insert(
                 PRICE_REPORT_ROUTE,


### PR DESCRIPTION
This PR ensures that we compute and publish price reports for the correct pairs when price updates come in. Previously, we would report prices for the exact pair for which an update was received, however it is possible that was a conversion pair (e.g. (requested quote, default stable)), for which we don't actually care about the price. More importantly, for any converted pairs, we would never report the price for the actual requested (base, quote), since we never get price updates directly for that pair.

We now track the top-level `requested_pairs`, and a mapping from a conversion pair to the requested pairs that depend on it, in the `PriceStreamStatesManager`, so that when a price update comes in, we can report prices for all of the requested pairs that depend on that update.

I have tested this locally with both the native and external executors, ensuring that I can stream prices over the websocket API (i.e., without sending a separate `PeekPrice` job).