### PR TITLE
workers: api-server: wallet: Add order history route + handler

### DIFF
--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -1,7 +1,10 @@
 //! Groups API type definitions for wallet API operations
 
 use circuit_types::balance::Balance;
-use common::types::{tasks::TaskIdentifier, wallet::WalletIdentifier};
+use common::types::{
+    tasks::TaskIdentifier,
+    wallet::{order_metadata::OrderMetadata, WalletIdentifier},
+};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -37,6 +40,9 @@ pub const GET_BALANCE_BY_MINT_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:min
 pub const DEPOSIT_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/deposit";
 /// Withdraws an ERC-20 token from the darkpool
 pub const WITHDRAW_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint/withdraw";
+
+/// Returns the order history of a wallet
+pub const ORDER_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/order-history";
 
 // --------------------
 // | Wallet API Types |
@@ -252,29 +258,13 @@ pub struct WithdrawBalanceResponse {
     pub task_id: TaskIdentifier,
 }
 
-/// The request type to create an internal transfer to another darkpool wallet
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InternalTransferRequest {
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    ///
-    /// TODO: For now this is just a blob, we will add this feature in
-    /// a follow up
-    pub statement_sig: Vec<u8>,
-    /// The recipient's settle key
-    #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
-        deserialize_with = "deserialize_biguint_from_hex_string"
-    )]
-    pub recipient_key: BigUint,
-    /// The amount to transfer
-    pub amount: BigUint,
-}
+// ---------------------------
+// | Order History API Types |
+// ---------------------------
 
-/// The response type to a request to create an internal transfer
+/// The response type for order history
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InternalTransferResponse {
-    /// The ID of the task that was allocated on behalf of this request
-    pub task_id: TaskIdentifier,
+pub struct GetOrderHistoryResponse {
+    /// A history of orders in the wallet
+    pub orders: Vec<OrderMetadata>,
 }

--- a/state/src/interface/order_metadata.rs
+++ b/state/src/interface/order_metadata.rs
@@ -31,7 +31,7 @@ impl State {
         Ok(Some(md))
     }
 
-    /// Get a history of the wallet's orders
+    /// Get a truncated history of the wallet's orders
     pub fn get_order_history(
         &self,
         n: usize,

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -46,21 +46,25 @@ impl From<ApiServerError> for Response<Body> {
 }
 
 /// Create an `ApiServerError` with a 400 bad request code
-pub(crate) fn bad_request(e: String) -> ApiServerError {
-    ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, e)
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn bad_request<E: ToString>(e: E) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::BAD_REQUEST, e.to_string())
 }
 
 /// Create an `ApiServerError` with a 401 unauthorized code
-pub(crate) fn unauthorized(e: String) -> ApiServerError {
-    ApiServerError::HttpStatusCode(StatusCode::UNAUTHORIZED, e)
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn unauthorized<E: ToString>(e: E) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::UNAUTHORIZED, e.to_string())
 }
 
 /// Create an `ApiServerError` with a 404 not found code
-pub(crate) fn not_found(e: String) -> ApiServerError {
-    ApiServerError::HttpStatusCode(StatusCode::NOT_FOUND, e)
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn not_found<E: ToString>(e: E) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::NOT_FOUND, e.to_string())
 }
 
 /// Create an `ApiServerError` with a 500 internal server error code
-pub(crate) fn internal_error(e: String) -> ApiServerError {
-    ApiServerError::HttpStatusCode(StatusCode::INTERNAL_SERVER_ERROR, e)
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn internal_error<E: ToString>(e: E) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
 }

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -14,7 +14,7 @@ use state::State;
 
 use crate::{
     error::{not_found, ApiServerError},
-    router::{TypedHandler, UrlParams},
+    router::{QueryParams, TypedHandler, UrlParams},
 };
 
 use super::{parse_cluster_id_from_params, parse_peer_id_from_params};
@@ -54,6 +54,7 @@ impl TypedHandler for GetNetworkTopologyHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         _params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Fetch all peer info
         let peers = self.global_state.get_peer_info_map()?;
@@ -94,6 +95,7 @@ impl TypedHandler for GetClusterInfoHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let cluster_id = parse_cluster_id_from_params(&params)?;
 
@@ -133,6 +135,7 @@ impl TypedHandler for GetPeerInfoHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let peer_id = parse_peer_id_from_params(&params)?;
         if let Some(info) = self.global_state.get_peer_info(&peer_id)? {

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -11,7 +11,7 @@ use state::State;
 
 use crate::{
     error::{not_found, ApiServerError},
-    router::{TypedHandler, UrlParams},
+    router::{QueryParams, TypedHandler, UrlParams},
 };
 
 use super::parse_order_id_from_params;
@@ -51,6 +51,7 @@ impl TypedHandler for GetNetworkOrdersHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         _params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Fetch all orders from state and convert to api type
         let all_orders = self.global_state.get_all_orders()?;
@@ -84,6 +85,7 @@ impl TypedHandler for GetNetworkOrderByIdHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let order_id = parse_order_id_from_params(&params)?;
         if let Some(order) = self.global_state.get_order(&order_id)? {

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot::channel;
 
 use crate::{
     error::ApiServerError,
-    router::{TypedHandler, UrlParams},
+    router::{QueryParams, TypedHandler, UrlParams},
     worker::ApiServerConfig,
 };
 
@@ -41,6 +41,7 @@ impl TypedHandler for PriceReportHandler {
         _headers: HeaderMap,
         req: Self::Request,
         _params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let (price_reporter_state_sender, price_reporter_state_receiver) = channel();
         self.config

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -14,7 +14,7 @@ use state::State;
 
 use crate::{
     error::{not_found, ApiServerError},
-    router::{TypedHandler, UrlParams},
+    router::{QueryParams, TypedHandler, UrlParams},
 };
 
 use super::{parse_task_id_from_params, parse_wallet_id_from_params};
@@ -53,6 +53,7 @@ impl TypedHandler for GetTaskStatusHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Lookup the task status in the task driver's state
         let task_id = parse_task_id_from_params(&params)?;
@@ -90,6 +91,7 @@ impl TypedHandler for GetTaskQueueHandler {
         _headers: HeaderMap,
         _req: Self::Request,
         params: UrlParams,
+        _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let wallet_id = parse_wallet_id_from_params(&params)?;
 


### PR DESCRIPTION
### Purpose
This PR adds an HTTP route for querying order history on a wallet. I also added URL query parameters to the handler signature to allow for urls like `/wallet/:id/order-history?order_history_len=10` rather than forcing a client to send a body in a `GET`.

### Testing
- Tested locally