### PR TITLE
state: storage, applicator: implement task queue clearing

### DIFF
--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -222,6 +222,17 @@ impl<'db> StateTxn<'db, RW> {
 
         Ok(value)
     }
+
+    /// Clear a queue
+    ///
+    /// Assumes the underlying queue is represented by a `VecDeque`
+    pub(crate) fn clear_queue<K: Key, V: Value>(
+        &self,
+        table_name: &str,
+        key: &K,
+    ) -> Result<(), StorageError> {
+        self.write_queue(table_name, key, &VecDeque::<V>::new())
+    }
 }
 
 // -------------------------


### PR DESCRIPTION
This PR has the task queue get cleared whenever a task fails. This is because it's likely that any subsequent tasks will fail, too. Concretely, only wallet update tasks are certain to fail, but the simplest approach is to clear the entire queue. We ensure that cleared tasks are still recorded in the task history in a "failed" state.

All unit tests pass, and I tested this locally by modifying wallet update tasks to fail trivially, enqueuing a number of them, and ensuring that none others executed after the first failed.

Empirically, order bots & quoters in dev do not seem to be struggling with queue lengths.