### PR TITLE
docker: release: add bootloader script

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -43,9 +43,15 @@ FROM --platform=arm64 debian:bookworm-slim
 
 RUN apt-get update && \
     apt-get install -y libssl-dev && \
-    apt-get install -y ca-certificates
+    apt-get install -y ca-certificates && \
+    apt-get install -y awscli
 
 # Copy the binary from the build stage
 COPY --from=builder /build/target/release/renegade-relayer /bin/renegade-relayer
 
-ENTRYPOINT [ "/bin/renegade-relayer", "--config-file", "/config.toml" ]
+# Copy the bootloader script & make it executable
+COPY ./docker/release/bootloader.sh /bootloader.sh
+RUN chmod +x /bootloader.sh
+
+# Set the bootloader as the entrypoint
+ENTRYPOINT ["/bootloader.sh"]

--- a/docker/release/bootloader.sh
+++ b/docker/release/bootloader.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Expects the following environment variables to be passed to the container:
+# CONFIG_BUCKET: The S3 bucket containing the cluster config
+# CLUSTER_CONFIG_FILE: The name of the cluster config file
+# HTTP_PORT: The port to use for HTTP traffic
+# WEBSOCKET_PORT: The port to use for WebSocket traffic
+# P2P_PORT: The port to use for gossip traffic
+# P2P_KEY_PATH: The path to the file containing the P2P key
+
+
+config_path="/config.toml"
+
+# Fetch the cluster config from S3
+aws s3 cp s3://$CONFIG_BUCKET/$CLUSTER_CONFIG_FILE $config_path
+
+# Write the used ports to the config file
+echo "http-port = $HTTP_PORT" >> $config_path
+echo "websocket-port = $WEBSOCKET_PORT" >> $config_path
+echo "p2p-port = $P2P_PORT" >> $config_path
+
+# Copy the P2P key to the config file
+p2p_key=$(cat "$P2P_KEY_PATH")
+echo "p2p-key = \"$p2p_key\"" >> $config_path
+
+# Run the relayer
+/bin/renegade-relayer --config-file $config_path

--- a/docker/release/bootloader.sh
+++ b/docker/release/bootloader.sh
@@ -6,7 +6,6 @@
 # HTTP_PORT: The port to use for HTTP traffic
 # WEBSOCKET_PORT: The port to use for WebSocket traffic
 # P2P_PORT: The port to use for gossip traffic
-# P2P_KEY_PATH: The path to the file containing the P2P key
 
 
 config_path="/config.toml"
@@ -18,10 +17,6 @@ aws s3 cp s3://$CONFIG_BUCKET/$CLUSTER_CONFIG_FILE $config_path
 echo "http-port = $HTTP_PORT" >> $config_path
 echo "websocket-port = $WEBSOCKET_PORT" >> $config_path
 echo "p2p-port = $P2P_PORT" >> $config_path
-
-# Copy the P2P key to the config file
-p2p_key=$(cat "$P2P_KEY_PATH")
-echo "p2p-key = \"$p2p_key\"" >> $config_path
 
 # Run the relayer
 /bin/renegade-relayer --config-file $config_path


### PR DESCRIPTION
This PR adds a basic "bootloader" script to the Docker image which fetches the node's config file from S3, and fills it in with values set via environment variables.