### PR TITLE
workers: task-driver: tasks: update_wallet: check reblind progression

### DIFF
--- a/common/src/types/tasks/descriptors.rs
+++ b/common/src/types/tasks/descriptors.rs
@@ -434,7 +434,7 @@ impl UpdateWalletTaskDescriptor {
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
     ) -> Result<Self, String> {
-        // Check that the new wallet is properly reblinded
+        // Check that the new wallet's shares are well formed
         if !new_wallet.check_wallet_shares() {
             return Err(INVALID_WALLET_SHARES.to_string());
         }


### PR DESCRIPTION
This PR adds a check in the creation of an `UpdateWalletTask` which ensures that the new wallet is "one reblind on top of" the old wallet. It also tweaks the error handling of spawning tasks to notify listeners if creating a task fails (not just running it).

I tested this by running a local relayer and asserting that a valid deposit passes this check, and that a doubly-reblinded deposit does not.