### PR TITLE
github: workflows: Change relayer cluster to use us-east-2

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ github.ref_name == 'dev' && 'us-east-2' || 'ca-central-1' }}
+          aws-region: "us-east-2"
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -93,7 +93,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ github.ref_name == 'dev' && 'us-east-2' || 'ca-central-1' }}
+          aws-region: "us-east-2"
 
       - name: Get the existing task definitions
         id: fetch-task-def


### PR DESCRIPTION
### Purpose
This PR targets only the `us-east-2` cluster on upgrades seeing as we now run relayers in only `us-east-2`. 