### PR TITLE
workers: price-reporter: exchange: per-exchange pair support API calls

### DIFF
--- a/workers/price-reporter/src/errors.rs
+++ b/workers/price-reporter/src/errors.rs
@@ -19,8 +19,8 @@ pub enum ExchangeConnectionError {
     /// The maximum retry count was exceeded while trying to re-establish
     /// an exchange connection
     MaxRetries(Exchange),
-    /// No exchanges support the given token pair
-    NoSupportedExchanges(Token, Token),
+    /// The given pair is not supported by the exchange
+    UnsupportedPair(Token, Token, Exchange),
     /// Error sending on the `write` end of the websocket
     SendError(String),
     /// Error saving the state of a price stream

--- a/workers/price-reporter/src/exchange.rs
+++ b/workers/price-reporter/src/exchange.rs
@@ -54,6 +54,21 @@ pub async fn connect_exchange(
     })
 }
 
+/// Check if the given exchange supports the given pair
+pub async fn supports_pair(
+    exchange: &Exchange,
+    base_token: &Token,
+    quote_token: &Token,
+) -> Result<bool, ExchangeConnectionError> {
+    Ok(match exchange {
+        Exchange::Binance => BinanceConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Coinbase => CoinbaseConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Kraken => KrakenConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Okx => OkxConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::UniswapV3 => UniswapV3Connection::supports_pair(base_token, quote_token).await?,
+    })
+}
+
 /// The type that a price stream should return
 pub type PriceStreamType = Result<Price, ExchangeConnectionError>;
 

--- a/workers/price-reporter/src/exchange/binance.rs
+++ b/workers/price-reporter/src/exchange/binance.rs
@@ -151,14 +151,6 @@ impl ExchangeConnection for BinanceConnection {
     where
         Self: Sized,
     {
-        if !Self::supports_pair(&base_token, &quote_token).await? {
-            return Err(ExchangeConnectionError::UnsupportedPair(
-                base_token,
-                quote_token,
-                Exchange::Binance,
-            ));
-        }
-
         // Fetch an inital price report to setup the stream
         let initial_price_report =
             Self::fetch_price_report(base_token.clone(), quote_token.clone()).await?;

--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -16,7 +16,10 @@ use tungstenite::{Error as WsError, Message};
 use url::Url;
 use util::{err_str, get_current_time_seconds};
 
-use crate::{errors::ExchangeConnectionError, manager::exchange_lists_pair_tokens, worker::ExchangeConnectionsConfig};
+use crate::{
+    errors::ExchangeConnectionError, manager::exchange_lists_pair_tokens,
+    worker::ExchangeConnectionsConfig,
+};
 
 use super::{
     connection::{
@@ -194,14 +197,6 @@ impl ExchangeConnection for CoinbaseConnection {
         quote_token: Token,
         config: &ExchangeConnectionsConfig,
     ) -> Result<Self, ExchangeConnectionError> {
-        if !Self::supports_pair(&base_token, &quote_token).await? {
-            return Err(ExchangeConnectionError::UnsupportedPair(
-                base_token,
-                quote_token,
-                Exchange::Coinbase,
-            ));
-        }
-
         // Build the base websocket connection
         let url = Self::websocket_url();
         let (mut writer, read) = ws_connect(url).await?;

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -142,10 +142,16 @@ pub trait ExchangeConnection: Stream<Item = PriceStreamType> + Unpin + Send {
     ) -> Result<Self, ExchangeConnectionError>
     where
         Self: Sized;
+
     /// Send a keepalive signal on the connection if necessary
     async fn send_keepalive(&mut self) -> Result<(), ExchangeConnectionError> {
         Ok(())
     }
+
+    /// Check whether the exchange supports the given pair
+    async fn supports_pair(base_token: &Token, quote_token: &Token) -> Result<bool, ExchangeConnectionError>
+    where
+        Self: Sized;
 }
 
 // -----------------------------

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -149,7 +149,10 @@ pub trait ExchangeConnection: Stream<Item = PriceStreamType> + Unpin + Send {
     }
 
     /// Check whether the exchange supports the given pair
-    async fn supports_pair(base_token: &Token, quote_token: &Token) -> Result<bool, ExchangeConnectionError>
+    async fn supports_pair(
+        base_token: &Token,
+        quote_token: &Token,
+    ) -> Result<bool, ExchangeConnectionError>
     where
         Self: Sized;
 }

--- a/workers/price-reporter/src/exchange/kraken.rs
+++ b/workers/price-reporter/src/exchange/kraken.rs
@@ -126,14 +126,6 @@ impl ExchangeConnection for KrakenConnection {
     where
         Self: Sized,
     {
-        if !Self::supports_pair(&base_token, &quote_token).await? {
-            return Err(ExchangeConnectionError::UnsupportedPair(
-                base_token,
-                quote_token,
-                Exchange::Kraken,
-            ));
-        }
-
         // Connect to the websocket
         let url = Self::websocket_url();
         let (mut write, read) = ws_connect(url).await?;

--- a/workers/price-reporter/src/exchange/okx.rs
+++ b/workers/price-reporter/src/exchange/okx.rs
@@ -122,14 +122,6 @@ impl ExchangeConnection for OkxConnection {
     where
         Self: Sized,
     {
-        if !Self::supports_pair(&base_token, &quote_token).await? {
-            return Err(ExchangeConnectionError::UnsupportedPair(
-                base_token,
-                quote_token,
-                Exchange::Okx,
-            ));
-        }
-
         // Connect to the websocket
         let url = Self::websocket_url();
         let (mut write, read) = ws_connect(url).await?;

--- a/workers/price-reporter/src/exchange/uni_v3.rs
+++ b/workers/price-reporter/src/exchange/uni_v3.rs
@@ -386,4 +386,11 @@ impl ExchangeConnection for UniswapV3Connection {
 
         Ok(Self { price_stream: Box::new(price_stream) })
     }
+
+    async fn supports_pair(
+        _base_token: &Token,
+        _quote_token: &Token,
+    ) -> Result<bool, ExchangeConnectionError> {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
This PR adds a new method, `supports_pair`, to the `ExchangeConnection` trait, which we use to check if a given exchange supports a given pair by making the requisite API call for that exchange.

We use this in the `connect` methods of the `ExchangeConnection` implementors to error on connecting to a price stream for a pair that an exchange doesn't support. This change is absorbed by the price reporter, as well, since it invokes the same method.

We also expose a helper method for the external price reporter to use in its own validation logic before trying to `connect`.

We don't use this method for any pre-connection checks in the relayer, since the implementation of price conversion through "default" stables for each exchange (paired with the assumption that quote tokens are stables) lets us assume that each exchange has a market between any listed base token and the default stable, an assumption we have already been leveraging.