### PR TITLE
arbitrum-client: event-indexing: Query single tx for Merkle path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "ethers",
  "eyre",
  "inventory",
+ "itertools 0.12.1",
  "json",
  "lazy_static",
  "mpc-plonk",
@@ -3994,6 +3995,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -45,6 +45,7 @@ serde_with = "3.4"
 postcard = { version = "1", features = ["alloc"] }
 
 # === Misc === #
+itertools = "0.12"
 lazy_static = "1.4.0"
 tracing = { workspace = true }
 

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -24,7 +24,8 @@ abigen!(
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
-        event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
+        event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
+        event MerkleInsertion(uint128 indexed index, uint256 indexed value)
         event NullifierSpent(uint256 nullifier)
     ]"#
 );
@@ -50,7 +51,8 @@ abigen!(
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
 
         event WalletUpdated(uint256 indexed wallet_blinder_share)
-        event NodeChanged(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
+        event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
+        event MerkleInsertion(uint128 indexed index, uint256 indexed value)
         event NullifierSpent(uint256 nullifier)
 
         function clearMerkle() external


### PR DESCRIPTION
### Purpose
This PR uses the new event paradigm from the contracts, querying a single transaction to reconstruct a commitment's Merkle opening. This gives a constant time `FindingOpening` step for tasks.

I also removed the Merkle update listener from the `chain-events` worker instead of fixing the downstream errors -- it's not very useful at the moment.

### Todo
- Test on staging cluster

### Testing
- Unit tests pass