### PR TITLE
external-api: types: api-task-history: Add task history API types

### DIFF
--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -18,5 +18,5 @@ util = { path = "../util" }
 itertools = { workspace = true }
 hex = "0.4"
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/external-api/src/types/api_network_info.rs
+++ b/external-api/src/types/api_network_info.rs
@@ -1,0 +1,61 @@
+//! API types for network info requests
+use common::types::gossip::PeerInfo as IndexedPeerInfo;
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The network topology
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Network {
+    /// Identifier, e.g. "goerli"
+    pub id: String,
+    /// The list of clusters known to the local peer
+    pub clusters: Vec<Cluster>,
+}
+
+/// Cast from a map of cluster ID to peer list to the `Cluster` API type
+impl From<HashMap<String, Vec<Peer>>> for Network {
+    fn from(cluster_membership: HashMap<String, Vec<Peer>>) -> Self {
+        let mut clusters = Vec::with_capacity(cluster_membership.len());
+        for (cluster_id, peers) in cluster_membership.into_iter() {
+            clusters.push(Cluster { id: cluster_id, peers });
+        }
+
+        Self {
+            // TODO: Make this not a constant
+            id: "goerli".to_string(),
+            clusters,
+        }
+    }
+}
+
+/// A cluster of peers, in the security model a cluster is assumed to be
+/// controlled by a single actor
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Cluster {
+    /// Identifier
+    pub id: String,
+    /// The list of peers known to be members of the cluster
+    pub peers: Vec<Peer>,
+}
+
+/// A peer in the network known to the local node
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Peer {
+    /// Identifier
+    pub id: String,
+    /// The ID of the cluster this peer belongs to
+    pub cluster_id: String,
+    /// The dialable, libp2p address of the peer
+    pub addr: String,
+}
+
+impl From<IndexedPeerInfo> for Peer {
+    fn from(peer_info: IndexedPeerInfo) -> Self {
+        Self {
+            id: peer_info.get_peer_id().to_string(),
+            cluster_id: peer_info.get_cluster_id().to_string(),
+            addr: peer_info.get_addr().to_string(),
+        }
+    }
+}

--- a/external-api/src/types/api_order_book.rs
+++ b/external-api/src/types/api_order_book.rs
@@ -1,0 +1,46 @@
+//! API types for order book requests
+
+use common::types::network_order::{NetworkOrder, NetworkOrderState};
+use num_bigint::BigUint;
+use renegade_crypto::fields::scalar_to_biguint;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// The order book known to the local node, consisting of all opaque
+/// network orders being shopped around by peers
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OrderBook {
+    /// The list of known orders
+    pub orders: Vec<ApiNetworkOrder>,
+}
+
+/// An opaque order known to the local peer only by a few opaque identifiers
+/// possibly owned and known in the clear by the local peer as well
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiNetworkOrder {
+    /// Identifier
+    pub id: Uuid,
+    /// The nullifier of the containing wallet's public secret shares
+    pub public_share_nullifier: BigUint,
+    /// Whether this order is managed by the local cluster
+    pub local: bool,
+    /// The cluster that manages this order
+    pub cluster: String,
+    /// The state of the order in the network
+    pub state: NetworkOrderState,
+    /// The timestamp that this order was first received at
+    pub timestamp: u64,
+}
+
+impl From<NetworkOrder> for ApiNetworkOrder {
+    fn from(order: NetworkOrder) -> Self {
+        ApiNetworkOrder {
+            id: order.id,
+            public_share_nullifier: scalar_to_biguint(&order.public_share_nullifier),
+            local: order.local,
+            cluster: order.cluster.to_string(),
+            state: order.state,
+            timestamp: order.timestamp,
+        }
+    }
+}

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -1,0 +1,130 @@
+//! API types for task history
+//!
+//! We redefine types from the `common` crate here to provide better enum JSON
+//! serialization. Our `common` types cannot use the internally tagged
+//! representations as the `bincode` crate does not support them
+
+use std::str::FromStr;
+
+use circuit_types::{order::Order, r#match::MatchResult};
+use common::types::tasks::{
+    HistoricalTask, HistoricalTaskDescription, QueuedTaskState, TaskIdentifier, WalletUpdateType,
+};
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use serde_json::Number;
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Converts a `u128` to a `Number`
+fn u128_to_number(value: u128) -> Number {
+    Number::from_str(&value.to_string()).unwrap()
+}
+
+// ---------
+// | Types |
+// ---------
+
+/// A historical task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiHistoricalTask {
+    /// The id of the task
+    pub id: TaskIdentifier,
+    /// The state of the task
+    pub state: QueuedTaskState,
+    /// The time the task was created
+    pub created_at: u64,
+    /// The axillary information that specifies the transformation the task took
+    pub task_info: ApiHistoricalTaskDescription,
+}
+
+impl From<HistoricalTask> for ApiHistoricalTask {
+    fn from(value: HistoricalTask) -> Self {
+        Self {
+            id: value.id,
+            state: value.state,
+            created_at: value.created_at,
+            task_info: value.task_info.into(),
+        }
+    }
+}
+
+/// A historical description of a task
+///
+/// Separated out from the task descriptors as the descriptors may contain
+/// runtime information irrelevant for storage
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "task_type")]
+pub enum ApiHistoricalTaskDescription {
+    /// A new wallet was created
+    NewWallet,
+    /// An update to a wallet
+    UpdateWallet(ApiWalletUpdateType),
+    /// A match was settled
+    SettleMatch(MatchResult),
+    /// A fee was paid
+    PayOfflineFee,
+}
+
+impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
+    fn from(value: HistoricalTaskDescription) -> Self {
+        match value {
+            HistoricalTaskDescription::NewWallet => Self::NewWallet,
+            HistoricalTaskDescription::UpdateWallet(update) => {
+                Self::UpdateWallet(ApiWalletUpdateType::from(update))
+            },
+            HistoricalTaskDescription::SettleMatch(match_result) => Self::SettleMatch(match_result),
+            HistoricalTaskDescription::PayOfflineFee => Self::PayOfflineFee,
+        }
+    }
+}
+
+/// A type representing a description of an update wallet task
+///
+/// Differentiates between order vs balance updates, and holds fields for
+/// display
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "update_type")]
+pub enum ApiWalletUpdateType {
+    /// Deposit a balance
+    Deposit {
+        /// The deposited mint
+        mint: BigUint,
+        /// The amount deposited
+        amount: Number,
+    },
+    /// Withdraw a balance
+    Withdraw {
+        /// The withdrawn mint
+        mint: BigUint,
+        /// The amount withdrawn
+        amount: Number,
+    },
+    /// Place an order
+    PlaceOrder {
+        /// The order to place
+        order: Order,
+    },
+    /// Cancel an order
+    CancelOrder {
+        /// The order that was cancelled
+        order: Order,
+    },
+}
+
+impl From<WalletUpdateType> for ApiWalletUpdateType {
+    fn from(value: WalletUpdateType) -> Self {
+        match value {
+            WalletUpdateType::Deposit { mint, amount } => {
+                Self::Deposit { mint, amount: u128_to_number(amount) }
+            },
+            WalletUpdateType::Withdraw { mint, amount } => {
+                Self::Withdraw { mint, amount: u128_to_number(amount) }
+            },
+            WalletUpdateType::PlaceOrder { order } => Self::PlaceOrder { order },
+            WalletUpdateType::CancelOrder { order } => Self::CancelOrder { order },
+        }
+    }
+}

--- a/external-api/src/types/mod.rs
+++ b/external-api/src/types/mod.rs
@@ -1,0 +1,11 @@
+//! API types for the relayer's websocket and HTTP APIs
+
+mod api_network_info;
+mod api_order_book;
+mod api_task_history;
+mod api_wallet;
+
+pub use api_network_info::*;
+pub use api_order_book::*;
+pub use api_task_history::*;
+pub use api_wallet::*;


### PR DESCRIPTION
### Purpose
This PR adds API types for the task history API and destructures the existing types into multiple files. We need to replicate these types at the API layer to give proper enum tagging. We cannot used internally tagged enums at the storage layer as `bincode` doesn't support them.

### Testing
- Unit tests pass