### PR TITLE
state: applicator: wallet-index: Update order history on wallet update

### DIFF
--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -2,6 +2,7 @@
 
 use circuit_types::Amount;
 use serde::{Deserialize, Serialize};
+use util::get_current_time_millis;
 
 use super::OrderIdentifier;
 
@@ -20,6 +21,14 @@ pub enum OrderState {
     Cancelled,
 }
 
+impl OrderState {
+    /// Whether the order state is terminal, i.e. it is either filled or
+    /// cancelled
+    pub fn is_terminal(self) -> bool {
+        self == OrderState::Filled || self == OrderState::Cancelled
+    }
+}
+
 /// Metadata for an order in a wallet, possibly historical
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OrderMetadata {
@@ -31,4 +40,12 @@ pub struct OrderMetadata {
     pub filled: Amount,
     /// The unix timestamp in milliseconds since the order was created
     pub created: u64,
+}
+
+impl OrderMetadata {
+    /// Create a new order metadata instance, defaults to `Created` state
+    pub fn new(id: OrderIdentifier) -> Self {
+        let created = get_current_time_millis() as u64;
+        Self { id, state: OrderState::Created, filled: 0, created }
+    }
 }

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -4,6 +4,8 @@ use circuit_types::order::Order;
 use constants::MAX_ORDERS;
 use itertools::Itertools;
 
+use crate::keyed_list::KeyedList;
+
 use super::{OrderIdentifier, Wallet};
 
 /// Error message emitted when the orders of a wallet are full
@@ -13,6 +15,11 @@ impl Wallet {
     // -----------
     // | Getters |
     // -----------
+
+    /// Whether or not the wallet contains an order with the given identifier
+    pub fn contains_order(&self, order_id: &OrderIdentifier) -> bool {
+        self.orders.contains_key(order_id)
+    }
 
     /// Get the given order
     pub fn get_order(&self, order_id: &OrderIdentifier) -> Option<&Order> {
@@ -34,6 +41,11 @@ impl Wallet {
             .collect::<Vec<_>>()
             .try_into()
             .unwrap()
+    }
+
+    /// Get the non-zero orders in the wallet
+    pub fn get_nonzero_orders(&self) -> KeyedList<OrderIdentifier, Order> {
+        self.orders.iter().filter(|(_id, order)| !order.is_zero()).cloned().collect()
     }
 
     /// Get the list of orders that are eligible for matching

--- a/state/src/interface/order_metadata.rs
+++ b/state/src/interface/order_metadata.rs
@@ -55,7 +55,7 @@ impl State {
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use std::cmp::Reverse;
 
     use common::types::wallet::order_metadata::OrderState;
@@ -67,7 +67,7 @@ mod test {
     use super::*;
 
     /// Get a random order metadata instance
-    fn random_metadata() -> OrderMetadata {
+    pub fn random_metadata() -> OrderMetadata {
         let mut rng = thread_rng();
         OrderMetadata {
             id: OrderIdentifier::new_v4(),
@@ -78,7 +78,7 @@ mod test {
     }
 
     /// Setup an order history using the given orders and wallet id
-    fn setup_order_history(wallet_id: &WalletIdentifier, orders: &[OrderMetadata], db: &DB) {
+    pub fn setup_order_history(wallet_id: &WalletIdentifier, orders: &[OrderMetadata], db: &DB) {
         // Add orders to the history
         let tx = db.new_write_tx().unwrap();
         orders.iter().for_each(|o| tx.push_order_history(wallet_id, *o).unwrap());

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -60,11 +60,142 @@ impl State {
 
     /// Propose a new wallet to be added to the index
     pub fn new_wallet(&self, wallet: Wallet) -> Result<ProposalWaiter, StateError> {
+        assert!(wallet.orders.is_empty(), "use `update-wallet` for non-empty wallets");
         self.send_proposal(StateTransition::AddWallet { wallet })
     }
 
     /// Update a wallet in the index
     pub fn update_wallet(&self, wallet: Wallet) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::UpdateWallet { wallet })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // --- Order History Tests --- //
+    // We test order history updates here to give access to state interfaces
+    // Wallet update handlers in the applicator handle order history changes to
+    // hide the wallet index/order history denormalization
+
+    use circuit_types::balance::Balance;
+    use common::types::{
+        wallet::{
+            order_metadata::{OrderMetadata, OrderState},
+            OrderIdentifier, WalletIdentifier,
+        },
+        wallet_mocks::{mock_empty_wallet, mock_order},
+    };
+    use itertools::Itertools;
+    use num_bigint::BigUint;
+
+    use crate::{order_metadata::test::setup_order_history, test_helpers::mock_state, State};
+
+    /// Create a set of mock historical orders
+    fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &State) {
+        let history = (0..n)
+            .map(|_| OrderMetadata {
+                id: OrderIdentifier::new_v4(),
+                state: OrderState::Filled,
+                filled: 1,
+                created: 0,
+            })
+            .collect_vec();
+
+        setup_order_history(&wallet_id, &history, &state.db);
+    }
+
+    /// Test creating a wallet with an order
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn test_order_history__new_wallet() {
+        let state = mock_state();
+
+        let mut wallet = mock_empty_wallet();
+        let order = mock_order();
+        let order_id = OrderIdentifier::new_v4();
+        wallet.add_order(order_id, order.clone()).unwrap();
+
+        // Add the wallet to state
+        state.update_wallet(wallet.clone()).unwrap().await.unwrap();
+
+        // Check the order history for a wallet
+        let history = state.get_order_history(10 /* len */, &wallet.wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].id, order_id);
+        assert_eq!(history[0].state, OrderState::Created);
+    }
+
+    /// Tests that updating a wallet marks all orders in the history as
+    /// `Created`
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn test_order_history__existing_order() {
+        let state = mock_state();
+        let mut wallet = mock_empty_wallet();
+        let order = mock_order();
+        let order_id = OrderIdentifier::new_v4();
+        wallet.add_order(order_id, order.clone()).unwrap();
+
+        // Update the wallet
+        state.update_wallet(wallet.clone()).unwrap().await.unwrap();
+
+        // Mark the order's state in the history as `Matching`, simulating an order that
+        // now has validity proofs ready for match
+        let mut meta = state.get_order_metadata(&order_id).unwrap().unwrap();
+        meta.state = OrderState::Matching;
+        state.update_order_metadata(meta).unwrap().await.unwrap();
+
+        // Update the wallet
+        wallet.add_balance(Balance::new_from_mint(BigUint::from(1u8))).unwrap();
+        state.update_wallet(wallet.clone()).unwrap().await.unwrap();
+
+        // Check the order history
+        let history = state.get_order_history(10 /* len */, &wallet.wallet_id).unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].id, order_id);
+        // The order should now be back in the `Created` state, awaiting new proofs
+        assert_eq!(history[0].state, OrderState::Created);
+    }
+
+    /// Test updating a wallet in which we cancel one order and replace with
+    /// another
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn test_order_history__cancel_replace() {
+        const N: usize = 100;
+        let state = mock_state();
+        let mut wallet = mock_empty_wallet();
+
+        // Setup a longer mock order history of filled orders
+        create_mock_historical_orders(N, wallet.wallet_id, &state);
+
+        // Add an existing order
+        let order_id = OrderIdentifier::new_v4();
+        let order = mock_order();
+        wallet.add_order(order_id, order).unwrap();
+
+        // Update the wallet
+        state.update_wallet(wallet.clone()).unwrap().await.unwrap();
+
+        // Now remove this order and add another
+        wallet.remove_order(&order_id).unwrap();
+        let order_id2 = OrderIdentifier::new_v4();
+        let order = mock_order();
+        wallet.add_order(order_id2, order).unwrap();
+
+        // Update the wallet
+        state.update_wallet(wallet.clone()).unwrap().await.unwrap();
+
+        // Now fetch history, it should contain one order in the `Created` state
+        // another in the `Cancelled` state and
+        let history = state.get_order_history(10 /* len */, &wallet.wallet_id).unwrap();
+        assert_eq!(history.len(), 10);
+        assert_eq!(history[0].id, order_id2);
+        assert_eq!(history[0].state, OrderState::Created);
+        assert_eq!(history[1].id, order_id);
+        assert_eq!(history[1].state, OrderState::Cancelled);
+
+        // The rest of the orders should be unaffected
+        assert!(history[2..].iter().all(|meta| meta.state == OrderState::Filled));
     }
 }


### PR DESCRIPTION
### Purpose
This PR updates order history for new and cancelled orders in the wallet update handlers. We modify order history here to hide the wallet index / order history denormalization from the interface. That is, when a wallet is updated, the order history is brought to a consistent state without the caller having to separately update order history.

### Testing
- Unit tests pass
- Tested order history via wallet update interface