### PR TITLE
state: storage: order-book: Delete orders when nullified

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -26,7 +26,7 @@ abigen!(
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
         event MerkleInsertion(uint128 indexed index, uint256 indexed value)
-        event NullifierSpent(uint256 nullifier)
+        event NullifierSpent(uint256 indexed nullifier)
     ]"#
 );
 
@@ -53,7 +53,7 @@ abigen!(
         event WalletUpdated(uint256 indexed wallet_blinder_share)
         event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
         event MerkleInsertion(uint128 indexed index, uint256 indexed value)
-        event NullifierSpent(uint256 nullifier)
+        event NullifierSpent(uint256 indexed nullifier)
 
         function clearMerkle() external
     ]"#

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -51,8 +51,6 @@ pub const SELECTOR_LEN: usize = 4;
 
 /// The abi signature for the `WalletUpdated` event
 pub const WALLET_UPDATED_EVENT_NAME: &str = "WalletUpdated";
-/// The abi signature for the `NodeChanged` event
-pub const MERKLE_NODE_CHANGED_EVENT_NAME: &str = "NodeChanged";
 /// The abi signature for the `NullifierSpent` event
 pub const NULLIFIER_SPENT_EVENT_NAME: &str = "NullifierSpent";
 


### PR DESCRIPTION
### Purpose
This PR explicitly deletes orders after their wallets have been nullified. Keeping these orders around after they've been nullified only results in state bloat. Orders that are still valid will be re-gossiped by their managing cluster anyways.

### Testing
- Unit tests pass
- Tested submitting and cancelling orders in a wallet. Verified that the `/v0/order_book/orders` route reflected these changes