### PR TITLE
common: types: descriptors: proper commitment serialization in signature check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,6 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "ark-ec",
- "ark-ff 0.4.2",
  "ark-mpc",
  "ark-poly",
  "base64 0.13.1",
@@ -1607,6 +1606,7 @@ dependencies = [
  "circuit-types",
  "circuits",
  "constants",
+ "contracts-common",
  "crossbeam",
  "derivative",
  "ecdsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "ark-ec",
+ "ark-ff 0.4.2",
  "ark-mpc",
  "ark-poly",
  "base64 0.13.1",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,7 +20,6 @@ mocks = [
 ark-mpc = { workspace = true }
 ark-ec = { version = "0.4", optional = true }
 ark-poly = { version = "0.4", optional = true }
-ark-ff = "0.4.0"
 
 ecdsa = { version = "0.16", optional = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
@@ -46,6 +45,9 @@ circuit-types = { path = "../circuit-types" }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 util = { path = "../util" }
+
+# === Contracts Repo Dependencies === #
+contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
 
 # === Misc Dependencies === #
 base64 = { version = "0.13" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,6 +20,7 @@ mocks = [
 ark-mpc = { workspace = true }
 ark-ec = { version = "0.4", optional = true }
 ark-poly = { version = "0.4", optional = true }
+ark-ff = "0.4.0"
 
 ecdsa = { version = "0.16", optional = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }

--- a/common/src/types/tasks/descriptors.rs
+++ b/common/src/types/tasks/descriptors.rs
@@ -1,11 +1,11 @@
 //! Defines task related types
 
-use ark_ff::{BigInteger, PrimeField};
 use circuit_types::{
     fixed_point::FixedPoint, keychain::PublicSigningKey, note::Note, order::Order,
     r#match::MatchResult, Amount,
 };
 use constants::Scalar;
+use contracts_common::custom_serde::BytesSerializable;
 use ethers::core::types::Signature;
 use ethers::core::utils::keccak256;
 use ethers::utils::public_key_to_address;
@@ -606,9 +606,9 @@ pub fn verify_wallet_update_signature(
     let key: K256VerifyingKey = key.into();
     let new_wallet_comm = wallet.get_wallet_share_commitment();
 
-    // Serialize the commitment, matches the contract's serialization here:
+    // Serialize the commitment, uses the contract's serialization here:
     //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-    let comm_bytes = new_wallet_comm.inner().into_bigint().to_bytes_be();
+    let comm_bytes = new_wallet_comm.inner().serialize_to_bytes();
     let digest = keccak256(comm_bytes);
 
     // Verify the signature

--- a/common/src/types/tasks/descriptors.rs
+++ b/common/src/types/tasks/descriptors.rs
@@ -1,5 +1,6 @@
 //! Defines task related types
 
+use ark_ff::{BigInteger, PrimeField};
 use circuit_types::{
     fixed_point::FixedPoint, keychain::PublicSigningKey, note::Note, order::Order,
     r#match::MatchResult, Amount,
@@ -607,7 +608,7 @@ pub fn verify_wallet_update_signature(
 
     // Serialize the commitment, matches the contract's serialization here:
     //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-    let comm_bytes = new_wallet_comm.to_biguint().to_bytes_be();
+    let comm_bytes = new_wallet_comm.inner().into_bigint().to_bytes_be();
     let digest = keccak256(comm_bytes);
 
     // Verify the signature


### PR DESCRIPTION
This PR fixes the `verify_wallet_update_signature` method to use the same exact serialization of the wallet commitment as the contracts do. While the previous `BigUint::to_bytes_be` _seemed_ correct, it would exclude leading zero bytes from the serialization, whereas in the contracts, we serialize to exactly 32 bytes, including leading zeros.

Since the JS SDK also generates signatures with the faulty serialization, the relayer would verify those signatures, while the contracts would not.