### PR TITLE
workers: network-manager: Multithread task handlers

### DIFF
--- a/workers/network-manager/src/error.rs
+++ b/workers/network-manager/src/error.rs
@@ -14,8 +14,12 @@ pub enum NetworkManagerError {
     Cancelled(String),
     /// Error forwarding a job from the network layer to a worker
     EnqueueJob(String),
+    /// Error looking up dialable addresses for a peer
+    LookupAddr(String),
     /// An error with the underlying network operation
     Network(String),
+    /// An error sending a response to an internal request
+    SendInternal(String),
     /// An error while setting up the network manager
     SetupError(String),
     /// An error serializing or deserializing a message

--- a/workers/network-manager/src/executor/behavior.rs
+++ b/workers/network-manager/src/executor/behavior.rs
@@ -1,0 +1,110 @@
+//! Handles jobs that should be forwarded directly to the libp2p behavior
+//! underlying the swarm
+
+use gossip_api::{
+    pubsub::AuthenticatedPubsubMessage,
+    request_response::{AuthenticatedGossipRequest, AuthenticatedGossipResponse},
+};
+use job_types::network_manager::NetworkResponseChannel;
+use libp2p::{gossipsub::Sha256Topic, request_response::ResponseChannel, Multiaddr, PeerId, Swarm};
+use libp2p_core::Endpoint;
+use libp2p_swarm::{ConnectionId, NetworkBehaviour};
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender},
+    oneshot,
+};
+use util::err_str;
+
+use crate::{composed_protocol::ComposedNetworkBehavior, error::NetworkManagerError};
+
+use super::{NetworkManagerExecutor, ERR_NO_KNOWN_ADDR};
+
+/// Error message emitted when a response fails to be sent
+const ERR_SEND_INTERNAL: &str = "Failed to send internal worker response";
+/// Error sending a response to a peer on the network
+const ERR_SEND_RESPONSE: &str = "Failed to send response";
+
+/// The queue sender type for behavior jobs
+pub type BehaviorSender = TokioSender<BehaviorJob>;
+/// The queue receiver type for behavior jobs
+pub type BehaviorReceiver = TokioReceiver<BehaviorJob>;
+/// Create a new behavior queue
+pub fn new_behavior_queue() -> (BehaviorSender, BehaviorReceiver) {
+    unbounded_channel()
+}
+
+/// The job type of behavior requests
+pub enum BehaviorJob {
+    // --- Messaging --- //
+    /// Send an outbound request
+    SendReq(PeerId, AuthenticatedGossipRequest, Option<NetworkResponseChannel>),
+    /// Send an outbound response
+    SendResp(ResponseChannel<AuthenticatedGossipResponse>, AuthenticatedGossipResponse),
+    /// Send a pubsub message
+    SendPubsub(Sha256Topic, AuthenticatedPubsubMessage),
+
+    // --- KDHT --- //
+    /// Add an address to the DHT
+    AddAddress(PeerId, Multiaddr),
+    /// Expire a peer
+    RemovePeer(PeerId),
+
+    // --- Address Lookup --- //
+    /// Lookup known addresses for a peer and return on a channel
+    ///
+    /// Used when brokering an MPC network
+    LookupAddr(PeerId, oneshot::Sender<Vec<Multiaddr>>),
+}
+
+impl NetworkManagerExecutor {
+    /// Enqueue a behavior job from elsewhere in the network manager
+    pub(crate) fn send_behavior(&self, job: BehaviorJob) -> Result<(), NetworkManagerError> {
+        self.behavior_tx.send(job).map_err(err_str!(NetworkManagerError::EnqueueJob))
+    }
+
+    /// Handle a behavior job
+    pub(crate) async fn handle_behavior_job(
+        &mut self,
+        job: BehaviorJob,
+        swarm: &mut Swarm<ComposedNetworkBehavior>,
+    ) -> Result<(), NetworkManagerError> {
+        match job {
+            BehaviorJob::SendReq(peer_id, req, chan) => {
+                let _rid = swarm.behaviour_mut().request_response.send_request(&peer_id, req);
+                Ok(())
+            },
+            BehaviorJob::SendResp(channel, resp) => swarm
+                .behaviour_mut()
+                .request_response
+                .send_response(channel, resp)
+                .map_err(|_| NetworkManagerError::Network(ERR_SEND_RESPONSE.to_string())),
+            BehaviorJob::SendPubsub(topic, msg) => {
+                swarm.behaviour_mut().pubsub.publish(topic, msg);
+                Ok(())
+            },
+            BehaviorJob::AddAddress(peer_id, addr) => {
+                swarm.behaviour_mut().kademlia_dht.add_address(&peer_id, addr);
+                Ok(())
+            },
+            BehaviorJob::RemovePeer(peer_id) => {
+                swarm.behaviour_mut().kademlia_dht.remove_peer(&peer_id);
+                Ok(())
+            },
+            BehaviorJob::LookupAddr(peer_id, sender) => {
+                let addr = swarm
+                    .behaviour_mut()
+                    .handle_pending_outbound_connection(
+                        ConnectionId::new_unchecked(0),
+                        Some(peer_id),
+                        &[],
+                        Endpoint::Dialer,
+                    )
+                    .map_err(|_| NetworkManagerError::Network(ERR_NO_KNOWN_ADDR.to_string()))?;
+
+                sender
+                    .send(addr)
+                    .map_err(|_| NetworkManagerError::SendInternal(ERR_SEND_INTERNAL.to_string()))
+            },
+        }
+    }
+}

--- a/workers/network-manager/src/lib.rs
+++ b/workers/network-manager/src/lib.rs
@@ -10,5 +10,5 @@
 
 mod composed_protocol;
 pub mod error;
-pub mod manager;
+pub mod executor;
 pub mod worker;

--- a/workers/network-manager/src/worker.rs
+++ b/workers/network-manager/src/worker.rs
@@ -3,15 +3,19 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::thread::{Builder, JoinHandle};
 
-use common::types::gossip::{ClusterId, PeerInfo};
+use common::default_wrapper::DefaultOption;
+use common::types::gossip::{ClusterId, PeerInfo, WrappedPeerId};
 use common::types::CancelChannel;
 use common::worker::Worker;
 use ed25519_dalek::Keypair;
 use external_api::bus_message::SystemBusMessage;
+use gossip_api::pubsub::orderbook::ORDER_BOOK_TOPIC;
 use job_types::gossip_server::GossipServerQueue;
 use job_types::handshake_manager::HandshakeManagerQueue;
 use job_types::network_manager::NetworkManagerReceiver;
-use state::replication::network::traits::RaftMessageQueue;
+use libp2p::gossipsub::Sha256Topic;
+use libp2p::identity::Keypair as LibP2PKeypair;
+use libp2p::Swarm;
 use state::State;
 use system_bus::SystemBus;
 
@@ -22,19 +26,20 @@ use libp2p_core::Transport;
 use libp2p_swarm::SwarmBuilder;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
 use tracing::info;
+use util::runtime::block_current;
 
 use crate::composed_protocol::ComposedNetworkBehavior;
 
 use super::{
-    composed_protocol::ProtocolVersion,
-    error::NetworkManagerError,
-    manager::{NetworkManager, NetworkManagerExecutor},
+    composed_protocol::ProtocolVersion, error::NetworkManagerError,
+    executor::NetworkManagerExecutor,
 };
 
 /// The number of threads backing the network
 const NETWORK_MANAGER_N_THREADS: usize = 3;
 
 /// The worker configuration for the network manager
+#[derive(Clone)]
 pub struct NetworkManagerConfig {
     /// The port to listen for inbound traffic on
     pub port: u16,
@@ -46,7 +51,7 @@ pub struct NetworkManagerConfig {
     pub allow_local: bool,
     /// The cluster keypair, wrapped in an option to allow the worker thread to
     /// take ownership of the keypair
-    pub cluster_keypair: Option<Keypair>,
+    pub cluster_keypair: DefaultOption<Keypair>,
     /// The known public addr that the local node is listening behind, if one
     /// exists
     pub known_public_addr: Option<SocketAddr>,
@@ -55,9 +60,7 @@ pub struct NetworkManagerConfig {
     /// This is wrapped in an option to allow the worker thread to take
     /// ownership of the work queue once it is started. The coordinator
     /// will be left with `None` after this happens
-    pub send_channel: Option<NetworkManagerReceiver>,
-    /// The queue to send raft messages from the network manager
-    pub raft_queue: RaftMessageQueue,
+    pub send_channel: DefaultOption<NetworkManagerReceiver>,
     /// The work queue to forward inbound heartbeat requests to
     pub gossip_work_queue: GossipServerQueue,
     /// The work queue to forward inbound handshake requests to
@@ -71,13 +74,80 @@ pub struct NetworkManagerConfig {
     pub cancel_channel: CancelChannel,
 }
 
+// -----------
+// | Manager |
+// -----------
+
+/// Groups logic around monitoring and requesting the network
+pub struct NetworkManager {
+    /// The config passed from the coordinator thread
+    pub(super) config: NetworkManagerConfig,
+    /// The peerId of the locally running node
+    pub local_peer_id: WrappedPeerId,
+    /// The multiaddr of the local peer
+    pub local_addr: Multiaddr,
+    /// The cluster ID of the local peer
+    pub(crate) cluster_id: ClusterId,
+    /// The public key of the local peer
+    pub(super) local_keypair: LibP2PKeypair,
+    /// The join handle of the executor loop
+    pub(super) thread_handle: Option<JoinHandle<NetworkManagerError>>,
+}
+
+/// The NetworkManager handles both incoming and outbound messages to the p2p
+/// network It accepts events from workers elsewhere in the relayer that are to
+/// be propagated out to the network; as well as listening on the network for
+/// messages from other peers.
+impl NetworkManager {
+    /// Setup global state after peer_id and address have been assigned
+    pub async fn update_global_state_after_startup(&self) -> Result<(), NetworkManagerError> {
+        // Add self to peer info index
+        self.config
+            .global_state
+            .add_peer(PeerInfo::new_with_cluster_secret_key(
+                self.local_peer_id,
+                self.cluster_id.clone(),
+                self.local_addr.clone(),
+                self.config.cluster_keypair.as_ref().unwrap(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    /// Setup pubsub subscriptions for the network manager
+    pub fn setup_pubsub_subscriptions(
+        &self,
+        swarm: &mut Swarm<ComposedNetworkBehavior>,
+    ) -> Result<(), NetworkManagerError> {
+        for topic in [
+            self.cluster_id.get_management_topic(), // Cluster management for local cluster
+            ORDER_BOOK_TOPIC.to_string(),           // Network order book management
+        ]
+        .iter()
+        {
+            swarm
+                .behaviour_mut()
+                .pubsub
+                .subscribe(&Sha256Topic::new(topic))
+                .map_err(|err| NetworkManagerError::SetupError(err.to_string()))?;
+        }
+
+        Ok(())
+    }
+}
+
+// ----------
+// | Worker |
+// ----------
+
 impl Worker for NetworkManager {
     type WorkerConfig = NetworkManagerConfig;
     type Error = NetworkManagerError;
 
     fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
-        let local_peer_id = config.global_state.get_peer_id()?;
-        let local_keypair = config.global_state.get_node_keypair()?;
+        let local_peer_id = block_current(config.global_state.get_peer_id())?;
+        let local_keypair = block_current(config.global_state.get_node_keypair())?;
 
         // If the local node is given a known dialable addr for itself at startup,
         // construct the local addr directly, otherwise set it to the canonical
@@ -103,7 +173,7 @@ impl Worker for NetworkManager {
             local_addr.clone(),
             config.cluster_keypair.as_ref().unwrap(),
         );
-        config.global_state.set_local_peer_info(info)?;
+        block_current(config.global_state.set_local_peer_info(info))?;
 
         Ok(Self {
             cluster_id: config.cluster_id.clone(),
@@ -151,7 +221,7 @@ impl Worker for NetworkManager {
         )?;
 
         // Add any bootstrap addresses to the peer info table
-        let peer_index = self.config.global_state.get_peer_info_map()?;
+        let peer_index = block_current(self.config.clone().global_state.get_peer_info_map())?;
         for (peer_id, peer_info) in peer_index.iter() {
             info!("Adding {:?}: {} to routing table...", peer_id, peer_info.get_addr());
             behavior.kademlia_dht.add_address(peer_id, peer_info.get_addr());
@@ -164,7 +234,7 @@ impl Worker for NetworkManager {
         swarm.listen_on(addr).map_err(|err| NetworkManagerError::SetupError(err.to_string()))?;
 
         // After assigning address and peer ID, update the global state
-        self.update_global_state_after_startup()?;
+        block_current(self.update_global_state_after_startup())?;
         // Subscribe to all relevant topics
         self.setup_pubsub_subscriptions(&mut swarm)?;
 
@@ -174,9 +244,7 @@ impl Worker for NetworkManager {
             self.local_peer_id,
             self.config.allow_local,
             self.config.cluster_keypair.take().unwrap(),
-            swarm,
             self.config.send_channel.take().unwrap(),
-            self.config.raft_queue.clone(),
             self.config.gossip_work_queue.clone(),
             self.config.handshake_work_queue.clone(),
             self.config.global_state.clone(),
@@ -194,7 +262,7 @@ impl Worker for NetworkManager {
                     .expect("building a runtime to the network manager failed");
 
                 // Block on this to execute the future in a separate thread
-                runtime.block_on(executor.executor_loop())
+                runtime.block_on(executor.executor_loop(swarm))
             })
             .map_err(|err| NetworkManagerError::SetupError(err.to_string()))?;
 


### PR DESCRIPTION
### Purpose
We spawn network manager tasks on a tokio runtime instead of using a single thread. This is complicated by `Swarm` not implementing `Sync`, so we broker access to the `Swarm` via a `behavior_rx` queue. This queue is drained and its events handled on the main thread to obviate synchronization on the `Swarm`.

This is done ahead of the raft request/response integration to avoid processing raft messages (or otherwise awaiting their processing) on the main thread.

### Testing
- Deferred until the relayer builds