### PR TITLE
state: replicationv2: raft: Node join and leave

### DIFF
--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -53,6 +53,8 @@ pub enum ReplicationV2Error {
     Proposal(String),
     /// An error setting up a raft
     RaftSetup(String),
+    /// An error tearing down a raft
+    RaftTeardown(String),
     /// An error occurred while snapshotting
     Snapshot(String),
     /// An error in storage
@@ -64,6 +66,7 @@ impl Display for ReplicationV2Error {
         match self {
             ReplicationV2Error::Proposal(e) => write!(f, "Proposal error: {e}"),
             ReplicationV2Error::RaftSetup(e) => write!(f, "Raft setup error: {e}"),
+            ReplicationV2Error::RaftTeardown(e) => write!(f, "Raft teardown error: {e}"),
             ReplicationV2Error::Snapshot(e) => write!(f, "Snapshot error: {e}"),
             ReplicationV2Error::Storage(e) => write!(f, "Storage error: {e}"),
         }

--- a/state/src/replicationv2/network/mock.rs
+++ b/state/src/replicationv2/network/mock.rs
@@ -1,6 +1,6 @@
 //! Mock networking implementation for testing
 
-use openraft::error::{RPCError, RaftError};
+use openraft::error::{RPCError, RaftError, Unreachable};
 use openraft::RaftNetworkFactory;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::{
@@ -71,7 +71,6 @@ impl P2PRaftNetwork for MockNetworkNode {
         let (send, recv) = new_response_queue();
         self.switch_sender.send((target, request, send)).expect("channel closed");
 
-        let resp = recv.await.unwrap();
-        Ok(resp)
+        recv.await.map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))
     }
 }


### PR DESCRIPTION
### Purpose
This PR supports node membership updates in the raft client interface and adds tests for joining and leaving clusters, scaling up and down.

### Todo
- Proposal waiters
- Connection to gossip network
- Connect raft client to state interface

### Testing
- All unit tests pass