### PR TITLE
workers: network-manager: remove expired peers from KDHT

### DIFF
--- a/workers/job-types/src/network_manager.rs
+++ b/workers/job-types/src/network_manager.rs
@@ -89,6 +89,12 @@ pub enum NetworkManagerControlSignal {
         /// The new address
         address: Multiaddr,
     },
+    /// A command signalling to the network manager that a peer has been expired
+    /// and it should be removed from the Kademlia DHT
+    PeerExpired {
+        /// The PeerID of the expired Peer
+        peer_id: WrappedPeerId,
+    },
     /// A command informing the network manager that the gossip protocol has
     /// warmed up in the network
     ///

--- a/workers/network-manager/src/manager/control_directives.rs
+++ b/workers/network-manager/src/manager/control_directives.rs
@@ -38,6 +38,12 @@ impl NetworkManagerExecutor {
                 Ok(())
             },
 
+            // Remove a peer from the distributed routing tables
+            NetworkManagerControlSignal::PeerExpired { peer_id } => {
+                self.handle_peer_expired(&peer_id.inner());
+                Ok(())
+            },
+
             // Inform the network manager that the gossip server has warmed up the local node in
             // the cluster by advertising the local node's presence
             //
@@ -75,6 +81,11 @@ impl NetworkManagerExecutor {
         }
 
         self.swarm.behaviour_mut().kademlia_dht.add_address(&peer_id, addr);
+    }
+
+    /// Handle removing a peer from the DHT
+    fn handle_peer_expired(&mut self, peer_id: &PeerId) {
+        self.swarm.behaviour_mut().kademlia_dht.remove_peer(peer_id);
     }
 
     /// Handle a complete gossip warmup


### PR DESCRIPTION
This PR creates a new control signal for the network manager responsible for signaling the removal of a peer from the Kademlia DHT, and issues this control signal whenever a peer is expired.

Without this, a cluster will continue trying to dial expired peers (e.g. after a cluster upgrade), which is a safe failure but still wastes bandwidth.