### PR TITLE
state: order-history: Add all order fields to stored history

### DIFF
--- a/common/src/types/tasks.rs
+++ b/common/src/types/tasks.rs
@@ -295,6 +295,8 @@ pub struct SettleMatchTaskDescriptor {
     /// The state entry from the handshake manager that parameterizes the
     /// match process
     pub handshake_state: HandshakeState,
+    /// The match result from the matching engine
+    pub match_res: MatchResult,
     /// The proof that comes from the collaborative match-settle process
     pub match_bundle: MatchBundle,
     /// The validity proofs submitted by the first party
@@ -308,6 +310,7 @@ impl SettleMatchTaskDescriptor {
     pub fn new(
         wallet_id: WalletIdentifier,
         handshake_state: HandshakeState,
+        match_res: MatchResult,
         match_bundle: MatchBundle,
         party0_validity_proof: OrderValidityProofBundle,
         party1_validity_proof: OrderValidityProofBundle,
@@ -315,6 +318,7 @@ impl SettleMatchTaskDescriptor {
         Ok(SettleMatchTaskDescriptor {
             wallet_id,
             handshake_state,
+            match_res,
             match_bundle,
             party0_validity_proof,
             party1_validity_proof,

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -1,6 +1,6 @@
 //! Order metadata for a wallet's orders
 
-use circuit_types::Amount;
+use circuit_types::{order::Order, Amount};
 use serde::{Deserialize, Serialize};
 use util::get_current_time_millis;
 
@@ -30,10 +30,12 @@ impl OrderState {
 }
 
 /// Metadata for an order in a wallet, possibly historical
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OrderMetadata {
     /// The order ID
     pub id: OrderIdentifier,
+    /// The data of the order
+    pub data: Order,
     /// The order state
     pub state: OrderState,
     /// The amount that has been filled
@@ -44,8 +46,8 @@ pub struct OrderMetadata {
 
 impl OrderMetadata {
     /// Create a new order metadata instance, defaults to `Created` state
-    pub fn new(id: OrderIdentifier) -> Self {
+    pub fn new(id: OrderIdentifier, order: Order) -> Self {
         let created = get_current_time_millis() as u64;
-        Self { id, state: OrderState::Created, filled: 0, created }
+        Self { id, data: order, state: OrderState::Created, filled: 0, created }
     }
 }

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -15,7 +15,7 @@ use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 pub mod error;
 pub mod mpc_preprocessing;
 pub mod order_book;
-pub mod order_metadata;
+pub mod order_history;
 pub mod return_type;
 pub mod task_queue;
 pub mod wallet_index;

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -132,9 +132,9 @@ impl StateApplicator {
 
         // New orders
         let wallet_id = wallet.wallet_id;
-        for id in wallet.get_nonzero_orders().into_keys() {
+        for (id, o) in wallet.get_nonzero_orders() {
             if !old_orders.contains(&id) {
-                let new_state = OrderMetadata::new(id);
+                let new_state = OrderMetadata::new(id, o);
                 self.update_order_metadata_with_tx(new_state, tx)?;
             }
         }

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -6,7 +6,7 @@ pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod notifications;
 pub mod order_book;
-pub mod order_metadata;
+pub mod order_history;
 pub mod peer_index;
 pub mod raft;
 pub mod task_queue;

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -106,7 +106,7 @@ mod test {
     use itertools::Itertools;
     use num_bigint::BigUint;
 
-    use crate::{order_metadata::test::setup_order_history, test_helpers::mock_state, State};
+    use crate::{order_history::test::setup_order_history, test_helpers::mock_state, State};
 
     /// Create a set of mock historical orders
     fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &State) {
@@ -116,6 +116,7 @@ mod test {
                 state: OrderState::Filled,
                 filled: 1,
                 created: 0,
+                data: mock_order(),
             })
             .collect_vec();
 

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -9,7 +9,7 @@
 pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod order_book;
-pub mod order_metadata;
+pub mod order_history;
 pub mod peer_index;
 pub mod raft_log;
 pub mod task_queue;

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -116,7 +116,10 @@ impl<'db> StateTxn<'db, RW> {
 mod tests {
     use std::cmp::Reverse;
 
-    use common::types::wallet::order_metadata::{OrderMetadata, OrderState};
+    use common::types::{
+        wallet::order_metadata::{OrderMetadata, OrderState},
+        wallet_mocks::mock_order,
+    };
     use itertools::Itertools;
     use rand::{thread_rng, Rng, RngCore};
     use uuid::Uuid;
@@ -131,6 +134,7 @@ mod tests {
             state: OrderState::Created,
             filled: 0,
             created: rng.next_u64(),
+            data: mock_order(),
         }
     }
 
@@ -185,7 +189,7 @@ mod tests {
         // Choose a random order
         let mut rng = rand::thread_rng();
         let index = rng.gen_range(0..history.len());
-        let curr_order = history[index];
+        let curr_order = history[index].clone();
 
         // Check the current state of that order
         let tx = db.new_read_tx().unwrap();
@@ -197,7 +201,7 @@ mod tests {
         updated_order.filled = rng.gen();
 
         let tx = db.new_write_tx().unwrap();
-        tx.update_order_metadata(&wallet_id, updated_order).unwrap();
+        tx.update_order_metadata(&wallet_id, updated_order.clone()).unwrap();
         tx.commit().unwrap();
 
         // Get the updated order

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -303,7 +303,14 @@ impl HandshakeExecutor {
                 .unwrap()?;
 
                 // Record the match in the cache
-                self.submit_match(party0_proof, party1_proof, order_state, match_bundle).await?;
+                self.submit_match(
+                    party0_proof,
+                    party1_proof,
+                    order_state,
+                    match_result.clone(),
+                    match_bundle,
+                )
+                .await?;
                 self.record_completed_match(request_id, &match_result).await
             },
 
@@ -462,6 +469,7 @@ impl HandshakeExecutor {
         party0_proof: OrderValidityProofBundle,
         party1_proof: OrderValidityProofBundle,
         handshake_state: HandshakeState,
+        match_result: MatchResult,
         match_bundle: MatchBundle,
     ) -> Result<(), HandshakeManagerError> {
         // Enqueue a task to settle the match
@@ -473,6 +481,7 @@ impl HandshakeExecutor {
         let task: TaskDescriptor = SettleMatchTaskDescriptor::new(
             wallet_id,
             handshake_state,
+            match_result,
             match_bundle,
             party0_proof,
             party1_proof,

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -415,6 +415,7 @@ async fn test_settle_mpc_match(test_args: IntegrationTestArgs) -> Result<()> {
     let task = SettleMatchTaskDescriptor::new(
         buy_wallet.wallet_id,
         handshake_state,
+        match_res.clone(),
         match_settle_proof,
         get_first_order_proofs(&buy_wallet, state)?,
         get_first_order_proofs(&sell_wallet, state)?,


### PR DESCRIPTION
### Purpose
This PR updates the order history to store the order itself under the `data` field. As well, this PR fixes a bug wherein the settlement logic failed to update the `filled` field on the order metadata.

### Testing
- Unit tests pass
- @sehyunc will test frontend integration 