### PR TITLE
workers: api-server: Add `/v0/wallet/:id/back_of_queue` endpoint

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -125,7 +125,7 @@ impl TaskDescriptor {
                 unimplemented!("SettleMatchInternal should preempt queue, no key needed")
             },
             TaskDescriptor::UpdateMerkleProof(task) => task.wallet.wallet_id,
-            TaskDescriptor::UpdateWallet(task) => task.old_wallet.wallet_id,
+            TaskDescriptor::UpdateWallet(task) => task.wallet_id,
         }
     }
 
@@ -358,7 +358,7 @@ pub struct UpdateWalletTaskDescriptor {
     /// The external transfer & auth data, if one exists
     pub transfer: Option<ExternalTransferWithAuth>,
     /// The old wallet before update
-    pub old_wallet: Wallet,
+    pub wallet_id: WalletIdentifier,
     /// The new wallet after update
     pub new_wallet: Wallet,
     /// A signature of the `VALID WALLET UPDATE` statement by the wallet's root
@@ -368,6 +368,7 @@ pub struct UpdateWalletTaskDescriptor {
 
 impl UpdateWalletTaskDescriptor {
     /// Constructor
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(
         description: String,
         transfer_with_auth: Option<ExternalTransferWithAuth>,
@@ -388,7 +389,7 @@ impl UpdateWalletTaskDescriptor {
         Ok(UpdateWalletTaskDescriptor {
             description,
             transfer: transfer_with_auth,
-            old_wallet,
+            wallet_id: old_wallet.wallet_id,
             new_wallet,
             wallet_update_signature,
         })

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -24,6 +24,9 @@ pub const CREATE_WALLET_ROUTE: &str = "/v0/wallet";
 pub const FIND_WALLET_ROUTE: &str = "/v0/wallet/lookup";
 /// Returns the wallet information for the given id
 pub const GET_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
+/// Get the wallet at the "back of the queue", i.e. the speculatively updated
+/// wallet as if all enqueued wallet tasks had completed
+pub const BACK_OF_QUEUE_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id/back_of_queue";
 /// Route to the orders of a given wallet
 pub const WALLET_ORDERS_ROUTE: &str = "/v0/wallet/:wallet_id/orders";
 /// Returns a single order by the given identifier

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -12,8 +12,9 @@ use external_api::{
         price_report::PRICE_REPORT_ROUTE,
         task::{GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         wallet::{
-            CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE, DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE,
-            GET_BALANCES_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
+            BACK_OF_QUEUE_WALLET_ROUTE, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE,
+            DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE,
+            GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
             ORDER_HISTORY_ROUTE, UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
         },
         PingResponse,
@@ -48,9 +49,9 @@ use self::{
     task::{GetTaskQueueHandler, GetTaskStatusHandler},
     wallet::{
         CancelOrderHandler, CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler,
-        FindWalletHandler, GetBalanceByMintHandler, GetBalancesHandler, GetOrderByIdHandler,
-        GetOrderHistoryHandler, GetOrdersHandler, GetWalletHandler, UpdateOrderHandler,
-        WithdrawBalanceHandler,
+        FindWalletHandler, GetBackOfQueueWalletHandler, GetBalanceByMintHandler,
+        GetBalancesHandler, GetOrderByIdHandler, GetOrderHistoryHandler, GetOrdersHandler,
+        GetWalletHandler, UpdateOrderHandler, WithdrawBalanceHandler,
     },
 };
 
@@ -229,6 +230,14 @@ impl HttpServer {
             GET_WALLET_ROUTE.to_string(),
             true, // auth_required
             GetWalletHandler::new(global_state.clone()),
+        );
+
+        // The "/wallet/:id/back_of_queue" route
+        router.add_route(
+            &Method::GET,
+            BACK_OF_QUEUE_WALLET_ROUTE.to_string(),
+            true, // auth_required
+            GetBackOfQueueWalletHandler::new(global_state.clone()),
         );
 
         // The "/wallet" route


### PR DESCRIPTION
### Purpose
This PR adds an endpoint to query the "back of queue" wallet: that is, the wallet after all queued tasks have been speculatively applied to it. This allows clients to sign multiple queued state transitions by having the relayer simulate their in-flight state transitions.

We use this functionality to construct `UpdateWalletTaskDescriptor` types so that the API layer correctly constructs the  updated wallet from the back of queue.

I also fixed a bug that results from being able to enqueue multiple tasks: the `UpdateWalletTask` needs to fetch the most recent version of the `old_wallet` in its constructor to -- in particular -- update to the most recent Merkle path.

### Testing
- Unit tests pass
- Implemented the client logic in the CLI and tested there. Queued up multiple tasks of all kinds and verified their transitions were successful and correct.