### PR TITLE
api-server: websocket: task: Add task history websocket handler

### DIFF
--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -12,7 +12,10 @@ use common::types::{
 };
 use serde::Serialize;
 
-use crate::{http::task::ApiTaskStatus, types::ApiWallet};
+use crate::{
+    http::task::ApiTaskStatus,
+    types::{ApiHistoricalTask, ApiWallet},
+};
 
 // ----------------------------
 // | System Bus Message Types |
@@ -37,6 +40,11 @@ pub fn wallet_order_history_topic(wallet_id: &WalletIdentifier) -> String {
 /// Get the topic name for a given task
 pub fn task_topic(task_id: &TaskIdentifier) -> String {
     format!("task-updates-{}", task_id)
+}
+
+/// Get the task history topic name for a wallet
+pub fn task_history_topic(wallet_id: &WalletIdentifier) -> String {
+    format!("task-history-{}", wallet_id)
 }
 
 /// Get the topic name for a price report
@@ -124,6 +132,13 @@ pub enum SystemBusMessage {
     OrderMetadataUpdated {
         /// The new state of the order
         order: OrderMetadata,
+    },
+
+    // --- Task History Updates -- //
+    /// A message indicating an update to a task in the task history
+    TaskHistoryUpdate {
+        /// The new state of the task
+        task: ApiHistoricalTask,
     },
 }
 

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -11,7 +11,8 @@ use circuit_types::{
     r#match::MatchResult,
 };
 use common::types::tasks::{
-    HistoricalTask, HistoricalTaskDescription, QueuedTaskState, TaskIdentifier, WalletUpdateType,
+    HistoricalTask, HistoricalTaskDescription, QueuedTask, QueuedTaskState, TaskIdentifier,
+    TaskQueueKey, WalletUpdateType,
 };
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -51,6 +52,15 @@ impl From<HistoricalTask> for ApiHistoricalTask {
             created_at: value.created_at,
             task_info: value.task_info.into(),
         }
+    }
+}
+
+impl ApiHistoricalTask {
+    /// Convert from a queued task
+    pub fn from_queued_task(key: TaskQueueKey, task: QueuedTask) -> Option<Self> {
+        let task_info =
+            HistoricalTaskDescription::from_task_descriptor(&task.descriptor, key)?.into();
+        Some(Self { id: task.id, state: task.state, created_at: task.created_at, task_info })
     }
 }
 

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -75,7 +75,7 @@ impl StateApplicator {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
-            StateTransition::AppendTask { task } => self.append_task(&task),
+            StateTransition::AppendTask { task } => self.append_task(task),
             StateTransition::PopTask { task_id, success } => self.pop_task(task_id, success),
             StateTransition::TransitionTask { task_id, state } => {
                 self.transition_task_state(task_id, state)

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -17,6 +17,11 @@ impl State {
     // | Getters |
     // -----------
 
+    /// Whether the wallet exists
+    pub fn contains_wallet(&self, id: &WalletIdentifier) -> Result<bool, StateError> {
+        Ok(self.get_wallet(id)?.is_some())
+    }
+
     /// Get the wallet with the given id
     pub fn get_wallet(&self, id: &WalletIdentifier) -> Result<Option<Wallet>, StateError> {
         let tx = self.db.new_read_tx()?;


### PR DESCRIPTION
### Purpose
This PR adds a websocket handler for the task history endpoint. This pushes updates about historical tasks as well as active tasks and their state. In this way, this endpoint is a superset of the current task status websocket.

### Testing
- Unit tests pass
- Tested websockets locally