### PR TITLE
workers: proof-manager: worker: increase stack size & frontload circuit preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6151,6 +6151,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ serde = { version = "=1.0.197" }
 serde_json = "1.0.64"
 tracing = "0.1"
 metrics = "=0.22.3"
+lazy_static = "1.4"
 
 [patch.crates-io]
 # We patch `ahash` here since version mismatches w/ the contracts code have

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -46,7 +46,7 @@ postcard = { version = "1", features = ["alloc"] }
 
 # === Misc === #
 itertools = "0.12"
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 tracing = { workspace = true }
 
 # === Contracts Repo Dependencies === #

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -35,7 +35,7 @@ renegade-crypto = { path = "../renegade-crypto" }
 # === Misc === #
 byteorder = "1.5"
 itertools = "0.10"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"
 

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -92,7 +92,7 @@ tracing-subscriber = { version = "0.3", features = [
 ], optional = true }
 futures = { workspace = true }
 itertools = "0.10"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 rand = { version = "0.8" }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -52,7 +52,7 @@ bimap = "0.6.2"
 derivative = "2.2"
 indexmap = { workspace = true }
 itertools = "0.10"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 rand = { workspace = true, optional = true }
 renegade-dealer-api = { git = "https://github.com/renegade-fi/renegade-dealer.git" }
 serde = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,7 +36,7 @@ util = { path = "../util" }
 # === Misc Dependencies === #
 clap = { version = "3.2.8", features = ["derive"] }
 ethers = { workspace = true }
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 tracing = { workspace = true }
 opentelemetry = { version = "0.21", default-features = false, features = [
     "trace",

--- a/renegade-crypto/Cargo.toml
+++ b/renegade-crypto/Cargo.toml
@@ -40,7 +40,7 @@ constants = { path = "../constants", default-features = false }
 
 # === Misc Dependencies === #
 itertools = "0.10"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 rand = { version = "0.8", optional = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -40,7 +40,7 @@ test-helpers = { path = "../test-helpers", optional = true }
 crossterm = "0.27"
 itertools = "0.10"
 fxhash = "0.2"
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 libp2p = { workspace = true }
 rand = "0.8"
 serde_json = "1.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -54,4 +54,4 @@ metrics-exporter-statsd = "0.7"
 metrics-tracing-context = "0.15"
 
 [dev-dependencies]
-lazy_static = "1.4"
+lazy_static = { workspace = true }

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -21,5 +21,5 @@ job-types = { path = "../job-types" }
 state = { path = "../../state" }
 
 # === Misc Dependencies === #
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 tracing = { workspace = true }

--- a/workers/handshake-manager-tests/Cargo.toml
+++ b/workers/handshake-manager-tests/Cargo.toml
@@ -33,7 +33,7 @@ util = { path = "../../util" }
 ark-mpc = { workspace = true }
 base64 = "0.13"
 ethers = { workspace = true }
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 tracing = { workspace = true }
 num-bigint = "0.4"
 rand = { workspace = true }

--- a/workers/handshake-manager/Cargo.toml
+++ b/workers/handshake-manager/Cargo.toml
@@ -33,7 +33,7 @@ renegade-metrics = { path = "../../renegade-metrics" }
 # === Misc Dependencies === #
 ark-serialize = "0.4"
 itertools = "0.11"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 lru = "0.11"
 portpicker = "0.1"
 rand = { workspace = true }
@@ -47,7 +47,7 @@ colored = "2"
 eyre = { workspace = true }
 inventory = "0.3"
 
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 num-traits = "0.2"
 
 rand = { workspace = true }

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -24,4 +24,4 @@ tokio = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
-lazy_static = "1.4"
+lazy_static = { workspace = true }

--- a/workers/price-reporter/Cargo.toml
+++ b/workers/price-reporter/Cargo.toml
@@ -36,7 +36,7 @@ bimap = { version = "0.6.2", optional = true }
 create2 = "0.0.2"
 hex = "0.3.1"
 itertools = "0.11"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 statrs = "0.16"

--- a/workers/proof-manager/Cargo.toml
+++ b/workers/proof-manager/Cargo.toml
@@ -22,6 +22,7 @@ circuit-types = { path = "../../circuit-types", optional = true }
 common = { path = "../../common" }
 constants = { path = "../../constants" }
 job-types = { path = "../job-types" }
+util = { path = "../../util" }
 
 # === Misc Dependencies === #
 serde = { workspace = true }

--- a/workers/proof-manager/src/worker.rs
+++ b/workers/proof-manager/src/worker.rs
@@ -40,8 +40,6 @@ impl Worker for ProofManager {
     where
         Self: Sized,
     {
-        // TODO: Initialize pkeys/vkeys for all circuits
-
         // Build a thread pool for the worker
         let proof_generation_thread_pool = ThreadPoolBuilder::new()
             .thread_name(|i| format!("{}-{}", WORKER_THREAD_PREFIX, i))

--- a/workers/proof-manager/src/worker.rs
+++ b/workers/proof-manager/src/worker.rs
@@ -17,6 +17,10 @@ use super::{
 
 /// The name of the main worker thread
 const MAIN_THREAD_NAME: &str = "proof-generation-main";
+/// The name prefix for worker threads
+const WORKER_THREAD_PREFIX: &str = "proof-generation-worker";
+/// The stack size for worker threads
+const WORKER_STACK_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
 /// The configuration of the manager, used to hold work queues and tunables
 #[derive(Clone, Debug)]
@@ -36,8 +40,12 @@ impl Worker for ProofManager {
     where
         Self: Sized,
     {
+        // TODO: Initialize pkeys/vkeys for all circuits
+
         // Build a thread pool for the worker
         let proof_generation_thread_pool = ThreadPoolBuilder::new()
+            .thread_name(|i| format!("{}-{}", WORKER_THREAD_PREFIX, i))
+            .stack_size(WORKER_STACK_SIZE)
             .num_threads(PROOF_GENERATION_N_THREADS)
             .build()
             .map_err(|err| ProofManagerError::Setup(err.to_string()))?;

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -60,7 +60,7 @@ colored = "2"
 eyre = { workspace = true }
 inventory = "0.3"
 
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 num-traits = "0.2"
 
 rand = { workspace = true }


### PR DESCRIPTION
This PR makes the following changes to the proof manager:
1. Name all threads (why not)
2. Increase the thread stack size to 10MB (default is 2MB)
3. Preprocess all the circuit keys & layouts when the proof manager starts up

Empirically (when testing on an EC2 instance w/ a dev build) this no longer triggers the stack overflows we were seeing in the dev environment, which seemed to be coming from the proof manager, typically when generating the preprocessed circuit keys.

The way the orderbots/quoters all hit the relayer at ~the same time, it's possible there was redundant work being done in generating the keys - this wouldn't directly explain the stack overflow, but regardless it is helpful to have this be done at startup.

We are no longer seeing stack overflows in dev.