### PR TITLE
workers: api-server: websocket: Add order status websocket handler

### DIFF
--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -25,6 +25,7 @@ use crate::{
 
 use self::{
     handler::{DefaultHandler, WebsocketTopicHandler},
+    order_status::OrderStatusHandler,
     price_report::PriceReporterHandler,
     task::TaskStatusHandler,
     wallet::WalletTopicHandler,
@@ -36,6 +37,7 @@ use super::{
 };
 
 mod handler;
+mod order_status;
 mod price_report;
 mod task;
 mod wallet;
@@ -58,6 +60,8 @@ const ERR_HEADER_PARSE: &str = "error parsing headers";
 const HANDSHAKE_ROUTE: &str = "/v0/handshake";
 /// The wallet topic, events about wallet updates are streamed here
 const WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
+/// The wallet order status topic, streams events about wallet's orders
+const WALLET_ORDERS_ROUTE: &str = "/v0/wallet/:wallet_id/order-status";
 /// The price report topic, events about price updates are streamed
 const PRICE_REPORT_ROUTE: &str = "/v0/price_report/:source/:base/:quote";
 /// The order book topic, streams events about known network orders
@@ -108,6 +112,17 @@ impl WebsocketServer {
             .insert(
                 WALLET_ROUTE,
                 Box::new(WalletTopicHandler::new(
+                    config.global_state.clone(),
+                    config.system_bus.clone(),
+                )),
+            )
+            .unwrap();
+
+        // The "/v0/wallet/:id/order-status" route
+        router
+            .insert(
+                WALLET_ORDERS_ROUTE,
+                Box::new(OrderStatusHandler::new(
                     config.global_state.clone(),
                     config.system_bus.clone(),
                 )),

--- a/workers/api-server/src/websocket/order_status.rs
+++ b/workers/api-server/src/websocket/order_status.rs
@@ -1,0 +1,64 @@
+//! Handler for the order status topic
+
+use async_trait::async_trait;
+use external_api::bus_message::{wallet_order_history_topic, SystemBusMessage};
+use state::State;
+use system_bus::{SystemBus, TopicReader};
+
+use crate::{
+    error::{not_found, ApiServerError},
+    http::parse_wallet_id_from_params,
+    router::{UrlParams, ERR_WALLET_NOT_FOUND},
+};
+
+use super::handler::WebsocketTopicHandler;
+
+/// The handler for the wallet order status topic
+#[derive(Clone)]
+pub struct OrderStatusHandler {
+    /// A reference to the relayer-global state
+    state: State,
+    /// A reference to the system bus
+    bus: SystemBus<SystemBusMessage>,
+}
+
+impl OrderStatusHandler {
+    /// Constructor
+    pub fn new(state: State, bus: SystemBus<SystemBusMessage>) -> Self {
+        Self { state, bus }
+    }
+}
+
+#[async_trait]
+impl WebsocketTopicHandler for OrderStatusHandler {
+    /// Handle a new subscription, validate that the wallet is present
+    async fn handle_subscribe_message(
+        &self,
+        _topic: String,
+        route_params: &UrlParams,
+    ) -> Result<TopicReader<SystemBusMessage>, ApiServerError> {
+        // Parse the wallet ID from the topic captures
+        let wallet_id = parse_wallet_id_from_params(route_params)?;
+
+        // If the wallet doesn't exist, throw an error
+        if self.state.get_wallet(&wallet_id)?.is_none() {
+            return Err(not_found(ERR_WALLET_NOT_FOUND.to_string()));
+        }
+
+        // Subscribe to the topic
+        Ok(self.bus.subscribe(wallet_order_history_topic(&wallet_id)))
+    }
+
+    /// Does nothing for now, `TopicReader`s clean themselves up
+    async fn handle_unsubscribe_message(
+        &self,
+        _topic: String,
+        _route_params: &UrlParams,
+    ) -> Result<(), ApiServerError> {
+        Ok(())
+    }
+
+    fn requires_wallet_auth(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds an order status websocket handler. This handler listens to updates on the order history topic for a wallet and forwards them to the client.

### Testing
- Unit tests pass crate wide
- Tested the websocket topic with a local relayer running on my machine