### PR TITLE
workers: proof-manager: infer num threads & spawn fifo

### DIFF
--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -49,8 +49,6 @@ use super::error::ProofManagerError;
 
 /// Error message when sending a proof response fails
 const ERR_SENDING_RESPONSE: &str = "error sending proof response, channel closed";
-/// The number of threads to allocate towards the proof generation worker pool
-pub(crate) const PROOF_GENERATION_N_THREADS: usize = 10;
 
 // --------------------
 // | Proof Generation |
@@ -97,7 +95,7 @@ impl ProofManager {
                 .recv()
                 .map_err(|err| ProofManagerError::JobQueueClosed(err.to_string()))?;
 
-            thread_pool.spawn(move || {
+            thread_pool.spawn_fifo(move || {
                 let _span = info_span!("handle_proof_job").entered();
                 if let Err(e) = Self::handle_proof_job(job) {
                     error!("Error handling proof manager job: {}", e)

--- a/workers/proof-manager/src/worker.rs
+++ b/workers/proof-manager/src/worker.rs
@@ -10,10 +10,7 @@ use common::{types::CancelChannel, worker::Worker};
 use job_types::proof_manager::ProofManagerReceiver;
 use rayon::ThreadPoolBuilder;
 
-use super::{
-    error::ProofManagerError,
-    proof_manager::{ProofManager, PROOF_GENERATION_N_THREADS},
-};
+use super::{error::ProofManagerError, proof_manager::ProofManager};
 
 /// The name of the main worker thread
 const MAIN_THREAD_NAME: &str = "proof-generation-main";
@@ -44,7 +41,6 @@ impl Worker for ProofManager {
         let proof_generation_thread_pool = ThreadPoolBuilder::new()
             .thread_name(|i| format!("{}-{}", WORKER_THREAD_PREFIX, i))
             .stack_size(WORKER_STACK_SIZE)
-            .num_threads(PROOF_GENERATION_N_THREADS)
             .build()
             .map_err(|err| ProofManagerError::Setup(err.to_string()))?;
 


### PR DESCRIPTION
This PR tunes the proof manager worker to:
1. Infer the number of threads to spawn automatically, which [defaults to the number of logical CPUs](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads)
2. Spawn tasks in FIFO order - by default, tasks are [generally executed in LIFO order](https://docs.rs/rayon/latest/rayon/fn.spawn.html) to optimize for cache locality on the executing thread, but in our case it's a much fairer queueing mechanism to process proof tasks in the order they were enqueued

This is running smoothly in dev