### PR TITLE
renegade-metrics, workers: gossip-server: set gauge metrics directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6617,6 +6617,8 @@ dependencies = [
  "common",
  "metrics",
  "num-bigint",
+ "state",
+ "tracing",
  "util",
 ]
 

--- a/renegade-metrics/Cargo.toml
+++ b/renegade-metrics/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # === Telemetry === #
+tracing = { workspace = true }
 metrics = { workspace = true }
 
 # === Cryptography / Arithmetic === #
@@ -14,3 +15,4 @@ num-bigint = { workspace = true }
 circuit-types = { path = "../circuit-types" }
 util = { path = "../util" }
 common = { path = "../common" }
+state = { path = "../state" }

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::{
     GossipRequest,
 };
 use job_types::network_manager::NetworkManagerJob;
-use renegade_metrics::labels::{NUM_LOCAL_PEERS_METRIC, NUM_REMOTE_PEERS_METRIC};
+use renegade_metrics::helpers::record_num_peers_metrics;
 use tracing::info;
 use util::{err_str, get_current_time_seconds};
 
@@ -145,11 +145,7 @@ impl GossipProtocolExecutor {
         let mut locked_expiry_cache = self.peer_expiry_cache.write().await;
         locked_expiry_cache.put(peer_id, now);
 
-        if same_cluster {
-            metrics::gauge!(NUM_LOCAL_PEERS_METRIC).decrement(1.0);
-        } else {
-            metrics::gauge!(NUM_REMOTE_PEERS_METRIC).decrement(1.0);
-        }
+        record_num_peers_metrics(&self.global_state);
 
         Ok(())
     }

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -7,7 +7,7 @@ use gossip_api::request_response::{
 };
 use itertools::Itertools;
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use renegade_metrics::labels::{NUM_LOCAL_PEERS_METRIC, NUM_REMOTE_PEERS_METRIC};
+use renegade_metrics::helpers::record_num_peers_metrics;
 use tracing::warn;
 use util::{err_str, get_current_time_seconds};
 
@@ -108,13 +108,7 @@ impl GossipProtocolExecutor {
         // Add all filtered peers to the global peer index
         self.global_state.add_peer_batch(filtered_peers.clone())?;
 
-        let my_cluster_id = self.global_state.get_cluster_id()?;
-        let num_local_peers =
-            filtered_peers.iter().filter(|peer| peer.cluster_id == my_cluster_id).count();
-        let num_remote_peers = filtered_peers.len() - num_local_peers;
-
-        metrics::gauge!(NUM_LOCAL_PEERS_METRIC).increment(num_local_peers as f64);
-        metrics::gauge!(NUM_REMOTE_PEERS_METRIC).increment(num_remote_peers as f64);
+        record_num_peers_metrics(&self.global_state);
 
         Ok(())
     }


### PR DESCRIPTION
This PR ensures that we `.set` gauge metrics directly, as the [`metrics_exporter_statsd`](https://docs.rs/metrics-exporter-statsd/latest/metrics_exporter_statsd/) crate [doesn't support incrementing/decrementing gauges](https://arc.net/l/quote/ucictrkr)