### PR TITLE
state: replicationv2: raft: Add `RaftClient` initial interface

### DIFF
--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -49,6 +49,10 @@ pub fn new_snapshot_error(
 /// TODO: Rename
 #[derive(Debug)]
 pub enum ReplicationV2Error {
+    /// An error proposing a state transition
+    Proposal(String),
+    /// An error setting up a raft
+    RaftSetup(String),
     /// An error occurred while snapshotting
     Snapshot(String),
     /// An error in storage
@@ -58,6 +62,8 @@ pub enum ReplicationV2Error {
 impl Display for ReplicationV2Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            ReplicationV2Error::Proposal(e) => write!(f, "Proposal error: {e}"),
+            ReplicationV2Error::RaftSetup(e) => write!(f, "Raft setup error: {e}"),
             ReplicationV2Error::Snapshot(e) => write!(f, "Snapshot error: {e}"),
             ReplicationV2Error::Storage(e) => write!(f, "Storage error: {e}"),
         }

--- a/state/src/replicationv2/network/mod.rs
+++ b/state/src/replicationv2/network/mod.rs
@@ -4,18 +4,25 @@ mod address_translation;
 #[cfg(test)]
 pub mod mock;
 
+use std::{fmt::Display, marker::PhantomData};
+
 use openraft::{
-    error::{InstallSnapshotError, RPCError, RaftError},
+    add_async_trait,
+    error::{InstallSnapshotError, RPCError, RaftError, RemoteError},
     network::RPCOption,
     raft::{
         AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest,
         InstallSnapshotResponse, VoteRequest, VoteResponse,
     },
-    RaftNetwork, RaftNetworkFactory,
+    RaftNetwork, RaftNetworkFactory, RaftTypeConfig,
 };
 use serde::{Deserialize, Serialize};
 
 use super::{Node, NodeId, TypeConfig};
+
+// ---------
+// | Types |
+// ---------
 
 /// The request type a raft node may send to another
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,7 +41,7 @@ pub enum RaftResponse {
     /// A response to an append entries request
     AppendEntries(AppendEntriesResponse<NodeId>),
     /// A response to an install snapshot request
-    InstallSnapshot(InstallSnapshotResponse<NodeId>),
+    InstallSnapshot(Result<InstallSnapshotResponse<NodeId>, InstallSnapshotError>),
     /// A response to a vote request
     Vote(VoteResponse<NodeId>),
 }
@@ -49,7 +56,9 @@ impl RaftResponse {
     }
 
     /// Convert the response to an install snapshot request
-    pub fn into_install_snapshot(self) -> InstallSnapshotResponse<NodeId> {
+    pub fn into_install_snapshot(
+        self,
+    ) -> Result<InstallSnapshotResponse<NodeId>, InstallSnapshotError> {
         match self {
             RaftResponse::InstallSnapshot(resp) => resp,
             _ => panic!("Expected InstallSnapshot response, got {:?}", self),
@@ -62,6 +71,111 @@ impl RaftResponse {
             RaftResponse::Vote(resp) => resp,
             _ => panic!("Expected Vote response, got {:?}", self),
         }
+    }
+}
+
+// -----------------------------
+// | Networking Implementation |
+// -----------------------------
+
+/// A generalization of the raft network trait that specifically allows for
+/// point-to-point communication
+///
+/// We implement the general raft network trait for all types that fit this
+/// signature by simply calling out to the p2p implementation
+#[add_async_trait]
+pub trait P2PRaftNetwork: 'static + Sync + Send {
+    /// The target this client is sending requests to
+    fn target(&self) -> NodeId;
+    /// Send an request to the target node
+    async fn send_request(
+        &mut self,
+        target: NodeId,
+        request: RaftRequest,
+    ) -> Result<RaftResponse, RPCError<NodeId, Node, RaftError<NodeId>>>;
+}
+
+/// A wrapper around the p2p raft network that allows for a default
+/// `RaftNetwork` implementation
+#[derive(Clone)]
+pub struct P2PRaftNetworkWrapper<T: P2PRaftNetwork> {
+    /// The inner p2p network
+    inner: T,
+}
+
+impl<T: P2PRaftNetwork> P2PRaftNetworkWrapper<T> {
+    /// Create a new wrapper around the p2p network
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Get the inner p2p network
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner p2p network
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: P2PRaftNetwork> RaftNetwork<TypeConfig> for P2PRaftNetworkWrapper<T> {
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
+        let target = self.inner().target();
+        let req = RaftRequest::AppendEntries(rpc);
+        self.inner.send_request(target, req).await.map(|resp| resp.into_append_entries())
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<NodeId>,
+        RPCError<NodeId, Node, RaftError<NodeId, InstallSnapshotError>>,
+    > {
+        let target = self.inner().target();
+        let req = RaftRequest::InstallSnapshot(rpc);
+        let res =
+            self.inner.send_request(target, req).await.map(|resp| resp.into_install_snapshot());
+
+        // Map the error to have the correct remote error type
+        // We do this because the remote error type can only be reported by the remote
+        // peer. Other error types are determined locally by the RPC handler
+        if res.is_err() {
+            let mapped_err = match res.err().unwrap() {
+                RPCError::Network(e) => RPCError::Network(e),
+                RPCError::PayloadTooLarge(e) => RPCError::PayloadTooLarge(e),
+                RPCError::Timeout(e) => RPCError::Timeout(e),
+                RPCError::Unreachable(e) => RPCError::Unreachable(e),
+                _ => unreachable!("remote errors sent in response"),
+            };
+
+            return Err(mapped_err);
+        };
+
+        match res.unwrap() {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                let err = RaftError::APIError(e);
+                Err(RPCError::RemoteError(RemoteError::new(target, err)))
+            },
+        }
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
+        let target = self.inner().target();
+        let req = RaftRequest::Vote(rpc);
+        self.inner.send_request(target, req).await.map(|resp| resp.into_vote())
     }
 }
 

--- a/state/src/replicationv2/raft.rs
+++ b/state/src/replicationv2/raft.rs
@@ -1,0 +1,127 @@
+//! Wraps the inner raft in a client interface that handles requests and waiters
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use openraft::{Config as RaftConfig, RaftNetworkFactory};
+use util::err_str;
+
+use crate::{
+    applicator::{StateApplicator, StateApplicatorConfig},
+    storage::db::DB,
+    StateTransition,
+};
+
+use super::{
+    error::ReplicationV2Error,
+    log_store::LogStore,
+    network::{P2PRaftNetwork, P2PRaftNetworkWrapper},
+    state_machine::{StateMachine, StateMachineConfig},
+    NodeId, Raft, TypeConfig,
+};
+
+/// The default cluster name
+const DEFAULT_CLUSTER_NAME: &str = "relayer-raft-cluster";
+/// The default heartbeat interval for the raft client
+const DEFAULT_HEARTBEAT_INTERVAL: u64 = 1000; // 1 second
+/// The default election timeout min
+const DEFAULT_ELECTION_TIMEOUT_MIN: u64 = 10000; // 10 seconds
+/// The default election timeout max
+const DEFAULT_ELECTION_TIMEOUT_MAX: u64 = 15000; // 15 seconds
+
+/// The config for the raft client
+#[derive(Clone)]
+pub struct RaftClientConfig {
+    /// The id of the local node
+    pub id: NodeId,
+    /// The name of the cluster
+    pub cluster_name: String,
+    /// The interval in milliseconds between heartbeats
+    pub heartbeat_interval: u64,
+    /// The minimum election timeout in milliseconds
+    pub election_timeout_min: u64,
+    /// The maximum election timeout in milliseconds
+    pub election_timeout_max: u64,
+    /// The nodes to initialize the membership with
+    pub initial_nodes: Vec<NodeId>,
+}
+
+impl Default for RaftClientConfig {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            cluster_name: DEFAULT_CLUSTER_NAME.to_string(),
+            heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL,
+            election_timeout_min: DEFAULT_ELECTION_TIMEOUT_MIN,
+            election_timeout_max: DEFAULT_ELECTION_TIMEOUT_MAX,
+            initial_nodes: vec![],
+        }
+    }
+}
+
+/// A client interface to the raft
+#[derive(Clone)]
+pub struct RaftClient<N: RaftNetworkFactory<TypeConfig>> {
+    /// The inner raft
+    raft: Raft,
+    /// The network to use for the raft client
+    net: N,
+}
+
+impl<N: RaftNetworkFactory<TypeConfig> + Clone> RaftClient<N> {
+    /// Create a new raft client
+    pub async fn new(
+        config: RaftClientConfig,
+        db: Arc<DB>,
+        net: N,
+        applicator: StateApplicator,
+    ) -> Result<Self, ReplicationV2Error> {
+        let raft_config = Arc::new(RaftConfig {
+            cluster_name: config.cluster_name,
+            heartbeat_interval: config.heartbeat_interval,
+            election_timeout_min: config.election_timeout_min,
+            election_timeout_max: config.election_timeout_max,
+            ..Default::default()
+        });
+
+        // Create the raft
+        let sm_config = StateMachineConfig::new(db.path().to_string());
+        let sm = StateMachine::new(sm_config, applicator);
+        let log_store = LogStore::new(db.clone());
+        let raft = Raft::new(config.id, raft_config, net.clone(), log_store, sm)
+            .await
+            .map_err(err_str!(ReplicationV2Error::RaftSetup))?;
+
+        // Initialize the raft
+        let mut initial_nodes = config.initial_nodes;
+        if !initial_nodes.contains(&config.id) {
+            initial_nodes.push(config.id);
+        }
+
+        let members = initial_nodes.iter().copied().collect::<BTreeSet<_>>();
+        raft.initialize(members).await.map_err(err_str!(ReplicationV2Error::RaftSetup))?;
+
+        Ok(Self { raft, net })
+    }
+
+    /// Get the inner raft
+    pub fn raft(&self) -> &Raft {
+        &self.raft
+    }
+
+    /// Get the current leader
+    pub async fn leader(&self) -> Option<NodeId> {
+        self.raft.current_leader().await
+    }
+
+    /// Propose an update to the raft
+    pub async fn propose_transition(
+        &self,
+        update: StateTransition,
+    ) -> Result<(), ReplicationV2Error> {
+        self.raft
+            .client_write(Box::new(update))
+            .await
+            .map_err(err_str!(ReplicationV2Error::Proposal))
+            .map(|_| ())
+    }
+}


### PR DESCRIPTION
### Purpose
This PR sets up the raft client interface that the high level state will interact with. This interface will handle a number of tasks beyond what the raft exposes directly, namely:
- Forwarding proposals to the leader
- Returning handles so that clients can fire and forget, then later await a proposal
- Learner promotion

### Testing
- Updated the mock network to use the `RaftClient` and the tests to go through the client