### PR TITLE
state: replicationv2: Initialize module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyerror"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd04a72664a65fb9adeae7ced0c98efd68a2b7a45adda8319b3bb36538404b8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1143,16 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byte-unit"
+version = "4.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
 
 [[package]]
 name = "bytemuck"
@@ -4682,6 +4701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,6 +5378,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "openraft"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea4c15625735c6f4693c84046022081f9d54b2e376da699cd059161ef771b5f"
+dependencies = [
+ "anyerror",
+ "byte-unit",
+ "clap 4.5.4",
+ "derive_more",
+ "futures",
+ "maplit",
+ "openraft-macros",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "validit",
+]
+
+[[package]]
+name = "openraft-macros"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8514e44dab27259559f6594ff08ce0b7db2d850d9af304109867cce57d345d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7740,6 +7798,7 @@ dependencies = [
  "libp2p",
  "multiaddr",
  "num-bigint",
+ "openraft",
  "protobuf",
  "raft",
  "rand 0.8.5",
@@ -8799,6 +8858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8859,6 +8924,15 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.14",
  "serde",
+]
+
+[[package]]
+name = "validit"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fad49f3eae9c160c06b4d49700a99e75817f127cf856e494b56d5e23170020"
+dependencies = [
+ "anyerror",
 ]
 
 [[package]]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -11,6 +11,7 @@ mocks = ["dep:tempfile", "dep:test-helpers"]
 [dependencies]
 
 # === Replication === #
+openraft = { version = "0.9", features = ["serde", "storage-v2"] }
 raft = "0.7"
 
 # === Storage === #

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 pub mod applicator;
 mod interface;
 pub mod replication;
+pub mod replicationv2;
 pub mod storage;
 pub mod tui;
 

--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -1,0 +1,23 @@
+//! Error types and conversions for the replication interface
+use openraft::{ErrorSubject, ErrorVerb, RaftTypeConfig, StorageError as RaftStorageError};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+
+use crate::storage::error::StorageError;
+
+use super::TypeConfig;
+
+/// Convert a storage error reading logs into a raft error
+pub fn new_log_read_error(
+    err: StorageError,
+) -> RaftStorageError<<TypeConfig as RaftTypeConfig>::NodeId> {
+    let io_err = IoError::new(IoErrorKind::Other, Box::new(err));
+    RaftStorageError::from_io_error(ErrorSubject::Logs, ErrorVerb::Read, io_err)
+}
+
+/// Convert a storage error writing logs into a raft error
+pub fn new_log_write_error(
+    err: StorageError,
+) -> RaftStorageError<<TypeConfig as RaftTypeConfig>::NodeId> {
+    let io_err = IoError::new(IoErrorKind::Other, Box::new(err));
+    RaftStorageError::from_io_error(ErrorSubject::Logs, ErrorVerb::Write, io_err)
+}

--- a/state/src/replicationv2/log_store.rs
+++ b/state/src/replicationv2/log_store.rs
@@ -1,0 +1,168 @@
+//! Defines a raft log access via libmdbx
+//!
+//! We use libmdbx to index and persist raft logs as well as application data,
+//! this module fits our DB into the log trait expected by raft
+
+use std::fmt::Debug;
+use std::ops::Bound;
+use std::{ops::RangeBounds, sync::Arc};
+
+use libmdbx::{RO, RW};
+use openraft::storage::LogFlushed;
+use openraft::{storage::RaftLogStorage, RaftLogReader};
+use openraft::{LogId, LogState, StorageError as RaftStorageError, Vote};
+
+use crate::replicationv2::error::new_log_read_error;
+use crate::storage::db::DB;
+use crate::storage::error::StorageError;
+use crate::storage::tx::raft_log::{lsn_to_key, parse_lsn};
+use crate::storage::tx::StateTxn;
+
+use super::error::new_log_write_error;
+use super::{Entry, NodeId, TypeConfig};
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Parse low and high values from a range bound
+fn parse_low_high<B: RangeBounds<u64>>(bound: B) -> (u64, u64) {
+    let lo = match bound.start_bound() {
+        Bound::Included(lo) => *lo,
+        Bound::Excluded(lo) => lo + 1,
+        Bound::Unbounded => u64::MIN,
+    };
+
+    let hi = match bound.end_bound() {
+        Bound::Included(hi) => *hi,
+        Bound::Excluded(hi) => hi - 1,
+        Bound::Unbounded => u64::MAX,
+    };
+
+    (lo, hi)
+}
+
+// ---------------------------
+// | LogStore Implementation |
+// ---------------------------
+
+/// The log storage, a thin wrapper around the DB handle
+#[derive(Clone)]
+pub struct LogStore {
+    /// The handle to the DB
+    db: Arc<DB>,
+}
+
+impl LogStore {
+    /// Constructor
+    pub fn new(db: Arc<DB>) -> Self {
+        Self { db }
+    }
+
+    /// Run a callback with a read tx in scope
+    fn with_read_tx<F, T>(&self, f: F) -> Result<T, StorageError>
+    where
+        F: FnOnce(&StateTxn<RO>) -> Result<T, StorageError>,
+    {
+        let tx = self.db.new_read_tx()?;
+        let res = f(&tx)?;
+        tx.commit()?;
+
+        Ok(res)
+    }
+
+    /// Run a callback with a write tx in scope
+    fn with_write_tx<F, T>(&self, f: F) -> Result<T, StorageError>
+    where
+        F: FnOnce(&StateTxn<RW>) -> Result<T, StorageError>,
+    {
+        let tx = self.db.new_write_tx()?;
+        let res = f(&tx)?;
+        tx.commit()?;
+
+        Ok(res)
+    }
+}
+
+impl RaftLogReader<TypeConfig> for LogStore {
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<Entry>, RaftStorageError<NodeId>> {
+        self.with_read_tx(|tx| {
+            let mut log_cursor = tx.logs_cursor()?;
+            let (low, high) = parse_low_high(range);
+
+            // Read the range
+            let mut res = Vec::with_capacity((high - low) as usize);
+            log_cursor.seek(&lsn_to_key(low))?;
+            for record in log_cursor.into_iter() {
+                let (key, entry) = record?;
+                let index = parse_lsn(&key).expect("invalid LSN");
+                if index > high {
+                    break;
+                }
+
+                res.push(entry);
+            }
+
+            Ok(res)
+        })
+        .map_err(new_log_read_error)
+    }
+}
+
+impl RaftLogStorage<TypeConfig> for LogStore {
+    type LogReader = Self;
+
+    async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, RaftStorageError<NodeId>> {
+        self.with_read_tx(|tx| {
+            let last_purged_log_id = tx.get_last_purged_log_id()?;
+            let last_log = tx.last_raft_log()?.map(|(_, entry)| entry.log_id);
+
+            Ok(LogState { last_log_id: last_log, last_purged_log_id })
+        })
+        .map_err(new_log_read_error)
+    }
+
+    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), RaftStorageError<NodeId>> {
+        self.with_write_tx(|tx| tx.set_last_vote(vote)).map_err(new_log_write_error)
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, RaftStorageError<NodeId>> {
+        self.with_read_tx(|tx| tx.get_last_vote()).map_err(new_log_read_error)
+    }
+
+    async fn append<I>(
+        &mut self,
+        entries: I,
+        callback: LogFlushed<TypeConfig>,
+    ) -> Result<(), RaftStorageError<NodeId>>
+    where
+        I: IntoIterator<Item = Entry>,
+    {
+        self.with_write_tx(|tx| {
+            let entries = entries.into_iter().collect();
+            tx.append_log_entries(entries)
+        })
+        .map_err(new_log_write_error)?;
+
+        // Report success to the raft callback
+        callback.log_io_completed(Ok(()));
+        Ok(())
+    }
+
+    /// Truncate all logs after the given id (inclusive)
+    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), RaftStorageError<NodeId>> {
+        self.with_write_tx(|tx| tx.truncate_logs(log_id.index)).map_err(new_log_write_error)
+    }
+
+    /// Purge all logs before the given id (inclusive)
+    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), RaftStorageError<NodeId>> {
+        self.with_write_tx(|tx| tx.purge_logs(log_id.index)).map_err(new_log_write_error)
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+}

--- a/state/src/replicationv2/mod.rs
+++ b/state/src/replicationv2/mod.rs
@@ -1,0 +1,26 @@
+//! Defines replication primitives for the relayer state on top of a
+//! base raft implementation. Raft provides a consistent, distributed log
+//! with serializable access. We describe state transitions and persist these
+//! to the raft log
+
+pub mod error;
+mod log_store;
+
+use openraft::{EmptyNode, RaftTypeConfig};
+use std::io::Cursor;
+
+use crate::StateTransition;
+
+// Declare the types config for the raft
+openraft::declare_raft_types! (
+    /// The type config for the raft
+    pub TypeConfig:
+        D = StateTransition,
+        R = (), // Response
+        Node = EmptyNode,
+);
+
+/// A type alias for entries in the raft log
+pub type Entry = <TypeConfig as RaftTypeConfig>::Entry;
+/// A type alias for the node id type
+pub type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;

--- a/state/src/storage/tx/raft_log.rs
+++ b/state/src/storage/tx/raft_log.rs
@@ -3,12 +3,13 @@
 use std::cmp;
 
 use libmdbx::{TransactionKind, RW};
-use raft::eraftpb::{
-    ConfState, Entry as RaftEntry, HardState, Snapshot as RaftSnapshot, SnapshotMetadata,
-};
+use openraft::{LogId, Vote};
+use raft::eraftpb::{ConfState, HardState, Snapshot as RaftSnapshot, SnapshotMetadata};
+use util::res_some;
 
 use crate::{
     replication::error::ReplicationError,
+    replicationv2::{Entry, NodeId},
     storage::{cursor::DbCursor, error::StorageError, ProtoStorageWrapper},
 };
 
@@ -24,14 +25,26 @@ pub const RAFT_METADATA_TABLE: &str = "raft-metadata";
 pub const RAFT_LOGS_TABLE: &str = "raft-logs";
 
 /// The name of the raft hard state key in the KV store
+///
+/// TODO: Delete this
 pub const HARD_STATE_KEY: &str = "hard-state";
 /// The name of the raft conf state key in the KV store
+///
+/// TODO: Delete this
 pub const CONF_STATE_KEY: &str = "conf-state";
+/// The key for the last purged log
+pub const LAST_PURGED_LOG_KEY: &str = "last-purged-raft-log";
+/// The key for the local node's vote in the current term
+pub const LAST_VOTE_KEY: &str = "last-vote";
 /// The name of the snapshot metadata key in the KV store
+///
+/// TODO: Delete this
 pub const SNAPSHOT_METADATA_KEY: &str = "snapshot-metadata";
 
 /// The error message used when a log entry cannot be found
 const ERR_LOG_NOT_FOUND: &str = "Log entry not found";
+/// Error message when a last log cannot be found
+const ERR_NO_LAST_LOG: &str = "No last log found";
 
 // -----------
 // | Helpers |
@@ -47,22 +60,70 @@ pub fn lsn_to_key(lsn: u64) -> String {
     lsn.to_string()
 }
 
+/// The key type for the raft logs
+pub type LogKeyType = String;
+/// The value type for the raft logs
+pub type LogValueType = Entry;
+
 // -----------
 // | Getters |
 // -----------
 
 impl<'db, T: TransactionKind> StateTxn<'db, T> {
-    /// Read a log entry, returning an error if it does not exist
-    pub fn read_log_entry(&self, index: u64) -> Result<RaftEntry, StorageError> {
-        let entry: ProtoStorageWrapper<RaftEntry> = self
-            .inner()
-            .read(RAFT_LOGS_TABLE, &lsn_to_key(index))?
-            .ok_or_else(|| StorageError::NotFound(ERR_LOG_NOT_FOUND.to_string()))?;
+    // --- Logs Metadata --- //
 
-        Ok(entry.into_inner())
+    /// Get the ID of the last purged log
+    pub fn get_last_purged_log_id(&self) -> Result<Option<LogId<NodeId>>, StorageError> {
+        self.inner().read(RAFT_METADATA_TABLE, &LAST_PURGED_LOG_KEY.to_string())
+    }
+
+    /// Get the local node's vote in the current term
+    pub fn get_last_vote(&self) -> Result<Option<Vote<NodeId>>, StorageError> {
+        self.inner().read(RAFT_METADATA_TABLE, &LAST_VOTE_KEY.to_string())
+    }
+
+    // --- Log Access --- //
+
+    /// Get the first log index stored in the DB
+    pub fn first_raft_log_index(&self) -> Result<Option<u64>, StorageError> {
+        let first_kv = self.first_raft_log()?;
+        Ok(first_kv.map(|(k, _)| k))
+    }
+
+    /// Get the first log stored in the DB
+    pub fn first_raft_log(&self) -> Result<Option<(u64, LogValueType)>, StorageError> {
+        let mut cursor = self.logs_cursor()?;
+        let (k, v) = res_some!(cursor.get_current()?);
+        let parsed_key = parse_lsn(&k).map_err(|_| StorageError::InvalidKey(k))?;
+        Ok(Some((parsed_key, v)))
+    }
+
+    /// Get the last log index stored in the DB
+    pub fn last_raft_log_index(&self) -> Result<Option<u64>, StorageError> {
+        let last_kv = self.last_raft_log()?;
+        Ok(last_kv.map(|(k, _)| k))
+    }
+
+    /// Get the last log stored in the DB
+    pub fn last_raft_log(&self) -> Result<Option<(u64, LogValueType)>, StorageError> {
+        let mut cursor = self.logs_cursor()?;
+        cursor.seek_last()?;
+
+        let (k, v) = res_some!(cursor.get_current()?);
+        let parsed_key = parse_lsn(&k).map_err(|_| StorageError::InvalidKey(k))?;
+        Ok(Some((parsed_key, v)))
+    }
+
+    /// Read a log entry, returning an error if it does not exist
+    pub fn read_log_entry(&self, index: u64) -> Result<LogValueType, StorageError> {
+        self.inner()
+            .read(RAFT_LOGS_TABLE, &lsn_to_key(index))?
+            .ok_or_else(|| StorageError::NotFound(ERR_LOG_NOT_FOUND.to_string()))
     }
 
     /// Read the `ConfState` of the raft from storage
+    ///
+    /// TODO: Delete this
     pub fn read_conf_state(&self) -> Result<ConfState, StorageError> {
         let conf_state: ProtoStorageWrapper<ConfState> = self
             .inner()
@@ -74,6 +135,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// Read the `HardState` of the raft from storage
+    ///
+    /// TODO: Delete this
     pub fn read_hard_state(&self) -> Result<HardState, StorageError> {
         let hard_state: ProtoStorageWrapper<HardState> = self
             .inner()
@@ -84,6 +147,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// Read the snapshot metadata from storage
+    ///
+    /// TODO: Delete this
     pub fn read_snapshot_metadata(&self) -> Result<SnapshotMetadata, StorageError> {
         let stored_metadata: ProtoStorageWrapper<SnapshotMetadata> = self
             .inner()
@@ -94,10 +159,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// A helper to construct a cursor over the logs
-    pub fn logs_cursor(
-        &self,
-    ) -> Result<DbCursor<'_, T, String, ProtoStorageWrapper<RaftEntry>>, ReplicationError> {
-        self.inner().cursor(RAFT_LOGS_TABLE).map_err(ReplicationError::Storage)
+    pub fn logs_cursor(&self) -> Result<DbCursor<'_, T, LogKeyType, LogValueType>, StorageError> {
+        self.inner().cursor(RAFT_LOGS_TABLE)
     }
 }
 
@@ -106,32 +169,86 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
 // -----------
 
 impl<'db> StateTxn<'db, RW> {
+    // --- Log Metadata --- //
+
+    /// Set the ID of the last purged log
+    pub fn set_last_purged_log_id(&self, id: &LogId<NodeId>) -> Result<(), StorageError> {
+        self.inner().write(RAFT_METADATA_TABLE, &LAST_PURGED_LOG_KEY.to_string(), id)
+    }
+
+    /// Set the local node's vote in the current term
+    pub fn set_last_vote(&self, vote: &Vote<NodeId>) -> Result<(), StorageError> {
+        self.inner().write(RAFT_METADATA_TABLE, &LAST_VOTE_KEY.to_string(), vote)
+    }
+
+    // --- Log Access --- //
+
     /// Apply a config change to the log store
+    ///
+    /// TODO: Delete this
     pub fn apply_config_state(&self, change: ConfState) -> Result<(), StorageError> {
         let value = ProtoStorageWrapper(change);
         self.inner().write(RAFT_METADATA_TABLE, &CONF_STATE_KEY.to_string(), &value)
     }
 
     /// Apply a hard state to the log store
+    ///
+    /// TODO: Delete this
     pub fn apply_hard_state(&self, state: HardState) -> Result<(), StorageError> {
         let value = ProtoStorageWrapper(state);
         self.inner().write(RAFT_METADATA_TABLE, &HARD_STATE_KEY.to_string(), &value)
     }
 
     /// Append entries to the raft log
-    pub fn append_log_entries(&self, entries: Vec<RaftEntry>) -> Result<(), StorageError> {
+    pub fn append_log_entries(&self, entries: Vec<LogValueType>) -> Result<(), StorageError> {
         let tx = self.inner();
-        for entry in entries.into_iter() {
-            let key = lsn_to_key(entry.index);
-            let value = ProtoStorageWrapper(entry);
+        let first_idx = self.last_raft_log_index()?.map(|idx| idx + 1).unwrap_or(0);
+        for (i, entry) in entries.into_iter().enumerate() {
+            let idx = first_idx + i as u64;
+            let key = lsn_to_key(idx);
+            tx.write(RAFT_LOGS_TABLE, &key, &entry)?;
+        }
 
-            tx.write(RAFT_LOGS_TABLE, &key, &value)?;
+        Ok(())
+    }
+
+    /// Truncate logs in the DB, deleting those beyond the given index
+    /// (inclusive)
+    pub fn truncate_logs(&self, index: u64) -> Result<(), StorageError> {
+        // Fetch the upper bound
+        let idx_lsn = lsn_to_key(index);
+        let last_log = self
+            .last_raft_log_index()?
+            .ok_or(StorageError::NotFound(ERR_NO_LAST_LOG.to_string()))?;
+
+        // Delete the logs
+        let mut log_cursor = self.logs_cursor()?;
+        log_cursor.seek(&idx_lsn)?;
+        for _ in index..=last_log {
+            log_cursor.delete()?;
+        }
+
+        Ok(())
+    }
+
+    /// Purge all logs before the given index (inclusive)
+    pub fn purge_logs(&self, index: u64) -> Result<(), StorageError> {
+        let idx_lsn = lsn_to_key(index);
+        let first_log = self.first_raft_log_index()?.unwrap_or(0);
+
+        // Purge the logs
+        let mut log_cursor = self.logs_cursor()?;
+        log_cursor.seek(&idx_lsn)?;
+        for _ in first_log..=index {
+            log_cursor.delete()?;
         }
 
         Ok(())
     }
 
     /// Apply a snapshot to the log store
+    ///
+    /// TODO: Delete this
     pub fn apply_snapshot(&self, snapshot: &RaftSnapshot) -> Result<(), StorageError> {
         let tx = self.inner();
         let meta = snapshot.get_metadata();


### PR DESCRIPTION
### Purpose
This PR initializes the `replicationv2` module and implements the shim interface between the consensus engine and the log store (mdbx). Testing is deferred until the `openraft::StateMachine` implementation is in place; at which point we can use the `openraft` test suite.

Other CI may fail in the meantime, will clean this up at the end.

Some code is marked as to be deleted, after the consensus engine swap is complete.