### PR TITLE
state: applicator, interface: Add order history state transitions

### DIFF
--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -6,7 +6,9 @@ use common::types::{
     network_order::NetworkOrder,
     tasks::TaskIdentifier,
     token::Token,
-    wallet::{OrderIdentifier, Wallet as StateWallet, WalletIdentifier},
+    wallet::{
+        order_metadata::OrderMetadata, OrderIdentifier, Wallet as StateWallet, WalletIdentifier,
+    },
 };
 use serde::Serialize;
 
@@ -23,17 +25,22 @@ pub const NETWORK_TOPOLOGY_TOPIC: &str = "network-topology";
 pub const ALL_WALLET_UPDATES_TOPIC: &str = "wallet-updates";
 
 /// Get the topic name for a given wallet
-pub fn wallet_topic_name(wallet_id: &WalletIdentifier) -> String {
+pub fn wallet_topic(wallet_id: &WalletIdentifier) -> String {
     format!("wallet-updates-{}", wallet_id)
 }
 
+/// Get the topic name for a wallet's order history
+pub fn wallet_order_history_topic(wallet_id: &WalletIdentifier) -> String {
+    format!("wallet-order-history-{}", wallet_id)
+}
+
 /// Get the topic name for a given task
-pub fn task_topic_name(task_id: &TaskIdentifier) -> String {
+pub fn task_topic(task_id: &TaskIdentifier) -> String {
     format!("task-updates-{}", task_id)
 }
 
 /// Get the topic name for a price report
-pub fn price_report_topic_name(base: &Token, quote: &Token) -> String {
+pub fn price_report_topic(base: &Token, quote: &Token) -> String {
     format!("price-report-{}-{}", base.get_addr(), quote.get_addr())
 }
 
@@ -110,6 +117,13 @@ pub enum SystemBusMessage {
     InternalWalletUpdate {
         /// The new wallet after update
         wallet: Box<StateWallet>,
+    },
+
+    // -- Order History Updates -- //
+    /// A message indicating that an order has been updated
+    OrderMetadataUpdated {
+        /// The new state of the order
+        order: OrderMetadata,
     },
 }
 

--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -12,7 +12,7 @@ pub enum StateApplicatorError {
     /// An error enqueueing a task
     EnqueueTask(String),
     /// Missing keys in the database necessary for a tx
-    MissingEntry(String),
+    MissingEntry(&'static str),
     /// An error interacting with storage
     Storage(StorageError),
     /// A task queue is empty when it should not be

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -15,6 +15,7 @@ use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 pub mod error;
 pub mod mpc_preprocessing;
 pub mod order_book;
+pub mod order_metadata;
 pub mod return_type;
 pub mod task_queue;
 pub mod wallet_index;
@@ -73,6 +74,7 @@ impl StateApplicator {
             StateTransition::AddOrderValidityBundle { order_id, proof, witness } => {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
+            StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
             StateTransition::AppendTask { task } => self.append_task(&task),
             StateTransition::PopTask { task_id } => self.pop_task(task_id),
             StateTransition::TransitionTask { task_id, state } => {

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -78,7 +78,7 @@ impl StateApplicator {
 
         let order_info = tx
             .get_order_info(&order_id)?
-            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_ORDER_MISSING.to_string()))?;
+            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_ORDER_MISSING))?;
         tx.commit()?;
 
         self.system_bus().publish(

--- a/state/src/applicator/order_metadata.rs
+++ b/state/src/applicator/order_metadata.rs
@@ -1,0 +1,65 @@
+//! Applicator handlers for order metadata updates
+
+use crate::order_metadata::ERR_MISSING_WALLET;
+
+use super::{error::StateApplicatorError, StateApplicator};
+use common::types::wallet::order_metadata::OrderMetadata;
+use external_api::bus_message::{wallet_order_history_topic, SystemBusMessage};
+
+impl StateApplicator {
+    /// Handle an update to an order's metadata
+    pub fn update_order_metadata(&self, meta: OrderMetadata) -> Result<(), StateApplicatorError> {
+        // Update the state
+        let tx = self.db().new_write_tx()?;
+        let wallet = tx
+            .get_wallet_for_order(&meta.id)?
+            .ok_or(StateApplicatorError::MissingEntry(ERR_MISSING_WALLET))?;
+        tx.update_order_metadata(&wallet, meta)?;
+
+        tx.commit()?;
+
+        // Write to system bus
+        let topic = wallet_order_history_topic(&wallet);
+        self.system_bus().publish(topic, SystemBusMessage::OrderMetadataUpdated { order: meta });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::types::wallet::order_metadata::OrderState;
+    use uuid::Uuid;
+
+    use crate::applicator::test_helpers::mock_applicator;
+
+    use super::*;
+
+    /// Tests updating an order in the history
+    #[test]
+    fn test_update_metadata() {
+        let applicator = mock_applicator();
+        let db = applicator.db();
+        let wallet_id = Uuid::new_v4();
+        let order_id = Uuid::new_v4();
+
+        // Add initial metadata
+        let mut md =
+            OrderMetadata { id: order_id, state: OrderState::Created, filled: 0, created: 1 };
+        let tx = db.new_write_tx().unwrap();
+        tx.push_order_history(&wallet_id, md).unwrap();
+
+        // Add an association of wallet to order
+        tx.index_orders(&wallet_id, &[order_id]).unwrap();
+        tx.commit().unwrap();
+
+        // Modify the metadata and push
+        md.filled += 1;
+        applicator.update_order_metadata(md).unwrap();
+
+        // Check the state
+        let tx = db.new_read_tx().unwrap();
+        let md = tx.get_order_metadata(wallet_id, order_id).unwrap().unwrap();
+        assert_eq!(md.filled, 1);
+    }
+}

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -5,7 +5,7 @@ use common::types::{
     wallet::WalletIdentifier,
 };
 use external_api::{
-    bus_message::{task_topic_name, SystemBusMessage},
+    bus_message::{task_topic, SystemBusMessage},
     http::task::ApiTaskStatus,
 };
 use job_types::{handshake_manager::HandshakeExecutionJob, task_driver::TaskDriverJob};
@@ -58,7 +58,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
         let key = tx
             .get_queue_key_for_task(&task_id)?
-            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_NO_KEY.to_string()))?;
+            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_NO_KEY))?;
 
         if tx.is_queue_paused(&key)? {
             return Err(StateApplicatorError::QueuePaused(key));
@@ -87,7 +87,7 @@ impl StateApplicator {
         let mut status = ApiTaskStatus::from(task);
         status.state = "Completed".to_string();
         self.system_bus()
-            .publish(task_topic_name(&task_id), SystemBusMessage::TaskStatusUpdate { status });
+            .publish(task_topic(&task_id), SystemBusMessage::TaskStatusUpdate { status });
 
         Ok(())
     }
@@ -102,7 +102,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
         let key = tx
             .get_queue_key_for_task(&task_id)?
-            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_NO_KEY.to_string()))?;
+            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_NO_KEY))?;
 
         if tx.is_queue_paused(&key)? {
             return Err(StateApplicatorError::QueuePaused(key));
@@ -116,7 +116,7 @@ impl StateApplicator {
         if let Some(task) = task {
             let status: ApiTaskStatus = task.into();
             self.system_bus()
-                .publish(task_topic_name(&task_id), SystemBusMessage::TaskStatusUpdate { status });
+                .publish(task_topic(&task_id), SystemBusMessage::TaskStatusUpdate { status });
         }
 
         Ok(())

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -1,7 +1,7 @@
 //! Applicator methods for the wallet index, separated out for discoverability
 
 use common::types::{network_order::NetworkOrder, wallet::Wallet};
-use external_api::bus_message::{wallet_topic_name, SystemBusMessage};
+use external_api::bus_message::{wallet_topic, SystemBusMessage};
 use itertools::Itertools;
 use libmdbx::RW;
 
@@ -26,7 +26,7 @@ impl StateApplicator {
         tx.commit()?;
 
         // Publish a message to the bus describing the wallet update
-        let wallet_topic = wallet_topic_name(&wallet.wallet_id);
+        let wallet_topic = wallet_topic(&wallet.wallet_id);
         self.system_bus().publish(
             wallet_topic,
             SystemBusMessage::WalletUpdate { wallet: Box::new(wallet.clone().into()) },
@@ -67,7 +67,7 @@ impl StateApplicator {
         tx.commit()?;
 
         // Push an update to the bus
-        let wallet_topic = wallet_topic_name(&wallet.wallet_id);
+        let wallet_topic = wallet_topic(&wallet.wallet_id);
         self.system_bus().publish(
             wallet_topic,
             SystemBusMessage::WalletUpdate { wallet: Box::new(wallet.clone().into()) },

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -6,6 +6,7 @@ pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod notifications;
 pub mod order_book;
+pub mod order_metadata;
 pub mod peer_index;
 pub mod raft;
 pub mod task_queue;

--- a/state/src/interface/order_metadata.rs
+++ b/state/src/interface/order_metadata.rs
@@ -1,0 +1,134 @@
+//! State interface methods for order metadata
+
+use common::types::wallet::{order_metadata::OrderMetadata, OrderIdentifier, WalletIdentifier};
+use util::res_some;
+
+use crate::{
+    error::StateError, notifications::ProposalWaiter, storage::error::StorageError, State,
+    StateTransition,
+};
+
+/// The error message emitted when a wallet cannot be found for an order
+pub const ERR_MISSING_WALLET: &str = "Wallet not found for order";
+
+impl State {
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Get the metadata for an order
+    pub fn get_order_metadata(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<OrderMetadata>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let wallet_id = tx
+            .get_wallet_for_order(order_id)?
+            .ok_or(StateError::Db(StorageError::NotFound(ERR_MISSING_WALLET.to_string())))?;
+        let md = res_some!(tx.get_order_metadata(wallet_id, *order_id)?);
+        tx.commit()?;
+
+        Ok(Some(md))
+    }
+
+    /// Get a history of the wallet's orders
+    pub fn get_order_history(
+        &self,
+        n: usize,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<Vec<OrderMetadata>, StateError> {
+        let tx = self.db.new_read_tx()?;
+        let orders = tx.get_order_history_truncated(n, wallet_id)?;
+        tx.commit()?;
+
+        Ok(orders)
+    }
+
+    // -----------
+    // | Setters |
+    // -----------
+
+    /// Update the state of an order in a wallet
+    pub fn update_order_metadata(&self, meta: OrderMetadata) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::UpdateOrderMetadata { meta })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cmp::Reverse;
+
+    use common::types::wallet::order_metadata::OrderState;
+    use itertools::Itertools;
+    use rand::{seq::IteratorRandom, thread_rng, RngCore};
+
+    use crate::{storage::db::DB, test_helpers::mock_state};
+
+    use super::*;
+
+    /// Get a random order metadata instance
+    fn random_metadata() -> OrderMetadata {
+        let mut rng = thread_rng();
+        OrderMetadata {
+            id: OrderIdentifier::new_v4(),
+            state: OrderState::Created,
+            filled: 0,
+            created: rng.next_u64(),
+        }
+    }
+
+    /// Setup an order history using the given orders and wallet id
+    fn setup_order_history(wallet_id: &WalletIdentifier, orders: &[OrderMetadata], db: &DB) {
+        // Add orders to the history
+        let tx = db.new_write_tx().unwrap();
+        orders.iter().for_each(|o| tx.push_order_history(wallet_id, *o).unwrap());
+        let order_ids = orders.iter().map(|o| o.id).collect_vec();
+        tx.index_orders(wallet_id, &order_ids).unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// Tests updating order history and metadata
+    #[test]
+    fn test_order_history() {
+        const N: usize = 100;
+        let state = mock_state();
+        let mut orders = (0..N).map(|_| random_metadata()).collect_vec();
+        let wallet_id = WalletIdentifier::new_v4();
+
+        setup_order_history(&wallet_id, &orders, &state.db);
+        orders.sort_by_key(|o| Reverse(o.created));
+
+        // Get back the order history
+        let n = 10;
+        let history = state.get_order_history(n, &wallet_id).unwrap();
+        assert_eq!(orders[..n], history);
+
+        // Read back a random order's metadata
+        let idx = (0..orders.len()).choose(&mut thread_rng()).unwrap();
+        let meta = orders[idx];
+        let found = state.get_order_metadata(&meta.id).unwrap().unwrap();
+        assert_eq!(meta, found);
+    }
+
+    /// Test updating an order's metadata    
+    #[tokio::test]
+    async fn test_update_order_metadata() {
+        const N: usize = 100;
+        let state = mock_state();
+        let orders = (0..N).map(|_| random_metadata()).collect_vec();
+        let wallet_id = WalletIdentifier::new_v4();
+
+        setup_order_history(&wallet_id, &orders, &state.db);
+
+        // Modify a single order's metadata
+        let idx = (0..orders.len()).choose(&mut thread_rng()).unwrap();
+        let mut meta = orders[idx];
+        meta.filled += 1;
+
+        // Update and retrieve the order's metadata
+        let waiter = state.update_order_metadata(meta).unwrap();
+        waiter.await.unwrap();
+        let fetched_meta = state.get_order_metadata(&meta.id).unwrap().unwrap();
+        assert_eq!(meta, fetched_meta);
+    }
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -20,7 +20,7 @@ use common::types::{
     mpc_preprocessing::{PairwiseOfflineSetup, PreprocessingSlice},
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey},
-    wallet::{OrderIdentifier, Wallet},
+    wallet::{order_metadata::OrderMetadata, OrderIdentifier, Wallet},
 };
 use interface::notifications::ProposalResultSender;
 use replication::RaftPeerId;
@@ -81,6 +81,7 @@ pub struct Proposal {
 /// allowing transitions to be handled generically before they are applied
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[allow(missing_docs)]
+#[rustfmt::skip]
 pub enum StateTransition {
     // --- Wallets --- //
     /// Add a wallet to the managed state
@@ -93,6 +94,10 @@ pub enum StateTransition {
         proof: OrderValidityProofBundle,
         witness: OrderValidityWitnessBundle,
     },
+
+    // --- Order History --- //
+    /// Update the metadata for a given order
+    UpdateOrderMetadata { meta: OrderMetadata },
 
     // --- Task Queue --- //
     /// Add a task to the task queue

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 13;
+const NUM_TABLES: usize = 14;
 /// The total maximum size of the DB in bytes
 const MAX_DB_SIZE_BYTES: usize = 1 << 36; // 64 GB
 

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -43,7 +43,7 @@ const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
 /// Values in the node metadata should always be present, so we promote
 /// `Option::None` to an error
 fn err_not_found(key: &str) -> StorageError {
-    StorageError::NotFound(format!("node metadata key {} not found", key))
+    StorageError::NotFound(format!("node metadata key {key} not found"))
 }
 
 // -----------

--- a/state/src/storage/tx/order_metadata.rs
+++ b/state/src/storage/tx/order_metadata.rs
@@ -23,12 +23,13 @@ fn order_history_key(wallet_id: &WalletIdentifier) -> String {
 
 impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Get metadata for a given order
+    #[allow(clippy::needless_pass_by_value)]
     pub fn get_order_metadata(
         &self,
-        wallet_id: &WalletIdentifier,
+        wallet_id: WalletIdentifier,
         order_id: OrderIdentifier,
     ) -> Result<Option<OrderMetadata>, StorageError> {
-        let orders = self.get_order_history(wallet_id)?;
+        let orders = self.get_order_history(&wallet_id)?;
         Ok(orders.iter().find(|o| o.id == order_id).cloned())
     }
 
@@ -188,7 +189,7 @@ mod tests {
 
         // Check the current state of that order
         let tx = db.new_read_tx().unwrap();
-        let order = tx.get_order_metadata(&wallet_id, curr_order.id).unwrap().unwrap();
+        let order = tx.get_order_metadata(wallet_id, curr_order.id).unwrap().unwrap();
         assert_eq!(order, curr_order);
 
         // Update the order
@@ -201,7 +202,7 @@ mod tests {
 
         // Get the updated order
         let tx = db.new_read_tx().unwrap();
-        let order = tx.get_order_metadata(&wallet_id, updated_order.id).unwrap().unwrap();
+        let order = tx.get_order_metadata(wallet_id, updated_order.id).unwrap().unwrap();
         assert_eq!(order, updated_order);
     }
 }

--- a/workers/api-server/src/websocket/price_report.rs
+++ b/workers/api-server/src/websocket/price_report.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use common::types::token::Token;
-use external_api::bus_message::{price_report_topic_name, SystemBusMessage};
+use external_api::bus_message::{price_report_topic, SystemBusMessage};
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};
 use system_bus::{SystemBus, TopicReader};
 
@@ -93,7 +93,7 @@ impl WebsocketTopicHandler for PriceReporterHandler {
             })
             .map_err(|_| ApiServerError::WebsocketServerFailure(ERR_SENDING_MESSAGE.to_string()))?;
 
-        Ok(self.system_bus.subscribe(price_report_topic_name(&base, &quote)))
+        Ok(self.system_bus.subscribe(price_report_topic(&base, &quote)))
     }
 
     /// Handle an unsubscribe message from the price reporter

--- a/workers/api-server/src/websocket/task.rs
+++ b/workers/api-server/src/websocket/task.rs
@@ -5,7 +5,7 @@
 // ------------------
 
 use async_trait::async_trait;
-use external_api::bus_message::{task_topic_name, SystemBusMessage};
+use external_api::bus_message::{task_topic, SystemBusMessage};
 use state::State;
 use system_bus::{SystemBus, TopicReader};
 
@@ -56,7 +56,7 @@ impl WebsocketTopicHandler for TaskStatusHandler {
         }
 
         // Subscribe to the topic
-        Ok(self.system_bus.subscribe(task_topic_name(&task_id)))
+        Ok(self.system_bus.subscribe(task_topic(&task_id)))
     }
 
     async fn handle_unsubscribe_message(

--- a/workers/api-server/src/websocket/wallet.rs
+++ b/workers/api-server/src/websocket/wallet.rs
@@ -1,6 +1,6 @@
 //! Handler definitions for wallet websocket topics
 use async_trait::async_trait;
-use external_api::bus_message::{wallet_topic_name, SystemBusMessage};
+use external_api::bus_message::{wallet_topic, SystemBusMessage};
 use state::State;
 use system_bus::{SystemBus, TopicReader};
 
@@ -56,7 +56,7 @@ impl WebsocketTopicHandler for WalletTopicHandler {
         }
 
         // Subscribe to the topic
-        Ok(self.system_bus.subscribe(wallet_topic_name(&wallet_id)))
+        Ok(self.system_bus.subscribe(wallet_topic(&wallet_id)))
     }
 
     /// Does nothing for now, `TopicReader`s clean themselves up

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -17,7 +17,7 @@ use common::{
     },
     AsyncShared,
 };
-use external_api::bus_message::{price_report_topic_name, SystemBusMessage};
+use external_api::bus_message::{price_report_topic, SystemBusMessage};
 use itertools::Itertools;
 use statrs::statistics::{Data, Median};
 use util::get_current_time_seconds;
@@ -213,7 +213,7 @@ impl SharedPriceStreamStates {
         quote: Token,
         config: &PriceReporterConfig,
     ) {
-        let topic_name = price_report_topic_name(&base, &quote);
+        let topic_name = price_report_topic(&base, &quote);
         if config.system_bus.has_listeners(&topic_name) {
             if let PriceReporterState::Nominal(report) = self.get_state(base, quote, config).await {
                 config.system_bus.publish(topic_name, SystemBusMessage::PriceReport(report));

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -120,8 +120,6 @@ pub enum UpdateWalletTaskError {
     State(String),
     /// An error while updating validity proofs for a wallet
     UpdatingValidityProofs(String),
-    /// Wallet is already locked, cannot update
-    WalletLocked,
 }
 
 impl TaskError for UpdateWalletTaskError {


### PR DESCRIPTION
### Purpose
This PR adds order metadata update methods to the `state` module. These allow orders in a wallet's order history to have their state updated.

### Todo
- When a wallet is updated, modify its order history. We isolate these changes to the `state` module to avoid floating the wallet / wallet history denormalization up to the interface

### Testing
- Unit tests pass