### PR TITLE
workers: task-driver: simulation: reblind wallet in offline fee sim

### DIFF
--- a/workers/task-driver/src/simulation/wallet_tasks.rs
+++ b/workers/task-driver/src/simulation/wallet_tasks.rs
@@ -181,5 +181,7 @@ fn simulate_offline_fee_payment(
         balance.relayer_fee_balance = 0;
     }
 
+    wallet.reblind_wallet();
+
     Ok(())
 }


### PR DESCRIPTION
This PR adds a wallet reblind step to the offline fee task simulation, this ensures that any back-of-queue fetches when these tasks are in the queue serve properly reblinded public shares.