### PR TITLE
task-driver: node-startup: Create new raft cluster after gossip warmup

### DIFF
--- a/common/src/types/tasks/descriptors/node_startup.rs
+++ b/common/src/types/tasks/descriptors/node_startup.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::TaskIdentifier;
+use super::{TaskDescriptor, TaskIdentifier};
 
 /// The task descriptor for the node startup task
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -12,4 +12,18 @@ pub struct NodeStartupTaskDescriptor {
     /// The amount of time to wait for the gossip layer to warmup before setting
     /// up the rest of the node
     pub gossip_warmup_ms: u64,
+}
+
+impl NodeStartupTaskDescriptor {
+    /// Construct a new node startup task descriptor
+    pub fn new(gossip_warmup_ms: u64) -> Self {
+        let id = TaskIdentifier::new_v4();
+        Self { id, gossip_warmup_ms }
+    }
+}
+
+impl From<NodeStartupTaskDescriptor> for TaskDescriptor {
+    fn from(desc: NodeStartupTaskDescriptor) -> Self {
+        TaskDescriptor::NodeStartup(desc)
+    }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -82,6 +82,7 @@ async fn main() -> Result<(), CoordinatorError> {
         .await
         .expect("error blocking on config parse")
         .expect("error parsing command line args");
+    let setup_config = args.clone();
 
     // Configure telemetry before all else so we don't lose any data
     if !args.debug {
@@ -231,19 +232,10 @@ async fn main() -> Result<(), CoordinatorError> {
 
     // Setup the relayer wallet once the task driver, proof manager, and gossip
     // server are running
-
-    // TODO(@joey): This will be a more involved task when implementing raft
-    // snapshots, state sync, etc
     let chain_id =
         arbitrum_client.chain_id().await.map_err(err_str!(CoordinatorError::Arbitrum))?;
-    node_setup(
-        &args.arbitrum_private_key,
-        chain_id,
-        task_sender.clone(),
-        &arbitrum_client,
-        &global_state,
-    )
-    .await?;
+    node_setup(&setup_config, chain_id, task_sender.clone(), &arbitrum_client, &global_state)
+        .await?;
 
     // --- Workers Setup Phase --- //
 

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -156,7 +156,7 @@ impl State {
 
         RaftClientConfig {
             id: raft_id,
-            init: relayer_config.assume_raft_leader,
+            init: relayer_config.assume_leader,
             heartbeat_interval: DEFAULT_HEARTBEAT_MS,
             election_timeout_min: DEFAULT_MIN_ELECTION_MS,
             election_timeout_max: DEFAULT_MAX_ELECTION_MS,

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -177,8 +177,13 @@ impl State {
             })
             .await?;
 
-        for (raft_id, info) in learners.into_iter() {
-            this.raft.add_learner(raft_id, info).await?;
+        // Only add learners if a raft is setup
+        // Before a raft is setup, we only want to populate the peer index, and not
+        // attempt to form a raft
+        if self.raft.is_initialized() {
+            for (raft_id, info) in learners.into_iter() {
+                this.raft.add_learner(raft_id, info).await?;
+            }
         }
 
         Ok(())

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -1,14 +1,42 @@
 //! Handlers for incoming raft commands and messages
 
+use std::collections::BTreeMap;
+
+use common::types::gossip::WrappedPeerId;
 use util::err_str;
 
 use crate::{
     error::StateError,
-    replicationv2::network::{RaftRequest, RaftResponse},
+    replicationv2::{
+        get_raft_id,
+        network::{RaftRequest, RaftResponse},
+        Node, NodeId, RaftNode,
+    },
     State,
 };
 
 impl State {
+    // --- Raft Control --- //
+
+    /// Whether the raft is initialized (has non-empty voters)
+    pub fn is_raft_initialized(&self) -> bool {
+        self.raft.is_initialized()
+    }
+
+    /// Initialize a new raft with the given set of peers
+    pub async fn initialize_raft(&self, peers: Vec<WrappedPeerId>) -> Result<(), StateError> {
+        let mut node_info: BTreeMap<NodeId, Node> = BTreeMap::new();
+        for peer in peers.into_iter() {
+            let nid = get_raft_id(&peer);
+            let info = RaftNode::new(peer);
+            node_info.insert(nid, info);
+        }
+
+        self.raft.initialize(node_info).await.map_err(StateError::Replication)
+    }
+
+    // --- Networking --- //
+
     /// Handle a raft request from a peer
     ///
     /// We (de)serialize at the raft layer to avoid dependency leak

--- a/state/src/replicationv2/mod.rs
+++ b/state/src/replicationv2/mod.rs
@@ -44,7 +44,7 @@ pub type Raft = RaftInner<TypeConfig>;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct RaftNode {
     /// The peer ID associated with the node
-    peer_id: WrappedPeerId,
+    pub(crate) peer_id: WrappedPeerId,
 }
 
 impl RaftNode {

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -50,6 +50,13 @@ pub trait Task: Send + Sized {
     }
     /// Get a displayable name for the task
     fn name(&self) -> String;
+    /// Whether or not updates to this task should bypass the task queue
+    ///
+    /// Defined on this trait to allow maximally granular control over which
+    /// tasks bypass the task queue in the future
+    fn bypass_task_queue(&self) -> bool {
+        false
+    }
     /// Take a step in the task, steps should represent largely async behavior
     async fn step(&mut self) -> Result<(), Self::Error>;
     /// A cleanup step that is run in the event of a task failure


### PR DESCRIPTION
### Purpose
This PR implements the process by which a new raft is initialized if none is detected during gossip warmup. The node startup task waits for a configurable timeout to elapse before checking whether it has been added to an initialized (non-empty voters) raft cluster. If not, it will initialize a new raft cluster with the peer ids it knows to be in its cluster.

### Todo
- When joining an existing cluster, a node must:
    - Request a snapshot and begin catchup
    - Request promotion to a voter when it has replicated all logs

### Testing
- Unit tests pass crate wide
- Tested consistency after wallet updates between raft nodes given the following conditions:
    - Node 1 starts up, completes gossip warmup and initializes a new cluster. Node 2 starts up and learns about this raft after it is intialized.
    - Node 1 starts up; while warming up gossip Node 2 starts up and the two learn of one another. Node 1 finishes gossip warmup first and initializes a new raft with both peers.
    - Node 1 starts up; while warming up gossip, Node 2 starts up and _finishes its warmup before Node 1_. The nodes have learned of one another, so Node 2 initializes a raft with both peers