### PR TITLE
github, docker: sequencer: support dev env & deploy erc20s first

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - 'staging'
+      - 'dev'
       - 'testnet'
       - 'mainnet'
 
@@ -11,7 +12,7 @@ jobs:
   build-and-push-ecr:
     runs-on: buildjet-16vcpu-ubuntu-2204-arm
     outputs:
-      image: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}:${{ github.sha }}
+      image: ${{ steps.login-ecr.outputs.registry }}/relayer-${{ github.ref_name }}:${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +21,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          aws-region: ${{ github.ref_name == 'dev' && 'us-east-2' || 'ca-central-1' }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -33,7 +34,7 @@ jobs:
         id: docker-build-push
         uses: docker/build-push-action@v5
         env:
-          IMAGE: ${{ steps.login-ecr.outputs.registry }}/renegade-${{ github.ref_name }}
+          IMAGE: ${{ steps.login-ecr.outputs.registry }}/relayer-${{ github.ref_name }}
         with:
           platforms: linux/arm64
           context: .
@@ -58,6 +59,9 @@ jobs:
           if [[ "${{ github.ref_name }}" == "staging" ]]; then
             NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_STAGING }}
             NUM_SINGLENODE_CLUSTERS=${{ vars.NUM_SINGLENODE_CLUSTERS_STAGING }}
+          elif [[ "${{ github.ref_name }}" == "dev" ]]; then
+            NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_DEV }}
+            NUM_SINGLENODE_CLUSTERS=${{ vars.NUM_SINGLENODE_CLUSTERS_DEV }}
           elif [[ "${{ github.ref_name }}" == "testnet" ]]; then
             NUM_CLUSTERS=${{ vars.NUM_CLUSTERS_TESTNET }}
             NUM_SINGLENODE_CLUSTERS=${{ vars.NUM_SINGLENODE_CLUSTERS_TESTNET }}
@@ -89,7 +93,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          aws-region: ${{ github.ref_name == 'dev' && 'us-east-2' || 'ca-central-1' }}
 
       - name: Get the existing task definitions
         id: fetch-task-def

--- a/bin/release.zsh
+++ b/bin/release.zsh
@@ -1,16 +1,16 @@
 set -e
 
-# Check if the first argument is either "staging", "testnet", or "mainnet"
-if [[ $1 != "staging" && $1 != "testnet" && $1 != "mainnet" ]]; then
-    echo "Error: First argument must be either 'staging', 'testnet', or 'mainnet'."
+# Check if the first argument is either "staging", "dev", "testnet", or "mainnet"
+if [[ $1 != "staging" && $1 != "testnet" && $1 != "mainnet" && $1 != "dev" ]]; then
+    echo "Error: First argument must be either 'staging', 'testnet', 'mainnet', or 'dev'."
     exit 1
 fi
 
 # Set variables
 aws_account_id="377928551571"
-aws_region="ca-central-1"
-ecr_repository_name="renegade-$1"
-image_name="renegade-relayer"
+aws_region="us-east-2"
+ecr_repository_name="relayer-$1"
+image_name="relayer"
 image_tag="latest"
 
 # Log in to Amazon ECR

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -31,6 +31,46 @@ done
 # Exit on error
 set -e
 
+# Deploy the Permit2 contract.
+# This must be deployed before the ERC20s so they can approve it
+cargo run \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
+    deploy-permit2
+
+# Deploy the dummy ERC20 contracts
+# The funding amount here is 1 million of a token with 18 decimal places
+cargo run \
+    --package scripts -- \
+    --priv-key $DEVNET_PKEY \
+    --rpc-url $DEVNET_RPC_URL \
+    --deployments-path $DEPLOYMENTS_PATH \
+    deploy-erc20s \
+    --account-skeys $DEVNET_PKEY \
+    --tickers \
+        WBTC \
+        WETH \
+        BNB \
+        MATIC \
+        LDO \
+        USDC \
+        USDT \
+        LINK \
+        UNI \
+        SUSHI \
+        1INCH \
+        AAVE \
+        COMP \
+        MKR \
+        REN \
+        MANA \
+        ENS \
+        DYDX \
+        CRV \
+    --funding-amount 1000000000000000000000000
+
 # If $NO_VERIFY is set, write dummy addresses to the deployments file.
 # Otherwise, deploy the verification keys.
 if [[ -n $NO_VERIFY ]]; then
@@ -78,27 +118,6 @@ cargo run \
     deploy-stylus \
     --contract transfer-executor \
     $no_verify_flag
-
-# Deploy the Permit2 contract.
-# This must be deployed before the ERC20s so they can approve it
-cargo run \
-    --package scripts -- \
-    --priv-key $DEVNET_PKEY \
-    --rpc-url $DEVNET_RPC_URL \
-    --deployments-path $DEPLOYMENTS_PATH \
-    deploy-permit2
-
-# Deploy the dummy ERC20 contracts
-# The funding amount here is 1 million of a token with 18 decimal places
-cargo run \
-    --package scripts -- \
-    --priv-key $DEVNET_PKEY \
-    --rpc-url $DEVNET_RPC_URL \
-    --deployments-path $DEPLOYMENTS_PATH \
-    deploy-erc20s \
-    --account-skeys $DEVNET_PKEY \
-    --tickers DUMMY1 DUMMY2 \
-    --funding-amount 1000000000000000000000000
 
 # If the $NO_VERIFY env var is unset, deploy the verifier.
 # We do this after deploying the other contracts because it uses


### PR DESCRIPTION
This PR ensures that the `upgrade` Github Action supports the new `dev` environment appropriately, and has the sequencer deploy the full suite of testing ERC20s first, so that their addresses are consistent regardless of changes in the Renegade contracts.