### PR TITLE
workers: task-driver, api-server: Settle fees only on withdrawal

### DIFF
--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -32,8 +32,8 @@ use crate::driver::StateWrapper;
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
 
 use crate::helpers::{
-    enqueue_fee_settlement_tasks, find_merkle_path, transition_order_filled,
-    transition_order_settling, update_wallet_validity_proofs,
+    find_merkle_path, transition_order_filled, transition_order_settling,
+    update_wallet_validity_proofs,
 };
 
 /// The error message the contract emits when a nullifier has been used
@@ -310,14 +310,7 @@ impl SettleMatchTask {
         wallet.merkle_proof = Some(opening);
 
         // Index the updated wallet in global state
-        let wallet_id = wallet.wallet_id;
         self.global_state.update_wallet(wallet)?.await?;
-
-        // Enqueue a job to settle the wallet's fees
-        enqueue_fee_settlement_tasks(wallet_id, &self.global_state)
-            .await
-            .map_err(SettleMatchTaskError::State)?;
-
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -5,8 +5,8 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::helpers::{
-    enqueue_fee_settlement_tasks, enqueue_proof_job, transition_order_filled,
-    transition_order_settling, update_wallet_validity_proofs,
+    enqueue_proof_job, transition_order_filled, transition_order_settling,
+    update_wallet_validity_proofs,
 };
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
 use crate::{driver::StateWrapper, helpers::find_merkle_path};
@@ -358,19 +358,8 @@ impl SettleMatchInternalTask {
         self.find_opening(&mut wallet2).await?;
 
         // Re-index the updated wallets in the global state
-        let id1 = wallet1.wallet_id;
-        let id2 = wallet2.wallet_id;
         self.state.update_wallet(wallet1)?.await?;
         self.state.update_wallet(wallet2)?.await?;
-
-        // Enqueue jobs to pay fees for the wallets
-        let state = &self.state;
-        enqueue_fee_settlement_tasks(id1, state)
-            .await
-            .map_err(SettleMatchInternalTaskError::State)?;
-        enqueue_fee_settlement_tasks(id2, state)
-            .await
-            .map_err(SettleMatchInternalTaskError::State)?;
 
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR moves fee payment out of the match-settle flow. Instead, fee payment is done when a user withdraws. This removes the period after a match in which a wallet is ineligible for another match.

### Testing
- Tested against a local relayer