### PR TITLE
api-server: http: wallet: Add fee payment API

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -69,6 +69,11 @@ impl Wallet {
         Some(balance)
     }
 
+    /// Return whether the wallet has any fees to pay
+    pub fn has_outstanding_fees(&self) -> bool {
+        self.balances.values().any(|balance| balance.fees().total() > 0)
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -26,7 +26,7 @@ pub const FIND_WALLET_ROUTE: &str = "/v0/wallet/lookup";
 pub const GET_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id";
 /// Get the wallet at the "back of the queue", i.e. the speculatively updated
 /// wallet as if all enqueued wallet tasks had completed
-pub const BACK_OF_QUEUE_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id/back_of_queue";
+pub const BACK_OF_QUEUE_WALLET_ROUTE: &str = "/v0/wallet/:wallet_id/back-of-queue";
 /// Route to the orders of a given wallet
 pub const WALLET_ORDERS_ROUTE: &str = "/v0/wallet/:wallet_id/orders";
 /// Returns a single order by the given identifier
@@ -43,6 +43,8 @@ pub const GET_BALANCE_BY_MINT_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:min
 pub const DEPOSIT_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/deposit";
 /// Withdraws an ERC-20 token from the darkpool
 pub const WITHDRAW_BALANCE_ROUTE: &str = "/v0/wallet/:wallet_id/balances/:mint/withdraw";
+/// Pays all wallet fees
+pub const PAY_FEES_ROUTE: &str = "/v0/wallet/:wallet_id/pay-fees";
 
 /// Returns the order history of a wallet
 pub const ORDER_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/order-history";
@@ -259,6 +261,17 @@ pub struct WithdrawBalanceRequest {
 pub struct WithdrawBalanceResponse {
     /// The ID of the task allocated for this operation
     pub task_id: TaskIdentifier,
+}
+
+// ------------------
+// | Fees API Types |
+// ------------------
+
+/// The response type to a request to pay all wallet fees
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PayFeesResponse {
+    /// The fee payment tasks allocated for the request
+    pub task_ids: Vec<TaskIdentifier>,
 }
 
 // ---------------------------

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -15,7 +15,8 @@ use external_api::{
             BACK_OF_QUEUE_WALLET_ROUTE, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE,
             DEPOSIT_BALANCE_ROUTE, FIND_WALLET_ROUTE, GET_BALANCES_ROUTE,
             GET_BALANCE_BY_MINT_ROUTE, GET_ORDER_BY_ID_ROUTE, GET_WALLET_ROUTE,
-            ORDER_HISTORY_ROUTE, UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
+            ORDER_HISTORY_ROUTE, PAY_FEES_ROUTE, UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE,
+            WITHDRAW_BALANCE_ROUTE,
         },
         PingResponse,
     },
@@ -51,7 +52,7 @@ use self::{
         CancelOrderHandler, CreateOrderHandler, CreateWalletHandler, DepositBalanceHandler,
         FindWalletHandler, GetBackOfQueueWalletHandler, GetBalanceByMintHandler,
         GetBalancesHandler, GetOrderByIdHandler, GetOrderHistoryHandler, GetOrdersHandler,
-        GetWalletHandler, UpdateOrderHandler, WithdrawBalanceHandler,
+        GetWalletHandler, PayFeesHandler, UpdateOrderHandler, WithdrawBalanceHandler,
     },
 };
 
@@ -326,6 +327,14 @@ impl HttpServer {
             WITHDRAW_BALANCE_ROUTE.to_string(),
             true, // auth_required
             WithdrawBalanceHandler::new(global_state.clone()),
+        );
+
+        // The `wallet/:id/pay-fees` route
+        router.add_route(
+            &Method::POST,
+            PAY_FEES_ROUTE.to_string(),
+            true, // auth_required
+            PayFeesHandler::new(global_state.clone()),
         );
 
         // The "/wallet/:id/order-history" route


### PR DESCRIPTION
### Purpose
This PR separates out fee payment from the withdrawal API. Given the new `/wallet/:id/back-of-queue` endpoint; clients can hit `/wallet/:id/pay-fees` then `/wallet/:id/balances/:mint/withdraw` to withdraw a balance. This avoids the need for a client to compute the withdrawal wallet state _after_ fee payment happens.

### Testing
- Tested locally
- Unit tests pass