### PR TITLE
state: replicationv2: snapshot: Apply snapshot to state machine

### DIFF
--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -138,7 +138,8 @@ impl State {
         translation_map: SharedPeerIdTranslationMap,
     ) -> Result<(Self, ReplicationNodeWorker<N>, Sender<()>), StateError> {
         // Open up the DB
-        let db = DB::new(&DbConfig { path: config.db_path.clone() }).map_err(StateError::Db)?;
+        let db_config = DbConfig::new_with_path(&config.db_path);
+        let db = DB::new(&db_config).map_err(StateError::Db)?;
         let db = Arc::new(db);
 
         // Setup the tables in the DB

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -40,6 +40,9 @@ pub use interface::*;
 // | Constants |
 // -------------
 
+/// The number of tables to open in the database
+const NUM_TABLES: usize = 14;
+
 /// The name of the db table that stores node metadata
 pub(crate) const NODE_METADATA_TABLE: &str = "node-metadata";
 
@@ -69,6 +72,28 @@ pub(crate) const TASK_HISTORY_TABLE: &str = "task-history";
 
 /// The name of the db table that stores the offline phase values
 pub(crate) const MPC_PREPROCESSING_TABLE: &str = "mpc-preprocessing";
+
+/// The name of the raft metadata table in the database
+pub const RAFT_METADATA_TABLE: &str = "raft-metadata";
+/// The name of the raft logs table in the database
+pub const RAFT_LOGS_TABLE: &str = "raft-logs";
+/// All tables in the database
+pub const ALL_TABLES: [&str; NUM_TABLES] = [
+    NODE_METADATA_TABLE,
+    PEER_INFO_TABLE,
+    CLUSTER_MEMBERSHIP_TABLE,
+    PRIORITIES_TABLE,
+    ORDERS_TABLE,
+    ORDER_HISTORY_TABLE,
+    ORDER_TO_WALLET_TABLE,
+    WALLETS_TABLE,
+    TASK_QUEUE_TABLE,
+    TASK_TO_KEY_TABLE,
+    TASK_HISTORY_TABLE,
+    MPC_PREPROCESSING_TABLE,
+    RAFT_METADATA_TABLE,
+    RAFT_LOGS_TABLE,
+];
 
 /// The `Proposal` type wraps a state transition and the channel on which to
 /// send the result of the proposal's application
@@ -189,7 +214,8 @@ pub mod test_helpers {
     pub fn mock_db() -> DB {
         // Open the DB
         let path = tmp_db_path();
-        let config = DbConfig { path: path.to_string() };
+        // Allocate a DB with more tables than needed
+        let config = DbConfig { path: path.to_string(), num_tables: 100 };
 
         let db = DB::new(&config).unwrap();
 

--- a/state/src/replication/log_store.rs
+++ b/state/src/replication/log_store.rs
@@ -2,20 +2,17 @@
 //! snapshots, metadata, etc in the storage layer -- concretely an embedded KV
 //! store
 
-use std::{cmp::Ordering, sync::Arc};
+use std::sync::Arc;
 
-use protobuf::Message;
 use raft::{
     eraftpb::{ConfState, HardState},
     prelude::{Entry as RaftEntry, Snapshot as RaftSnapshot},
     Error as RaftError, GetEntriesContext, RaftState, Result as RaftResult, Storage,
-    StorageError as RaftStorageError,
 };
 
-use crate::storage::{
-    db::DB,
-    error::StorageError,
-    tx::raft_log::{lsn_to_key, parse_lsn, RAFT_LOGS_TABLE, RAFT_METADATA_TABLE},
+use crate::{
+    storage::{db::DB, tx::raft_log::parse_lsn},
+    RAFT_LOGS_TABLE, RAFT_METADATA_TABLE,
 };
 
 use super::error::ReplicationError;

--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -64,3 +64,9 @@ impl Display for ReplicationV2Error {
     }
 }
 impl Error for ReplicationV2Error {}
+
+impl From<StorageError> for ReplicationV2Error {
+    fn from(value: StorageError) -> Self {
+        ReplicationV2Error::Storage(value)
+    }
+}

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -22,13 +22,7 @@ use libmdbx::{
     Error as MdbxError, Table, TableFlags, Transaction, TransactionKind, WriteFlags, WriteMap, RW,
 };
 
-use crate::{
-    CLUSTER_MEMBERSHIP_TABLE, MPC_PREPROCESSING_TABLE, NODE_METADATA_TABLE, ORDERS_TABLE,
-    ORDER_HISTORY_TABLE, ORDER_TO_WALLET_TABLE, PEER_INFO_TABLE, PRIORITIES_TABLE,
-    TASK_HISTORY_TABLE, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE, WALLETS_TABLE,
-};
-
-use self::raft_log::{RAFT_LOGS_TABLE, RAFT_METADATA_TABLE};
+use crate::ALL_TABLES;
 
 use super::{
     cursor::DbCursor,
@@ -93,26 +87,21 @@ impl<'db> StateTxn<'db, RW> {
         self.inner.create_table(table_name)
     }
 
+    /// Drop a table in the database
+    ///
+    /// # Safety
+    ///
+    /// This method is marked unsafe as it permanently deletes a table from the
+    /// database, care should be taken by the caller to ensure this operation
+    /// is not taken erroneously
+    #[allow(unsafe_code)]
+    pub unsafe fn drop_table(&self, table_name: &str) -> Result<(), StorageError> {
+        self.inner().drop_table(table_name)
+    }
+
     /// Create the tables used by the state interface
     pub fn setup_tables(&self) -> Result<(), StorageError> {
-        for table in [
-            PEER_INFO_TABLE,
-            CLUSTER_MEMBERSHIP_TABLE,
-            PRIORITIES_TABLE,
-            ORDERS_TABLE,
-            ORDER_HISTORY_TABLE,
-            ORDER_TO_WALLET_TABLE,
-            WALLETS_TABLE,
-            TASK_QUEUE_TABLE,
-            TASK_TO_KEY_TABLE,
-            TASK_HISTORY_TABLE,
-            MPC_PREPROCESSING_TABLE,
-            NODE_METADATA_TABLE,
-            RAFT_METADATA_TABLE,
-            RAFT_LOGS_TABLE,
-        ]
-        .iter()
-        {
+        for table in ALL_TABLES.iter() {
             self.create_table(table)?;
         }
 
@@ -344,6 +333,20 @@ impl<'db> DbTxn<'db, RW> {
         // Delete the value
         let table = self.open_table(table_name)?;
         self.txn.del(&table, key_bytes, None /* data */).map_err(StorageError::TxOp)
+    }
+
+    /// Copy the contents of a cursor into a table
+    pub fn copy_cursor_to_table<T: TransactionKind>(
+        &self,
+        table_name: &str,
+        cursor: DbCursor<'_, T, CowBuffer, CowBuffer>,
+    ) -> Result<(), StorageError> {
+        for record in cursor.into_iter() {
+            let (k, v) = record?;
+            self.write(table_name, &k, &v)?;
+        }
+
+        Ok(())
     }
 
     // -----------


### PR DESCRIPTION
### Purpose
This PR implements the logic to update a `StateMachine` from a snapshot that has finished being received. We do so by opening a cursor on each table and copying out of the cursor exhaustively.

I also restructured some of how DB tables are allocated to make the table index more explicit and centrally defined. 

### Testing
- Tested DB copy operation and snapshot application
- Unit tests pass generally
- Deferring passing the `openraft` suite to a follow-up