### PR TITLE
arbitrum-client: Use `NonceManager` ethers middleware

### DIFF
--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -23,7 +23,7 @@ use crate::{
         newWalletCall, processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall,
         settleOnlineRelayerFeeCall, updateWalletCall,
     },
-    client::SignerHttpProvider,
+    client::MiddlewareStack,
     errors::ArbitrumClientError,
 };
 
@@ -43,7 +43,7 @@ pub fn deserialize_calldata<'de, T: Deserialize<'de>>(
 
 /// Sends a transaction, awaiting its confirmation and returning the receipt
 pub async fn send_tx(
-    tx: ContractCall<SignerHttpProvider, impl Detokenize>,
+    tx: ContractCall<MiddlewareStack, impl Detokenize>,
 ) -> Result<TransactionReceipt, ArbitrumClientError> {
     tx.send()
         .await

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -59,7 +59,7 @@ impl ApiHistoricalTask {
     /// Convert from a queued task
     pub fn from_queued_task(key: TaskQueueKey, task: QueuedTask) -> Option<Self> {
         let task_info =
-            HistoricalTaskDescription::from_task_descriptor(&task.descriptor, key)?.into();
+            HistoricalTaskDescription::from_task_descriptor(key, &task.descriptor)?.into();
         Some(Self { id: task.id, state: task.state, created_at: task.created_at, task_info })
     }
 }

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -71,7 +71,7 @@ impl StateApplicator {
         let mut task =
             tx.pop_task(&key)?.ok_or_else(|| StateApplicatorError::TaskQueueEmpty(key))?;
         task.state = if success { QueuedTaskState::Completed } else { QueuedTaskState::Failed };
-        if let Some(t) = HistoricalTask::from_queued_task(task.clone(), key) {
+        if let Some(t) = HistoricalTask::from_queued_task(key, task.clone()) {
             tx.append_task_to_history(&key, t)?;
         }
 
@@ -161,7 +161,7 @@ impl StateApplicator {
         tx.resume_task_queue(&key)?;
         let mut task = tx.pop_task(&key)?.expect("expected preemptive task");
         task.state = if success { QueuedTaskState::Completed } else { QueuedTaskState::Failed };
-        if let Some(t) = HistoricalTask::from_queued_task(task.clone(), key) {
+        if let Some(t) = HistoricalTask::from_queued_task(key, task.clone()) {
             tx.append_task_to_history(&key, t)?;
         }
 

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -15,6 +15,7 @@ use common::{
     worker::Worker,
 };
 use constants::Scalar;
+use ethers::middleware::Middleware;
 use ethers::types::Address;
 use eyre::Result;
 use job_types::{
@@ -197,7 +198,7 @@ pub async fn authorize_transfer(
     let darkpool_address = AlloyAddress::from_slice(client.darkpool_contract.address().as_bytes());
 
     let eth_client = client.darkpool_contract.client(); // Assigned to avoid dropping
-    let signer = eth_client.signer();
+    let signer = eth_client.inner().signer();
 
     gen_transfer_with_auth(signer, pk_root, permit2_address, darkpool_address, chain_id, transfer)
 }


### PR DESCRIPTION
### Purpose
This PR updates the `arbitrum-client` to use the `ethers` `NonceManager` middleware. This allows the client to submit multiple concurrent transactions in a nonce-consistent way, rather than relying on a nonce-fetch which may be out of date with respect to a transaction yet to be executed.

### Testing
- Unit tests pass
- Replicated the out of date nonce bug on a local relayer targeting the staging sequencer. Verified that the bug was fixed after this change