### PR TITLE
workers: task-driver: running_task: await task completion before popping

### DIFF
--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -518,6 +518,21 @@ impl StateWrapper {
             },
         }
     }
+
+    /// Whether the underlying state is completed or not
+    pub fn completed(&self) -> bool {
+        match self {
+            StateWrapper::LookupWallet(state) => state.completed(),
+            StateWrapper::NewWallet(state) => state.completed(),
+            StateWrapper::PayOfflineFee(state) => state.completed(),
+            StateWrapper::PayRelayerFee(state) => state.completed(),
+            StateWrapper::RedeemRelayerFee(state) => state.completed(),
+            StateWrapper::SettleMatch(state) => state.completed(),
+            StateWrapper::SettleMatchInternal(state) => state.completed(),
+            StateWrapper::UpdateWallet(state) => state.completed(),
+            StateWrapper::UpdateMerkleProof(state) => state.completed(),
+        }
+    }
 }
 
 impl Display for StateWrapper {

--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -94,11 +94,12 @@ impl<T: Task> RunnableTask<T> {
             return Ok(());
         }
 
-        // If this state commits the task (first state past the commit point) then await
-        // consensus before continuing
+        // If this state commits the task (first state past the commit point),
+        // or if the task is completed, then await consensus before continuing
         let is_commit = new_state.is_committing();
+        let is_completed = new_state.completed();
         let waiter = self.state.transition_task(task_id, new_state.into())?;
-        if is_commit {
+        if is_commit || is_completed {
             waiter.await?;
         }
 


### PR DESCRIPTION
This PR updates the running task `transition_state` method to await the application of the transition to a completed state. This prevents the issue of the subsequent `pop_task` state transition being applied before the `transition_state` transition, despite being proposed after.

I've tested this locally with a two-node cluster and am no longer seeing the ordering issue.