### PR TITLE
workers: network-manager: Respond to waiting workers on gossip response

### DIFF
--- a/state/src/interface/error.rs
+++ b/state/src/interface/error.rs
@@ -23,6 +23,8 @@ pub enum StateError {
     Replication(ReplicationV2Error),
     /// An error awaiting a runtime task
     Runtime(String),
+    /// An error deserializing a message
+    Serde(String),
 }
 
 impl Display for StateError {

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -7,6 +7,7 @@ pub mod node_metadata;
 pub mod order_book;
 pub mod order_history;
 pub mod peer_index;
+pub mod raft;
 pub mod task_queue;
 pub mod wallet_index;
 

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -1,0 +1,23 @@
+//! Handlers for incoming raft commands and messages
+
+use util::err_str;
+
+use crate::{
+    error::StateError,
+    replicationv2::{
+        network::{RaftRequest, RaftResponse},
+        raft::NetworkEssential,
+    },
+    StateHandle,
+};
+
+impl<N: NetworkEssential> StateHandle<N> {
+    /// Handle a raft request from a peer
+    ///
+    /// We (de)serialize at the raft layer to avoid dependency leak
+    pub async fn handle_raft_req(&self, msg_bytes: Vec<u8>) -> Result<RaftResponse, StateError> {
+        let msg: RaftRequest =
+            bincode::deserialize(&msg_bytes).map_err(err_str!(StateError::Serde))?;
+        self.raft.handle_raft_request(msg).await.map_err(StateError::Replication)
+    }
+}

--- a/state/src/replicationv2/error.rs
+++ b/state/src/replicationv2/error.rs
@@ -1,7 +1,7 @@
 //! Error types and conversions for the replication interface
 use std::{
     error::Error,
-    fmt::Display,
+    fmt::{Debug, Display},
     io::{Error as IoError, ErrorKind as IoErrorKind},
 };
 
@@ -62,6 +62,8 @@ pub enum ReplicationV2Error {
     Deserialize(String),
     /// An error proposing a state transition
     Proposal(String),
+    /// A generic raft error
+    Raft(String),
     /// An error setting up a raft
     RaftSetup(String),
     /// An error tearing down a raft
@@ -77,6 +79,7 @@ impl Display for ReplicationV2Error {
         match self {
             ReplicationV2Error::Deserialize(e) => write!(f, "Deserialization error: {e}"),
             ReplicationV2Error::Proposal(e) => write!(f, "Proposal error: {e}"),
+            ReplicationV2Error::Raft(e) => write!(f, "Raft error: {e}"),
             ReplicationV2Error::RaftSetup(e) => write!(f, "Raft setup error: {e}"),
             ReplicationV2Error::RaftTeardown(e) => write!(f, "Raft teardown error: {e}"),
             ReplicationV2Error::Snapshot(e) => write!(f, "Snapshot error: {e}"),
@@ -89,5 +92,11 @@ impl Error for ReplicationV2Error {}
 impl From<StorageError> for ReplicationV2Error {
     fn from(value: StorageError) -> Self {
         ReplicationV2Error::Storage(value)
+    }
+}
+
+impl<E: Debug> From<RaftError<NodeId, E>> for ReplicationV2Error {
+    fn from(value: RaftError<NodeId, E>) -> Self {
+        ReplicationV2Error::Raft(format!("{value:?}"))
     }
 }

--- a/state/src/replicationv2/network/mod.rs
+++ b/state/src/replicationv2/network/mod.rs
@@ -15,8 +15,9 @@ use openraft::{
     RaftNetwork,
 };
 use serde::{Deserialize, Serialize};
+use util::err_str;
 
-use crate::Proposal;
+use crate::{error::StateError, Proposal};
 
 use super::{Node, NodeId, TypeConfig};
 
@@ -51,6 +52,11 @@ pub enum RaftResponse {
 }
 
 impl RaftResponse {
+    /// Serialize a raft response to bytes
+    pub fn to_bytes(&self) -> Result<Vec<u8>, StateError> {
+        bincode::serialize(self).map_err(err_str!(StateError::Serde))
+    }
+
     /// Convert the response to an append entries request
     pub fn into_append_entries(self) -> AppendEntriesResponse<NodeId> {
         match self {

--- a/workers/network-manager/src/executor/control_directives.rs
+++ b/workers/network-manager/src/executor/control_directives.rs
@@ -37,13 +37,13 @@ impl NetworkManagerExecutor {
         match command {
             // Register a new peer in the distributed routing tables
             NetworkManagerControlSignal::NewAddr { peer_id, address } => {
-                self.handle_new_addr(peer_id.inner(), address);
+                self.handle_new_addr(peer_id.inner(), address)?;
                 Ok(())
             },
 
             // Remove a peer from the distributed routing tables
             NetworkManagerControlSignal::PeerExpired { peer_id } => {
-                self.handle_peer_expired(&peer_id.inner());
+                self.handle_peer_expired(&peer_id.inner())?;
                 Ok(())
             },
 
@@ -117,8 +117,8 @@ impl NetworkManagerExecutor {
     ) -> Result<(), NetworkManagerError> {
         // Get the known addresses for the peer
         let (send, recv) = oneshot::channel();
-        self.send_behavior(BehaviorJob::LookupAddr(peer_id, send));
-        let known_peer_addrs = recv.await.map_err(|e| err_str!(NetworkManagerError::LookupAddr))?;
+        self.send_behavior(BehaviorJob::LookupAddr(peer_id, send))?;
+        let known_peer_addrs = recv.await.map_err(err_str!(NetworkManagerError::LookupAddr))?;
 
         // If we have no known addresses for the peer, return an error
         if known_peer_addrs.is_empty() {

--- a/workers/network-manager/src/executor/request_response.rs
+++ b/workers/network-manager/src/executor/request_response.rs
@@ -10,6 +10,7 @@ use gossip_api::{
 use job_types::{gossip_server::GossipServerJob, network_manager::NetworkResponseChannel};
 use libp2p::request_response::{Message as RequestResponseMessage, ResponseChannel};
 use libp2p::PeerId;
+use tracing::error;
 use util::err_str;
 
 use crate::error::NetworkManagerError;
@@ -22,7 +23,7 @@ impl NetworkManagerExecutor {
     // -----------
 
     /// Handle an incoming message from the network's request/response protocol
-    pub(super) fn handle_inbound_request_response_message(
+    pub(super) async fn handle_inbound_request_response_message(
         &self,
         peer: PeerId,
         message: RequestResponseMessage<AuthenticatedGossipRequest, AuthenticatedGossipResponse>,
@@ -38,7 +39,7 @@ impl NetworkManagerExecutor {
                 let body = request.body;
                 match body.destination() {
                     GossipDestination::NetworkManager => {
-                        self.handle_internal_request(body, channel)
+                        self.handle_internal_request(body, channel).await
                     },
                     GossipDestination::GossipServer => {
                         let job = GossipServerJob::NetworkRequest(peer, body, channel);
@@ -51,9 +52,15 @@ impl NetworkManagerExecutor {
             },
 
             // Handle inbound response
-            RequestResponseMessage::Response { response, .. } => {
+            RequestResponseMessage::Response { request_id, response } => {
                 response.verify_cluster_auth(&self.cluster_key.public)?;
                 let body = response.body;
+                if let Some(chan) = self.response_waiters.pop(request_id).await {
+                    if chan.send(body.clone()).is_err() {
+                        error!("error sending response notification for request: {request_id}");
+                    }
+                }
+
                 match body.destination() {
                     GossipDestination::NetworkManager => self.handle_internal_response(body),
                     GossipDestination::GossipServer => {
@@ -69,27 +76,18 @@ impl NetworkManagerExecutor {
     }
 
     /// Handle an internally routed request
-    fn handle_internal_request(
+    async fn handle_internal_request(
         &self,
         req: GossipRequest,
         chan: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Result<(), NetworkManagerError> {
         match req {
             GossipRequest::Ack => Ok(()),
-            GossipRequest::Raft(raft_message) => self.handle_raft_message(raft_message, chan),
+            GossipRequest::Raft(raft_message) => self.handle_raft_req(raft_message, chan).await,
             _ => Err(NetworkManagerError::UnhandledRequest(format!(
                 "unhandled internal request: {req:?}",
             ))),
         }
-    }
-
-    /// Handle a raft message
-    fn handle_raft_message(
-        &self,
-        msg_buf: Vec<u8>,
-        chan: ResponseChannel<AuthenticatedGossipResponse>,
-    ) -> Result<(), NetworkManagerError> {
-        todo!()
     }
 
     /// Handle an internally routed response
@@ -97,10 +95,28 @@ impl NetworkManagerExecutor {
     fn handle_internal_response(&self, resp: GossipResponse) -> Result<(), NetworkManagerError> {
         match resp {
             GossipResponse::Ack => Ok(()),
+            // The response will be forwarded directly to the raft client via the waiters
+            GossipResponse::Raft(_) => Ok(()),
             _ => Err(NetworkManagerError::UnhandledRequest(format!(
                 "unhandled internal response: {resp:?}",
             ))),
         }
+    }
+
+    /// Handle a raft request
+    async fn handle_raft_req(
+        &self,
+        msg_buf: Vec<u8>,
+        chan: ResponseChannel<AuthenticatedGossipResponse>,
+    ) -> Result<(), NetworkManagerError> {
+        let resp = self
+            .global_state
+            .handle_raft_req(msg_buf)
+            .await
+            .map_err(err_str!(NetworkManagerError::State))?;
+
+        let resp = GossipResponse::Raft(resp.to_bytes()?);
+        self.handle_outbound_resp(resp, chan)
     }
 
     // ------------

--- a/workers/network-manager/src/lib.rs
+++ b/workers/network-manager/src/lib.rs
@@ -11,4 +11,5 @@
 mod composed_protocol;
 pub mod error;
 pub mod executor;
+pub mod waiters;
 pub mod worker;

--- a/workers/network-manager/src/waiters.rs
+++ b/workers/network-manager/src/waiters.rs
@@ -1,0 +1,38 @@
+//! Implements a thread-safe mapping between request IDs and channels waiting to
+//! be notified of the response
+
+use std::collections::HashMap;
+
+use common::{new_async_shared, AsyncShared};
+use job_types::network_manager::NetworkResponseChannel;
+use libp2p::request_response::RequestId;
+
+/// Maps request IDs to channels waiting to be notified of the response
+#[derive(Clone)]
+pub struct ResponseWaiters {
+    /// The underlying map
+    map: AsyncShared<HashMap<RequestId, NetworkResponseChannel>>,
+}
+
+impl Default for ResponseWaiters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResponseWaiters {
+    /// Constructor
+    pub fn new() -> Self {
+        Self { map: new_async_shared(HashMap::new()) }
+    }
+
+    /// Get the channel for the given request ID
+    pub async fn pop(&self, request_id: RequestId) -> Option<NetworkResponseChannel> {
+        self.map.write().await.remove(&request_id)
+    }
+
+    /// Push a channel to wait for the response of the given request ID
+    pub async fn insert(&self, request_id: RequestId, channel: NetworkResponseChannel) {
+        self.map.write().await.insert(request_id, channel);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds the notion of waiters to the network manager; allowing requesting workers to await gossip responses from peers. We use this in the raft networking implementation to directly await an asynchronous response from a peer. 

### Testing
- Deferred until workspace builds