### PR TITLE
state: applicator: task-queue: Append to task history on queue pop

### DIFF
--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -3,7 +3,7 @@
 use circuit_types::r#match::MatchResult;
 use serde::{Deserialize, Serialize};
 
-use super::{QueuedTaskState, TaskDescriptor, TaskIdentifier, WalletUpdateType};
+use super::{QueuedTask, QueuedTaskState, TaskDescriptor, TaskIdentifier, WalletUpdateType};
 
 /// A historical task executed by the task driver
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -17,6 +17,17 @@ pub struct HistoricalTask {
     /// The auxiliary information from the task descriptor that we keep in the
     /// history
     pub task_info: HistoricalTaskDescription,
+}
+
+impl HistoricalTask {
+    /// Create a new historical task from a `QueuedTask`
+    ///
+    /// Returns `None` for tasks that should not be stored in history
+    pub fn from_queued_task(task: QueuedTask) -> Option<Self> {
+        let desc = task.descriptor.clone();
+        let task_info = HistoricalTaskDescription::from_task_descriptor(&desc)?;
+        Some(Self { id: task.id, state: task.state, created_at: task.created_at, task_info })
+    }
 }
 
 /// A historical description of a task

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -76,7 +76,7 @@ impl StateApplicator {
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
             StateTransition::AppendTask { task } => self.append_task(&task),
-            StateTransition::PopTask { task_id } => self.pop_task(task_id),
+            StateTransition::PopTask { task_id, success } => self.pop_task(task_id, success),
             StateTransition::TransitionTask { task_id, state } => {
                 self.transition_task_state(task_id, state)
             },

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -111,10 +111,14 @@ impl State {
     }
 
     /// Pop a task from the queue
-    #[instrument(name = "propose_pop_task", skip_all, err, fields(task_id = %task_id))]
-    pub fn pop_task(&self, task_id: TaskIdentifier) -> Result<ProposalWaiter, StateError> {
+    #[instrument(name = "propose_pop_task", skip_all, err, fields(task_id = %task_id, success = %success))]
+    pub fn pop_task(
+        &self,
+        task_id: TaskIdentifier,
+        success: bool,
+    ) -> Result<ProposalWaiter, StateError> {
         // Propose the task to the task queue
-        self.send_proposal(StateTransition::PopTask { task_id })
+        self.send_proposal(StateTransition::PopTask { task_id, success })
     }
 
     /// Transition the state of the top task in a queue
@@ -214,7 +218,7 @@ mod test {
         waiter.await.unwrap();
 
         // Pop the task from the queue
-        let waiter = state.pop_task(task_id).unwrap();
+        let waiter = state.pop_task(task_id, true /* success */).unwrap();
         waiter.await.unwrap();
 
         // Check that the task was removed

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -105,7 +105,7 @@ pub enum StateTransition {
     /// Add a task to the task queue
     AppendTask { task: QueuedTask },
     /// Pop the top task from the task queue
-    PopTask { task_id: TaskIdentifier },
+    PopTask { task_id: TaskIdentifier, success: bool },
     /// Transition the state of the top task in the task queue
     TransitionTask { task_id: TaskIdentifier, state: QueuedTaskState },
     /// Preempt the given task queue

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -403,7 +403,7 @@ impl TaskExecutor {
         let res = Self::run_task_to_completion(&mut task, args).await;
 
         // Cleanup
-        let cleanup_res = task.cleanup().await;
+        let cleanup_res = task.cleanup(res.is_ok()).await;
         let combined_res = res.and(cleanup_res);
 
         // Notify any listeners that the task has completed

--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -107,7 +107,7 @@ impl<T: Task> RunnableTask<T> {
     }
 
     /// Cleanup the underlying task
-    pub async fn cleanup(&mut self) -> Result<(), TaskDriverError> {
+    pub async fn cleanup(&mut self, success: bool) -> Result<(), TaskDriverError> {
         // Do not propagate errors from cleanup, continue to cleanup
         if let Err(e) = self.task.cleanup().await {
             error!("error cleaning up task: {e:?}");
@@ -116,7 +116,7 @@ impl<T: Task> RunnableTask<T> {
         // Pop the task from the state
         // Preemptive tasks are not indexed, so no work needs to be done
         if !self.preemptive {
-            self.state.pop_task(self.task_id)?.await?;
+            self.state.pop_task(self.task_id, success)?.await?;
         }
 
         Ok(())


### PR DESCRIPTION
### Purpose
This PR handles the state transition logic to update task history; specifically by placing the popped task in the history when the queue is popped. This PR also passes success/failure information into the pop state transition so that the task history may store which tasks were successful vs not.

### Testing
- Unit tests pass 