### PR TITLE
state: applicator: mpc-preprocessing: Implement state transitions

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -13,6 +13,7 @@ use crate::{storage::db::DB, StateTransition};
 use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 
 pub mod error;
+pub mod mpc_preprocessing;
 pub mod order_book;
 pub mod return_type;
 pub mod task_queue;
@@ -79,6 +80,12 @@ impl StateApplicator {
             },
             StateTransition::PreemptTaskQueue { key } => self.preempt_task_queue(key),
             StateTransition::ResumeTaskQueue { key } => self.resume_task_queue(key),
+            StateTransition::AddMpcPreprocessingValues { cluster, values } => {
+                self.add_preprocessing_values(&cluster, &values)
+            },
+            StateTransition::ConsumePreprocessingValues { recipient, cluster, request } => {
+                return self.consume_preprocessing_values(recipient, &cluster, &request);
+            },
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
         .map(|_| ApplicatorReturnType::None)

--- a/state/src/applicator/mpc_preprocessing.rs
+++ b/state/src/applicator/mpc_preprocessing.rs
@@ -1,0 +1,184 @@
+//! Applicator implementation for the preprocessing functionality
+
+use common::types::{
+    gossip::{ClusterId, WrappedPeerId},
+    mpc_preprocessing::{PairwiseOfflineSetup, PreprocessingSlice},
+};
+
+use super::{error::StateApplicatorError, return_type::ApplicatorReturnType, StateApplicator};
+
+impl StateApplicator {
+    /// Add values to the preprocessing state for a given cluster
+    pub fn add_preprocessing_values(
+        &self,
+        cluster: &ClusterId,
+        value: &PairwiseOfflineSetup,
+    ) -> Result<(), StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        tx.append_mpc_prep_values(cluster, value)?;
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    /// Consume values from the preprocessing state for a given cluster
+    pub fn consume_preprocessing_values(
+        &self,
+        recipient: WrappedPeerId,
+        cluster: &ClusterId,
+        slice: &PreprocessingSlice,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        let values = tx.consume_mpc_prep_values(cluster, slice)?;
+        let my_id = tx.get_peer_id()?;
+        tx.commit()?;
+
+        // Only the recipient should take ownership of the values
+        if my_id == recipient {
+            return Ok(ApplicatorReturnType::MpcPrep(values));
+        }
+
+        Ok(ApplicatorReturnType::None)
+    }
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use common::types::mpc_preprocessing::PairwiseOfflineSetup;
+    use constants::{Scalar, ScalarShare};
+    use itertools::Itertools;
+    use rand::thread_rng;
+
+    /// Get a random preprocessing values set
+    pub fn mock_prep_values(
+        bits: usize,
+        values: usize,
+        inverse_pairs: usize,
+        input_masks: usize,
+        triplets: usize,
+    ) -> PairwiseOfflineSetup {
+        let mut rng = thread_rng();
+        let key = Scalar::random(&mut rng);
+        let mut prep = PairwiseOfflineSetup::new(key);
+        let vals = &mut prep.values;
+
+        let share = ScalarShare::new(Scalar::random(&mut rng), Scalar::random(&mut rng));
+        vals.random_bits = (0..bits).map(|_| share).collect_vec();
+        vals.random_values = (0..values).map(|_| share).collect_vec();
+        vals.inverse_pairs.0 = (0..inverse_pairs).map(|_| share).collect_vec();
+        vals.inverse_pairs.1 = (0..inverse_pairs).map(|_| share).collect_vec();
+        vals.my_input_masks.0 = (0..input_masks).map(|_| Scalar::random(&mut rng)).collect_vec();
+        vals.my_input_masks.1 = (0..input_masks).map(|_| share).collect_vec();
+        vals.counterparty_input_masks = (0..input_masks).map(|_| share).collect_vec();
+        vals.beaver_triples.0 = (0..triplets).map(|_| share).collect_vec();
+        vals.beaver_triples.1 = (0..triplets).map(|_| share).collect_vec();
+        vals.beaver_triples.2 = (0..triplets).map(|_| share).collect_vec();
+
+        prep
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use common::types::{
+        gossip::{ClusterId, WrappedPeerId},
+        mpc_preprocessing::PreprocessingSlice,
+    };
+
+    use crate::{
+        applicator::{
+            mpc_preprocessing::test_helpers::mock_prep_values, return_type::ApplicatorReturnType,
+            test_helpers::mock_applicator,
+        },
+        storage::db::DB,
+    };
+
+    /// Set the local peer ID
+    fn set_local_peer_id(peer_id: &WrappedPeerId, db: &DB) {
+        let tx = db.new_write_tx().unwrap();
+        tx.set_peer_id(peer_id).unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// Tests adding preprocessing values to the state
+    #[test]
+    fn test_add_prep_values() {
+        let applicator = mock_applicator();
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        // One inverse pair and two bits
+        let prep = mock_prep_values(2, 0, 1, 0, 0);
+        applicator.add_preprocessing_values(&cluster, &prep).unwrap();
+
+        // Check the size of the preprocessing state
+        let tx = applicator.db().new_read_tx().unwrap();
+        let values = tx.get_mpc_prep_size(&cluster).unwrap().unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(
+            values,
+            PreprocessingSlice { num_bits: 2, num_inverse_pairs: 1, ..Default::default() }
+        );
+    }
+
+    /// Tests consuming preprocessing values from a node that isn't the
+    /// recipient
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_consume_prep__not_recipient() {
+        let peer_id = WrappedPeerId::random();
+        let applicator = mock_applicator();
+        set_local_peer_id(&peer_id, applicator.db());
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        // Add values to the preprocessing
+        let prep = mock_prep_values(0, 0, 0, 1, 2);
+        applicator.add_preprocessing_values(&cluster, &prep).unwrap();
+
+        // Consume a single triple
+        let slice = PreprocessingSlice { num_triples: 1, ..Default::default() };
+        let result = applicator
+            .consume_preprocessing_values(WrappedPeerId::random(), &cluster, &slice)
+            .unwrap();
+
+        // No value should be received
+        match result {
+            ApplicatorReturnType::None => (),
+            _ => panic!("Expected MpcPrep"),
+        };
+    }
+
+    /// Tests consuming preprocessing values from a node that is the
+    /// recipient
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_consume_prep__as_recipient() {
+        let peer_id = WrappedPeerId::random();
+        let applicator = mock_applicator();
+        set_local_peer_id(&peer_id, applicator.db());
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        // Add values to the preprocessing
+        let prep = mock_prep_values(0, 0, 0, 1, 2);
+        applicator.add_preprocessing_values(&cluster, &prep).unwrap();
+
+        // Consume a single triple
+        let slice = PreprocessingSlice { num_triples: 1, ..Default::default() };
+        let result = applicator.consume_preprocessing_values(peer_id, &cluster, &slice).unwrap();
+        let values = match result {
+            ApplicatorReturnType::MpcPrep(prep) => prep.values,
+            _ => panic!("Expected MpcPrep"),
+        };
+
+        assert_eq!(values.beaver_triples.0[0], prep.values.beaver_triples.0[0]);
+        assert_eq!(values.beaver_triples.1[0], prep.values.beaver_triples.1[0]);
+        assert_eq!(values.beaver_triples.2[0], prep.values.beaver_triples.2[0]);
+        assert_eq!(values.random_bits.len(), 0);
+        assert_eq!(values.random_values.len(), 0);
+        assert_eq!(values.inverse_pairs.0.len(), 0);
+        assert_eq!(values.my_input_masks.0.len(), 0);
+        assert_eq!(values.counterparty_input_masks.len(), 0);
+    }
+}

--- a/state/src/storage/tx/mpc_preprocessing.rs
+++ b/state/src/storage/tx/mpc_preprocessing.rs
@@ -14,6 +14,10 @@ use crate::{storage::error::StorageError, MPC_PREPROCESSING_TABLE};
 
 use super::StateTxn;
 
+/// Error message emitted when the preprocessing values for a given cluster
+/// cannot support a requested slice
+const ERR_INSUFFICIENT_CAPACITY: &str = "Requested preprocessing values exceed capacity";
+
 /// Generate the key under which we store preprocessing values between the local
 /// cluster and a given remote cluster
 fn preprocessing_key(remote_cluster: &ClusterId) -> String {
@@ -81,13 +85,34 @@ impl<'db> StateTxn<'db, RW> {
         self.set_mpc_prep(cluster, &prep)?;
         Ok(())
     }
+
+    /// Consume values from the preprocessing store
+    pub fn consume_mpc_prep_values(
+        &self,
+        cluster: &ClusterId,
+        slice: &PreprocessingSlice,
+    ) -> Result<PairwiseOfflineSetup, StorageError> {
+        // Read the preprocessing store
+        let mut prep = self.get_mpc_prep(cluster)?.unwrap_or_default();
+        if !prep.has_capacity_for_slice(slice) {
+            return Err(StorageError::Other(ERR_INSUFFICIENT_CAPACITY.to_string()));
+        }
+
+        // Consume the values and write back
+        let values = prep.pop(slice);
+        self.set_mpc_prep(cluster, &prep)?;
+        Ok(values)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
 
-    use common::types::{gossip::ClusterId, mpc_preprocessing::PairwiseOfflineSetup};
+    use common::types::{
+        gossip::ClusterId,
+        mpc_preprocessing::{PairwiseOfflineSetup, PreprocessingSlice},
+    };
     use constants::{Scalar, ScalarShare};
     use rand::thread_rng;
 
@@ -144,5 +169,80 @@ mod test {
         let tx = db.new_read_tx().unwrap();
         let fetched = tx.get_mpc_prep(&cluster).unwrap();
         assert_eq!(fetched, Some(new_vals));
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    #[should_panic(expected = "exceed capacity")]
+    fn test_consume_prep__insufficient_capacity() {
+        let mut rng = thread_rng();
+        let db = mock_db();
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        let key = Scalar::random(&mut rng);
+        let prep = PairwiseOfflineSetup::new(key);
+        let tx = db.new_write_tx().unwrap();
+        tx.set_mpc_prep(&cluster, &prep).unwrap();
+        tx.commit().unwrap();
+
+        // Consume the prep
+        let slice = PreprocessingSlice {
+            num_bits: 1,
+            num_values: 1,
+            num_input_masks: 1,
+            num_inverse_pairs: 1,
+            num_triples: 1,
+        };
+        let tx = db.new_write_tx().unwrap();
+        tx.consume_mpc_prep_values(&cluster, &slice).unwrap();
+    }
+
+    #[test]
+    fn test_consume_prep_values() {
+        let mut rng = thread_rng();
+        let db = mock_db();
+        let cluster = ClusterId::from_str("test").unwrap();
+
+        // Setup a mock prep
+        let mut prep = PairwiseOfflineSetup::new(Scalar::random(&mut rng));
+        let share = ScalarShare::new(Scalar::random(&mut rng), Scalar::random(&mut rng));
+        prep.values.random_bits.push(share);
+        prep.values.random_values.push(share);
+        prep.values.beaver_triples.0.push(share);
+        prep.values.beaver_triples.1.push(share);
+        prep.values.beaver_triples.2.push(share);
+
+        let tx = db.new_write_tx().unwrap();
+        tx.set_mpc_prep(&cluster, &prep).unwrap();
+        tx.commit().unwrap();
+
+        // Consume the prep
+        let slice = PreprocessingSlice {
+            num_bits: 1,
+            num_values: 0, // leave the random value
+            num_input_masks: 0,
+            num_inverse_pairs: 0,
+            num_triples: 1,
+        };
+
+        let tx = db.new_write_tx().unwrap();
+        let vals = tx.consume_mpc_prep_values(&cluster, &slice).unwrap().values;
+        tx.commit().unwrap();
+
+        // Check the values
+        assert_eq!(vals.random_bits, vec![share]);
+        assert_eq!(vals.random_values.len(), 0);
+        assert_eq!(vals.beaver_triples.0, vec![share]);
+        assert_eq!(vals.beaver_triples.1, vec![share]);
+        assert_eq!(vals.beaver_triples.2, vec![share]);
+
+        // Check the size of the remaining prep
+        let tx = db.new_read_tx().unwrap();
+        let size = tx.get_mpc_prep_size(&cluster).unwrap().unwrap();
+        assert_eq!(size.num_bits, 0);
+        assert_eq!(size.num_values, 1); // one left
+        assert_eq!(size.num_input_masks, 0);
+        assert_eq!(size.num_inverse_pairs, 0);
+        assert_eq!(size.num_triples, 0);
     }
 }


### PR DESCRIPTION
### Purpose
This PR implements the state transition logic for consuming and appending MPC preprocessing values to the preprocessing store for a given cluster pair. 

### Testing
- Unit tests pass
- Tested the applicator methods as well as through raft consensus