### PR TITLE
state: storage: task-history: Define storage access methods

### DIFF
--- a/common/src/types/tasks/descriptors.rs
+++ b/common/src/types/tasks/descriptors.rs
@@ -367,7 +367,6 @@ impl From<UpdateMerkleProofTaskDescriptor> for TaskDescriptor {
 /// Differentiates between order vs balance updates, and holds fields for
 /// display
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum WalletUpdateType {
     /// Deposit a balance
     Deposit {

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -24,7 +24,6 @@ pub struct HistoricalTask {
 /// Separated out from the task descriptors as the descriptors may contain
 /// runtime information irrelevant for storage
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub enum HistoricalTaskDescription {
     /// A new wallet was created
     NewWallet,
@@ -50,6 +49,32 @@ impl HistoricalTaskDescription {
             },
             TaskDescriptor::OfflineFee(_) => Some(Self::PayOfflineFee),
             _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "mocks")]
+pub mod historical_mocks {
+    //! Mock helpers for testing task history
+
+    use rand::{thread_rng, RngCore};
+
+    use crate::types::{
+        tasks::{QueuedTaskState, TaskIdentifier, WalletUpdateType},
+        wallet_mocks::mock_order,
+    };
+
+    use super::{HistoricalTask, HistoricalTaskDescription};
+
+    /// Return a mock historical task
+    pub fn mock_historical_task() -> HistoricalTask {
+        let mut rng = thread_rng();
+        let ty = WalletUpdateType::PlaceOrder { order: mock_order() };
+        HistoricalTask {
+            id: TaskIdentifier::new_v4(),
+            state: QueuedTaskState::Completed,
+            created_at: rng.next_u64(),
+            task_info: HistoricalTaskDescription::UpdateWallet(ty),
         }
     }
 }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -63,6 +63,8 @@ pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
 /// The name of the db table that maps tasks to their queue key
 pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
+/// The name of the db table that stores historical task information
+pub(crate) const TASK_HISTORY_TABLE: &str = "task-history";
 
 /// The name of the db table that stores the offline phase values
 pub(crate) const MPC_PREPROCESSING_TABLE: &str = "mpc-preprocessing";

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 14;
+const NUM_TABLES: usize = 15;
 /// The total maximum size of the DB in bytes
 const MAX_DB_SIZE_BYTES: usize = 1 << 36; // 64 GB
 

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -12,6 +12,7 @@ pub mod order_book;
 pub mod order_history;
 pub mod peer_index;
 pub mod raft_log;
+pub mod task_history;
 pub mod task_queue;
 pub mod wallet_index;
 
@@ -22,7 +23,7 @@ use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, Write
 use crate::{
     CLUSTER_MEMBERSHIP_TABLE, MPC_PREPROCESSING_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE,
     ORDER_HISTORY_TABLE, ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE,
-    TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
+    TASK_HISTORY_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
 };
 
 use self::raft_log::RAFT_METADATA_TABLE;
@@ -102,6 +103,7 @@ impl<'db> StateTxn<'db, RW> {
             WALLETS_TABLE,
             TASK_QUEUE_TABLE,
             TASK_TO_KEY_TABLE,
+            TASK_HISTORY_TABLE,
             MPC_PREPROCESSING_TABLE,
             NODE_METADATA_TABLE,
             RAFT_METADATA_TABLE,

--- a/state/src/storage/tx/task_history.rs
+++ b/state/src/storage/tx/task_history.rs
@@ -1,0 +1,131 @@
+//! Storage methods for task history
+
+use std::cmp::Reverse;
+
+use common::types::tasks::{HistoricalTask, TaskQueueKey};
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, TASK_HISTORY_TABLE};
+
+use super::StateTxn;
+
+/// Get the key for a given queue's history
+fn task_history_key(key: &TaskQueueKey) -> String {
+    format!("{key}-history")
+}
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the task history for a given task queue
+    pub fn get_task_history(
+        &self,
+        key: &TaskQueueKey,
+    ) -> Result<Vec<HistoricalTask>, StorageError> {
+        let key = task_history_key(key);
+        let mut tasks: Vec<HistoricalTask> =
+            self.inner.read(TASK_HISTORY_TABLE, &key)?.unwrap_or_default();
+        tasks.sort_by_key(|t| Reverse(t.created_at));
+
+        Ok(tasks)
+    }
+
+    /// Get up to `n` most recent tasks from the task history
+    pub fn get_truncated_task_history(
+        &self,
+        n: usize,
+        key: &TaskQueueKey,
+    ) -> Result<Vec<HistoricalTask>, StorageError> {
+        let mut tasks = self.get_task_history(key)?;
+        tasks.truncate(n);
+        Ok(tasks)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Append a task to the task history
+    pub fn append_task_to_history(
+        &self,
+        key: &TaskQueueKey,
+        task: HistoricalTask,
+    ) -> Result<(), StorageError> {
+        let mut tasks = self.get_task_history(key)?;
+
+        // Push to the front to keep the most recent tasks first
+        tasks.insert(0, task);
+        let key = task_history_key(key);
+        self.inner.write(TASK_HISTORY_TABLE, &key, &tasks)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Reverse;
+
+    use common::types::tasks::historical_mocks::mock_historical_task;
+    use common::types::wallet::WalletIdentifier;
+    use itertools::Itertools;
+
+    use crate::test_helpers::mock_db;
+
+    /// Tests getting the task history
+    #[test]
+    fn test_get_history() {
+        let db = mock_db();
+        let wallet_id = WalletIdentifier::new_v4();
+
+        // Fetch an empty history
+        let tx = db.new_read_tx().unwrap();
+        let history = tx.get_task_history(&wallet_id).unwrap();
+        tx.commit().unwrap();
+        assert!(history.is_empty());
+
+        // Add a task to the history
+        let task = mock_historical_task();
+        let tx = db.new_write_tx().unwrap();
+        tx.append_task_to_history(&wallet_id, task.clone()).unwrap();
+        tx.commit().unwrap();
+
+        // Fetch the history
+        let tx = db.new_read_tx().unwrap();
+        let history = tx.get_task_history(&wallet_id).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].id, task.id);
+    }
+
+    /// Tests getting a truncated task history
+    #[test]
+    fn test_truncated_history() {
+        const N: usize = 100;
+        let db = mock_db();
+        let wallet_id = WalletIdentifier::new_v4();
+
+        let mut tasks = (0..N).map(|_| mock_historical_task()).collect_vec();
+        let tx = db.new_write_tx().unwrap();
+        for task in tasks.iter() {
+            tx.append_task_to_history(&wallet_id, task.clone()).unwrap();
+        }
+        tx.commit().unwrap();
+
+        // Sort tasks by reverse creation
+        tasks.sort_by_key(|t| Reverse(t.created_at));
+
+        // Fetch the first half of the history
+        let tx = db.new_read_tx().unwrap();
+        let history = tx.get_truncated_task_history(N / 2, &wallet_id).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(history.len(), N / 2);
+        for (a, b) in history.iter().zip(tasks.iter()) {
+            assert_eq!(a.id, b.id);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds db access methods for task history. This closely models the order history with the exception that we need not lookup individual task states or modify them. So the interface is simpler.

I had to remove serde tagging configs from the task history enums, bincode does not implement this type of enum deserialization. We will define separate types at the API layer that re-introduce proper enum serialization. 

### Testing
- Unit tests pass