### PR TITLE
state: replicationv2: state-machine: Implement state machine

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -54,7 +54,7 @@ pub struct StateApplicatorConfig {
 #[derive(Clone)]
 pub struct StateApplicator {
     /// The config for the applicator
-    config: StateApplicatorConfig,
+    pub(crate) config: StateApplicatorConfig,
 }
 
 impl StateApplicator {
@@ -107,7 +107,7 @@ impl StateApplicator {
 }
 
 #[cfg(test)]
-mod test_helpers {
+pub mod test_helpers {
     use std::{mem, str::FromStr, sync::Arc};
 
     use common::types::gossip::ClusterId;

--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -1,10 +1,10 @@
 //! Error types and conversions for the replication interface
-use openraft::{ErrorSubject, ErrorVerb, RaftTypeConfig, StorageError as RaftStorageError};
+use openraft::{ErrorSubject, ErrorVerb, LogId, RaftTypeConfig, StorageError as RaftStorageError};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-use crate::storage::error::StorageError;
+use crate::{applicator::error::StateApplicatorError, storage::error::StorageError};
 
-use super::TypeConfig;
+use super::{NodeId, TypeConfig};
 
 /// Convert a storage error reading logs into a raft error
 pub fn new_log_read_error(
@@ -20,4 +20,13 @@ pub fn new_log_write_error(
 ) -> RaftStorageError<<TypeConfig as RaftTypeConfig>::NodeId> {
     let io_err = IoError::new(IoErrorKind::Other, Box::new(err));
     RaftStorageError::from_io_error(ErrorSubject::Logs, ErrorVerb::Write, io_err)
+}
+
+/// Convert an error applying a log into a raft error
+pub fn new_apply_error(
+    log_id: LogId<NodeId>,
+    err: StateApplicatorError,
+) -> RaftStorageError<<TypeConfig as RaftTypeConfig>::NodeId> {
+    let io_err = IoError::new(IoErrorKind::Other, Box::new(err));
+    RaftStorageError::from_io_error(ErrorSubject::Apply(log_id), ErrorVerb::Write, io_err)
 }

--- a/state/src/replicationv2/log_store.rs
+++ b/state/src/replicationv2/log_store.rs
@@ -141,11 +141,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
     where
         I: IntoIterator<Item = Entry>,
     {
-        self.with_write_tx(|tx| {
-            let entries = entries.into_iter().collect();
-            tx.append_log_entries(entries)
-        })
-        .map_err(new_log_write_error)?;
+        self.with_write_tx(|tx| tx.append_log_entries(entries)).map_err(new_log_write_error)?;
 
         // Report success to the raft callback
         callback.log_io_completed(Ok(()));

--- a/state/src/replicationv2/state_machine.rs
+++ b/state/src/replicationv2/state_machine.rs
@@ -1,0 +1,96 @@
+//! Defines the state machine for the raft node, responsible for applying logs
+//! to the state
+
+use openraft::{
+    storage::RaftStateMachine, EntryPayload, LogId, OptionalSend, RaftSnapshotBuilder, Snapshot,
+    SnapshotMeta, StorageError as RaftStorageError, StoredMembership,
+};
+
+use crate::{applicator::StateApplicator, replicationv2::error::new_apply_error};
+
+use super::{Entry, Node, NodeId, SnapshotData, TypeConfig};
+
+/// The state machine for the raft node
+#[derive(Clone)]
+pub struct StateMachine {
+    /// The index of the last applied log
+    last_applied_log: Option<LogId<NodeId>>,
+    /// The last cluster membership config
+    last_membership: StoredMembership<NodeId, Node>,
+    /// The underlying applicator
+    applicator: StateApplicator,
+}
+
+impl StateMachine {
+    /// Constructor
+    pub fn new(applicator: StateApplicator) -> Self {
+        Self { last_applied_log: None, last_membership: Default::default(), applicator }
+    }
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for StateMachine {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, RaftStorageError<NodeId>> {
+        todo!("implement snapshotting")
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for StateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, Node>), RaftStorageError<NodeId>>
+    {
+        Ok((self.last_applied_log, self.last_membership.clone()))
+    }
+
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<()>, RaftStorageError<NodeId>>
+    where
+        I: IntoIterator<Item = Entry> + OptionalSend,
+        I::IntoIter: OptionalSend,
+    {
+        for entry in entries.into_iter() {
+            let log_id = entry.log_id;
+            self.last_applied_log = Some(log_id);
+            match entry.payload {
+                // Sent by a new leader to confirm its leadership
+                EntryPayload::Blank => {},
+                EntryPayload::Membership(membership) => {
+                    self.last_membership = StoredMembership::new(Some(log_id), membership);
+                },
+                EntryPayload::Normal(transition) => {
+                    self.applicator
+                        .handle_state_transition(transition)
+                        .map_err(|err| new_apply_error(log_id, err))?;
+                },
+            }
+        }
+
+        Ok(vec![])
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> Result<Box<SnapshotData>, RaftStorageError<NodeId>> {
+        todo!("implement snapshotting")
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        _meta: &SnapshotMeta<NodeId, Node>,
+        _snapshot: Box<SnapshotData>,
+    ) -> Result<(), RaftStorageError<NodeId>> {
+        todo!("implement snapshotting")
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<TypeConfig>>, RaftStorageError<NodeId>> {
+        // TODO: Implement snapshotting
+        Ok(None)
+    }
+}

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -4,6 +4,7 @@ use std::{error::Error, fmt::Display};
 
 use bincode::Error as BincodeError;
 use libmdbx::Error as MdbxError;
+/// TODO: remove the above and rename to RaftStorageError
 use raft::{Error as RaftError, StorageError as RaftStorageError};
 
 /// The error type emitted by the storage layer

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     TASK_HISTORY_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
 };
 
-use self::raft_log::RAFT_METADATA_TABLE;
+use self::raft_log::{RAFT_LOGS_TABLE, RAFT_METADATA_TABLE};
 
 use super::{
     cursor::DbCursor,
@@ -107,6 +107,7 @@ impl<'db> StateTxn<'db, RW> {
             MPC_PREPROCESSING_TABLE,
             NODE_METADATA_TABLE,
             RAFT_METADATA_TABLE,
+            RAFT_LOGS_TABLE,
         ]
         .iter()
         {


### PR DESCRIPTION
### Purpose
This PR implements the `RaftStateMachine` trait for the new consensus engine. Additionally this PR fixes a few bugs with storage that were discovered while integrating.

Not all tests pass, snapshotting needs to be implemented before the `openraft` suite passes

### Testing
- Non-state tests pass