### PR TITLE
workers: price-reporter: exchange: coinbase: use json content type header

### DIFF
--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use common::types::{token::Token, Price};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use hmac_sha256::HMAC;
+use reqwest::{header::CONTENT_TYPE, Client};
 use serde_json::json;
 use tracing::error;
 use tungstenite::{Error as WsError, Message};
@@ -267,7 +268,12 @@ impl ExchangeConnection for CoinbaseConnection {
         // Query the `products` endpoint about the pair
         let request_url = format!("{COINBASE_REST_BASE_URL}/products/{product_id}");
 
-        let response = reqwest::get(request_url)
+        // TODO: Store client on price reporter somewhere to keep connections alive
+        let client = Client::new();
+        let response = client
+            .get(request_url)
+            .header(CONTENT_TYPE, "application/json")
+            .send()
             .await
             .map_err(err_str!(ExchangeConnectionError::ConnectionHangup))?;
 


### PR DESCRIPTION
This PR sets the `Content-Type: application/json` header in the API request to Coinbase when checking for the existence of a pair. Without this Coinbase will consider the request malformed.