### PR TITLE
handshake-manager: internal-engine: Add mutual exclusion list

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -246,6 +246,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the handshake manager
     let (handshake_cancel_sender, handshake_cancel_receiver) = watch::channel(());
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
+        mutual_exclusion_list: args.match_mutual_exclusion_list,
         global_state: global_state.clone(),
         network_channel: network_sender.clone(),
         price_reporter_job_queue: price_reporter_worker_sender.clone(),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
-use std::mem;
+use std::{collections::HashSet, mem};
 
 use api_server::worker::{ApiServer, ApiServerConfig};
 use arbitrum_client::client::{ArbitrumClient, ArbitrumClientConfig};
@@ -374,6 +374,7 @@ impl MockNodeController {
         let task_queue = self.task_queue.0.clone();
 
         let conf = HandshakeManagerConfig {
+            mutual_exclusion_list: HashSet::new(),
             global_state,
             network_channel,
             price_reporter_job_queue,


### PR DESCRIPTION
### Purpose
This PR adds a configurable `match-mutual-exclusion-list` to the config. This set is passed to the handshake manager which checks whether two wallets are in this list before matching. If they are, the match is skipped. 

We will use this config as a means to various ends: whitelisting, liquidity provisioning, etc.

### Testing
- Unit tests pass
- Tested the config value on live wallets