### PR TITLE
state: applicator: Add return types to applicator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,8 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Test 
       uses: actions-rs/cargo@v1
       with: 
         command: test
-        args: --workspace --all-features --verbose -- --skip integration
+        args: --workspace --release --all-features --verbose -- --skip integration

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -10,10 +10,11 @@ use system_bus::SystemBus;
 
 use crate::{storage::db::DB, StateTransition};
 
-use self::error::StateApplicatorError;
+use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 
 pub mod error;
 pub mod order_book;
+pub mod return_type;
 pub mod task_queue;
 pub mod wallet_index;
 
@@ -61,7 +62,10 @@ impl StateApplicator {
     }
 
     /// Handle a state transition
-    pub fn handle_state_transition(&self, transition: StateTransition) -> Result<()> {
+    pub fn handle_state_transition(
+        &self,
+        transition: StateTransition,
+    ) -> Result<ApplicatorReturnType> {
         match transition {
             StateTransition::AddWallet { wallet } => self.add_wallet(&wallet),
             StateTransition::UpdateWallet { wallet } => self.update_wallet(&wallet),
@@ -77,6 +81,7 @@ impl StateApplicator {
             StateTransition::ResumeTaskQueue { key } => self.resume_task_queue(key),
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
+        .map(|_| ApplicatorReturnType::None)
     }
 
     /// Get a reference to the db

--- a/state/src/applicator/return_type.rs
+++ b/state/src/applicator/return_type.rs
@@ -1,0 +1,30 @@
+//! Return types from applicator methods
+//!
+//! We provide "function call" like semantics over the consensus engine by
+//! allowing the applicator to return a value from the engine to its callers.
+//! In this case the callers are locations awaiting a proposal's application
+//!
+//! Each of such waiters will be given a copy of the return value
+
+use common::types::offline_phase::PairwiseOfflineSetup;
+
+/// The return type from the Applicator
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum ApplicatorReturnType {
+    /// A set of MPC preprocessing values that are ready to be used
+    MpcPrep(PairwiseOfflineSetup),
+    /// No return value
+    None,
+}
+
+// Downcasting conversions
+
+impl From<ApplicatorReturnType> for PairwiseOfflineSetup {
+    fn from(return_type: ApplicatorReturnType) -> Self {
+        match return_type {
+            ApplicatorReturnType::MpcPrep(setup) => setup,
+            _ => panic!("Expected MpcPrep, got: {return_type:?}"),
+        }
+    }
+}

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -145,7 +145,10 @@ mod test {
     };
     use system_bus::SystemBus;
 
-    use crate::{replication::network::traits::test_helpers::MockNetwork, State};
+    use crate::{
+        replication::network::traits::test_helpers::MockNetwork, test_helpers::mock_raft_config,
+        State,
+    };
 
     /// Tests the node metadata setup from a mock config
     #[test]
@@ -156,9 +159,16 @@ mod test {
         let (task_queue, _recv) = new_task_driver_queue();
         let (handshake_queue, _recv) = new_handshake_manager_queue();
         let bus = SystemBus::new();
-        let state =
-            State::new_with_network(&config, nets.remove(0), task_queue, handshake_queue, bus)
-                .unwrap();
+        let raft_config = mock_raft_config(&config);
+        let state = State::new_with_network(
+            &config,
+            &raft_config,
+            nets.remove(0),
+            task_queue,
+            handshake_queue,
+            bus,
+        )
+        .unwrap();
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -271,7 +271,8 @@ impl NewWalletTask {
         // Index the wallet in the global state
         let mut wallet = self.wallet.clone();
         wallet.merkle_proof = Some(wallet_auth_path);
-        Ok(self.global_state.new_wallet(wallet)?.await?)
+        self.global_state.new_wallet(wallet)?.await?;
+        Ok(())
     }
 
     // -----------


### PR DESCRIPTION
### Purpose
This PR adds return types to the state applicator. These return types allow the applicator to return a value to the waiters of a proposal. This will be used for allocating preprocessing values to a given node in the MPC prep.

I also changed the semantics of the `ProposalWaiter` so that they can no longer be joined. This simplifies the implementation of the return value semantics as we avoid buffering results of partially ready joins. This functionality was not used anywhere -- just vestigial complexity.

### Testing
- Unit tests pass crate-wide