### PR TITLE
workers: gossip-server: heartbeat: bump intra-cluster heartbeat timeout

### DIFF
--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -26,7 +26,7 @@ pub const CLUSTER_HEARTBEAT_INTERVAL_MS: u64 = 3_000; // 3 seconds
 pub const HEARTBEAT_FAILURE_MS: u64 = 20_000; // 20 seconds
 /// The amount of time without a successful heartbeat before the local
 /// relayer should assume its peer has failed; for cluster peers
-pub const CLUSTER_HEARTBEAT_FAILURE_MS: u64 = 7_000; // 7 seconds
+pub const CLUSTER_HEARTBEAT_FAILURE_MS: u64 = 10_000; // 10 seconds
 /// The minimum amount of time between a peer's expiry and when it can be
 /// added back to the peer info
 pub(crate) const EXPIRY_INVISIBILITY_WINDOW_MS: u64 = 30_000; // 30 seconds


### PR DESCRIPTION
This PR bumps the intra-cluster heartbeat timeout to 10s. This is because there's little benefit to having the intra-cluster timeout be shorter than the raft election timeout, we will always expire a leader before the election timeout runs down. Making it 10s lines these two timeouts up, and also gives us a tolerance of 3 missed heartbeats (at an interval of 3s) before a peer is expired.