### PR TITLE
core: Bring relayer to functional state with new raft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,7 @@ name = "chain-events"
 version = "0.1.0"
 dependencies = [
  "arbitrum-client",
+ "async-trait",
  "circuit-types",
  "common",
  "crossbeam",
@@ -1614,6 +1615,7 @@ dependencies = [
  "ark-ec",
  "ark-mpc",
  "ark-poly",
+ "async-trait",
  "base64 0.13.1",
  "bimap",
  "circuit-types",
@@ -3232,6 +3234,7 @@ name = "gossip-server"
 version = "0.1.0"
 dependencies = [
  "arbitrum-client",
+ "async-trait",
  "circuit-types",
  "circuits",
  "common",
@@ -3350,6 +3353,7 @@ dependencies = [
  "arbitrum-client",
  "ark-mpc",
  "ark-serialize 0.4.2",
+ "async-trait",
  "circuit-types",
  "circuits",
  "clap 4.5.4",
@@ -4889,6 +4893,7 @@ dependencies = [
  "task-driver",
  "test-helpers",
  "tokio",
+ "util",
 ]
 
 [[package]]
@@ -6180,6 +6185,7 @@ name = "proof-manager"
 version = "0.1.0"
 dependencies = [
  "ark-mpc",
+ "async-trait",
  "circuit-types",
  "circuits",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ futures = "0.3"
 tokio = { version = "1" }
 
 # === Misc === #
+async-trait = "0.1"
 ethers = "2"
 eyre = "0.6"
 indexmap = "2.0.2"

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4", features = ["rand", "serde"] }
 rand = "0.8"
 
 # === Async + Runtime === #
-async-trait = "0.1"
+async-trait = { workspace = true }
 futures = { workspace = true }
 
 # === Workspace Crates === #

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -33,6 +33,7 @@ num-traits = "0.2"
 signature = "2.0"
 
 # === Runtime + Networking === #
+async-trait = { workspace = true }
 crossbeam = { workspace = true }
 libp2p = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/common/src/worker.rs
+++ b/common/src/worker.rs
@@ -6,11 +6,13 @@ use std::{
     thread::{Builder, JoinHandle},
 };
 
+use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 use tracing::error;
 
 /// The Worker trait abstracts over worker functionality with a series of
 /// callbacks that allow a worker to be started, cleaned up, and restarted
+#[async_trait]
 pub trait Worker {
     /// The configuration needed to spawn the implementing worker
     type WorkerConfig;
@@ -18,7 +20,7 @@ pub trait Worker {
     type Error: 'static + Send + Debug;
 
     /// Create a new instance of the implementing worker
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
     where
         Self: Sized;
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -135,6 +135,10 @@ struct Cli {
     /// The path at which to save raft snapshots
     #[clap(long, value_parser, default_value = "./raft_snapshots")]
     pub raft_snapshot_path: String,
+    /// Whether or not to assume the node is a leader of a new cluster at
+    /// startup
+    #[clap(long, value_parser, default_value = "false")]
+    pub assume_raft_leader: bool,
     /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
     /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
     #[clap(long, value_parser, default_value = "100")]
@@ -259,6 +263,9 @@ pub struct RelayerConfig {
     pub db_path: String,
     /// The path at which to save raft snapshots
     pub raft_snapshot_path: String,
+    /// Whether or not to assume the node is a leader of a new cluster at
+    /// startup
+    pub assume_raft_leader: bool,
     /// The maximum staleness (number of newer roots observed) to allow on
     /// Merkle proofs for managed wallets. After this threshold is exceeded,
     /// the Merkle proof will be updated
@@ -306,6 +313,13 @@ pub struct RelayerConfig {
     pub statsd_port: u16,
 }
 
+impl RelayerConfig {
+    /// Get the peer ID associated with the p2p key
+    pub fn peer_id(&self) -> WrappedPeerId {
+        WrappedPeerId(self.p2p_key.public().to_peer_id())
+    }
+}
+
 impl Default for RelayerConfig {
     fn default() -> Self {
         // Parse a dummy set of command line args and convert this to a config
@@ -331,6 +345,7 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
+            assume_raft_leader: self.assume_raft_leader,
             max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,
@@ -457,6 +472,7 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         p2p_key,
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
+        assume_raft_leader: cli_args.assume_raft_leader,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         disable_price_reporter: cli_args.disable_price_reporter,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2018"
 default-run = "renegade-relayer"
 
-[features]
-debug-tui = []
-
 [dependencies]
 # === Runtime + Async === #
 crossbeam = { workspace = true }
@@ -28,7 +25,7 @@ job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
 price-reporter = { path = "../workers/price-reporter" }
 proof-manager = { path = "../workers/proof-manager" }
-state = { path = "../state", features = ["mocks"] }
+state = { path = "../state" }
 system-bus = { path = "../system-bus" }
 task-driver = { path = "../workers/task-driver" }
 util = { path = "../util" }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -18,6 +18,7 @@ use std::{process::exit, thread, time::Duration};
 use api_server::worker::{ApiServer, ApiServerConfig};
 use arbitrum_client::client::{ArbitrumClient, ArbitrumClientConfig};
 use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
+use common::default_wrapper::default_option;
 use common::worker::{watch_worker, Worker};
 use constants::VERSION;
 use external_api::bus_message::SystemBusMessage;
@@ -29,13 +30,12 @@ use job_types::network_manager::new_network_manager_queue;
 use job_types::price_reporter::new_price_reporter_queue;
 use job_types::proof_manager::new_proof_manager_queue;
 use job_types::task_driver::new_task_driver_queue;
-use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
+use network_manager::{worker::NetworkManager, worker::NetworkManagerConfig};
 use price_reporter::worker::ExchangeConnectionsConfig;
 use price_reporter::{manager::PriceReporter, worker::PriceReporterConfig};
 use proof_manager::{proof_manager::ProofManager, worker::ProofManagerConfig};
-use state::replication::worker::ReplicationNodeWorker;
+use state::tui::StateTuiApp;
 use state::State;
-use state::{replication::network::traits::new_raft_message_queue, tui::StateTuiApp};
 use system_bus::SystemBus;
 
 use error::CoordinatorError;
@@ -105,7 +105,6 @@ async fn main() -> Result<(), CoordinatorError> {
     // First, the global shared mpmc bus that all workers have access to
     let system_bus = SystemBus::<SystemBusMessage>::new();
     let (network_sender, network_receiver) = new_network_manager_queue();
-    let (raft_sender, raft_receiver) = new_raft_message_queue();
     let (gossip_worker_sender, gossip_worker_receiver) = new_gossip_server_queue();
     let (handshake_worker_sender, handshake_worker_receiver) = new_handshake_manager_queue();
     let (price_reporter_worker_sender, price_reporter_worker_receiver) = new_price_reporter_queue();
@@ -114,16 +113,14 @@ async fn main() -> Result<(), CoordinatorError> {
     let (task_sender, task_receiver) = new_task_driver_queue();
 
     // Construct a global state
-    let (global_state, mut raft_worker, raft_cancel_sender) = State::new(
-        network_sender.clone(),
-        raft_receiver,
+    let global_state = State::new(
         &args,
+        network_sender.clone(),
         task_sender.clone(),
         handshake_worker_sender.clone(),
         system_bus.clone(),
-    )?;
-    let (raft_failure_sender, mut raft_failure_receiver) = mpsc::channel(1 /* buffer_size */);
-    watch_worker::<ReplicationNodeWorker<_>>(&mut raft_worker, &raft_failure_sender);
+    )
+    .await?;
 
     if args.debug {
         // Build the TUI
@@ -166,7 +163,8 @@ async fn main() -> Result<(), CoordinatorError> {
         system_bus.clone(),
         global_state.clone(),
     );
-    let mut task_driver = TaskDriver::new(task_driver_config).expect("failed to build task driver");
+    let mut task_driver =
+        TaskDriver::new(task_driver_config).await.expect("failed to build task driver");
     task_driver.start().expect("failed to start task driver");
 
     let (task_driver_failure_sender, mut task_driver_failure_receiver) =
@@ -179,6 +177,7 @@ async fn main() -> Result<(), CoordinatorError> {
         job_queue: proof_generation_worker_receiver,
         cancel_channel: proof_manager_cancel_receiver,
     })
+    .await
     .expect("failed to build proof generation module");
     proof_manager.start().expect("failed to start proof generation module");
     let (proof_manager_failure_sender, mut proof_manager_failure_receiver) =
@@ -193,9 +192,8 @@ async fn main() -> Result<(), CoordinatorError> {
         known_public_addr: args.public_ip,
         allow_local: args.allow_local,
         cluster_id: args.cluster_id.clone(),
-        cluster_keypair: Some(args.cluster_keypair),
-        send_channel: Some(network_receiver),
-        raft_queue: raft_sender,
+        cluster_keypair: default_option(args.cluster_keypair),
+        send_channel: default_option(network_receiver),
         gossip_work_queue: gossip_worker_sender.clone(),
         handshake_work_queue: handshake_worker_sender.clone(),
         global_state: global_state.clone(),
@@ -203,7 +201,7 @@ async fn main() -> Result<(), CoordinatorError> {
         cancel_channel: network_cancel_receiver,
     };
     let mut network_manager =
-        NetworkManager::new(network_manager_config).expect("failed to build network manager");
+        NetworkManager::new(network_manager_config).await.expect("failed to build network manager");
     network_manager.start().expect("failed to start network manager");
 
     let (network_failure_sender, mut network_failure_receiver) =
@@ -224,6 +222,7 @@ async fn main() -> Result<(), CoordinatorError> {
         network_sender: network_sender.clone(),
         cancel_channel: gossip_cancel_receiver,
     })
+    .await
     .expect("failed to build gossip server");
     gossip_server.start().expect("failed to start gossip server");
     let (gossip_failure_sender, mut gossip_failure_receiver) =
@@ -261,6 +260,7 @@ async fn main() -> Result<(), CoordinatorError> {
         system_bus: system_bus.clone(),
         cancel_channel: handshake_cancel_receiver,
     })
+    .await
     .expect("failed to build handshake manager");
     handshake_manager.start().expect("failed to start handshake manager");
     let (handshake_failure_sender, mut handshake_failure_receiver) =
@@ -282,6 +282,7 @@ async fn main() -> Result<(), CoordinatorError> {
         disabled: args.disable_price_reporter,
         disabled_exchanges: args.disabled_exchanges,
     })
+    .await
     .expect("failed to build price reporter manager");
     price_reporter_manager.start().expect("failed to start price reporter manager");
     let (price_reporter_failure_sender, mut price_reporter_failure_receiver) =
@@ -299,6 +300,7 @@ async fn main() -> Result<(), CoordinatorError> {
         network_sender: network_sender.clone(),
         cancel_channel: chain_listener_cancel_receiver,
     })
+    .await
     .expect("failed to build on-chain event listener");
     chain_listener.start().expect("failed to start on-chain event listener");
     let (chain_listener_failure_sender, mut chain_listener_failure_receiver) =
@@ -317,6 +319,7 @@ async fn main() -> Result<(), CoordinatorError> {
         proof_generation_work_queue: proof_generation_worker_sender,
         cancel_channel: api_cancel_receiver,
     })
+    .await
     .expect("failed to build api server");
     api_server.start().expect("failed to start api server");
     let (api_failure_sender, mut api_failure_receiver) = mpsc::channel(1 /* buffer_size */);
@@ -327,11 +330,6 @@ async fn main() -> Result<(), CoordinatorError> {
     let recovery_loop = || async {
         loop {
             select! {
-                _ = raft_failure_receiver.recv() => {
-                    raft_cancel_sender.send(())
-                        .map_err(|err| CoordinatorError::CancelSend(err.to_string()))?;
-                    raft_worker = recover_worker(raft_worker)?;
-                }
                 _ = task_driver_failure_receiver.recv() => {
                     task_driver = recover_worker(task_driver)?;
                 }
@@ -381,7 +379,6 @@ async fn main() -> Result<(), CoordinatorError> {
 
     // Send cancel signals to all workers
     for cancel_channel in [
-        raft_cancel_sender,
         network_cancel_sender,
         gossip_cancel_sender,
         handshake_cancel_sender,

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -41,7 +41,7 @@ pub async fn node_setup(
 
     // TODO: remove this once we have a more fleshed
     // out startup flow
-    tokio::time::sleep(Duration::from_secs(15)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
     // Setup the contract constants
     fetch_contract_constants(client).await?;
@@ -81,7 +81,10 @@ async fn setup_relayer_wallet(
 
     // Set the node metadata entry for the relayer's wallet
     let wallet_id = derive_wallet_id(key).map_err(err_str!(CoordinatorError::Setup))?;
-    state.set_local_relayer_wallet_id(wallet_id).map_err(err_str!(CoordinatorError::Setup))?;
+    state
+        .set_local_relayer_wallet_id(wallet_id)
+        .await
+        .map_err(err_str!(CoordinatorError::Setup))?;
 
     // Attempt to find the wallet on-chain
     if find_wallet_onchain(

--- a/mock-node/Cargo.toml
+++ b/mock-node/Cargo.toml
@@ -29,6 +29,7 @@ state = { path = "../state", features = ["mocks"] }
 system-bus = { path = "../system-bus" }
 task-driver = { path = "../workers/task-driver" }
 test-helpers = { path = "../test-helpers" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -21,6 +21,7 @@ use common::{
 use config::RelayerConfig;
 use ed25519_dalek::Keypair;
 use external_api::bus_message::SystemBusMessage;
+use futures::Future;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};
 use job_types::{
@@ -43,7 +44,7 @@ use job_types::{
     task_driver::{new_task_driver_queue, TaskDriverJob, TaskDriverQueue, TaskDriverReceiver},
 };
 use libp2p::Multiaddr;
-use network_manager::{manager::NetworkManager, worker::NetworkManagerConfig};
+use network_manager::worker::{NetworkManager, NetworkManagerConfig};
 use price_reporter::{
     manager::PriceReporter,
     mock::{setup_mock_token_remap, MockPriceReporter},
@@ -54,14 +55,23 @@ use proof_manager::{
 };
 use reqwest::{blocking::Client, Method};
 use serde::{de::DeserializeOwned, Serialize};
-use state::{
-    replication::network::traits::{new_raft_message_queue, RaftMessageQueue, RaftMessageReceiver},
-    State,
-};
+use state::State;
 use system_bus::SystemBus;
 use task_driver::worker::{TaskDriver, TaskDriverConfig};
 use test_helpers::mocks::mock_cancel;
 use tokio::runtime::Runtime as TokioRuntime;
+
+/// A helper that creates a dummy runtime and blocks a task on it
+///
+/// We use this to give a synchronous mock node api, which emits a convenient
+/// builder pattern
+fn run_fut<F>(fut: F) -> F::Output
+where
+    F: Future,
+{
+    let rt = TokioRuntime::new().expect("Failed to create tokio runtime");
+    rt.block_on(fut)
+}
 
 /// The mock node struct, used to build testing nodes
 ///
@@ -93,8 +103,6 @@ pub struct MockNodeController {
     // --- Worker Queues --- //
     /// The network manager's queue
     network_queue: (NetworkManagerQueue, DefaultOption<NetworkManagerReceiver>),
-    /// The raft message queue
-    raft_queue: (RaftMessageQueue, DefaultOption<RaftMessageReceiver>),
     /// The gossip message queue
     gossip_queue: (GossipServerQueue, DefaultOption<GossipServerReceiver>),
     /// The handshake manager's queue
@@ -113,7 +121,6 @@ impl MockNodeController {
     pub fn new(config: RelayerConfig) -> Self {
         let bus = SystemBus::new();
         let (network_sender, network_recv) = new_network_manager_queue();
-        let (raft_sender, raft_recv) = new_raft_message_queue();
         let (gossip_sender, gossip_recv) = new_gossip_server_queue();
         let (handshake_send, handshake_recv) = new_handshake_manager_queue();
         let (price_sender, price_recv) = new_price_reporter_queue();
@@ -127,7 +134,6 @@ impl MockNodeController {
             bus,
             state: None,
             network_queue: (network_sender, default_option(network_recv)),
-            raft_queue: (raft_sender, default_option(raft_recv)),
             gossip_queue: (gossip_sender, default_option(gossip_recv)),
             handshake_queue: (handshake_send, default_option(handshake_recv)),
             price_queue: (price_sender, default_option(price_recv)),
@@ -239,9 +245,7 @@ impl MockNodeController {
         };
 
         // Expects to be running in a Tokio runtime
-        let rt = TokioRuntime::new().expect("Failed to create tokio runtime");
-        let client =
-            rt.block_on(ArbitrumClient::new(conf)).expect("Failed to create arbitrum client");
+        let client = run_fut(ArbitrumClient::new(conf)).expect("Failed to create arbitrum client");
         self.arbitrum_client = Some(client);
 
         self
@@ -251,26 +255,15 @@ impl MockNodeController {
     pub fn with_state(mut self) -> Self {
         // Create a global state instance
         let network_queue = self.network_queue.0.clone();
-        let raft_receiver = self.raft_queue.1.take().unwrap();
         let task_sender = self.task_queue.0.clone();
         let handshake_queue = self.handshake_queue.0.clone();
         let bus = self.bus.clone();
 
-        let (state, _, raft_cancel) = State::new(
-            network_queue,
-            raft_receiver,
-            &self.config,
-            task_sender,
-            handshake_queue,
-            bus,
-        )
-        .expect("Failed to create state instance");
-
-        // Forget the raft cancel sender to avoid dropping it
-        mem::forget(raft_cancel);
+        let state =
+            run_fut(State::new(&self.config, network_queue, task_sender, handshake_queue, bus))
+                .expect("Failed to create state instance");
 
         self.state = Some(state);
-
         self
     }
 
@@ -292,7 +285,7 @@ impl MockNodeController {
             bus,
             state,
         );
-        let mut driver = TaskDriver::new(conf).expect("Failed to create task driver");
+        let mut driver = run_fut(TaskDriver::new(conf)).expect("Failed to create task driver");
         driver.start().expect("Failed to start task driver");
 
         self
@@ -302,7 +295,6 @@ impl MockNodeController {
     pub fn with_network_manager(mut self) -> Self {
         let config = &self.config;
         let network_recv = self.network_queue.1.take().unwrap();
-        let raft_sender = self.raft_queue.0.clone();
         let gossip_sender = self.gossip_queue.0.clone();
         let handshake_send = self.handshake_queue.0.clone();
         let cancel_channel = mock_cancel();
@@ -313,21 +305,20 @@ impl MockNodeController {
             known_public_addr: config.public_ip,
             allow_local: config.allow_local,
             cluster_id: config.cluster_id.clone(),
-            cluster_keypair: Some(self.clone_cluster_key()),
-            send_channel: Some(network_recv),
-            raft_queue: raft_sender,
+            cluster_keypair: default_option(self.clone_cluster_key()),
+            send_channel: default_option(network_recv),
             gossip_work_queue: gossip_sender,
             handshake_work_queue: handshake_send,
             system_bus: self.bus.clone(),
             global_state: self.state.clone().expect("State not initialized"),
             cancel_channel,
         };
-        let mut manager = NetworkManager::new(conf).expect("Failed to create network manager");
+        let mut manager =
+            run_fut(NetworkManager::new(conf)).expect("Failed to create network manager");
         manager.start().expect("Failed to start network manager");
 
         // Set the local addr after the manager binds to it
         self.local_addr = manager.local_addr;
-
         self
     }
 
@@ -335,7 +326,7 @@ impl MockNodeController {
     pub fn with_gossip_server(mut self) -> Self {
         let config = &self.config;
         let state = self.state.clone().expect("State not initialized");
-        let local_peer_id = state.get_peer_id().expect("Failed to get peer id");
+        let local_peer_id = run_fut(state.get_peer_id()).expect("Failed to get peer id");
         let arbitrum_client =
             self.arbitrum_client.clone().expect("Arbitrum client not initialized");
 
@@ -355,7 +346,7 @@ impl MockNodeController {
             network_sender,
             cancel_channel: mock_cancel(),
         };
-        let mut server = GossipServer::new(conf).expect("Failed to create gossip server");
+        let mut server = run_fut(GossipServer::new(conf)).expect("Failed to create gossip server");
         server.start().expect("Failed to start gossip server");
 
         self
@@ -383,7 +374,8 @@ impl MockNodeController {
             system_bus,
             cancel_channel,
         };
-        let mut manager = HandshakeManager::new(conf).expect("Failed to create handshake manager");
+        let mut manager =
+            run_fut(HandshakeManager::new(conf)).expect("Failed to create handshake manager");
         manager.start().expect("Failed to start handshake manager");
 
         self
@@ -409,7 +401,8 @@ impl MockNodeController {
             system_bus,
             cancel_channel,
         };
-        let mut reporter = PriceReporter::new(conf).expect("Failed to create price reporter");
+        let mut reporter =
+            run_fut(PriceReporter::new(conf)).expect("Failed to create price reporter");
         reporter.start().expect("Failed to start price reporter");
 
         self
@@ -423,7 +416,6 @@ impl MockNodeController {
 
         // Setup a mock token map
         setup_mock_token_remap();
-
         self
     }
 
@@ -448,8 +440,8 @@ impl MockNodeController {
             cancel_channel,
         };
 
-        let mut listener =
-            OnChainEventListener::new(conf).expect("Failed to create chain event listener");
+        let mut listener = run_fut(OnChainEventListener::new(conf))
+            .expect("Failed to create chain event listener");
         listener.start().expect("Failed to start chain event listener");
 
         self
@@ -476,12 +468,11 @@ impl MockNodeController {
             cancel_channel,
         };
 
-        let mut server = ApiServer::new(conf).expect("Failed to create API server");
+        let mut server = run_fut(ApiServer::new(conf)).expect("Failed to create API server");
         server.start().expect("Failed to start API server");
 
         // Forget the server to avoid dropping it and its runtime
         mem::forget(server);
-
         self
     }
 
@@ -492,7 +483,7 @@ impl MockNodeController {
 
         let conf = ProofManagerConfig { job_queue, cancel_channel };
 
-        let mut manager = ProofManager::new(conf).expect("Failed to create proof manager");
+        let mut manager = run_fut(ProofManager::new(conf)).expect("Failed to create proof manager");
         manager.start().expect("Failed to start proof manager");
 
         self
@@ -513,6 +504,7 @@ mod test {
     use config::RelayerConfig;
     use external_api::{http::PingResponse, EmptyRequestResponse};
     use reqwest::Method;
+    use state::test_helpers::tmp_db_path;
     use test_helpers::arbitrum::get_devnet_key;
 
     use crate::MockNodeController;
@@ -520,9 +512,12 @@ mod test {
     /// Tests a simple constructor of the mock node
     #[test]
     fn test_ping_mock() {
+        let db_path = tmp_db_path();
         let conf = RelayerConfig {
             rpc_url: Some("http://localhost:1234".to_string()),
             arbitrum_private_key: get_devnet_key(),
+            raft_snapshot_path: db_path.clone(),
+            db_path,
             ..Default::default()
         };
 

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -5,7 +5,7 @@ use common::types::{token::Token, transfer_auth::ExternalTransferWithAuth};
 use num_bigint::BigUint;
 use state::{error::StateError, State};
 use tracing::error;
-use util::{hex::biguint_to_hex_string, runtime::block_current};
+use util::hex::biguint_to_hex_string;
 
 use crate::labels::{
     ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
@@ -68,17 +68,17 @@ pub fn record_relayer_fee_settlement(mint: &BigUint, amount: u128) {
 }
 
 /// Get the number of local and remote peers the cluster is connected to
-fn get_num_peers(state: &State) -> Result<(usize, usize), StateError> {
-    let cluster_id = block_current(state.get_cluster_id())?;
-    let num_local_peers = block_current(state.get_cluster_peers(&cluster_id))?.len();
-    let num_remote_peers = block_current(state.get_non_cluster_peers(&cluster_id))?.len();
+async fn get_num_peers(state: &State) -> Result<(usize, usize), StateError> {
+    let cluster_id = state.get_cluster_id().await?;
+    let num_local_peers = state.get_cluster_peers(&cluster_id).await?.len();
+    let num_remote_peers = state.get_non_cluster_peers(&cluster_id).await?.len();
 
     Ok((num_local_peers, num_remote_peers))
 }
 
 /// Record the number of local and remote peers the cluster is connected to
-pub fn record_num_peers_metrics(state: &State) {
-    let (num_local_peers, num_remote_peers) = match get_num_peers(state) {
+pub async fn record_num_peers_metrics(state: &State) {
+    let (num_local_peers, num_remote_peers) = match get_num_peers(state).await {
         Ok(peers) => peers,
         Err(e) => {
             error!("Error getting number of peers: {}", e);

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -37,7 +37,7 @@ util = { path = "../util" }
 test-helpers = { path = "../test-helpers", optional = true }
 
 # === Misc === #
-async-trait = "0.1"
+async-trait = { workspace = true }
 crossterm = "0.27"
 itertools = "0.10"
 fxhash = "0.2"

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -100,8 +100,7 @@ impl State {
 
     /// Setup the node metadata table from a relayer config
     pub async fn setup_node_metadata(&self, config: &RelayerConfig) -> Result<(), StateError> {
-        let keypair = config.p2p_key.clone();
-        let peer_id = WrappedPeerId(keypair.public().to_peer_id());
+        let peer_id = config.peer_id();
         let cluster_id = config.cluster_id.clone();
         let p2p_key = config.p2p_key.clone();
         let fee_decryption_key = config.fee_decryption_key;

--- a/state/src/notifications.rs
+++ b/state/src/notifications.rs
@@ -52,7 +52,9 @@ impl OpenNotifications {
     /// Notify a listener that a proposal has been applied
     pub async fn notify(&self, id: ProposalId, result: ProposalReturnType) {
         if let Some(sender) = self.map.write().await.remove(&id) {
-            sender.send(result).unwrap();
+            if !sender.is_closed() {
+                let _ = sender.send(result);
+            }
         }
     }
 

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -6,7 +6,7 @@ description = "Helpers for setting up and running integration tests for the rela
 
 [dependencies]
 # === Runtime + Networking === #
-async-trait = "0.1"
+async-trait = { workspace = true }
 dns-lookup = "1.0"
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -37,7 +37,7 @@ task-driver = { path = "../task-driver" }
 util = { path = "../../util" }
 
 # === Misc Dependencies === #
-async-trait = "0.1.60"
+async-trait = { workspace = true }
 base64 = "0.21"
 itertools = "0.11"
 serde = { workspace = true }

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -1,5 +1,6 @@
 //! Defines the implementation of the `Worker` trait for the ApiServer
 
+use async_trait::async_trait;
 use common::{types::CancelChannel, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use futures::executor::block_on;
@@ -59,11 +60,12 @@ pub struct ApiServerConfig {
     pub cancel_channel: CancelChannel,
 }
 
+#[async_trait]
 impl Worker for ApiServer {
     type WorkerConfig = ApiServerConfig;
     type Error = ApiServerError;
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -21,5 +21,6 @@ job-types = { path = "../job-types" }
 state = { path = "../../state" }
 
 # === Misc Dependencies === #
+async-trait = { workspace = true }
 lazy_static = "1.4"
 tracing = { workspace = true }

--- a/workers/chain-events/src/worker.rs
+++ b/workers/chain-events/src/worker.rs
@@ -1,5 +1,6 @@
 //! The relayer worker implementation for the event listener
 
+use async_trait::async_trait;
 use common::worker::Worker;
 use std::thread::{Builder, JoinHandle};
 use tokio::runtime::Builder as RuntimeBuilder;
@@ -10,11 +11,12 @@ use super::{
     listener::{OnChainEventListener, OnChainEventListenerConfig, OnChainEventListenerExecutor},
 };
 
+#[async_trait]
 impl Worker for OnChainEventListener {
     type WorkerConfig = OnChainEventListenerConfig;
     type Error = OnChainEventListenerError;
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {

--- a/workers/gossip-server/Cargo.toml
+++ b/workers/gossip-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # === Async + Concurrency === #
+async-trait = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -148,7 +148,7 @@ impl GossipProtocolExecutor {
         let mut locked_expiry_cache = self.peer_expiry_cache.write().await;
         locked_expiry_cache.put(peer_id, now);
 
-        record_num_peers_metrics(&self.global_state);
+        record_num_peers_metrics(&self.global_state).await;
 
         Ok(())
     }

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -108,7 +108,7 @@ impl GossipProtocolExecutor {
         // Add all filtered peers to the global peer index
         self.global_state.add_peer_batch(filtered_peers.clone()).await?;
 
-        record_num_peers_metrics(&self.global_state);
+        record_num_peers_metrics(&self.global_state).await;
 
         Ok(())
     }

--- a/workers/gossip-server/src/worker.rs
+++ b/workers/gossip-server/src/worker.rs
@@ -1,6 +1,7 @@
 //! Implements the `Worker` trait for the GossipServer
 
 use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
 use common::default_wrapper::DefaultWrapper;
 use common::types::gossip::{ClusterId, WrappedPeerId};
 use common::types::CancelChannel;
@@ -45,11 +46,12 @@ pub struct GossipServerConfig {
     pub cancel_channel: CancelChannel,
 }
 
+#[async_trait]
 impl Worker for GossipServer {
     type WorkerConfig = GossipServerConfig;
     type Error = GossipError;
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
         Ok(Self { config, protocol_executor_handle: None })
     }
 

--- a/workers/handshake-manager-tests/src/helpers.rs
+++ b/workers/handshake-manager-tests/src/helpers.rs
@@ -25,7 +25,7 @@ pub(crate) async fn allocate_wallet(wallet: &mut Wallet, args: &IntegrationTestA
     lookup_wallet(blinder_seed, share_seed, wallet, args).await?;
 
     // Finally read the wallet from state into the mutable reference
-    *wallet = state.get_wallet(&wallet.wallet_id)?.unwrap();
+    *wallet = state.get_wallet(&wallet.wallet_id).await?.unwrap();
     Ok(())
 }
 
@@ -45,7 +45,7 @@ pub(crate) async fn lookup_wallet(
         blinder_seed,
         key_chain: wallet.key_chain.clone(),
     };
-    let (id, waiter) = state.append_task(task.into())?;
+    let (id, waiter) = state.append_task(task.into()).await?;
     waiter.await?;
 
     // Enqueue a notification with the driver

--- a/workers/handshake-manager/Cargo.toml
+++ b/workers/handshake-manager/Cargo.toml
@@ -9,6 +9,7 @@ ark-mpc = { workspace = true }
 mpc-plonk = { workspace = true }
 
 # === Concurrency + Networking === #
+async-trait = { workspace = true }
 crossbeam = { workspace = true }
 futures = { workspace = true }
 libp2p = { workspace = true }

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -5,6 +5,7 @@ use std::{
     thread::{Builder, JoinHandle},
 };
 
+use async_trait::async_trait;
 use common::types::{wallet::WalletIdentifier, CancelChannel};
 use common::worker::Worker;
 use external_api::bus_message::SystemBusMessage;
@@ -53,11 +54,12 @@ pub struct HandshakeManagerConfig {
     pub cancel_channel: CancelChannel,
 }
 
+#[async_trait]
 impl Worker for HandshakeManager {
     type WorkerConfig = HandshakeManagerConfig;
     type Error = HandshakeManagerError;
 
-    fn new(mut config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+    async fn new(mut config: Self::WorkerConfig) -> Result<Self, Self::Error> {
         // Start a timer thread, periodically asks workers to begin handshakes with
         // peers
         let scheduler = HandshakeScheduler::new(

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -24,7 +24,8 @@ pub enum PriceReporterJob {
     /// If using the external executor, this will send a subscription request
     /// for the pair across all exchanges.
     ///
-    /// If using the native executor, this will create and start a new PriceReporter for the pair.
+    /// If using the native executor, this will create and start a new
+    /// PriceReporter for the pair.
     ///
     /// If the PriceReporter does not yet exist, spawn it and begin publication
     /// to the global system bus. If the PriceReporter already exists and id

--- a/workers/network-manager/Cargo.toml
+++ b/workers/network-manager/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # === Concurrency + Networking === #
-async-trait = "0.1.60"
+async-trait = { workspace = true }
 futures = { workspace = true }
 libp2p = { workspace = true, features = [
     "gossipsub",

--- a/workers/network-manager/src/executor.rs
+++ b/workers/network-manager/src/executor.rs
@@ -24,7 +24,7 @@ use libp2p::{
     request_response::Event as RequestResponseEvent, swarm::SwarmEvent, Multiaddr, Swarm,
 };
 use state::State;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use std::sync::{atomic::AtomicBool, Arc};
 
@@ -213,7 +213,7 @@ impl NetworkManagerExecutor {
                             info!("Listening on {}/p2p/{}\n", address, self.local_peer_id);
                         },
                         // This catchall may be enabled for fine-grained libp2p introspection
-                        x => { info!("Unhandled swarm event: {:?}", x) }
+                        x => { debug!("Unhandled swarm event: {:?}", x) }
                     }
                 }
 

--- a/workers/network-manager/src/executor/request_response.rs
+++ b/workers/network-manager/src/executor/request_response.rs
@@ -56,7 +56,7 @@ impl NetworkManagerExecutor {
                 response.verify_cluster_auth(&self.cluster_key.public)?;
                 let body = response.body;
                 if let Some(chan) = self.response_waiters.pop(request_id).await {
-                    if chan.send(body.clone()).is_err() {
+                    if !chan.is_closed() && chan.send(body.clone()).is_err() {
                         error!("error sending response notification for request: {request_id}");
                     }
                 }

--- a/workers/price-reporter/Cargo.toml
+++ b/workers/price-reporter/Cargo.toml
@@ -11,7 +11,7 @@ mocks = ["bimap"]
 hmac-sha256 = "1.1"
 
 # === Async + Runtime === #
-async-trait = "0.1"
+async-trait = { workspace = true }
 futures = { workspace = true }
 futures-util = "0.3"
 tokio = { workspace = true }

--- a/workers/price-reporter/src/worker.rs
+++ b/workers/price-reporter/src/worker.rs
@@ -1,6 +1,7 @@
 //! Defines the Worker logic for the PriceReporterManger, which simply
 //! dispatches jobs to the PriceReporterExecutor.
 
+use async_trait::async_trait;
 use common::{
     default_wrapper::DefaultOption,
     types::{exchange::Exchange, CancelChannel},
@@ -82,11 +83,12 @@ impl PriceReporterConfig {
     }
 }
 
+#[async_trait]
 impl Worker for PriceReporter {
     type WorkerConfig = PriceReporterConfig;
     type Error = PriceReporterError;
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
         Ok(Self { config, manager_executor_handle: None })
     }
 

--- a/workers/proof-manager/Cargo.toml
+++ b/workers/proof-manager/Cargo.toml
@@ -12,6 +12,7 @@ ark-mpc = { workspace = true }
 mpc-plonk = { workspace = true }
 
 # === Runtime + Threading === #
+async-trait = { workspace = true }
 crossbeam = { workspace = true }
 rayon = { version = "1.5.3" }
 tokio = { workspace = true }

--- a/workers/proof-manager/src/worker.rs
+++ b/workers/proof-manager/src/worker.rs
@@ -6,6 +6,7 @@ use std::{
     thread::{Builder, JoinHandle},
 };
 
+use async_trait::async_trait;
 use common::{types::CancelChannel, worker::Worker};
 use job_types::proof_manager::ProofManagerReceiver;
 use rayon::ThreadPoolBuilder;
@@ -28,11 +29,12 @@ pub struct ProofManagerConfig {
     pub cancel_channel: CancelChannel,
 }
 
+#[async_trait]
 impl Worker for ProofManager {
     type WorkerConfig = ProofManagerConfig;
     type Error = ProofManagerError;
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["integration"]
 
 [dependencies]
 # === Async + Runtime === #
-async-trait = "0.1.60"
+async-trait = { workspace = true }
 crossbeam = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -25,7 +25,7 @@ use job_types::{
 };
 use num_bigint::BigUint;
 use rand::thread_rng;
-use state::test_helpers::MockState;
+use state::State;
 use system_bus::SystemBus;
 use task_driver::{
     driver::RuntimeArgs,
@@ -38,6 +38,7 @@ use test_helpers::{
         transfer_auth::gen_transfer_with_auth,
     },
 };
+use util::runtime::block_current;
 
 use crate::IntegrationTestArgs;
 
@@ -214,7 +215,7 @@ pub fn new_mock_task_driver(
     arbitrum_client: ArbitrumClient,
     network_queue: NetworkManagerQueue,
     proof_queue: ProofManagerQueue,
-    state: MockState,
+    state: State,
 ) {
     let bus = SystemBus::new();
     // Set a runtime config with fast failure
@@ -237,6 +238,6 @@ pub fn new_mock_task_driver(
     };
 
     // Start the driver
-    let mut driver = TaskDriver::new(config).unwrap();
+    let mut driver = block_current(TaskDriver::new(config)).unwrap();
     driver.start().unwrap();
 }

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -29,7 +29,10 @@ use job_types::{
 };
 use proof_manager::mock::MockProofManager;
 use rand::thread_rng;
-use state::test_helpers::{mock_relayer_config, mock_state_with_task_queue, MockState};
+use state::{
+    test_helpers::{mock_relayer_config, mock_state_with_task_queue},
+    State,
+};
 use test_helpers::{
     arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
     integration_test_main,
@@ -93,7 +96,7 @@ struct IntegrationTestArgs {
     /// Held here to avoid closing the channel on `Drop`
     _network_receiver: Arc<NetworkManagerReceiver>,
     /// A reference to the global state of the mock proof manager
-    state: MockState,
+    state: State,
     /// The job queue for the mock proof manager
     proof_job_queue: CrossbeamSender<ProofManagerJob>,
     /// The task driver queue used to enqueue tasks
@@ -157,7 +160,7 @@ impl From<CliArgs> for IntegrationTestArgs {
 }
 
 /// Create a global state mock for the `task-driver` integration tests
-async fn setup_global_state_mock(task_queue: TaskDriverQueue) -> MockState {
+async fn setup_global_state_mock(task_queue: TaskDriverQueue) -> State {
     mock_state_with_task_queue(task_queue, &mock_relayer_config()).await
 }
 

--- a/workers/task-driver/src/worker.rs
+++ b/workers/task-driver/src/worker.rs
@@ -3,6 +3,7 @@
 use std::thread::{self, JoinHandle};
 
 use arbitrum_client::client::ArbitrumClient;
+use async_trait::async_trait;
 use common::{default_wrapper::DefaultOption, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
@@ -73,6 +74,7 @@ pub struct TaskDriver {
     handle: Option<JoinHandle<TaskDriverError>>,
 }
 
+#[async_trait]
 impl Worker for TaskDriver {
     type Error = TaskDriverError;
     type WorkerConfig = TaskDriverConfig;
@@ -81,7 +83,7 @@ impl Worker for TaskDriver {
         "task-driver".to_string()
     }
 
-    fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {


### PR DESCRIPTION
### Purpose
This PR fixes a host of bugs with the new consensus engine to get it into a working state. 

### Todo
- Gossip-centric setup
- Automatic learner promotion
- Snapshots

### Testing
- Unit tests pass crate wide
- Ran a raft of two nodes, went through the process of setting up two wallets (one on each node) and letting the internal matching engine run on the nodes