### PR TITLE
state: applicator: task-queue: Run matching engine after resuming queue

### DIFF
--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -176,6 +176,12 @@ impl StateApplicator {
             // the task was previously running
             self.maybe_start_task(task, &tx)?;
         }
+
+        // Possibly run the matching engine on the wallet
+        if Self::should_run_matching_engine(&tasks, &task, &tx)? {
+            self.run_matching_engine_on_wallet(key, &tx)?;
+        }
+
         tx.commit()?;
 
         self.publish_task_updates(key, &task);


### PR DESCRIPTION
### Purpose
This PR fixes a bug wherein the matching engine is not run after a wallet's task queue is unpaused; i.e. after a match settles. This prevents recursive matches from being settled even when available. 

### Testing
- Unit tests pass workspace-wide
- Tested a recursive match with two wallets created on a local relayer