### PR TITLE
core: setup, state: interface: increase election & heartbeat intervals

### DIFF
--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -36,9 +36,12 @@ pub async fn node_setup(
     client: &ArbitrumClient,
     state: &State,
 ) -> Result<(), CoordinatorError> {
-    // Wait a small amount of time for raft to stabilize
-    // TODO: remove this once we have a more fleshed out startup flow
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Wait for raft to stabilize, this must be at least the length of the max
+    // election timeout
+
+    // TODO: remove this once we have a more fleshed
+    // out startup flow
+    tokio::time::sleep(Duration::from_secs(15)).await;
 
     // Setup the contract constants
     fetch_contract_constants(client).await?;


### PR DESCRIPTION
This PR increases the Raft heartbeat interval to 1s and the election timeout to be bounded between 10-15s. This ensures that Raft elections are not instigated unnecessarily when the network manager is handling bursts of load, in which case Raft heartbeats take longer to dequeue and execute.

We also move the node setup to after the gossip server is spun up, so that nodes are able to gossip raft messages, receive heartbeats, and establish leadership accordingly before the node setup delay kicks in - otherwise this gives nodes enough time to self-elect before heartbeating and thus never have a consistent view of leadership (as they would self-elect as leaders w/ the same term and # of log entries before ever heartbeating, leading to a stalemate)

I tested this by running a 2-node cluster locally in debug mode, and am able to successfully go from empty state to two wallets that match and settle an order internally.