### PR TITLE
chore: pin serde to 1.0.197 for contracts compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,9 +7252,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -7270,9 +7270,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ ethers = "2"
 eyre = "0.6"
 indexmap = "2.0.2"
 itertools = "0.10"
-serde = { version = "1.0.139" }
+serde = { version = "=1.0.197" }
 serde_json = "1.0.64"
 tracing = "0.1"
 metrics = "=0.22.3"

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -36,7 +36,7 @@ renegade-crypto = { path = "../renegade-crypto" }
 byteorder = "1.5"
 itertools = "0.10"
 lazy_static = "1.4"
-serde = { version = "1.0.139", features = ["serde_derive"] }
+serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -94,7 +94,7 @@ futures = { workspace = true }
 itertools = "0.10"
 lazy_static = "1.4"
 rand = { version = "0.8" }
-serde = { version = "1.0.139", features = ["serde_derive"] }
+serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 

--- a/renegade-crypto/Cargo.toml
+++ b/renegade-crypto/Cargo.toml
@@ -42,7 +42,7 @@ constants = { path = "../constants", default-features = false }
 itertools = "0.10"
 lazy_static = "1.4"
 rand = { version = "0.8", optional = true }
-serde = { version = "1.0.139", features = ["serde_derive"] }
+serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/rustc-ice-2024-04-27T23_52_08-98557.txt
+++ b/rustc-ice-2024-04-27T23_52_08-98557.txt
@@ -1,0 +1,61 @@
+thread 'rustc' panicked at compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs:23:54:
+called `Option::unwrap()` on a `None` value
+stack backtrace:
+   0:        0x1025c138c - std::backtrace::Backtrace::create::h3c5f0bb88635b065
+   1:        0x10baefaf4 - std[11477bd025474483]::panicking::update_hook::<alloc[f9d6debfd87887c]::boxed::Box<rustc_driver_impl[55162aa11c5af315]::install_ice_hook::{closure#0}>>::{closure#0}
+   2:        0x1025da12c - std::panicking::rust_panic_with_hook::hba6149685af3b41f
+   3:        0x1025d9ac4 - std::panicking::begin_panic_handler::{{closure}}::h43fe5d8d89dcb2a4
+   4:        0x1025d7428 - std::sys_common::backtrace::__rust_end_short_backtrace::h85585bc7dd9092f8
+   5:        0x1025d9868 - _rust_begin_unwind
+   6:        0x102634734 - core::panicking::panic_fmt::hfbac5bdaf98aee43
+   7:        0x1026347bc - core::panicking::panic::ha7e3b27e843d10c9
+   8:        0x1026346e4 - core::option::unwrap_failed::h445c13a3fd3afffa
+   9:        0x10c412750 - <rustc_metadata[cbeb17629eb5bbfb]::creader::CStore as rustc_session[5b258304fe825397]::cstore::CrateStore>::def_path_hash_to_def_id
+  10:        0x10c4e60a8 - <rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt>::def_path_hash_to_def_id
+  11:        0x10cd373e4 - <rustc_query_impl[e85e45acba87412a]::plumbing::query_callback<rustc_query_impl[e85e45acba87412a]::query_impl::type_of::QueryType>::{closure#0} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_query_system[f2f8b20c094afe3b]::dep_graph::dep_node::DepNode)>>::call_once
+  12:        0x10cf01544 - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  13:        0x10cf0158c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  14:        0x10cf0158c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  15:        0x10cf0158c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  16:        0x10cf0158c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  17:        0x10cf01314 - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  18:        0x10ccae2b8 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::DefaultCache<rustc_type_ir[e25bbdebf53b37a0]::canonical::Canonical<rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_middle[52d0c952e706a7f4]::ty::ParamEnvAnd<rustc_middle[52d0c952e706a7f4]::ty::predicate::Predicate>>, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 2usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  19:        0x10cf2e02c - rustc_query_impl[e85e45acba87412a]::query_impl::evaluate_obligation::get_query_incr::__rust_end_short_backtrace
+  20:        0x10d3e8f8c - <rustc_infer[51d9aeac2dac4bb0]::infer::InferCtxt as rustc_trait_selection[37e442d26d0c12fb]::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation
+  21:        0x10d3e92fc - <rustc_infer[51d9aeac2dac4bb0]::infer::InferCtxt as rustc_trait_selection[37e442d26d0c12fb]::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation_no_overflow
+  22:        0x10d396610 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor>::process_trait_obligation
+  23:        0x10d395e14 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor as rustc_data_structures[5487d50b6ce214c2]::obligation_forest::ObligationProcessor>::process_obligation
+  24:        0x10d298340 - <rustc_data_structures[5487d50b6ce214c2]::obligation_forest::ObligationForest<rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::PendingPredicateObligation>>::process_obligations::<rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor>
+  25:        0x10d393430 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillmentContext as rustc_infer[51d9aeac2dac4bb0]::traits::engine::TraitEngine>::select_where_possible
+  26:        0x10bed4144 - <rustc_hir_typeck[288db856541404c3]::fn_ctxt::FnCtxt>::select_obligations_where_possible::<rustc_hir_typeck[288db856541404c3]::typeck_with_fallback<rustc_hir_typeck[288db856541404c3]::inspect_typeck::{closure#0}>::{closure#0}::{closure#2}>
+  27:        0x10c006d40 - rustc_hir_typeck[288db856541404c3]::typeck
+  28:        0x10cd55fb8 - rustc_query_impl[e85e45acba87412a]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[e85e45acba87412a]::query_impl::typeck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 8usize]>>
+  29:        0x10ce335e4 - <rustc_query_impl[e85e45acba87412a]::query_impl::typeck::dynamic_query::{closure#2} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_span[d21793098b958899]::def_id::LocalDefId)>>::call_once
+  30:        0x10cd11f64 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::VecCache<rustc_span[d21793098b958899]::def_id::LocalDefId, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  31:        0x10ce86630 - rustc_query_impl[e85e45acba87412a]::query_impl::typeck::get_query_incr::__rust_end_short_backtrace
+  32:        0x10bd10d94 - <rustc_middle[52d0c952e706a7f4]::hir::map::Map>::par_body_owners::<rustc_hir_analysis[1c099dcaf3b9b897]::check_crate::{closure#6}>::{closure#0}
+  33:        0x10bd396c8 - <rustc_data_structures[5487d50b6ce214c2]::sync::parallel::ParallelGuard>::run::<(), rustc_data_structures[5487d50b6ce214c2]::sync::parallel::enabled::par_for_each_in<&rustc_span[d21793098b958899]::def_id::LocalDefId, &[rustc_span[d21793098b958899]::def_id::LocalDefId], <rustc_middle[52d0c952e706a7f4]::hir::map::Map>::par_body_owners<rustc_hir_analysis[1c099dcaf3b9b897]::check_crate::{closure#6}>::{closure#0}>::{closure#0}::{closure#1}::{closure#0}>
+  34:        0x10be5645c - rustc_hir_analysis[1c099dcaf3b9b897]::check_crate
+  35:        0x10c25eca4 - rustc_interface[55e76f5af7bad9d1]::passes::analysis
+  36:        0x10cd56058 - rustc_query_impl[e85e45acba87412a]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[e85e45acba87412a]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 1usize]>>
+  37:        0x10ce33890 - <rustc_query_impl[e85e45acba87412a]::query_impl::analysis::dynamic_query::{closure#2} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, ())>>::call_once
+  38:        0x10cc86508 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::SingleCache<rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 1usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  39:        0x10ce84374 - rustc_query_impl[e85e45acba87412a]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  40:        0x10bac51c4 - <rustc_middle[52d0c952e706a7f4]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}::{closure#1}::{closure#3}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  41:        0x10baac450 - <rustc_interface[55e76f5af7bad9d1]::interface::Compiler>::enter::<rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}::{closure#1}, core[e0108a028e95754e]::result::Result<core[e0108a028e95754e]::option::Option<rustc_interface[55e76f5af7bad9d1]::queries::Linker>, rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  42:        0x10baf2354 - rustc_span[d21793098b958899]::set_source_map::<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}::{closure#0}>
+  43:        0x10baf37e0 - rustc_span[d21793098b958899]::create_session_globals_then::<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}>
+  44:        0x10bad5e90 - std[11477bd025474483]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_with_globals<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  45:        0x10bad6d48 - <<std[11477bd025474483]::thread::Builder>::spawn_unchecked_<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_with_globals<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#1} as core[e0108a028e95754e]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  46:        0x1025e2940 - std::sys::pal::unix::thread::Thread::new::thread_start::h94af384edc7b5549
+  47:        0x180e73034 - __pthread_joiner_wake
+
+
+rustc version: 1.78.0-nightly (0ecbd0605 2024-02-25)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [evaluate_obligation] evaluating trait selection obligation `running_task::<impl at workers/task-driver/src/running_task.rs:32:1: 32:30>::from_descriptor::{opaque#0}: core::marker::Send`
+#1 [typeck] type-checking `driver::<impl at workers/task-driver/src/driver.rs:118:1: 118:18>::run`
+#2 [analysis] running analysis passes on this crate
+end of query stack

--- a/rustc-ice-2024-04-27T23_52_08-98561.txt
+++ b/rustc-ice-2024-04-27T23_52_08-98561.txt
@@ -1,0 +1,61 @@
+thread 'rustc' panicked at compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs:23:54:
+called `Option::unwrap()` on a `None` value
+stack backtrace:
+   0:        0x10580538c - std::backtrace::Backtrace::create::h3c5f0bb88635b065
+   1:        0x10ed33af4 - std[11477bd025474483]::panicking::update_hook::<alloc[f9d6debfd87887c]::boxed::Box<rustc_driver_impl[55162aa11c5af315]::install_ice_hook::{closure#0}>>::{closure#0}
+   2:        0x10581e12c - std::panicking::rust_panic_with_hook::hba6149685af3b41f
+   3:        0x10581dac4 - std::panicking::begin_panic_handler::{{closure}}::h43fe5d8d89dcb2a4
+   4:        0x10581b428 - std::sys_common::backtrace::__rust_end_short_backtrace::h85585bc7dd9092f8
+   5:        0x10581d868 - _rust_begin_unwind
+   6:        0x105878734 - core::panicking::panic_fmt::hfbac5bdaf98aee43
+   7:        0x1058787bc - core::panicking::panic::ha7e3b27e843d10c9
+   8:        0x1058786e4 - core::option::unwrap_failed::h445c13a3fd3afffa
+   9:        0x10f656750 - <rustc_metadata[cbeb17629eb5bbfb]::creader::CStore as rustc_session[5b258304fe825397]::cstore::CrateStore>::def_path_hash_to_def_id
+  10:        0x10f72a0a8 - <rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt>::def_path_hash_to_def_id
+  11:        0x10ff7b3e4 - <rustc_query_impl[e85e45acba87412a]::plumbing::query_callback<rustc_query_impl[e85e45acba87412a]::query_impl::type_of::QueryType>::{closure#0} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_query_system[f2f8b20c094afe3b]::dep_graph::dep_node::DepNode)>>::call_once
+  12:        0x110145544 - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  13:        0x11014558c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  14:        0x11014558c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  15:        0x11014558c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  16:        0x11014558c - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_previous_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  17:        0x110145314 - <rustc_query_system[f2f8b20c094afe3b]::dep_graph::graph::DepGraphData<rustc_middle[52d0c952e706a7f4]::dep_graph::DepsType>>::try_mark_green::<rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt>
+  18:        0x10fef22b8 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::DefaultCache<rustc_type_ir[e25bbdebf53b37a0]::canonical::Canonical<rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_middle[52d0c952e706a7f4]::ty::ParamEnvAnd<rustc_middle[52d0c952e706a7f4]::ty::predicate::Predicate>>, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 2usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  19:        0x11017202c - rustc_query_impl[e85e45acba87412a]::query_impl::evaluate_obligation::get_query_incr::__rust_end_short_backtrace
+  20:        0x11062cf8c - <rustc_infer[51d9aeac2dac4bb0]::infer::InferCtxt as rustc_trait_selection[37e442d26d0c12fb]::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation
+  21:        0x11062d2fc - <rustc_infer[51d9aeac2dac4bb0]::infer::InferCtxt as rustc_trait_selection[37e442d26d0c12fb]::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation_no_overflow
+  22:        0x1105da610 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor>::process_trait_obligation
+  23:        0x1105d9e14 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor as rustc_data_structures[5487d50b6ce214c2]::obligation_forest::ObligationProcessor>::process_obligation
+  24:        0x1104dc340 - <rustc_data_structures[5487d50b6ce214c2]::obligation_forest::ObligationForest<rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::PendingPredicateObligation>>::process_obligations::<rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillProcessor>
+  25:        0x1105d7430 - <rustc_trait_selection[37e442d26d0c12fb]::traits::fulfill::FulfillmentContext as rustc_infer[51d9aeac2dac4bb0]::traits::engine::TraitEngine>::select_where_possible
+  26:        0x10f118144 - <rustc_hir_typeck[288db856541404c3]::fn_ctxt::FnCtxt>::select_obligations_where_possible::<rustc_hir_typeck[288db856541404c3]::typeck_with_fallback<rustc_hir_typeck[288db856541404c3]::inspect_typeck::{closure#0}>::{closure#0}::{closure#2}>
+  27:        0x10f24ad40 - rustc_hir_typeck[288db856541404c3]::typeck
+  28:        0x10ff99fb8 - rustc_query_impl[e85e45acba87412a]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[e85e45acba87412a]::query_impl::typeck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 8usize]>>
+  29:        0x1100775e4 - <rustc_query_impl[e85e45acba87412a]::query_impl::typeck::dynamic_query::{closure#2} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, rustc_span[d21793098b958899]::def_id::LocalDefId)>>::call_once
+  30:        0x10ff55f64 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::VecCache<rustc_span[d21793098b958899]::def_id::LocalDefId, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  31:        0x1100ca630 - rustc_query_impl[e85e45acba87412a]::query_impl::typeck::get_query_incr::__rust_end_short_backtrace
+  32:        0x10ef54d94 - <rustc_middle[52d0c952e706a7f4]::hir::map::Map>::par_body_owners::<rustc_hir_analysis[1c099dcaf3b9b897]::check_crate::{closure#6}>::{closure#0}
+  33:        0x10ef7d6c8 - <rustc_data_structures[5487d50b6ce214c2]::sync::parallel::ParallelGuard>::run::<(), rustc_data_structures[5487d50b6ce214c2]::sync::parallel::enabled::par_for_each_in<&rustc_span[d21793098b958899]::def_id::LocalDefId, &[rustc_span[d21793098b958899]::def_id::LocalDefId], <rustc_middle[52d0c952e706a7f4]::hir::map::Map>::par_body_owners<rustc_hir_analysis[1c099dcaf3b9b897]::check_crate::{closure#6}>::{closure#0}>::{closure#0}::{closure#1}::{closure#0}>
+  34:        0x10f09a45c - rustc_hir_analysis[1c099dcaf3b9b897]::check_crate
+  35:        0x10f4a2ca4 - rustc_interface[55e76f5af7bad9d1]::passes::analysis
+  36:        0x10ff9a058 - rustc_query_impl[e85e45acba87412a]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[e85e45acba87412a]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 1usize]>>
+  37:        0x110077890 - <rustc_query_impl[e85e45acba87412a]::query_impl::analysis::dynamic_query::{closure#2} as core[e0108a028e95754e]::ops::function::FnOnce<(rustc_middle[52d0c952e706a7f4]::ty::context::TyCtxt, ())>>::call_once
+  38:        0x10feca508 - rustc_query_system[f2f8b20c094afe3b]::query::plumbing::try_execute_query::<rustc_query_impl[e85e45acba87412a]::DynamicConfig<rustc_query_system[f2f8b20c094afe3b]::query::caches::SingleCache<rustc_middle[52d0c952e706a7f4]::query::erase::Erased<[u8; 1usize]>>, false, false, false>, rustc_query_impl[e85e45acba87412a]::plumbing::QueryCtxt, true>
+  39:        0x1100c8374 - rustc_query_impl[e85e45acba87412a]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
+  40:        0x10ed091c4 - <rustc_middle[52d0c952e706a7f4]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}::{closure#1}::{closure#3}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  41:        0x10ecf0450 - <rustc_interface[55e76f5af7bad9d1]::interface::Compiler>::enter::<rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}::{closure#1}, core[e0108a028e95754e]::result::Result<core[e0108a028e95754e]::option::Option<rustc_interface[55e76f5af7bad9d1]::queries::Linker>, rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  42:        0x10ed36354 - rustc_span[d21793098b958899]::set_source_map::<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}::{closure#0}>
+  43:        0x10ed377e0 - rustc_span[d21793098b958899]::create_session_globals_then::<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}>
+  44:        0x10ed19e90 - std[11477bd025474483]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_with_globals<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>
+  45:        0x10ed1ad48 - <<std[11477bd025474483]::thread::Builder>::spawn_unchecked_<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_with_globals<rustc_interface[55e76f5af7bad9d1]::util::run_in_thread_pool_with_globals<rustc_interface[55e76f5af7bad9d1]::interface::run_compiler<core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>, rustc_driver_impl[55162aa11c5af315]::run_compiler::{closure#0}>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[e0108a028e95754e]::result::Result<(), rustc_span[d21793098b958899]::ErrorGuaranteed>>::{closure#1} as core[e0108a028e95754e]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  46:        0x105826940 - std::sys::pal::unix::thread::Thread::new::thread_start::h94af384edc7b5549
+  47:        0x180e73034 - __pthread_joiner_wake
+
+
+rustc version: 1.78.0-nightly (0ecbd0605 2024-02-25)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [evaluate_obligation] evaluating trait selection obligation `running_task::<impl at workers/task-driver/src/running_task.rs:32:1: 32:30>::from_descriptor::{opaque#0}: core::marker::Send`
+#1 [typeck] type-checking `driver::<impl at workers/task-driver/src/driver.rs:118:1: 118:18>::run`
+#2 [analysis] running analysis passes on this crate
+end of query stack


### PR DESCRIPTION
This PR pins the version of `serde` used throughout the relayer to `1.0.197`, to ensure it is the same version used by all of the deployed contracts. This doesn't limit current usage of serde functionality and seems to be causing invalid signature errors in the contracts.