### PR TITLE
state: storage: order-metadata: Setup order metadata storage primitive

### DIFF
--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -8,6 +8,7 @@ mod keychain;
 mod r#match;
 #[cfg(feature = "mocks")]
 pub mod mocks;
+pub mod order_metadata;
 mod orders;
 mod shares;
 mod types;

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -1,0 +1,34 @@
+//! Order metadata for a wallet's orders
+
+use circuit_types::Amount;
+use serde::{Deserialize, Serialize};
+
+use super::OrderIdentifier;
+
+/// The state of an order in the wallet
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum OrderState {
+    /// The order has been created, but validity proofs are not yet proven
+    Created,
+    /// The order is ready to match, and is being shopped around the network
+    Matching,
+    /// A match has been found and is being settled
+    SettlingMatch,
+    /// The order has been entirely filled
+    Filled,
+    /// The order was canceled before it could be filled
+    Cancelled,
+}
+
+/// Metadata for an order in a wallet, possibly historical
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct OrderMetadata {
+    /// The order ID
+    pub id: OrderIdentifier,
+    /// The order state
+    pub state: OrderState,
+    /// The amount that has been filled
+    pub filled: Amount,
+    /// The unix timestamp in milliseconds since the order was created
+    pub created: u64,
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -51,6 +51,8 @@ pub(crate) const CLUSTER_MEMBERSHIP_TABLE: &str = "cluster-membership";
 pub(crate) const PRIORITIES_TABLE: &str = "priorities";
 /// The name of the table that stores orders by their ID
 pub(crate) const ORDERS_TABLE: &str = "orders";
+/// The table that stores order metadata indexed by wallet id
+pub(crate) const ORDER_HISTORY_TABLE: &str = "order-history";
 
 /// The name of the db table that maps order to their encapsulating wallet
 pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -9,6 +9,7 @@
 pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod order_book;
+pub mod order_metadata;
 pub mod peer_index;
 pub mod raft_log;
 pub mod task_queue;
@@ -20,8 +21,8 @@ use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, Write
 
 use crate::{
     CLUSTER_MEMBERSHIP_TABLE, MPC_PREPROCESSING_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE,
-    ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE,
-    WALLETS_TABLE,
+    ORDER_HISTORY_TABLE, ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE,
+    TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
 };
 
 use self::raft_log::RAFT_METADATA_TABLE;
@@ -96,6 +97,7 @@ impl<'db> StateTxn<'db, RW> {
             CLUSTER_MEMBERSHIP_TABLE,
             PRIORITIES_TABLE,
             ORDERS_TABLE,
+            ORDER_HISTORY_TABLE,
             ORDER_TO_WALLET_TABLE,
             WALLETS_TABLE,
             TASK_QUEUE_TABLE,

--- a/state/src/storage/tx/order_metadata.rs
+++ b/state/src/storage/tx/order_metadata.rs
@@ -1,0 +1,207 @@
+//! Storage access methods for order metadata
+
+use common::types::wallet::{order_metadata::OrderMetadata, OrderIdentifier, WalletIdentifier};
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, ORDER_HISTORY_TABLE};
+
+use super::StateTxn;
+
+/// Error message emitted when a duplicate order is found
+const ERR_DUPLICATE_ORDER: &str = "Duplicate order";
+/// Error message emitted when a given order is not found
+const ERR_ORDER_NOT_FOUND: &str = "Order not found";
+
+/// Get the key for a given wallet's order history
+fn order_history_key(wallet_id: &WalletIdentifier) -> String {
+    format!("order-history/{wallet_id}")
+}
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get metadata for a given order
+    pub fn get_order_metadata(
+        &self,
+        wallet_id: &WalletIdentifier,
+        order_id: OrderIdentifier,
+    ) -> Result<Option<OrderMetadata>, StorageError> {
+        let orders = self.get_order_history(wallet_id)?;
+        Ok(orders.iter().find(|o| o.id == order_id).cloned())
+    }
+
+    /// Get the orders for a given wallet
+    ///
+    /// Sorted by descending creation time
+    pub fn get_order_history(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<Vec<OrderMetadata>, StorageError> {
+        let key = order_history_key(wallet_id);
+        let mut orders: Vec<OrderMetadata> =
+            self.inner.read(ORDER_HISTORY_TABLE, &key)?.unwrap_or_default();
+        orders.sort_by_key(|o| std::cmp::Reverse(o.created));
+
+        Ok(orders)
+    }
+
+    /// Get up to `n` most recent orders for a given wallet
+    pub fn get_order_history_truncated(
+        &self,
+        n: usize,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<Vec<OrderMetadata>, StorageError> {
+        let mut orders = self.get_order_history(wallet_id)?;
+        orders.truncate(n);
+        Ok(orders)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Append an order to the order history
+    pub fn push_order_history(
+        &self,
+        wallet_id: &WalletIdentifier,
+        metadata: OrderMetadata,
+    ) -> Result<(), StorageError> {
+        let mut orders = self.get_order_history(wallet_id)?;
+
+        // Check for a duplicate
+        if orders.iter().any(|o| o.id == metadata.id) {
+            return Err(StorageError::Other(ERR_DUPLICATE_ORDER.to_string()));
+        }
+
+        // Push to the front of the list
+        orders.insert(0, metadata);
+        self.write_order_history(wallet_id, orders)
+    }
+
+    /// Update an order in the order history
+    pub fn update_order_metadata(
+        &self,
+        wallet_id: &WalletIdentifier,
+        metadata: OrderMetadata,
+    ) -> Result<(), StorageError> {
+        let mut orders = self.get_order_history(wallet_id)?;
+        let index = orders.iter().position(|o| o.id == metadata.id);
+        if index.is_none() {
+            return Err(StorageError::Other(ERR_ORDER_NOT_FOUND.to_string()));
+        }
+
+        orders[index.unwrap()] = metadata;
+        self.write_order_history(wallet_id, orders)
+    }
+
+    /// Write the order history for a given wallet
+    #[allow(clippy::needless_pass_by_value)]
+    fn write_order_history(
+        &self,
+        wallet_id: &WalletIdentifier,
+        orders: Vec<OrderMetadata>,
+    ) -> Result<(), StorageError> {
+        let key = order_history_key(wallet_id);
+        self.inner.write(ORDER_HISTORY_TABLE, &key, &orders)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Reverse;
+
+    use common::types::wallet::order_metadata::{OrderMetadata, OrderState};
+    use itertools::Itertools;
+    use rand::{thread_rng, Rng, RngCore};
+    use uuid::Uuid;
+
+    use crate::test_helpers::mock_db;
+
+    /// Create a single random order metadata instance
+    fn random_order_md() -> OrderMetadata {
+        let mut rng = thread_rng();
+        OrderMetadata {
+            id: Uuid::new_v4(),
+            state: OrderState::Created,
+            filled: 0,
+            created: rng.next_u64(),
+        }
+    }
+
+    /// Create a random set of order metadata
+    fn random_order_history(n: usize) -> Vec<OrderMetadata> {
+        (0..n).map(|_| random_order_md()).collect_vec()
+    }
+
+    /// Test appending and retrieving order metadata
+    #[test]
+    fn test_append_orders() {
+        const N: usize = 1000;
+        let db = mock_db();
+        let wallet_id = Uuid::new_v4();
+        let mut history = random_order_history(N);
+
+        let tx = db.new_write_tx().unwrap();
+        for order_md in history.iter().cloned() {
+            tx.push_order_history(&wallet_id, order_md).unwrap();
+        }
+        tx.commit().unwrap();
+
+        // Sort the history by descending creation time
+        history.sort_by_key(|o| Reverse(o.created));
+
+        let tx = db.new_read_tx().unwrap();
+        let orders = tx.get_order_history(&wallet_id).unwrap();
+        assert_eq!(orders, history);
+
+        // Get the first 10 orders
+        let tx = db.new_read_tx().unwrap();
+        let orders = tx.get_order_history_truncated(10, &wallet_id).unwrap();
+        assert_eq!(orders.len(), 10);
+        assert_eq!(orders, history[..10].to_vec());
+    }
+
+    /// Tests updating an order in the history
+    #[test]
+    fn test_update_order() {
+        const N: usize = 1000;
+        let db = mock_db();
+        let wallet_id = Uuid::new_v4();
+        let history = random_order_history(N);
+
+        // Setup the history
+        let tx = db.new_write_tx().unwrap();
+        for order_md in history.iter().cloned() {
+            tx.push_order_history(&wallet_id, order_md).unwrap();
+        }
+        tx.commit().unwrap();
+
+        // Choose a random order
+        let mut rng = rand::thread_rng();
+        let index = rng.gen_range(0..history.len());
+        let curr_order = history[index];
+
+        // Check the current state of that order
+        let tx = db.new_read_tx().unwrap();
+        let order = tx.get_order_metadata(&wallet_id, curr_order.id).unwrap().unwrap();
+        assert_eq!(order, curr_order);
+
+        // Update the order
+        let mut updated_order = curr_order;
+        updated_order.filled = rng.gen();
+
+        let tx = db.new_write_tx().unwrap();
+        tx.update_order_metadata(&wallet_id, updated_order).unwrap();
+        tx.commit().unwrap();
+
+        // Get the updated order
+        let tx = db.new_read_tx().unwrap();
+        let order = tx.get_order_metadata(&wallet_id, updated_order.id).unwrap().unwrap();
+        assert_eq!(order, updated_order);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR sets up storage primitives for order metadata and order history. For each wallet, we store a list of historical orders with states. This store is denormalized from the wallet store.

### Testing
- Unit tests pass