### PR TITLE
common: types: token: rename USDC->USD for coinbase

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -156,7 +156,7 @@ pub static TICKER_NAMES: &[(
     (
         USDC_TICKER,
         ExchangeTicker::Same,
-        ExchangeTicker::Same,
+        ExchangeTicker::Renamed("USD"),
         ExchangeTicker::Same,
         ExchangeTicker::Same,
     ),


### PR DESCRIPTION
This PR renames USDC -> USD for Coinbase. This is not necessary for streaming prices, as the markets are directly aliased in the Advanced Trade API, but this is necessary for validating pairs, which uses a different Coinbase API. This API will, for example, 404 for the LDO-USDC market, but will have a success response for the LDO-USD market. So it's simpler to just always use USD.

Importantly, we don't set this as the default stable for Coinbase, since that incurs logic that assumes there is a USD-USDC market for price conversion, which there is not. A renaming is more apt.

This is working as expected in dev