### PR TITLE
state: replication: create `Worker` for Raft replication node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7748,6 +7748,7 @@ dependencies = [
  "slog",
  "system-bus",
  "tempfile",
+ "test-helpers",
  "tokio",
  "tracing",
  "tracing-slog",

--- a/common/src/worker.rs
+++ b/common/src/worker.rs
@@ -67,9 +67,14 @@ pub fn watch_worker<W: Worker>(worker: &mut W, failure_channel: &Sender<()>) {
         Builder::new()
             .name(watcher_name.clone())
             .spawn(move || {
-                #[allow(unused_must_use)]
-                let err = join_handle.join().unwrap();
-                error!("worker {worker_name} exited with error: {err:?}");
+                match join_handle.join() {
+                    Err(panic) => {
+                        error!("worker {worker_name} panicked with error: {panic:?}");
+                    },
+                    Ok(err) => {
+                        error!("worker {worker_name} exited with error: {err:?}");
+                    },
+                }
                 channel_clone.blocking_send(()).unwrap();
             })
             .unwrap();

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -5,6 +5,8 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::needless_pass_by_ref_mut)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 
 use std::{collections::HashSet, mem};
 
@@ -53,7 +55,7 @@ use proof_manager::{
 use reqwest::{blocking::Client, Method};
 use serde::{de::DeserializeOwned, Serialize};
 use state::{
-    replication::network::traits::{new_raft_message_queue, RaftMessageQueue, RaftMessageReceiver},
+    replication::{network::traits::{new_raft_message_queue, RaftMessageQueue, RaftMessageReceiver}, raft_node::{new_raft_proposal_queue, ProposalQueue, ProposalReceiver}, worker::ReplicationNodeWorker},
     State,
 };
 use system_bus::SystemBus;
@@ -100,6 +102,8 @@ pub struct MockNodeController {
     network_queue: (NetworkManagerQueue, DefaultOption<NetworkManagerReceiver>),
     /// The raft message queue
     raft_queue: (RaftMessageQueue, DefaultOption<RaftMessageReceiver>),
+    /// The raft proposal queue
+    proposal_queue: (ProposalQueue, DefaultOption<ProposalReceiver>),
     /// The gossip message queue
     gossip_queue: (GossipServerQueue, DefaultOption<GossipServerReceiver>),
     /// The handshake manager's queue
@@ -119,6 +123,7 @@ impl MockNodeController {
         let bus = SystemBus::new();
         let (network_sender, network_recv) = new_network_manager_queue();
         let (raft_sender, raft_recv) = new_raft_message_queue();
+        let (proposal_sender, proposal_receiver) = new_raft_proposal_queue();
         let (gossip_sender, gossip_recv) = new_gossip_server_queue();
         let (handshake_send, handshake_recv) = new_handshake_manager_queue();
         let (price_sender, price_recv) = new_price_reporter_queue();
@@ -133,6 +138,7 @@ impl MockNodeController {
             state: None,
             network_queue: (network_sender, default_option(network_recv)),
             raft_queue: (raft_sender, default_option(raft_recv)),
+            proposal_queue: (proposal_sender, default_option(proposal_receiver)),
             gossip_queue: (gossip_sender, default_option(gossip_recv)),
             handshake_queue: (handshake_send, default_option(handshake_recv)),
             price_queue: (price_sender, default_option(price_recv)),
@@ -257,21 +263,33 @@ impl MockNodeController {
         // Create a global state instance
         let network_queue = self.network_queue.0.clone();
         let raft_receiver = self.raft_queue.1.take().unwrap();
+        let proposal_sender = self.proposal_queue.0.clone();
+        let proposal_receiver = self.proposal_queue.1.take().unwrap();
         let task_sender = self.task_queue.0.clone();
         let handshake_queue = self.handshake_queue.0.clone();
         let bus = self.bus.clone();
 
         let state = State::new(
-            network_queue,
-            raft_receiver,
             &self.config,
-            task_sender,
-            handshake_queue,
+            proposal_sender,
             bus,
         )
         .expect("Failed to create state instance");
-        self.state = Some(state);
 
+        // Start the raft node
+        let replication_config = state.gen_replication_config(
+            self.config.clone(),
+            network_queue,
+            raft_receiver,
+            proposal_receiver,
+            task_sender,
+            handshake_queue,
+        );
+        let mut raft_worker = ReplicationNodeWorker::new(replication_config)
+            .expect("failed to build Raft replication node");
+        raft_worker.start().expect("failed to start Raft replication node");
+
+        self.state = Some(state);
         self
     }
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 # Used to enable mocks from other crates in tests
 all-tests = ["common/mocks"]
-mocks = ["dep:tempfile"]
+mocks = ["dep:tempfile", "dep:test-helpers"]
 
 [dependencies]
 
@@ -34,6 +34,7 @@ gossip-api = { path = "../gossip-api" }
 job-types = { path = "../workers/job-types" }
 system-bus = { path = "../system-bus" }
 util = { path = "../util" }
+test-helpers = { path = "../test-helpers", optional = true }
 
 # === Misc === #
 crossterm = "0.27"
@@ -57,3 +58,4 @@ num-bigint = "0.4"
 tempfile = "3.8"
 rand = { workspace = true }
 uuid = "1.4"
+test-helpers = { path = "../test-helpers" }

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -75,12 +75,12 @@ impl StateApplicator {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
-            StateTransition::AppendTask { task } => self.append_task(task),
+            StateTransition::AppendTask { task } => self.append_task(&task),
             StateTransition::PopTask { task_id, success } => self.pop_task(task_id, success),
             StateTransition::TransitionTask { task_id, state } => {
                 self.transition_task_state(task_id, state)
             },
-            StateTransition::PreemptTaskQueue { key, task } => self.preempt_task_queue(key, task),
+            StateTransition::PreemptTaskQueue { key, task } => self.preempt_task_queue(key, &task),
             StateTransition::ResumeTaskQueue { key, success } => {
                 self.resume_task_queue(key, success)
             },

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -146,7 +146,7 @@ mod test {
     fn test_node_metadata() {
         // Build the state mock manually to use the generated config
         let config = mock_relayer_config();
-        let state = mock_state_with_config(config.clone());
+        let state = mock_state_with_config(&config);
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -139,36 +139,14 @@ impl State {
 
 #[cfg(test)]
 mod test {
-    use config::RelayerConfig;
-    use job_types::{
-        handshake_manager::new_handshake_manager_queue, task_driver::new_task_driver_queue,
-    };
-    use system_bus::SystemBus;
-
-    use crate::{
-        replication::network::traits::test_helpers::MockNetwork, test_helpers::mock_raft_config,
-        State,
-    };
+    use crate::test_helpers::{mock_relayer_config, mock_state_with_config};
 
     /// Tests the node metadata setup from a mock config
     #[test]
     fn test_node_metadata() {
         // Build the state mock manually to use the generated config
-        let config = RelayerConfig::default();
-        let (_controller, mut nets) = MockNetwork::new_n_way_mesh(1 /* n_nodes */);
-        let (task_queue, _recv) = new_task_driver_queue();
-        let (handshake_queue, _recv) = new_handshake_manager_queue();
-        let bus = SystemBus::new();
-        let raft_config = mock_raft_config(&config);
-        let state = State::new_with_network(
-            &config,
-            &raft_config,
-            nets.remove(0),
-            task_queue,
-            handshake_queue,
-            bus,
-        )
-        .unwrap();
+        let config = mock_relayer_config();
+        let state = mock_state_with_config(config.clone());
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -397,7 +397,6 @@ mod test {
         state.nullify_orders(order.public_share_nullifier).unwrap();
 
         // Check for the order in the state
-        let stored_order = state.get_order(&order.id).unwrap().unwrap();
-        assert_eq!(stored_order.state, NetworkOrderState::Cancelled);
+        assert!(state.get_order(&order.id).unwrap().is_none());
     }
 }

--- a/state/src/replication/error.rs
+++ b/state/src/replication/error.rs
@@ -32,8 +32,6 @@ pub enum ReplicationError {
     SerializeValue(String),
     /// An error interacting with storage
     Storage(StorageError),
-    /// An error setting up the raft node
-    Setup(String),
 }
 
 impl Display for ReplicationError {
@@ -67,7 +65,6 @@ impl From<ReplicationError> for RaftError {
             ReplicationError::ProposalResponse(e) => {
                 RaftError::Io(IOError::new(IOErrorKind::Other, e))
             },
-            ReplicationError::Setup(e) => RaftError::ConfigInvalid(e),
         }
     }
 }

--- a/state/src/replication/error.rs
+++ b/state/src/replication/error.rs
@@ -32,6 +32,8 @@ pub enum ReplicationError {
     SerializeValue(String),
     /// An error interacting with storage
     Storage(StorageError),
+    /// An error setting up the raft node
+    Setup(String),
 }
 
 impl Display for ReplicationError {
@@ -65,6 +67,7 @@ impl From<ReplicationError> for RaftError {
             ReplicationError::ProposalResponse(e) => {
                 RaftError::Io(IOError::new(IOErrorKind::Other, e))
             },
+            ReplicationError::Setup(e) => RaftError::ConfigInvalid(e),
         }
     }
 }

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod log_store;
 pub mod network;
 pub mod raft_node;
+pub mod worker;
 
 /// The ID of a raft peer
 pub type RaftPeerId = u64;

--- a/state/src/replication/worker.rs
+++ b/state/src/replication/worker.rs
@@ -1,0 +1,98 @@
+//! Implements the `Worker` trait for the Raft node
+
+use std::thread::{Builder, JoinHandle};
+
+use ::raft::prelude::Config as RaftConfig;
+use common::{types::gossip::WrappedPeerId, worker::Worker};
+use config::RelayerConfig;
+use tracing::info;
+use util::err_str;
+
+use super::{
+    error::ReplicationError,
+    network::{address_translation::PeerIdTranslationMap, traits::RaftNetwork},
+    raft_node::{ReplicationNode, ReplicationNodeConfig},
+};
+
+// -------------
+// | CONSTANTS |
+// -------------
+
+/// The default tick interval for the raft node
+pub const DEFAULT_TICK_INTERVAL_MS: u64 = 10; // 10 milliseconds
+/// The default number of ticks between Raft heartbeats
+const DEFAULT_HEARTBEAT_TICKS: usize = 100; // 1 second at 10ms per tick
+/// The default lower bound on the number of ticks before a Raft election
+const DEFAULT_MIN_ELECTION_TICKS: usize = 1000; // 10 seconds at 10ms per tick
+/// The default upper bound on the number of ticks before a Raft election
+const DEFAULT_MAX_ELECTION_TICKS: usize = 1500; // 15 seconds at 10ms per tick
+
+/// Manages the Raft replication node thread
+pub struct ReplicationNodeWorker<N: RaftNetwork> {
+    /// The Raft node that this worker is managing.
+    ///
+    /// We wrap this in an option so that ownership can be transferred to the
+    /// executor thread.
+    raft_node: Option<ReplicationNode<N>>,
+    /// The handle to the raft node thread
+    raft_handle: Option<JoinHandle<ReplicationError>>,
+}
+
+impl<N: 'static + RaftNetwork + Send> Worker for ReplicationNodeWorker<N> {
+    type Error = ReplicationError;
+    type WorkerConfig = ReplicationNodeConfig<N>;
+
+    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+        let raft_config = build_raft_config(&config.relayer_config);
+        let raft_node = Some(ReplicationNode::new_with_config(config, &raft_config)?);
+
+        Ok(Self { raft_node, raft_handle: None })
+    }
+
+    fn is_recoverable(&self) -> bool {
+        false
+    }
+
+    fn name(&self) -> String {
+        "raft-replication-node-main".to_string()
+    }
+
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        vec![self.raft_handle.take().unwrap()]
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        info!("Starting Raft replication node");
+
+        let raft_node = self.raft_node.take().unwrap();
+        let raft_handle = Builder::new()
+            .name("raft-replication-node-executor".to_string())
+            .spawn(move || raft_node.run().unwrap_err())
+            .map_err(err_str!(ReplicationError::Setup))?;
+
+        self.raft_handle = Some(raft_handle);
+        Ok(())
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}
+
+// -----------
+// | HELPERS |
+// -----------
+
+/// Build the raft config for the node
+fn build_raft_config(relayer_config: &RelayerConfig) -> RaftConfig {
+    let peer_id = relayer_config.p2p_key.public().to_peer_id();
+    let raft_id = PeerIdTranslationMap::get_raft_id(&WrappedPeerId(peer_id));
+    RaftConfig {
+        id: raft_id,
+        heartbeat_tick: DEFAULT_HEARTBEAT_TICKS,
+        election_tick: DEFAULT_MIN_ELECTION_TICKS,
+        min_election_tick: DEFAULT_MIN_ELECTION_TICKS,
+        max_election_tick: DEFAULT_MAX_ELECTION_TICKS,
+        ..Default::default()
+    }
+}

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -7,5 +7,6 @@ pub mod arbitrum;
 pub mod assertions;
 pub mod contract_interaction;
 pub mod macros;
+pub mod mocks;
 pub mod mpc_network;
 pub mod types;

--- a/test-helpers/src/mocks.rs
+++ b/test-helpers/src/mocks.rs
@@ -1,0 +1,14 @@
+//! Utilities for mocking relayer functionality
+
+use std::mem;
+
+use common::types::{new_cancel_channel, CancelChannel};
+
+
+/// Create a cancel channel and forget the sender to avoid drops
+pub fn mock_cancel() -> CancelChannel {
+    let (send, recv) = new_cancel_channel();
+    mem::forget(send);
+
+    recv
+}

--- a/test-helpers/src/mocks.rs
+++ b/test-helpers/src/mocks.rs
@@ -4,7 +4,6 @@ use std::mem;
 
 use common::types::{new_cancel_channel, CancelChannel};
 
-
 /// Create a cancel channel and forget the sender to avoid drops
 pub fn mock_cancel() -> CancelChannel {
     let (send, recv) = new_cancel_channel();

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -29,7 +29,10 @@ use job_types::{
 };
 use proof_manager::mock::MockProofManager;
 use rand::thread_rng;
-use state::{test_helpers::{mock_relayer_config, mock_state_with_task_queue}, State};
+use state::{
+    test_helpers::{mock_relayer_config, mock_state_with_task_queue},
+    State,
+};
 use test_helpers::{
     arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
     integration_test_main,

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -161,7 +161,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 
 /// Create a global state mock for the `task-driver` integration tests
 fn setup_global_state_mock(task_queue: TaskDriverQueue) -> State {
-    mock_state_with_task_queue(task_queue, mock_relayer_config())
+    mock_state_with_task_queue(task_queue, &mock_relayer_config())
 }
 
 /// Setup a mock `ArbitrumClient` for the integration tests

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -29,7 +29,7 @@ use job_types::{
 };
 use proof_manager::mock::MockProofManager;
 use rand::thread_rng;
-use state::{test_helpers::mock_state_with_task_queue, State};
+use state::{test_helpers::{mock_relayer_config, mock_state_with_task_queue}, State};
 use test_helpers::{
     arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
     integration_test_main,
@@ -158,7 +158,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 
 /// Create a global state mock for the `task-driver` integration tests
 fn setup_global_state_mock(task_queue: TaskDriverQueue) -> State {
-    mock_state_with_task_queue(task_queue)
+    mock_state_with_task_queue(task_queue, mock_relayer_config())
 }
 
 /// Setup a mock `ArbitrumClient` for the integration tests


### PR DESCRIPTION
This PR implements the `Worker` trait for the `ReplicationNode` so that it can gracefully handle failures on the Raft thread. We already find ourselves needing to implement this and the most sensible approach is to hook into the worker management patterns that are already present.

All the unit tests pass, and I also tested locally that the node appropriately shuts down when the Raft thread panics (which we see occasionally in `dev`).