### PR TITLE
state: applicator: only run matching engine on executor of last task

### DIFF
--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -281,11 +281,7 @@ impl TaskExecutor {
     ) -> Result<(), TaskDriverError> {
         // Pause the queues for the affected local wallets
         for wallet_id in wallet_ids.iter() {
-            state
-                .pause_task_queue(wallet_id)
-                .expect("error proposing task queue pause for wallet {wallet_id}")
-                .await
-                .expect("error pausing task queue for wallet {wallet_id}");
+            state.pause_task_queue(wallet_id)?.await?;
         }
 
         // Add the task to the preemptive tasks list so that notification requests can
@@ -299,11 +295,7 @@ impl TaskExecutor {
 
         // Unpause the queues for the affected local wallets
         for wallet_id in wallet_ids.iter() {
-            state
-                .resume_task_queue(wallet_id)
-                .expect("error proposing task queue resume for wallet {wallet_id}")
-                .await
-                .expect("error resuming task queue for wallet {wallet_id}");
+            state.resume_task_queue(wallet_id)?.await?;
         }
 
         // Remove from the preemptive tasks list


### PR DESCRIPTION
This PR adjusts the conditions under which we execute the internal matching engine after popping a task, adding the clause that the engine should only be run by the executor of the last task. This is currently the most straightforward way to ensure that the engine is only run on one node.

Additionally, this PR removes the `expect`ation of successful task queue pausing when running a preemptive task, as this can error healthily in cases such as attempting to preempt a committed task, or pause an already-paused queue.

The combination of these two changes should remediate the issue we were seeing in `dev` where nodes would panic after a match was found.