### PR TITLE
common: types: task: history: Define task history storage types

### DIFF
--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -1,0 +1,55 @@
+//! Types for task history storage
+
+use circuit_types::r#match::MatchResult;
+use serde::{Deserialize, Serialize};
+
+use super::{QueuedTaskState, TaskDescriptor, TaskIdentifier, WalletUpdateType};
+
+/// A historical task executed by the task driver
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HistoricalTask {
+    /// The ID of the task
+    pub id: TaskIdentifier,
+    /// The state of the task
+    pub state: QueuedTaskState,
+    /// The time the task was created
+    pub created_at: u64,
+    /// The auxiliary information from the task descriptor that we keep in the
+    /// history
+    pub task_info: HistoricalTaskDescription,
+}
+
+/// A historical description of a task
+///
+/// Separated out from the task descriptors as the descriptors may contain
+/// runtime information irrelevant for storage
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum HistoricalTaskDescription {
+    /// A new wallet was created
+    NewWallet,
+    /// An update to a wallet
+    UpdateWallet(WalletUpdateType),
+    /// A match was settled
+    SettleMatch(MatchResult),
+    /// A fee was paid
+    PayOfflineFee,
+}
+
+impl HistoricalTaskDescription {
+    /// Create a historical task description from a task descriptor
+    pub fn from_task_descriptor(desc: &TaskDescriptor) -> Option<Self> {
+        match desc {
+            TaskDescriptor::NewWallet(_) => Some(Self::NewWallet),
+            TaskDescriptor::UpdateWallet(desc) => {
+                Some(Self::UpdateWallet(desc.description.clone()))
+            },
+            TaskDescriptor::SettleMatch(desc) => Some(Self::SettleMatch(desc.match_res.clone())),
+            TaskDescriptor::SettleMatchInternal(desc) => {
+                Some(Self::SettleMatch(desc.match_result.clone()))
+            },
+            TaskDescriptor::OfflineFee(_) => Some(Self::PayOfflineFee),
+            _ => None,
+        }
+    }
+}

--- a/common/src/types/tasks/mod.rs
+++ b/common/src/types/tasks/mod.rs
@@ -1,0 +1,7 @@
+//! Types for tasks run in the relayer
+
+mod descriptors;
+mod history;
+
+pub use descriptors::*;
+pub use history::*;

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -47,7 +47,7 @@ pub struct OrderMetadata {
 impl OrderMetadata {
     /// Create a new order metadata instance, defaults to `Created` state
     pub fn new(id: OrderIdentifier, order: Order) -> Self {
-        let created = get_current_time_millis() as u64;
+        let created = get_current_time_millis();
         Self { id, data: order, state: OrderState::Created, filled: 0, created }
     }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -22,6 +22,6 @@ pub fn get_current_time_seconds() -> u64 {
 }
 
 /// Returns the current unix timestamp in milliseconds, represented as u64
-pub fn get_current_time_millis() -> u128 {
-    SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis()
+pub fn get_current_time_millis() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis() as u64
 }

--- a/workers/api-server/src/auth.rs
+++ b/workers/api-server/src/auth.rs
@@ -127,7 +127,7 @@ mod test {
 
     /// Build a set of headers using the an expiration one second in the future
     fn build_headers(root_key: &SigningKey) -> HeaderMap {
-        let current_time = util::get_current_time_millis() as u64;
+        let current_time = util::get_current_time_millis();
         build_headers_with_expiration(current_time + 1_000, root_key)
     }
 
@@ -157,7 +157,7 @@ mod test {
     #[test]
     fn test_expired_sig() {
         let key: SigningKey = random_key();
-        let now = util::get_current_time_millis() as u64;
+        let now = util::get_current_time_millis();
         let headers = build_headers_with_expiration(now - 1, &key);
 
         let res = authenticate_wallet_request(&headers, MSG, &key.verifying_key().into());

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -373,12 +373,11 @@ impl TypedHandler for CreateOrderHandler {
         let new_order: Order = req.order.into();
 
         // Check that the timestamp is not too old, then add to the wallet
-        new_wallet.add_order(id, new_order).map_err(bad_request)?;
+        new_wallet.add_order(id, new_order.clone()).map_err(bad_request)?;
         new_wallet.reblind_wallet();
 
-        let task = UpdateWalletTaskDescriptor::new(
-            "Create Order".to_string(), // description
-            None,                       // transfer
+        let task = UpdateWalletTaskDescriptor::new_order(
+            new_order,
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -435,12 +434,11 @@ impl TypedHandler for UpdateOrderHandler {
             .orders
             .get_mut(&order_id)
             .ok_or_else(|| not_found(ERR_ORDER_NOT_FOUND.to_string()))?;
-        *order = new_order;
+        *order = new_order.clone();
         new_wallet.reblind_wallet();
 
-        let task = UpdateWalletTaskDescriptor::new(
-            "Update Order".to_string(), // description
-            None,                       // transfer
+        let task = UpdateWalletTaskDescriptor::new_order(
+            new_order,
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -491,9 +489,8 @@ impl TypedHandler for CancelOrderHandler {
             .ok_or_else(|| not_found(ERR_ORDER_NOT_FOUND.to_string()))?;
         new_wallet.reblind_wallet();
 
-        let task = UpdateWalletTaskDescriptor::new(
-            "Cancel Order".to_string(), // description
-            None,                       // transfer
+        let task = UpdateWalletTaskDescriptor::new_order_cancellation(
+            order.clone(),
             old_wallet,
             new_wallet,
             req.statement_sig,
@@ -638,9 +635,8 @@ impl TypedHandler for DepositBalanceHandler {
             },
         );
 
-        let task = UpdateWalletTaskDescriptor::new(
-            "Deposit".to_string(), // description
-            Some(deposit_with_auth),
+        let task = UpdateWalletTaskDescriptor::new_deposit(
+            deposit_with_auth,
             old_wallet,
             new_wallet,
             req.wallet_commitment_sig,
@@ -703,9 +699,8 @@ impl TypedHandler for WithdrawBalanceHandler {
             WithdrawalAuth { external_transfer_signature: req.external_transfer_sig },
         );
 
-        let task = UpdateWalletTaskDescriptor::new(
-            "Withdraw".to_string(), // description
-            Some(withdrawal_with_auth),
+        let task = UpdateWalletTaskDescriptor::new_withdrawal(
+            withdrawal_with_auth,
             old_wallet,
             new_wallet,
             req.wallet_commitment_sig,


### PR DESCRIPTION
### Purpose
This PR defines new types and type description representations that will enable storing semantically meaningful descriptions of tasks. These types will be stored in a per-wallet task history and querying by the API layer to implement a task history API.

### Testing
- Unit tests pass