### PR TITLE
state: replicationv2: snapshot: Implement table exclusion for snapshots

### DIFF
--- a/state/src/replicationv2/snapshot.rs
+++ b/state/src/replicationv2/snapshot.rs
@@ -8,6 +8,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use util::err_str;
 
+use crate::storage::db::DbConfig;
 use crate::storage::{db::DB, tx::raft_log::RAFT_LOGS_TABLE};
 use crate::{CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, PEER_INFO_TABLE};
 
@@ -25,7 +26,7 @@ const EXCLUDED_TABLES: &[&str] =
     &[RAFT_LOGS_TABLE, PEER_INFO_TABLE, CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE];
 
 /// An error awaiting a blocking zip task
-const ERR_AWAIT_ZIP: &str = "error awaiting zip task";
+const ERR_AWAIT_BUILD: &str = "error awaiting build task";
 
 /// Take a snapshot of the DB
 pub(crate) async fn take_db_snapshot(out_dir: &str, db: &DB) -> Result<(), ReplicationV2Error> {
@@ -34,11 +35,9 @@ pub(crate) async fn take_db_snapshot(out_dir: &str, db: &DB) -> Result<(), Repli
     let snapshot_path = make_data_copy(db.path(), out_dir).await?;
     tx.commit().map_err(ReplicationV2Error::Storage)?;
 
-    // TODO: Remove unneeded tables
-
-    // Zip the snapshot
-    let zip_task = tokio::task::spawn_blocking(move || zip_file(&snapshot_path));
-    zip_task.await.map_err(|_| ReplicationV2Error::Snapshot(ERR_AWAIT_ZIP.to_string()))?
+    // Build the snapshot
+    let build_task = tokio::task::spawn_blocking(move || build_snapshot(&snapshot_path));
+    build_task.await.map_err(|_| ReplicationV2Error::Snapshot(ERR_AWAIT_BUILD.to_string()))?
 }
 
 /// Copy the data file of the DB
@@ -54,6 +53,31 @@ async fn make_data_copy(path: &str, out_dir: &str) -> Result<PathBuf, Replicatio
         .await
         .map_err(err_str!(ReplicationV2Error::Snapshot))?;
     Ok(snapshot_path)
+}
+
+/// Build the snapshot from a copy of the data file
+///
+/// This involves removing excluded tables and zipping the data file
+fn build_snapshot(copy_path: &PathBuf) -> Result<(), ReplicationV2Error> {
+    remove_excluded_tables(copy_path.to_str().unwrap())?;
+    zip_file(copy_path)
+}
+
+/// Removes excluded tables from the snapshot
+///
+/// These tables are those that need not show up in a snapshot, or for which it
+/// would cause errors to snapshot on the consumer side
+fn remove_excluded_tables(copy_path: &str) -> Result<(), ReplicationV2Error> {
+    let path_str = copy_path.to_string();
+    let db_config = DbConfig { path: path_str };
+    let snapshot_db = DB::new(&db_config).map_err(ReplicationV2Error::Storage)?;
+
+    for table in EXCLUDED_TABLES {
+        #[allow(unsafe_code)]
+        unsafe { snapshot_db.drop_table(table) }.map_err(ReplicationV2Error::Storage)?;
+    }
+
+    Ok(())
 }
 
 /// Zip a file and delete the original
@@ -79,8 +103,9 @@ mod tests {
     use std::env::temp_dir;
 
     use flate2::bufread::GzDecoder;
+    use libmdbx::Error as MdbxError;
 
-    use crate::{storage::db::DbConfig, test_helpers::tmp_db_path};
+    use crate::{storage::error::StorageError, test_helpers::tmp_db_path};
 
     use super::*;
 
@@ -127,5 +152,69 @@ mod tests {
         let value: String = new_db.read(TABLE, &k).unwrap().unwrap();
 
         assert_eq!(value, v);
+    }
+
+    /// Tests taking a snapshot with a key in an excluded table
+    #[tokio::test]
+    async fn test_snapshot_excluded_table() {
+        const DUMMY_TABLE: &str = "dummy-table";
+        const EXCLUDED_TABLE: &str = EXCLUDED_TABLES[0];
+        let (k1, v1) = ("key1".to_string(), "value1".to_string());
+        let (k2, v2) = ("key2".to_string(), "value2".to_string());
+
+        let db_path = tmp_db_path();
+        let snap_path = db_path.clone();
+
+        // Create a DB and write to it
+        let db = DB::new(&DbConfig { path: db_path }).unwrap();
+        db.create_table(DUMMY_TABLE).unwrap();
+        db.create_table(EXCLUDED_TABLE).unwrap();
+        db.write(DUMMY_TABLE, &k1, &v1).unwrap();
+        db.write(EXCLUDED_TABLE, &k2, &v2).unwrap();
+
+        // Take a snapshot then recover from it
+        take_db_snapshot(&snap_path, &db).await.unwrap();
+        let new_data_file = recover_data_from_snapshot(&snap_path).await;
+
+        // Check that the original table still contains the excluded value
+        let value: String = db.read(EXCLUDED_TABLE, &k2).unwrap().unwrap();
+        assert_eq!(value, v2);
+
+        // Check that the recovered DB contains the same data minus the excluded table
+        let new_db = DB::new(&DbConfig { path: new_data_file }).unwrap();
+        let value1: String = new_db.read(DUMMY_TABLE, &k1).unwrap().unwrap();
+        let v2_err: StorageError = new_db.read::<_, String>(EXCLUDED_TABLE, &k2).err().unwrap();
+
+        assert_eq!(value1, v1);
+        assert!(matches!(v2_err, StorageError::OpenTable(MdbxError::NotFound)));
+    }
+
+    /// Test taking multiple snapshots after successive updates, ensuring that
+    /// snapshots overwrite one another
+    #[tokio::test]
+    async fn test_snapshot_overwrite() {
+        const TABLE: &str = "test-table";
+        let db_path = tmp_db_path();
+        let snap_path = db_path.clone();
+
+        let (k, v1) = ("key".to_string(), "value".to_string());
+        let v2 = "value2".to_string();
+
+        // Create a DB and write to it
+        let db = DB::new(&DbConfig { path: db_path }).unwrap();
+        db.create_table(TABLE).unwrap();
+        db.write(TABLE, &k, &v1).unwrap();
+
+        // Take a snapshot, write the value, then take another snapshot
+        take_db_snapshot(&snap_path, &db).await.unwrap();
+        db.write(TABLE, &k, &v2).unwrap();
+        take_db_snapshot(&snap_path, &db).await.unwrap();
+
+        // Recover the DB and verify that only the second value remains
+        let new_data_file = recover_data_from_snapshot(&snap_path).await;
+        let new_db = DB::new(&DbConfig { path: new_data_file }).unwrap();
+        let value: String = new_db.read(TABLE, &k).unwrap().unwrap();
+
+        assert_eq!(value, v2);
     }
 }

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -87,6 +87,21 @@ impl DB {
         tx.commit()
     }
 
+    /// Drop a table from the database
+    ///
+    /// # Safety
+    ///
+    /// This method is marked unsafe as it permanently deletes a table from the
+    /// database, care should be taken by the caller to ensure this operation is
+    /// not taken erroneously
+    #[allow(unsafe_code)]
+    pub unsafe fn drop_table(&self, table_name: &str) -> Result<(), StorageError> {
+        let tx = self.new_raw_write_tx()?;
+        tx.drop_table(table_name)?;
+
+        tx.commit()
+    }
+
     /// Get a key from the database
     pub fn read<K: Key, V: Value>(
         &self,

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -18,7 +18,9 @@ pub mod wallet_index;
 
 use std::collections::VecDeque;
 
-use libmdbx::{Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW};
+use libmdbx::{
+    Error as MdbxError, Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW,
+};
 
 use crate::{
     CLUSTER_MEMBERSHIP_TABLE, MPC_PREPROCESSING_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE,
@@ -302,6 +304,25 @@ impl<'db> DbTxn<'db, RW> {
             .create_table(Some(table_name), TableFlags::default())
             .map_err(StorageError::TxOp)
             .map(|_| ())
+    }
+
+    /// Drop a table from the database
+    ///
+    /// # Safety
+    ///
+    /// This method is marked unsafe as it permanently deletes a table from the
+    /// database, care should be taken by the caller to ensure this operation
+    /// is not taken erroneously
+    #[allow(unsafe_code)]
+    pub unsafe fn drop_table(&self, table_name: &str) -> Result<(), StorageError> {
+        let table = self.open_table(table_name);
+        let table = match table {
+            Ok(t) => t,
+            Err(StorageError::OpenTable(MdbxError::NotFound)) => return Ok(()),
+            Err(e) => return Err(e),
+        };
+
+        self.txn.drop_table(table).map_err(StorageError::TxOp)
     }
 
     /// Set a key in the database


### PR DESCRIPTION
### Purpose
This PR adds support for excluding tables from the snapshot. We will use this to exclude raft logs, peer index, local node metadata, and any other tables that don't need to be snapshotted as we decide.

### Testing
- Tested snapshotting with excluded tables
- Tested snapshot overwriting
- Unit tests pass

