### PR TITLE
state: storage: mpc-preprocessing: Define storage primitives

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,8 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Test 
       uses: actions-rs/cargo@v1
       with: 
         command: test
-        args: --workspace --all-features --verbose -- --skip integration
+        args: --workspace --release --all-features --verbose -- --skip integration

--- a/common/src/types/offline_phase.rs
+++ b/common/src/types/offline_phase.rs
@@ -6,7 +6,7 @@ use renegade_dealer_api::DealerResponse;
 use serde::{Deserialize, Serialize};
 
 /// The result of an offline phase
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CorrelatedRandomness {
     /// The random bits, shares of values in {0, 1}
     pub random_bits: Vec<ScalarShare>,
@@ -100,7 +100,7 @@ impl From<DealerResponse> for CorrelatedRandomness {
 }
 
 /// The result of an offline phase with the counterparty
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PairwiseOfflineSetup {
     /// The local share of the MAC key
     pub mac_key: Scalar,
@@ -109,6 +109,11 @@ pub struct PairwiseOfflineSetup {
 }
 
 impl PairwiseOfflineSetup {
+    /// Create a new empty setup
+    pub fn new(mac_key: Scalar) -> Self {
+        PairwiseOfflineSetup { mac_key, values: CorrelatedRandomness::default() }
+    }
+
     /// Append new correlated randomness to the setup
     pub fn append(&mut self, other: &CorrelatedRandomness) {
         self.values.append(other);

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -10,10 +10,11 @@ use system_bus::SystemBus;
 
 use crate::{storage::db::DB, StateTransition};
 
-use self::error::StateApplicatorError;
+use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 
 pub mod error;
 pub mod order_book;
+pub mod return_type;
 pub mod task_queue;
 pub mod wallet_index;
 
@@ -61,7 +62,10 @@ impl StateApplicator {
     }
 
     /// Handle a state transition
-    pub fn handle_state_transition(&self, transition: StateTransition) -> Result<()> {
+    pub fn handle_state_transition(
+        &self,
+        transition: StateTransition,
+    ) -> Result<ApplicatorReturnType> {
         match transition {
             StateTransition::AddWallet { wallet } => self.add_wallet(&wallet),
             StateTransition::UpdateWallet { wallet } => self.update_wallet(&wallet),
@@ -77,6 +81,7 @@ impl StateApplicator {
             StateTransition::ResumeTaskQueue { key } => self.resume_task_queue(key),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
+        .map(|_| ApplicatorReturnType::None)
     }
 
     /// Get a reference to the db

--- a/state/src/applicator/return_type.rs
+++ b/state/src/applicator/return_type.rs
@@ -1,0 +1,30 @@
+//! Return types from applicator methods
+//!
+//! We provide "function call" like semantics over the consensus engine by
+//! allowing the applicator to return a value from the engine to its callers.
+//! In this case the callers are locations awaiting a proposal's application
+//!
+//! Each of such waiters will be given a copy of the return value
+
+use common::types::offline_phase::PairwiseOfflineSetup;
+
+/// The return type from the Applicator
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum ApplicatorReturnType {
+    /// A set of MPC preprocessing values that are ready to be used
+    MpcPrep(PairwiseOfflineSetup),
+    /// No return value
+    None,
+}
+
+// Downcasting conversions
+
+impl From<ApplicatorReturnType> for PairwiseOfflineSetup {
+    fn from(return_type: ApplicatorReturnType) -> Self {
+        match return_type {
+            ApplicatorReturnType::MpcPrep(setup) => setup,
+            _ => panic!("Expected MpcPrep, got: {return_type:?}"),
+        }
+    }
+}

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -145,7 +145,10 @@ mod test {
     };
     use system_bus::SystemBus;
 
-    use crate::{replication::network::traits::test_helpers::MockNetwork, State};
+    use crate::{
+        replication::network::traits::test_helpers::MockNetwork, test_helpers::mock_raft_config,
+        State,
+    };
 
     /// Tests the node metadata setup from a mock config
     #[test]
@@ -156,9 +159,16 @@ mod test {
         let (task_queue, _recv) = new_task_driver_queue();
         let (handshake_queue, _recv) = new_handshake_manager_queue();
         let bus = SystemBus::new();
-        let state =
-            State::new_with_network(&config, nets.remove(0), task_queue, handshake_queue, bus)
-                .unwrap();
+        let raft_config = mock_raft_config(&config);
+        let state = State::new_with_network(
+            &config,
+            &raft_config,
+            nets.remove(0),
+            task_queue,
+            handshake_queue,
+            bus,
+        )
+        .unwrap();
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -60,6 +60,9 @@ pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
 /// The name of the db table that maps tasks to their queue key
 pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
 
+/// The name of the db table that stores the offline phase values
+pub(crate) const MPC_PREPROCESSING_TABLE: &str = "mpc-preprocessing";
+
 /// The `Proposal` type wraps a state transition and the channel on which to
 /// send the result of the proposal's application
 #[derive(Debug)]

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 12;
+const NUM_TABLES: usize = 13;
 /// The total maximum size of the DB in bytes
 const MAX_DB_SIZE_BYTES: usize = 1 << 36; // 64 GB
 

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -6,6 +6,7 @@
 //! Each of the files in this module are named after the high level interface
 //! they expose
 
+pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod order_book;
 pub mod peer_index;
@@ -18,8 +19,9 @@ use std::collections::VecDeque;
 use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW};
 
 use crate::{
-    CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE, ORDER_TO_WALLET_TABLE,
-    PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
+    CLUSTER_MEMBERSHIP_TABLE, MPC_PREPROCESSING_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE,
+    ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE,
+    WALLETS_TABLE,
 };
 
 use self::raft_log::RAFT_METADATA_TABLE;
@@ -98,6 +100,7 @@ impl<'db> StateTxn<'db, RW> {
             WALLETS_TABLE,
             TASK_QUEUE_TABLE,
             TASK_TO_KEY_TABLE,
+            MPC_PREPROCESSING_TABLE,
             NODE_METADATA_TABLE,
             RAFT_METADATA_TABLE,
         ]

--- a/state/src/storage/tx/mpc_preprocessing.rs
+++ b/state/src/storage/tx/mpc_preprocessing.rs
@@ -1,0 +1,97 @@
+//! Storage methods for the MPC preprocessing phase
+//!
+//! Clusters generate shared correlated randomness with each other cluster.
+//! These values allow the parties to accelerate computation in the online phase
+
+use common::types::{gossip::ClusterId, offline_phase::PairwiseOfflineSetup};
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, MPC_PREPROCESSING_TABLE};
+
+use super::StateTxn;
+
+/// Generate the key under which we store preprocessing values between the local
+/// cluster and a given remote cluster
+fn preprocessing_key(remote_cluster: &ClusterId) -> String {
+    format!("mpc-preprocessing/{}", remote_cluster)
+}
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the preprocessing values for the given cluster
+    pub fn get_mpc_prep(
+        &self,
+        cluster: &ClusterId,
+    ) -> Result<Option<PairwiseOfflineSetup>, StorageError> {
+        self.inner().read(MPC_PREPROCESSING_TABLE, &preprocessing_key(cluster))
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Set the preprocessing values for the given cluster
+    pub fn set_mpc_prep(
+        &self,
+        cluster: &ClusterId,
+        setup: &PairwiseOfflineSetup,
+    ) -> Result<(), StorageError> {
+        self.inner().write(MPC_PREPROCESSING_TABLE, &preprocessing_key(cluster), setup)
+    }
+
+    /// Append values to the preprocessing
+    pub fn append_mpc_prep_values(
+        &self,
+        cluster: &ClusterId,
+        new: &PairwiseOfflineSetup,
+    ) -> Result<(), StorageError> {
+        let mut prep =
+            self.get_mpc_prep(cluster)?.unwrap_or_else(|| PairwiseOfflineSetup::new(new.mac_key));
+        prep.append(&new.values);
+
+        self.set_mpc_prep(cluster, &prep)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use common::types::{gossip::ClusterId, offline_phase::PairwiseOfflineSetup};
+    use constants::{Scalar, ScalarShare};
+    use rand::thread_rng;
+
+    use crate::test_helpers::mock_db;
+
+    #[test]
+    fn test_get_set_prep() {
+        let mut rng = thread_rng();
+        let db = mock_db();
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        let key = Scalar::random(&mut rng);
+        let prep = PairwiseOfflineSetup::new(key);
+        let tx = db.new_write_tx().unwrap();
+        tx.set_mpc_prep(&cluster, &prep).unwrap();
+        tx.commit().unwrap();
+
+        // Append to the prep
+        let mut new_vals = PairwiseOfflineSetup::new(key);
+        let share = ScalarShare::new(Scalar::random(&mut rng), Scalar::random(&mut rng));
+        new_vals.values.random_values.push(share);
+        let tx = db.new_write_tx().unwrap();
+        tx.append_mpc_prep_values(&cluster, &new_vals).unwrap();
+        tx.commit().unwrap();
+
+        // Fetch the prep
+        let tx = db.new_read_tx().unwrap();
+        let fetched = tx.get_mpc_prep(&cluster).unwrap();
+        assert_eq!(fetched, Some(new_vals));
+    }
+}

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -271,7 +271,8 @@ impl NewWalletTask {
         // Index the wallet in the global state
         let mut wallet = self.wallet.clone();
         wallet.merkle_proof = Some(wallet_auth_path);
-        Ok(self.global_state.new_wallet(wallet)?.await?)
+        self.global_state.new_wallet(wallet)?.await?;
+        Ok(())
     }
 
     // -----------


### PR DESCRIPTION
### Purpose
This PR defines storage primitives for access to the MPC preprocessing phase. Currently we only have a method for appending in setters, the pop case is more complicated as this requires the applicator to _return_ values from the preprocessing functionality.

### Testing
- Tested a set, append, get sequence
- Unit tests pass