### PR TITLE
state, task-driver: Add misc order state transitions

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -17,7 +17,7 @@ use super::{
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::{KeyChain, Wallet, WalletIdentifier},
+    wallet::{KeyChain, OrderIdentifier, Wallet, WalletIdentifier},
 };
 
 /// The error message returned when a wallet's shares are invalid
@@ -227,6 +227,10 @@ impl From<LookupWalletTaskDescriptor> for TaskDescriptor {
 pub struct SettleMatchInternalTaskDescriptor {
     /// The price at which the match was executed
     pub execution_price: FixedPoint,
+    /// The identifier of the first order
+    pub order_id1: OrderIdentifier,
+    /// The identifier of the second order
+    pub order_id2: OrderIdentifier,
     /// The identifier of the first order's wallet
     pub wallet_id1: WalletIdentifier,
     /// The identifier of the second order's wallet
@@ -248,6 +252,8 @@ impl SettleMatchInternalTaskDescriptor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         execution_price: FixedPoint,
+        order_id1: OrderIdentifier,
+        order_id2: OrderIdentifier,
         wallet_id1: WalletIdentifier,
         wallet_id2: WalletIdentifier,
         order1_proof: OrderValidityProofBundle,
@@ -258,6 +264,8 @@ impl SettleMatchInternalTaskDescriptor {
     ) -> Result<Self, String> {
         Ok(SettleMatchInternalTaskDescriptor {
             execution_price,
+            order_id1,
+            order_id2,
             wallet_id1,
             wallet_id2,
             order1_proof,

--- a/state/src/applicator/order_metadata.rs
+++ b/state/src/applicator/order_metadata.rs
@@ -12,7 +12,7 @@ impl StateApplicator {
     pub fn update_order_metadata(&self, meta: OrderMetadata) -> Result<(), StateApplicatorError> {
         // Update the state
         let tx = self.db().new_write_tx()?;
-        self.update_order_metadata_with_tx(&tx, meta)?;
+        self.update_order_metadata_with_tx(meta, &tx)?;
         tx.commit()?;
 
         Ok(())
@@ -21,8 +21,8 @@ impl StateApplicator {
     /// Update the state of an order's metadata given a transaction
     pub(crate) fn update_order_metadata_with_tx(
         &self,
-        tx: &StateTxn<RW>,
         meta: OrderMetadata,
+        tx: &StateTxn<RW>,
     ) -> Result<(), StateApplicatorError> {
         let wallet = tx
             .get_wallet_for_order(&meta.id)?

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -96,7 +96,7 @@ impl StateApplicator {
                 .get_order_metadata(wallet_id, id)?
                 .ok_or(StateApplicatorError::MissingEntry(ERR_NO_METADATA))?;
             md.state = OrderState::Created;
-            self.update_order_metadata_with_tx(tx, md)?;
+            self.update_order_metadata_with_tx(md, tx)?;
         }
 
         Ok(())
@@ -135,7 +135,7 @@ impl StateApplicator {
         for id in wallet.get_nonzero_orders().into_keys() {
             if !old_orders.contains(&id) {
                 let new_state = OrderMetadata::new(id);
-                self.update_order_metadata_with_tx(tx, new_state)?;
+                self.update_order_metadata_with_tx(new_state, tx)?;
             }
         }
 
@@ -149,7 +149,7 @@ impl StateApplicator {
                 // Only update the state if it has not already entered a terminal state
                 if !old_meta.state.is_terminal() {
                     old_meta.state = OrderState::Cancelled;
-                    self.update_order_metadata_with_tx(tx, old_meta)?;
+                    self.update_order_metadata_with_tx(old_meta, tx)?;
                 }
             }
         }

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -95,6 +95,8 @@ impl HandshakeExecutor {
                 .try_match_and_settle(
                     my_order.clone(),
                     order2,
+                    network_order.id,
+                    order_id,
                     wallet.wallet_id,
                     other_wallet_id,
                     price,
@@ -128,6 +130,8 @@ impl HandshakeExecutor {
         &self,
         o1: Order,
         o2: Order,
+        order_id1: OrderIdentifier,
+        order_id2: OrderIdentifier,
         wallet_id1: WalletIdentifier,
         wallet_id2: WalletIdentifier,
         price: FixedPoint,
@@ -147,6 +151,8 @@ impl HandshakeExecutor {
         // Submit the match to the task driver
         let task: TaskDescriptor = SettleMatchInternalTaskDescriptor::new(
             price,
+            order_id1,
+            order_id2,
             wallet_id1,
             wallet_id2,
             validity_proof1,

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -352,10 +352,14 @@ async fn test_settle_internal_match(test_args: IntegrationTestArgs) -> Result<()
         setup_match_result(buy_wallet.clone(), sell_wallet.clone(), &test_args).await?;
 
     // Create the task
+    let order_id1 = *buy_wallet.orders.keys().next().unwrap();
+    let order_id2 = *sell_wallet.orders.keys().next().unwrap();
     let task = SettleMatchInternalTaskDescriptor::new(
         FixedPoint::from_f64_round_down(EXECUTION_PRICE),
         buy_wallet.wallet_id,
         sell_wallet.wallet_id,
+        order_id1,
+        order_id2,
         get_first_order_proofs(&buy_wallet, state)?,
         get_first_order_witness(&buy_wallet, state)?,
         get_first_order_proofs(&sell_wallet, state)?,

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -5,7 +5,8 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::helpers::{
-    enqueue_fee_settlement_tasks, enqueue_proof_job, update_wallet_validity_proofs,
+    enqueue_fee_settlement_tasks, enqueue_proof_job, transition_order_filled,
+    transition_order_settling, update_wallet_validity_proofs,
 };
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
 use crate::{driver::StateWrapper, helpers::find_merkle_path};
@@ -19,7 +20,7 @@ use circuits::zk_circuits::valid_match_settle::{
 };
 use common::types::proof_bundles::{MatchBundle, ProofBundle, ValidMatchSettleBundle};
 use common::types::tasks::SettleMatchInternalTaskDescriptor;
-use common::types::wallet::WalletIdentifier;
+use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::Wallet,
@@ -148,6 +149,10 @@ impl From<StateError> for SettleMatchInternalTaskError {
 pub struct SettleMatchInternalTask {
     /// The price at which the match was executed
     execution_price: FixedPoint,
+    /// The identifier of the first order
+    order_id1: OrderIdentifier,
+    /// The identifier of the second order
+    order_id2: OrderIdentifier,
     /// The identifier of the first order's wallet
     wallet_id1: WalletIdentifier,
     /// The identifier of the second order's wallet
@@ -185,6 +190,8 @@ impl Task for SettleMatchInternalTask {
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
         let SettleMatchInternalTaskDescriptor {
             execution_price,
+            order_id1,
+            order_id2,
             wallet_id1,
             wallet_id2,
             order1_proof,
@@ -196,6 +203,8 @@ impl Task for SettleMatchInternalTask {
 
         Ok(Self {
             execution_price,
+            order_id1,
+            order_id2,
             wallet_id1,
             wallet_id2,
             order1_proof,
@@ -301,6 +310,12 @@ impl SettleMatchInternalTask {
 
     /// Submit the match transaction
     async fn submit_match(&mut self) -> Result<(), SettleMatchInternalTaskError> {
+        // Transition both orders to the `SettlingMatch` state
+        transition_order_settling(self.order_id1, &self.state)
+            .map_err(SettleMatchInternalTaskError::State)?;
+        transition_order_settling(self.order_id2, &self.state)
+            .map_err(SettleMatchInternalTaskError::State)?;
+
         // Submit a `match` transaction
         self.arbitrum_client
             .process_match_settle(
@@ -334,6 +349,10 @@ impl SettleMatchInternalTask {
             &self.order2_validity_witness.reblind_witness.reblinded_wallet_private_shares;
         wallet1.update_from_shares(party0_private_shares, party0_public_shares);
         wallet2.update_from_shares(party1_private_shares, party1_public_shares);
+
+        // Transition the orders to the `Filled` state if necessary
+        self.maybe_transition_filled(&self.order_id1, &wallet1)?;
+        self.maybe_transition_filled(&self.order_id2, &wallet2)?;
 
         self.find_opening(&mut wallet1).await?;
         self.find_opening(&mut wallet2).await?;
@@ -401,6 +420,22 @@ impl SettleMatchInternalTask {
         self.state.get_wallet(wallet_id)?.ok_or_else(|| {
             SettleMatchInternalTaskError::MissingState(ERR_WALLET_NOT_FOUND.to_string())
         })
+    }
+
+    /// Transition the order to the `Filled` state if the match completely fills
+    /// the order
+    fn maybe_transition_filled(
+        &self,
+        order_id: &OrderIdentifier,
+        wallet: &Wallet,
+    ) -> Result<(), SettleMatchInternalTaskError> {
+        let is_filled = wallet.get_order(order_id).map(|o| o.amount == 0).unwrap_or(false);
+        if is_filled {
+            transition_order_filled(*order_id, &self.state)
+                .map_err(SettleMatchInternalTaskError::State)?;
+        }
+
+        Ok(())
     }
 
     /// Get the witness and statement for `VALID MATCH SETTLE`


### PR DESCRIPTION
### Purpose
This PR adds miscellaneous order state transition logic for transitioning into `SubmittingMatch` and `Filled` states in particular. As well, when a validity proof for an order comes in, we transition to `Matching`.

### Testing
- Unit tests pass
- Will test state transitions ad hoc when the API is in place (next pr)