### PR TITLE
state: replicationv2: network: Dynamically dispatch all network impls

### DIFF
--- a/state/src/interface/mpc_preprocessing.rs
+++ b/state/src/interface/mpc_preprocessing.rs
@@ -5,12 +5,9 @@ use common::types::{
     mpc_preprocessing::{PairwiseOfflineSetup, PreprocessingSlice},
 };
 
-use crate::{
-    error::StateError, notifications::ProposalWaiter, replicationv2::raft::NetworkEssential,
-    StateHandle, StateTransition,
-};
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -9,11 +9,9 @@ use config::RelayerConfig;
 use libp2p::{core::Multiaddr, identity::Keypair};
 use util::res_some;
 
-use crate::{
-    error::StateError, replicationv2::raft::NetworkEssential, StateHandle, NODE_METADATA_TABLE,
-};
+use crate::{error::StateError, State, NODE_METADATA_TABLE};
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -22,15 +22,15 @@ use rand::{
 use util::res_some;
 
 use crate::{
-    error::StateError, notifications::ProposalWaiter, replicationv2::raft::NetworkEssential,
-    storage::error::StorageError, StateHandle, StateTransition,
+    error::StateError, notifications::ProposalWaiter, storage::error::StorageError, State,
+    StateTransition,
 };
 
 /// The error message emitted when a caller attempts to add a local order
 /// directly
 const ERR_LOCAL_ORDER: &str = "local order should be updated through a wallet update";
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -4,14 +4,14 @@ use common::types::wallet::{order_metadata::OrderMetadata, OrderIdentifier, Wall
 use util::res_some;
 
 use crate::{
-    error::StateError, notifications::ProposalWaiter, replicationv2::raft::NetworkEssential,
-    storage::error::StorageError, StateHandle, StateTransition,
+    error::StateError, notifications::ProposalWaiter, storage::error::StorageError, State,
+    StateTransition,
 };
 
 /// The error message emitted when a wallet cannot be found for an order
 pub const ERR_MISSING_WALLET: &str = "Wallet not found for order";
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -15,11 +15,11 @@ use util::runtime::block_current;
 
 use crate::{
     error::StateError,
-    replicationv2::{get_raft_id, raft::NetworkEssential, RaftNode},
-    StateHandle,
+    replicationv2::{get_raft_id, RaftNode},
+    State,
 };
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -4,14 +4,11 @@ use util::err_str;
 
 use crate::{
     error::StateError,
-    replicationv2::{
-        network::{RaftRequest, RaftResponse},
-        raft::NetworkEssential,
-    },
-    StateHandle,
+    replicationv2::network::{RaftRequest, RaftResponse},
+    State,
 };
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     /// Handle a raft request from a peer
     ///
     /// We (de)serialize at the raft layer to avoid dependency leak

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -6,12 +6,9 @@ use common::types::tasks::{
 use tracing::instrument;
 use util::{get_current_time_millis, telemetry::helpers::backfill_trace_field};
 
-use crate::{
-    error::StateError, notifications::ProposalWaiter, replicationv2::raft::NetworkEssential,
-    StateHandle, StateTransition,
-};
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -10,12 +10,9 @@ use common::types::{
 };
 use util::res_some;
 
-use crate::{
-    error::StateError, notifications::ProposalWaiter, replicationv2::raft::NetworkEssential,
-    StateHandle, StateTransition,
-};
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
 
-impl<N: NetworkEssential> StateHandle<N> {
+impl State {
     // -----------
     // | Getters |
     // -----------
@@ -121,13 +118,10 @@ mod test {
     use itertools::Itertools;
     use num_bigint::BigUint;
 
-    use crate::{
-        order_history::test::setup_order_history,
-        test_helpers::{mock_state, MockState},
-    };
+    use crate::{order_history::test::setup_order_history, test_helpers::mock_state, State};
 
     /// Create a set of mock historical orders
-    fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &MockState) {
+    fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &State) {
         let history = (0..n)
             .map(|_| OrderMetadata {
                 id: OrderIdentifier::new_v4(),


### PR DESCRIPTION
### Purpose
This PR changes the raft networking implementations to use trait objects internally. This is key to avoiding generics that color all encapsulating interfaces, including those beyond the `state` crate. This change also vastly simplifies the mocking and testing approach in the integration tests of other crates.

The performance implications should be minimal -- certainly dwarfed by the I/O bound nature of these traits' implementation. 

### Testing
- Unit tests pass