### PR TITLE
state: interface: Use async state interface

### DIFF
--- a/state/src/interface/error.rs
+++ b/state/src/interface/error.rs
@@ -21,6 +21,8 @@ pub enum StateError {
     Proposal(String),
     /// An error in the replication substrate
     Replication(ReplicationV2Error),
+    /// An error awaiting a runtime task
+    Runtime(String),
 }
 
 impl Display for StateError {

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -10,8 +10,7 @@ use libp2p::{core::Multiaddr, identity::Keypair};
 use util::res_some;
 
 use crate::{
-    error::StateError, replicationv2::raft::NetworkEssential, State, StateHandle,
-    NODE_METADATA_TABLE,
+    error::StateError, replicationv2::raft::NetworkEssential, StateHandle, NODE_METADATA_TABLE,
 };
 
 impl<N: NetworkEssential> StateHandle<N> {
@@ -20,123 +19,107 @@ impl<N: NetworkEssential> StateHandle<N> {
     // -----------
 
     /// Get the peer ID of the local node
-    pub fn get_peer_id(&self) -> Result<WrappedPeerId, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let peer_id = tx.get_peer_id()?;
-        tx.commit()?;
-
-        Ok(peer_id)
+    pub async fn get_peer_id(&self) -> Result<WrappedPeerId, StateError> {
+        self.with_read_tx(|tx| tx.get_peer_id().map_err(StateError::Db)).await
     }
 
     /// Get the cluster ID of the local node
-    pub fn get_cluster_id(&self) -> Result<ClusterId, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let cluster_id = tx.get_cluster_id()?;
-        tx.commit()?;
-
-        Ok(cluster_id)
+    pub async fn get_cluster_id(&self) -> Result<ClusterId, StateError> {
+        self.with_read_tx(|tx| tx.get_cluster_id().map_err(StateError::Db)).await
     }
 
     /// Get the libp2p keypair of the local node
-    pub fn get_node_keypair(&self) -> Result<Keypair, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let keypair = tx.get_node_keypair()?;
-        tx.commit()?;
-
-        Ok(keypair)
+    pub async fn get_node_keypair(&self) -> Result<Keypair, StateError> {
+        self.with_read_tx(|tx| tx.get_node_keypair().map_err(StateError::Db)).await
     }
 
     /// Get the wallet ID that the local relayer owns
-    pub fn get_relayer_wallet_id(&self) -> Result<Option<WalletIdentifier>, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let wallet_id = tx.get_local_node_wallet()?;
-        tx.commit()?;
-
-        Ok(Some(wallet_id))
+    pub async fn get_relayer_wallet_id(&self) -> Result<WalletIdentifier, StateError> {
+        self.with_read_tx(|tx| tx.get_local_node_wallet().map_err(StateError::Db)).await
     }
 
     /// Get the wallet owned by the local relayer
-    pub fn get_local_relayer_wallet(&self) -> Result<Option<Wallet>, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let wallet_id = tx.get_local_node_wallet()?;
-        let wallet = res_some!(tx.get_wallet(&wallet_id)?);
-        tx.commit()?;
-
-        Ok(Some(wallet))
+    pub async fn get_local_relayer_wallet(&self) -> Result<Option<Wallet>, StateError> {
+        self.with_read_tx(|tx| {
+            let wallet_id = tx.get_local_node_wallet()?;
+            let wallet = res_some!(tx.get_wallet(&wallet_id)?);
+            Ok(Some(wallet))
+        })
+        .await
     }
 
     /// Get the decryption key used to settle managed match fees
-    pub fn get_fee_decryption_key(&self) -> Result<DecryptionKey, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let key = tx.get_fee_decryption_key()?;
-        tx.commit()?;
-
-        Ok(key)
+    pub async fn get_fee_decryption_key(&self) -> Result<DecryptionKey, StateError> {
+        self.with_read_tx(|tx| tx.get_fee_decryption_key().map_err(StateError::Db)).await
     }
 
     /// Get the local relayer's match take rate
-    pub fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
-        let tx = self.db.new_read_tx()?;
-        let rate = tx.get_relayer_take_rate()?;
-        tx.commit()?;
-
-        Ok(rate)
+    pub async fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
+        self.with_read_tx(|tx| tx.get_relayer_take_rate().map_err(StateError::Db)).await
     }
-
     // -----------
     // | Setters |
     // -----------
 
     /// Set the known public address of the local peer when discovered
-    pub fn update_local_peer_addr(&self, addr: Multiaddr) -> Result<(), StateError> {
-        let tx = self.db.new_write_tx()?;
-        // Update the local peer's address in the metadata table
-        tx.set_local_addr(&addr)?;
-        let peer_id = tx.get_peer_id()?;
-        // Update the peer's address in the peer info table
-        tx.update_peer_addr(&peer_id, addr)?;
-        Ok(tx.commit()?)
+    pub async fn update_local_peer_addr(&self, addr: Multiaddr) -> Result<(), StateError> {
+        self.with_write_tx(|tx| {
+            // Update the local peer's address in the metadata table
+            tx.set_local_addr(&addr)?;
+            let peer_id = tx.get_peer_id()?;
+            // Update the peer's address in the peer info table
+            tx.update_peer_addr(&peer_id, addr)?;
+            Ok(())
+        })
+        .await
     }
 
     /// Add the local peer's info to the info table
-    pub fn set_local_peer_info(&self, mut info: PeerInfo) -> Result<(), StateError> {
-        let tx = self.db.new_write_tx()?;
-
-        info.successful_heartbeat();
-        tx.write_peer(&info)?;
-        tx.add_to_cluster(&info.peer_id, &info.cluster_id)?;
-
-        Ok(tx.commit()?)
+    pub async fn set_local_peer_info(&self, mut info: PeerInfo) -> Result<(), StateError> {
+        self.with_write_tx(move |tx| {
+            info.successful_heartbeat();
+            tx.write_peer(&info)?;
+            tx.add_to_cluster(&info.peer_id, &info.cluster_id)?;
+            Ok(())
+        })
+        .await
     }
 
     /// Set the wallet ID of the local relayer's wallet
     ///
     /// This wallet is managed the same as any other wallet, but we index its ID
     /// here for retrieval
-    pub fn set_local_relayer_wallet_id(
+    pub async fn set_local_relayer_wallet_id(
         &self,
         wallet_id: WalletIdentifier,
     ) -> Result<(), StateError> {
-        let tx = self.db.new_write_tx()?;
-        tx.set_local_node_wallet(wallet_id)?;
-        Ok(tx.commit()?)
+        self.with_write_tx(move |tx| {
+            tx.set_local_node_wallet(wallet_id)?;
+            Ok(())
+        })
+        .await
     }
 
     /// Setup the node metadata table from a relayer config
-    pub fn setup_node_metadata(&self, config: &RelayerConfig) -> Result<(), StateError> {
-        let keypair = &config.p2p_key;
+    pub async fn setup_node_metadata(&self, config: &RelayerConfig) -> Result<(), StateError> {
+        let keypair = config.p2p_key.clone();
         let peer_id = WrappedPeerId(keypair.public().to_peer_id());
+        let cluster_id = config.cluster_id.clone();
+        let p2p_key = config.p2p_key.clone();
+        let fee_decryption_key = config.fee_decryption_key;
+        let match_take_rate = config.match_take_rate;
 
-        let tx = self.db.new_write_tx()?;
-        tx.create_table(NODE_METADATA_TABLE)?;
-        tx.set_peer_id(&peer_id)?;
-        tx.set_cluster_id(&config.cluster_id)?;
-        tx.set_node_keypair(&config.p2p_key)?;
-        tx.set_fee_decryption_key(&config.fee_decryption_key)?;
-        tx.set_relayer_take_rate(&config.match_take_rate)?;
+        self.with_write_tx(move |tx| {
+            tx.create_table(NODE_METADATA_TABLE)?;
+            tx.set_peer_id(&peer_id)?;
+            tx.set_cluster_id(&cluster_id)?;
+            tx.set_node_keypair(&p2p_key)?;
+            tx.set_fee_decryption_key(&fee_decryption_key)?;
+            tx.set_relayer_take_rate(&match_take_rate)?;
 
-        tx.commit()?;
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 }
 
@@ -152,13 +135,13 @@ mod test {
         let state = mock_state_with_config(&config).await;
 
         // Check the metadata fields
-        let peer_id = state.get_peer_id().unwrap();
+        let peer_id = state.get_peer_id().await.unwrap();
         assert_eq!(peer_id.0, config.p2p_key.public().to_peer_id());
 
-        let cluster_id = state.get_cluster_id().unwrap();
+        let cluster_id = state.get_cluster_id().await.unwrap();
         assert_eq!(cluster_id, config.cluster_id);
 
-        let keypair = state.get_node_keypair().unwrap();
+        let keypair = state.get_node_keypair().await.unwrap();
         // Compare bytes
         assert_eq!(
             keypair.to_protobuf_encoding().unwrap(),

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -261,7 +261,7 @@ pub mod test_helpers {
         task_queue: TaskDriverQueue,
         config: &RelayerConfig,
     ) -> MockState {
-        let raft = MockRaft::create_raft(1 /* n_nodes */).await;
+        let raft = MockRaft::create_raft(2 /* n_nodes */).await;
         let net = raft.get_client(0).await.network();
         let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
         MockState::new_with_network(


### PR DESCRIPTION
### Purpose
This PR changes the interface of the state to use async methods all around. Callers of the state interface are all async, so we wish to avoid blocking their worker threads unnecessarily -- as mdbx may do.

Instead, we spawn all state access methods on blocking tasks that manage a read or write transaction, and await this blocking task's completion. 

### Testing
- All unit tests pass for the state library