### PR TITLE
api-server: websocket: Do not trace websocket `handle_connection`

### DIFF
--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -57,7 +57,7 @@ impl From<HistoricalTask> for ApiHistoricalTask {
 
 impl ApiHistoricalTask {
     /// Convert from a queued task
-    pub fn from_queued_task(key: TaskQueueKey, task: QueuedTask) -> Option<Self> {
+    pub fn from_queued_task(key: TaskQueueKey, task: &QueuedTask) -> Option<Self> {
         let task_info =
             HistoricalTaskDescription::from_task_descriptor(key, &task.descriptor)?.into();
         let state = task.state.display_description();

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -51,7 +51,7 @@ impl StateApplicator {
         }
 
         tx.commit()?;
-        self.publish_task_updates(queue_key, task);
+        self.publish_task_updates(queue_key, &task);
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl StateApplicator {
         tx.commit()?;
 
         // Publish a completed message to the system bus
-        self.publish_task_updates(key, task);
+        self.publish_task_updates(key, &task);
         Ok(())
     }
 
@@ -114,7 +114,7 @@ impl StateApplicator {
         tx.commit()?;
 
         if let Some(t) = task {
-            self.publish_task_updates(key, t);
+            self.publish_task_updates(key, &t);
         }
         Ok(())
     }
@@ -147,7 +147,7 @@ impl StateApplicator {
         tx.pause_task_queue(&key)?;
         tx.add_task_front(&key, &task)?;
         tx.commit()?;
-        self.publish_task_updates(key, task);
+        self.publish_task_updates(key, &task);
         Ok(())
     }
 
@@ -178,7 +178,7 @@ impl StateApplicator {
         }
         tx.commit()?;
 
-        self.publish_task_updates(key, task);
+        self.publish_task_updates(key, &task);
         Ok(())
     }
 
@@ -187,7 +187,7 @@ impl StateApplicator {
     // -----------
 
     /// Publish system bus messages indicating a task has been updated
-    fn publish_task_updates(&self, key: TaskQueueKey, task: QueuedTask) {
+    fn publish_task_updates(&self, key: TaskQueueKey, task: &QueuedTask) {
         let task_id = task.id;
 
         // Publish a message for the individual task

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -14,7 +14,7 @@ use system_bus::TopicReader;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::StreamMap;
 use tokio_tungstenite::{accept_async, WebSocketStream};
-use tracing::{error, instrument};
+use tracing::info;
 use tungstenite::Message;
 
 use crate::{
@@ -217,7 +217,6 @@ impl WebsocketServer {
     ///
     /// Manages subscriptions to internal channels and dispatches
     /// subscribe/unsubscribe requests
-    #[instrument(skip_all, err)]
     async fn handle_connection(&self, stream: TcpStream) -> Result<(), ApiServerError> {
         // Accept the websocket upgrade and split into read/write streams
         let websocket_stream = accept_async(stream)
@@ -250,7 +249,7 @@ impl WebsocketServer {
                     match message {
                         Some(msg) => {
                             if let Err(e) = msg {
-                                error!("error handling websocket connection: {e}");
+                                info!("error handling websocket connection: {e}");
                                 return Err(ApiServerError::WebsocketServerFailure(e.to_string()));
                             }
 


### PR DESCRIPTION
### Purpose
This PR removes the `handle_connection` traces in the relayer's websocket server and downgrades connection errors to `info`. The `handle_connection` ends up creating many long running traces that have no detailed information. As well, if a client hangs up, we report an error logs which distracts from actual errors in traces.