### PR TITLE
state: interface: Connect state interface to raft client

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -132,6 +132,9 @@ struct Cli {
     /// The path at which to open up the database
     #[clap(long, value_parser, default_value = "./relayer_state.db")]
     pub db_path: String,
+    /// The path at which to save raft snapshots
+    #[clap(long, value_parser, default_value = "./raft_snapshots")]
+    pub raft_snapshot_path: String,
     /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
     /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
     #[clap(long, value_parser, default_value = "100")]
@@ -254,6 +257,8 @@ pub struct RelayerConfig {
     pub p2p_key: Keypair,
     /// The path at which to open up the database
     pub db_path: String,
+    /// The path at which to save raft snapshots
+    pub raft_snapshot_path: String,
     /// The maximum staleness (number of newer roots observed) to allow on
     /// Merkle proofs for managed wallets. After this threshold is exceeded,
     /// the Merkle proof will be updated
@@ -325,6 +330,7 @@ impl Clone for RelayerConfig {
             websocket_port: self.websocket_port,
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
+            raft_snapshot_path: self.raft_snapshot_path.clone(),
             max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,
@@ -450,6 +456,7 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         max_merkle_staleness: cli_args.max_merkle_staleness,
         p2p_key,
         db_path: cli_args.db_path,
+        raft_snapshot_path: cli_args.raft_snapshot_path,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         disable_price_reporter: cli_args.disable_price_reporter,

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -27,6 +27,10 @@ pub mod wallet_index;
 /// A type alias for the result type given by the applicator
 pub(crate) type Result<T> = std::result::Result<T, StateApplicatorError>;
 
+// --------------
+// | Applicator |
+// --------------
+
 /// The config for the state applicator
 #[derive(Clone)]
 pub struct StateApplicatorConfig {
@@ -66,9 +70,9 @@ impl StateApplicator {
     /// Handle a state transition
     pub fn handle_state_transition(
         &self,
-        transition: StateTransition,
+        transition: Box<StateTransition>,
     ) -> Result<ApplicatorReturnType> {
-        match transition {
+        match *transition {
             StateTransition::AddWallet { wallet } => self.add_wallet(&wallet),
             StateTransition::UpdateWallet { wallet } => self.update_wallet(&wallet),
             StateTransition::AddOrderValidityBundle { order_id, proof, witness } => {
@@ -106,8 +110,9 @@ impl StateApplicator {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "mocks"))]
 pub mod test_helpers {
+    //! Test helpers for mock state applicator
     use std::{mem, str::FromStr, sync::Arc};
 
     use common::types::gossip::ClusterId;

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -1,11 +1,14 @@
 //! Applicator handlers for order metadata updates
 
-use crate::{order_history::ERR_MISSING_WALLET, storage::tx::StateTxn};
+use crate::storage::tx::StateTxn;
 
 use super::{error::StateApplicatorError, StateApplicator};
 use common::types::wallet::order_metadata::OrderMetadata;
 use external_api::bus_message::{wallet_order_history_topic, SystemBusMessage};
 use libmdbx::RW;
+
+/// Error emitted when a wallet cannot be found for an order
+const ERR_MISSING_WALLET: &str = "wallet not found";
 
 impl StateApplicator {
     /// Handle an update to an order's metadata

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -2,58 +2,44 @@
 //! proposing state transitions and reading from state
 
 pub mod error;
-pub mod mpc_preprocessing;
+// pub mod mpc_preprocessing;
 pub mod node_metadata;
-pub mod notifications;
-pub mod order_book;
-pub mod order_history;
-pub mod peer_index;
-pub mod raft;
-pub mod task_queue;
+// pub mod order_book;
+// pub mod order_history;
+// pub mod peer_index;
+// pub mod raft;
+// pub mod task_queue;
 pub mod wallet_index;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
-use ::raft::prelude::Config as RaftConfig;
-use common::{
-    types::{gossip::WrappedPeerId, new_cancel_channel},
-    worker::Worker,
-};
+use common::types::gossip::WrappedPeerId;
 use config::RelayerConfig;
-use crossbeam::channel::{unbounded, Sender as UnboundedSender};
+use crossbeam::channel::Sender as UnboundedSender;
 use external_api::bus_message::SystemBusMessage;
-use job_types::{
-    handshake_manager::HandshakeManagerQueue, network_manager::NetworkManagerQueue,
-    task_driver::TaskDriverQueue,
-};
+use job_types::{handshake_manager::HandshakeManagerQueue, task_driver::TaskDriverQueue};
 use system_bus::SystemBus;
-use tokio::sync::watch::Sender;
-use util::err_str;
 
 use crate::{
-    replication::{
-        network::{
-            address_translation::{PeerIdTranslationMap, SharedPeerIdTranslationMap},
-            gossip::GossipRaftNetwork,
-            traits::{RaftMessageReceiver, RaftNetwork},
-        },
-        raft_node::ReplicationNodeConfig,
-        worker::ReplicationNodeWorker,
+    applicator::{StateApplicator, StateApplicatorConfig},
+    notifications::{OpenNotifications, ProposalWaiter},
+    replicationv2::{
+        network::address_translation::PeerIdTranslationMap,
+        raft::{NetworkEssential, RaftClient, RaftClientConfig},
+        state_machine::{StateMachine, StateMachineConfig},
     },
     storage::db::{DbConfig, DB},
     Proposal, StateTransition,
 };
 
-use self::{error::StateError, notifications::ProposalWaiter};
+use self::error::StateError;
 
-/// The default tick interval for the raft node
-const DEFAULT_TICK_INTERVAL_MS: u64 = 10; // 10 milliseconds
 /// The default number of ticks between Raft heartbeats
-const DEFAULT_HEARTBEAT_TICKS: usize = 100; // 1 second at 10ms per tick
+const DEFAULT_HEARTBEAT_MS: u64 = 1000; // 1 second
 /// The default lower bound on the number of ticks before a Raft election
-const DEFAULT_MIN_ELECTION_TICKS: usize = 1000; // 10 seconds at 10ms per tick
+const DEFAULT_MIN_ELECTION_MS: u64 = 10000; // 10 seconds
 /// The default upper bound on the number of ticks before a Raft election
-const DEFAULT_MAX_ELECTION_TICKS: usize = 1500; // 15 seconds at 10ms per tick
+const DEFAULT_MAX_ELECTION_MS: u64 = 15000; // 15 seconds
 
 /// A type alias for a proposal queue of state transitions
 pub type ProposalQueue = UnboundedSender<Proposal>;
@@ -62,81 +48,32 @@ pub type ProposalQueue = UnboundedSender<Proposal>;
 // | State Interface |
 // -------------------
 
-/// A handle on the state that allows workers throughout the node to access the
+/// A handle on the state that allows workers throughout the node to acces the
 /// replication and durability primitives backing the state machine
 #[derive(Clone)]
-pub struct State {
+pub struct State<N: NetworkEssential> {
     /// Whether or not the node allows local peers when adding to the peer index
     allow_local: bool,
     /// A handle on the database
     db: Arc<DB>,
-    /// A handle on the proposal queue to the raft instance
-    proposal_queue: Arc<ProposalQueue>,
-    /// The shared mapping from raft IDs to peer IDs for translation
-    translation_map: SharedPeerIdTranslationMap,
     /// The system bus for sending notifications to other workers
     bus: SystemBus<SystemBusMessage>,
+    /// The notifications map
+    notifications: OpenNotifications,
+    /// The raft client
+    raft: RaftClient<N>,
 }
 
-impl State {
-    /// Create a new state object using a `GossipRaftNetwork`, returning the
-    /// handles to the state, Raft worker, and Raft cancel sender
-    pub fn new(
-        network_outbound: NetworkManagerQueue,
-        raft_inbound: RaftMessageReceiver,
-        config: &RelayerConfig,
-        task_queue: TaskDriverQueue,
-        handshake_manager_queue: HandshakeManagerQueue,
-        system_bus: SystemBus<SystemBusMessage>,
-    ) -> Result<(Self, ReplicationNodeWorker<GossipRaftNetwork>, Sender<()>), StateError> {
-        let shared_map = Arc::new(RwLock::new(PeerIdTranslationMap::default()));
-        let network = GossipRaftNetwork::new(network_outbound, raft_inbound, shared_map.clone());
-
-        // Build a raft config
-        let raft_config = Self::build_raft_config(config);
-        Self::new_with_network_and_map(
-            config,
-            raft_config,
-            network,
-            task_queue,
-            handshake_manager_queue,
-            system_bus,
-            shared_map,
-        )
-    }
-
-    /// Create a new state handle with a network specified, also returning
-    /// handles to the Raft worker & its cancel channel
-    pub fn new_with_network<N: 'static + RaftNetwork + Send>(
-        config: &RelayerConfig,
-        raft_config: RaftConfig,
-        network: N,
-        task_queue: TaskDriverQueue,
-        handshake_manager_queue: HandshakeManagerQueue,
-        system_bus: SystemBus<SystemBusMessage>,
-    ) -> Result<(Self, ReplicationNodeWorker<N>, Sender<()>), StateError> {
-        let shared_map = Arc::new(RwLock::new(PeerIdTranslationMap::default()));
-        Self::new_with_network_and_map(
-            config,
-            raft_config,
-            network,
-            task_queue,
-            handshake_manager_queue,
-            system_bus,
-            shared_map,
-        )
-    }
-
+impl<N: NetworkEssential> State<N> {
     /// The base constructor allowing for the variadic constructors above
-    fn new_with_network_and_map<N: 'static + RaftNetwork + Send>(
+    pub async fn new_with_network(
         config: &RelayerConfig,
-        raft_config: RaftConfig,
+        raft_config: RaftClientConfig,
         network: N,
         task_queue: TaskDriverQueue,
         handshake_manager_queue: HandshakeManagerQueue,
         system_bus: SystemBus<SystemBusMessage>,
-        translation_map: SharedPeerIdTranslationMap,
-    ) -> Result<(Self, ReplicationNodeWorker<N>, Sender<()>), StateError> {
+    ) -> Result<Self, StateError> {
         // Open up the DB
         let db_config = DbConfig::new_with_path(&config.db_path);
         let db = DB::new(&db_config).map_err(StateError::Db)?;
@@ -147,37 +84,30 @@ impl State {
         tx.setup_tables()?;
         tx.commit()?;
 
-        // Create a proposal queue and the raft config
-        let (proposal_send, proposal_receiver) = unbounded();
-        let (raft_cancel_sender, raft_cancel_receiver) = new_cancel_channel();
-        let replication_config = ReplicationNodeConfig {
-            tick_period_ms: DEFAULT_TICK_INTERVAL_MS,
-            relayer_config: config.clone(),
-            raft_config,
-            proposal_receiver,
-            network,
+        // Setup the state machine
+        let applicator_config = StateApplicatorConfig {
+            allow_local: config.allow_local,
+            cluster_id: config.cluster_id.clone(),
             task_queue,
             handshake_manager_queue,
             db: db.clone(),
             system_bus: system_bus.clone(),
-            cancel_channel: raft_cancel_receiver,
         };
+        let applicator = StateApplicator::new(applicator_config).map_err(StateError::Applicator)?;
+        let notifications = OpenNotifications::new();
+        let sm_config = StateMachineConfig::new(config.raft_snapshot_path.clone());
+        let sm = StateMachine::new(sm_config, notifications.clone(), applicator);
 
-        // Start the Raft worker
-        let mut raft_worker = ReplicationNodeWorker::new(replication_config)
-            .expect("failed to build Raft replication node");
-        raft_worker.start().expect("failed to start Raft replication node");
+        // Start a raft
+        let raft = RaftClient::new(raft_config, db.clone(), network, sm)
+            .await
+            .map_err(StateError::Replication)?;
 
         // Setup the node metadata from the config
-        let self_ = Self {
-            allow_local: config.allow_local,
-            db,
-            proposal_queue: Arc::new(proposal_send),
-            bus: system_bus,
-            translation_map,
-        };
-        self_.setup_node_metadata(config)?;
-        Ok((self_, raft_worker, raft_cancel_sender))
+        let this =
+            Self { allow_local: config.allow_local, db, bus: system_bus, notifications, raft };
+        this.setup_node_metadata(config)?;
+        Ok(this)
     }
 
     // -------------------
@@ -185,25 +115,29 @@ impl State {
     // -------------------
 
     /// Build the raft config for the node
-    fn build_raft_config(relayer_config: &RelayerConfig) -> RaftConfig {
+    fn build_raft_config(relayer_config: &RelayerConfig) -> RaftClientConfig {
         let peer_id = relayer_config.p2p_key.public().to_peer_id();
         let raft_id = PeerIdTranslationMap::get_raft_id(&WrappedPeerId(peer_id));
-        RaftConfig {
+
+        RaftClientConfig {
             id: raft_id,
-            heartbeat_tick: DEFAULT_HEARTBEAT_TICKS,
-            election_tick: DEFAULT_MIN_ELECTION_TICKS,
-            min_election_tick: DEFAULT_MIN_ELECTION_TICKS,
-            max_election_tick: DEFAULT_MAX_ELECTION_TICKS,
+            init: true,
+            heartbeat_interval: DEFAULT_HEARTBEAT_MS,
+            election_timeout_min: DEFAULT_MIN_ELECTION_MS,
+            election_timeout_max: DEFAULT_MAX_ELECTION_MS,
             ..Default::default()
         }
     }
 
     /// Send a proposal to the raft node
-    fn send_proposal(&self, transition: StateTransition) -> Result<ProposalWaiter, StateError> {
-        let (response, recv) = tokio::sync::oneshot::channel();
-        let proposal = Proposal { transition, response };
+    async fn send_proposal(
+        &self,
+        transition: StateTransition,
+    ) -> Result<ProposalWaiter, StateError> {
+        let proposal = Proposal::from(transition);
+        let recv = self.notifications.register_notification(proposal.id).await;
 
-        self.proposal_queue.send(proposal).map_err(err_str!(StateError::Proposal))?;
+        self.raft.propose_transition(proposal).await.map_err(StateError::Replication)?;
         Ok(ProposalWaiter::new(recv))
     }
 }
@@ -217,11 +151,10 @@ mod test {
     /// Test adding a wallet to the state
     #[tokio::test]
     async fn test_add_wallet() {
-        let state = mock_state();
+        let state = mock_state().await;
 
         let wallet = mock_empty_wallet();
-        let res = state.new_wallet(wallet.clone()).unwrap().await;
-        println!("res: {res:?}");
+        let res = state.new_wallet(wallet.clone()).await.unwrap().await;
         assert!(res.is_ok());
 
         // Check for the wallet in the state

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -9,9 +9,9 @@ use config::RelayerConfig;
 use libp2p::{core::Multiaddr, identity::Keypair};
 use util::res_some;
 
-use crate::{error::StateError, State, NODE_METADATA_TABLE};
+use crate::{error::StateError, replicationv2::raft::NetworkEssential, State, NODE_METADATA_TABLE};
 
-impl State {
+impl<N: NetworkEssential> State<N> {
     // -----------
     // | Getters |
     // -----------
@@ -142,11 +142,11 @@ mod test {
     use crate::test_helpers::{mock_relayer_config, mock_state_with_config};
 
     /// Tests the node metadata setup from a mock config
-    #[test]
-    fn test_node_metadata() {
+    #[tokio::test]
+    async fn test_node_metadata() {
         // Build the state mock manually to use the generated config
         let config = mock_relayer_config();
-        let state = mock_state_with_config(&config);
+        let state = mock_state_with_config(&config).await;
 
         // Check the metadata fields
         let peer_id = state.get_peer_id().unwrap();

--- a/state/src/notifications.rs
+++ b/state/src/notifications.rs
@@ -4,10 +4,18 @@
 //! The underlying raft node will dequeue a proposal and apply it to the state
 //! machine. Only then will the notification be sent to the worker.
 use common::{new_async_shared, AsyncShared};
-use std::collections::HashMap;
+use futures::{ready, Future};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use uuid::Uuid;
 
 use crate::{applicator::return_type::ApplicatorReturnType, error::StateError};
+
+/// Error message emitted when a proposal channel closes unexpectedly
+const ERR_PROPOSAL_CLOSED: &str = "Proposal channel closed unexpectedly";
 
 /// The id of a proposal
 pub type ProposalId = Uuid;
@@ -53,5 +61,29 @@ impl OpenNotifications {
         let (sender, receiver) = new_proposal_result_channel();
         self.map.write().await.insert(id, sender);
         receiver
+    }
+}
+
+/// A wrapper around a proposal receiver that gives a more convenient async
+/// interface without channel like semantics
+pub struct ProposalWaiter {
+    /// The inner channel
+    inner: ProposalResultReceiver,
+}
+
+impl ProposalWaiter {
+    /// Create a new waiter from the given channel
+    pub fn new(inner: ProposalResultReceiver) -> Self {
+        Self { inner }
+    }
+}
+
+impl Future for ProposalWaiter {
+    type Output = ProposalReturnType;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = ready!(Pin::new(&mut self.get_mut().inner).poll(cx))
+            .map_err(|_| StateError::Proposal(ERR_PROPOSAL_CLOSED.to_string()))?;
+        Poll::Ready(res)
     }
 }

--- a/state/src/replicationv2/network/mod.rs
+++ b/state/src/replicationv2/network/mod.rs
@@ -1,7 +1,7 @@
 //! Networking implement that shims between the consensus engine and the gossip
 //! layer
-mod address_translation;
-#[cfg(test)]
+pub mod address_translation;
+#[cfg(any(test, feature = "mocks"))]
 pub mod mock;
 
 use openraft::{


### PR DESCRIPTION
### Purpose
This PR sets up the connection between the state interface and the raft client. This involves spawning a raft inside the state constructor and tying together the notifications queue, dbs, state machine, etc.

We no longer run the raft as a separate worker, this is handled by `openraft`

### Testing
- Unit tests pass
- Tested some basic state transitions through the interface