### PR TITLE
task-driver: node-startup: Lookup relayer wallet if first node online

### DIFF
--- a/common/src/types/tasks/descriptors/node_startup.rs
+++ b/common/src/types/tasks/descriptors/node_startup.rs
@@ -1,5 +1,6 @@
 //! Task descriptor for the node startup task
 
+use ethers::signers::LocalWallet;
 use serde::{Deserialize, Serialize};
 
 use super::{TaskDescriptor, TaskIdentifier};
@@ -12,13 +13,20 @@ pub struct NodeStartupTaskDescriptor {
     /// The amount of time to wait for the gossip layer to warmup before setting
     /// up the rest of the node
     pub gossip_warmup_ms: u64,
+    /// The relayer's Arbitrum keypair
+    ///
+    /// We store the byte serialization here to allow the descriptor to be
+    /// serialized
+    pub key_bytes: Vec<u8>,
 }
 
 impl NodeStartupTaskDescriptor {
     /// Construct a new node startup task descriptor
-    pub fn new(gossip_warmup_ms: u64) -> Self {
+    pub fn new(gossip_warmup_ms: u64, keypair: &LocalWallet) -> Self {
         let id = TaskIdentifier::new_v4();
-        Self { id, gossip_warmup_ms }
+        let key_bytes = keypair.signer().to_bytes().to_vec();
+
+        Self { id, gossip_warmup_ms, key_bytes }
     }
 }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -140,10 +140,6 @@ struct Cli {
     /// The path at which to save raft snapshots
     #[clap(long, value_parser, default_value = "./raft_snapshots")]
     pub raft_snapshot_path: String,
-    /// Whether or not to assume the node is a leader of a new cluster at
-    /// startup
-    #[clap(long, value_parser, default_value = "false")]
-    pub assume_leader: bool,
     /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
     /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
     #[clap(long, value_parser, default_value = "100")]
@@ -270,9 +266,6 @@ pub struct RelayerConfig {
     pub db_path: String,
     /// The path at which to save raft snapshots
     pub raft_snapshot_path: String,
-    /// Whether or not to assume the node is a leader of a new cluster at
-    /// startup
-    pub assume_leader: bool,
     /// The maximum staleness (number of newer roots observed) to allow on
     /// Merkle proofs for managed wallets. After this threshold is exceeded,
     /// the Merkle proof will be updated
@@ -352,7 +345,6 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
-            assume_leader: self.assume_leader,
             max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,
@@ -480,7 +472,6 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         p2p_key,
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
-        assume_leader: cli_args.assume_leader,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         gossip_warmup: cli_args.gossip_warmup,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -161,6 +161,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // that are common among workers
     let task_driver_config = TaskDriverConfig::new(
         task_receiver,
+        task_sender.clone(),
         arbitrum_client.clone(),
         network_sender.clone(),
         proof_generation_worker_sender.clone(),
@@ -233,12 +234,11 @@ async fn main() -> Result<(), CoordinatorError> {
         mpsc::channel(1 /* buffer size */);
     watch_worker::<GossipServer>(&mut gossip_server, &gossip_failure_sender);
 
-    // Setup the relayer wallet once the task driver, proof manager, and gossip
-    // server are running
-    let chain_id =
-        arbitrum_client.chain_id().await.map_err(err_str!(CoordinatorError::Arbitrum))?;
-    node_setup(&setup_config, chain_id, task_sender.clone(), &arbitrum_client, &global_state)
-        .await?;
+    // Once the minimal set of workers are running, run the setup task
+    //
+    // This task bootstraps the relayer into a correct raft and sets up the
+    // relayer's wallet
+    node_setup(&setup_config, task_sender.clone()).await?;
 
     // --- Workers Setup Phase --- //
 

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -5,30 +5,10 @@
 
 use std::time::Duration;
 
-use arbitrum_client::client::ArbitrumClient;
-use common::types::{
-    tasks::{
-        LookupWalletTaskDescriptor, NewWalletTaskDescriptor, NodeStartupTaskDescriptor, QueuedTask,
-        QueuedTaskState, TaskDescriptor,
-    },
-    wallet::{
-        derivation::{
-            derive_blinder_seed, derive_share_seed, derive_wallet_id, derive_wallet_keychain,
-        },
-        KeyChain, Wallet, WalletIdentifier,
-    },
-};
+use common::types::tasks::NodeStartupTaskDescriptor;
 use config::RelayerConfig;
-use constants::Scalar;
-use ethers::signers::LocalWallet;
 use job_types::task_driver::{new_task_notification, TaskDriverJob, TaskDriverQueue};
-use state::State;
-use task_driver::{await_task, tasks::lookup_wallet::ERR_WALLET_NOT_FOUND};
-use tracing::info;
-use util::{
-    arbitrum::{PROTOCOL_FEE, PROTOCOL_PUBKEY},
-    err_str, get_current_time_millis,
-};
+use util::err_str;
 
 use crate::error::CoordinatorError;
 
@@ -38,13 +18,10 @@ const ERR_SENDING_STARTUP_TASK: &str = "error sending startup task to task drive
 /// Run the setup logic for the relayer
 pub async fn node_setup(
     config: &RelayerConfig,
-    _chain_id: u64,
     task_queue: TaskDriverQueue,
-    _client: &ArbitrumClient,
-    _state: &State,
 ) -> Result<(), CoordinatorError> {
     // Start the node setup task and await its completion
-    let desc = NodeStartupTaskDescriptor::new(config.gossip_warmup);
+    let desc = NodeStartupTaskDescriptor::new(config.gossip_warmup, &config.arbitrum_private_key);
     let id = desc.id;
     task_queue
         .send(TaskDriverJob::RunImmediate { task_id: id, wallet_ids: vec![], task: desc.into() })
@@ -57,109 +34,4 @@ pub async fn node_setup(
         .send(job)
         .map_err(|_| CoordinatorError::Setup(ERR_SENDING_STARTUP_TASK.to_string()))?;
     recv.await.unwrap().map_err(err_str!(CoordinatorError::Setup))
-}
-
-// TODO: Delete the following code once the setup task is complete
-
-/// Parameterize local constants by pulling them from the contract's storage
-///
-/// Concretely, this is the contract protocol key and the protocol fee
-async fn fetch_contract_constants(client: &ArbitrumClient) -> Result<(), CoordinatorError> {
-    // Fetch the values from the contract
-    let protocol_fee =
-        client.get_protocol_fee().await.map_err(err_str!(CoordinatorError::Setup))?;
-    let protocol_key =
-        client.get_protocol_pubkey().await.map_err(err_str!(CoordinatorError::Setup))?;
-    info!("Fetched protocol fee and protocol pubkey");
-
-    // Set the values in their constant refs
-    PROTOCOL_FEE.set(protocol_fee).expect("protocol fee already set");
-    PROTOCOL_PUBKEY.set(protocol_key).expect("protocol pubkey already set");
-    Ok(())
-}
-
-/// Lookup the relayer's wallet or create a new one
-async fn setup_relayer_wallet(
-    key: &LocalWallet,
-    chain_id: u64,
-    task_queue: TaskDriverQueue,
-    state: &State,
-) -> Result<(), CoordinatorError> {
-    // Derive the keychain, blinder seed, and share seed from the relayer pkey
-    let blinder_seed = derive_blinder_seed(key).map_err(err_str!(CoordinatorError::Setup))?;
-    let share_seed = derive_share_seed(key).map_err(err_str!(CoordinatorError::Setup))?;
-    let keychain =
-        derive_wallet_keychain(key, chain_id).map_err(err_str!(CoordinatorError::Setup))?;
-
-    // Set the node metadata entry for the relayer's wallet
-    let wallet_id = derive_wallet_id(key).map_err(err_str!(CoordinatorError::Setup))?;
-    state
-        .set_local_relayer_wallet_id(wallet_id)
-        .await
-        .map_err(err_str!(CoordinatorError::Setup))?;
-
-    // Attempt to find the wallet on-chain
-    if find_wallet_onchain(
-        wallet_id,
-        blinder_seed,
-        share_seed,
-        keychain.clone(),
-        task_queue.clone(),
-        state,
-    )
-    .await?
-    {
-        info!("found relayer wallet on-chain");
-        return Ok(());
-    }
-
-    // Otherwise, create a new wallet
-    create_wallet(wallet_id, blinder_seed, share_seed, keychain, task_queue, state).await
-}
-
-/// Attempt to fetch a wallet from on-chain
-async fn find_wallet_onchain(
-    wallet_id: WalletIdentifier,
-    blinder_seed: Scalar,
-    share_seed: Scalar,
-    keychain: KeyChain,
-    task_queue: TaskDriverQueue,
-    state: &State,
-) -> Result<bool, CoordinatorError> {
-    info!("Finding relayer wallet on-chain");
-    let descriptor = LookupWalletTaskDescriptor::new(wallet_id, blinder_seed, share_seed, keychain)
-        .expect("infallible");
-    let res = await_task(descriptor.into(), state, task_queue).await;
-
-    match res {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            // If the error is that the wallet was not found, return false and create a new
-            // wallet. Otherwise, propagate the error
-            if e.contains(ERR_WALLET_NOT_FOUND) {
-                Ok(false)
-            } else {
-                Err(CoordinatorError::Setup(e))
-            }
-        },
-    }
-}
-
-/// Create a new wallet for the relayer
-async fn create_wallet(
-    wallet_id: WalletIdentifier,
-    blinder_seed: Scalar,
-    share_seed: Scalar,
-    keychain: KeyChain,
-    task_queue: TaskDriverQueue,
-    state: &State,
-) -> Result<(), CoordinatorError> {
-    info!("Creating new relayer wallet");
-    let wallet = Wallet::new_empty_wallet(wallet_id, blinder_seed, share_seed, keychain);
-    let descriptor =
-        NewWalletTaskDescriptor::new(wallet).map_err(err_str!(CoordinatorError::Setup))?;
-
-    await_task(descriptor.into(), state, task_queue)
-        .await
-        .map_err(err_str!(CoordinatorError::Setup))
 }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -282,6 +282,7 @@ impl MockNodeController {
     /// Add a task driver to the mock node
     pub fn with_task_driver(mut self) -> Self {
         let task_queue = self.task_queue.1.take().unwrap();
+        let task_sender = self.task_queue.0.clone();
         let arbitrum_client =
             self.arbitrum_client.clone().expect("Arbitrum client not initialized");
         let network_queue = self.network_queue.0.clone();
@@ -291,6 +292,7 @@ impl MockNodeController {
 
         let conf = TaskDriverConfig::new(
             task_queue,
+            task_sender,
             arbitrum_client,
             network_queue,
             proof_queue,

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -164,7 +164,6 @@ impl State {
 
         RaftClientConfig {
             id: raft_id,
-            init: relayer_config.assume_leader,
             heartbeat_interval: DEFAULT_HEARTBEAT_MS,
             election_timeout_min: DEFAULT_MIN_ELECTION_MS,
             election_timeout_max: DEFAULT_MAX_ELECTION_MS,

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -3,7 +3,7 @@
 use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use common::types::{
     gossip::{ClusterId, PeerInfo, WrappedPeerId},
-    wallet::{Wallet, WalletIdentifier},
+    wallet::{derivation::derive_wallet_id, Wallet, WalletIdentifier},
 };
 use config::RelayerConfig;
 use libp2p::{core::Multiaddr, identity::Keypair};
@@ -105,6 +105,8 @@ impl State {
         let p2p_key = config.p2p_key.clone();
         let fee_decryption_key = config.fee_decryption_key;
         let match_take_rate = config.match_take_rate;
+        let relayer_wallet_id =
+            derive_wallet_id(&config.arbitrum_private_key).map_err(StateError::InvalidUpdate)?;
 
         self.with_write_tx(move |tx| {
             tx.create_table(NODE_METADATA_TABLE)?;
@@ -113,6 +115,7 @@ impl State {
             tx.set_node_keypair(&p2p_key)?;
             tx.set_fee_decryption_key(&fee_decryption_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
+            tx.set_local_node_wallet(relayer_wallet_id)?;
 
             Ok(())
         })

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -44,6 +44,7 @@ util = { path = "../../util" }
 renegade-metrics = { path = "../../renegade-metrics" }
 
 # === Misc Dependencies === #
+ethers = { workspace = true }
 itertools = "0.11"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -21,7 +21,7 @@ use eyre::Result;
 use job_types::{
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
-    task_driver::{new_task_notification, TaskDriverJob, TaskDriverReceiver},
+    task_driver::{new_task_notification, TaskDriverJob, TaskDriverQueue, TaskDriverReceiver},
 };
 use num_bigint::BigUint;
 use rand::thread_rng;
@@ -212,6 +212,7 @@ pub async fn authorize_transfer(
 /// Create a new mock `TaskDriver`
 pub fn new_mock_task_driver(
     task_queue: TaskDriverReceiver,
+    task_queue_sender: TaskDriverQueue,
     arbitrum_client: ArbitrumClient,
     network_queue: NetworkManagerQueue,
     proof_queue: ProofManagerQueue,
@@ -229,6 +230,7 @@ pub fn new_mock_task_driver(
 
     let config = TaskDriverConfig {
         task_queue,
+        task_queue_sender,
         runtime_config,
         system_bus: bus,
         arbitrum_client,

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -126,6 +126,7 @@ impl From<CliArgs> for IntegrationTestArgs {
         // Start a task driver
         new_mock_task_driver(
             task_recv,
+            task_queue.clone(),
             arbitrum_client.clone(),
             network_sender,
             proof_job_queue.clone(),

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -121,6 +121,7 @@ impl TaskExecutor {
             arbitrum_client: config.arbitrum_client,
             network_queue: config.network_queue,
             proof_queue: config.proof_queue,
+            task_queue: config.task_queue_sender,
             state: config.state,
             bus: config.system_bus.clone(),
         };

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -9,17 +9,34 @@ use std::{error::Error, fmt::Display, time::Duration};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use common::types::tasks::NodeStartupTaskDescriptor;
+use common::types::{
+    tasks::{LookupWalletTaskDescriptor, NewWalletTaskDescriptor, NodeStartupTaskDescriptor},
+    wallet::{
+        derivation::{
+            derive_blinder_seed, derive_share_seed, derive_wallet_id, derive_wallet_keychain,
+        },
+        KeyChain, Wallet, WalletIdentifier,
+    },
+};
+use constants::Scalar;
+use ethers::signers::LocalWallet;
 use job_types::{
     network_manager::{NetworkManagerControlSignal, NetworkManagerJob, NetworkManagerQueue},
     proof_manager::ProofManagerQueue,
+    task_driver::TaskDriverQueue,
 };
 use serde::Serialize;
 use state::{error::StateError, State};
 use tracing::{info, instrument};
+use util::{
+    arbitrum::{PROTOCOL_FEE, PROTOCOL_PUBKEY},
+    err_str,
+};
 
 use crate::{
+    await_task,
     driver::StateWrapper,
+    tasks::lookup_wallet::ERR_WALLET_NOT_FOUND,
     traits::{Task, TaskContext, TaskError, TaskState},
 };
 
@@ -28,16 +45,23 @@ const NODE_STARTUP_TASK_NAME: &str = "node-startup";
 
 /// Error sending a job to another worker
 const ERR_SEND_JOB: &str = "error sending job";
+/// Error deserializing the arbitrum private key
+const ERR_INVALID_KEY: &str = "invalid arbitrum private key";
 
 /// Defines the state of the node startup task
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NodeStartupTaskState {
     /// The task is awaiting scheduling
     Pending,
+    /// Fetch system parameters from the smart contracts
+    FetchConstants,
     /// The task is waiting for the gossip layer to warm up
     GossipWarmup,
     /// Initialize a new raft
     InitializeRaft,
+    /// Setup the relayer's wallet, the wallet at which the relayer will receive
+    /// fees
+    SetupRelayerWallet,
     /// Join an existing raft
     JoinRaft,
     /// The task is completed
@@ -58,8 +82,10 @@ impl Display for NodeStartupTaskState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Pending => write!(f, "Pending"),
+            Self::FetchConstants => write!(f, "Fetch Constants"),
             Self::GossipWarmup => write!(f, "Gossip Warmup"),
             Self::InitializeRaft => write!(f, "Initialize Raft"),
+            Self::SetupRelayerWallet => write!(f, "Setup Relayer Wallet"),
             Self::JoinRaft => write!(f, "Join Raft"),
             Self::Completed => write!(f, "Completed"),
         }
@@ -88,8 +114,16 @@ impl From<NodeStartupTaskState> for StateWrapper {
 /// The error type for the node startup task
 #[derive(Clone, Debug)]
 pub enum NodeStartupTaskError {
+    /// An error interacting with arbitrum
+    Arbitrum(String),
+    /// An error deriving a wallet
+    DeriveWallet(String),
     /// An error sending a job to another worker
     Enqueue(String),
+    /// An error fetching contract constants
+    FetchConstants(String),
+    /// An error setting up the task
+    Setup(String),
     /// An error interacting with global state
     State(String),
 }
@@ -121,6 +155,8 @@ impl From<StateError> for NodeStartupTaskError {
 pub struct NodeStartupTask {
     /// The amount of time to wait for the gossip layer to warm up
     pub gossip_warmup_ms: u64,
+    /// The arbitrum private key
+    pub keypair: LocalWallet,
     /// The arbitrum client to use for submitting transactions
     pub arbitrum_client: ArbitrumClient,
     /// A sender to the network manager's work queue
@@ -128,7 +164,9 @@ pub struct NodeStartupTask {
     /// A copy of the relayer-global state
     pub state: State,
     /// The work queue to add proof management jobs to
-    pub proof_manager_work_queue: ProofManagerQueue,
+    pub proof_queue: ProofManagerQueue,
+    /// A sender to the task driver queue
+    pub task_queue: TaskDriverQueue,
     /// The state of the task
     pub task_state: NodeStartupTaskState,
 }
@@ -140,12 +178,17 @@ impl Task for NodeStartupTask {
     type Descriptor = NodeStartupTaskDescriptor;
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        let keypair = LocalWallet::from_bytes(&descriptor.key_bytes)
+            .map_err(|_| NodeStartupTaskError::Setup(ERR_INVALID_KEY.to_string()))?;
+
         Ok(Self {
             gossip_warmup_ms: descriptor.gossip_warmup_ms,
+            keypair,
             arbitrum_client: ctx.arbitrum_client,
             network_sender: ctx.network_queue,
             state: ctx.state,
-            proof_manager_work_queue: ctx.proof_queue,
+            proof_queue: ctx.proof_queue,
+            task_queue: ctx.task_queue,
             task_state: NodeStartupTaskState::Pending,
         })
     }
@@ -159,6 +202,10 @@ impl Task for NodeStartupTask {
         // Dispatch based on the current transaction step
         match self.state() {
             NodeStartupTaskState::Pending => {
+                self.task_state = NodeStartupTaskState::FetchConstants;
+            },
+            NodeStartupTaskState::FetchConstants => {
+                self.fetch_contract_constants().await?;
                 self.task_state = NodeStartupTaskState::GossipWarmup;
             },
             NodeStartupTaskState::GossipWarmup => {
@@ -167,6 +214,10 @@ impl Task for NodeStartupTask {
             },
             NodeStartupTaskState::InitializeRaft => {
                 self.initialize_raft().await?;
+                self.task_state = NodeStartupTaskState::SetupRelayerWallet;
+            },
+            NodeStartupTaskState::SetupRelayerWallet => {
+                self.setup_relayer_wallet().await?;
                 self.task_state = NodeStartupTaskState::Completed;
             },
             NodeStartupTaskState::JoinRaft => {
@@ -204,6 +255,29 @@ impl Task for NodeStartupTask {
 // -----------------------
 
 impl NodeStartupTask {
+    /// Parameterize local constants by pulling them from the contract's storage
+    ///
+    /// Concretely, this is the contract protocol key and the protocol fee
+    async fn fetch_contract_constants(&self) -> Result<(), NodeStartupTaskError> {
+        // Fetch the values from the contract
+        let protocol_fee = self
+            .arbitrum_client
+            .get_protocol_fee()
+            .await
+            .map_err(err_str!(NodeStartupTaskError::FetchConstants))?;
+        let protocol_key = self
+            .arbitrum_client
+            .get_protocol_pubkey()
+            .await
+            .map_err(err_str!(NodeStartupTaskError::FetchConstants))?;
+        info!("Fetched protocol fee and protocol pubkey from on-chain");
+
+        // Set the values in their constant refs
+        PROTOCOL_FEE.set(protocol_fee).expect("protocol fee already set");
+        PROTOCOL_PUBKEY.set(protocol_key).expect("protocol pubkey already set");
+        Ok(())
+    }
+
     /// Warmup the gossip layer into the network
     pub async fn warmup_gossip(&mut self) -> Result<(), NodeStartupTaskError> {
         info!("Warming up gossip layer for {}ms", self.gossip_warmup_ms);
@@ -234,7 +308,41 @@ impl NodeStartupTask {
 
         info!("initializing raft with {} peers", peers.len());
         self.state.initialize_raft(peers).await?;
+
         Ok(())
+    }
+
+    /// Setup the relayer's wallet, the wallet at which the relayer will receive
+    /// fees
+    ///
+    /// If the wallet is found on-chain, recover it. Otherwise, create a new one
+    async fn setup_relayer_wallet(&self) -> Result<(), NodeStartupTaskError> {
+        let chain_id = self
+            .arbitrum_client
+            .chain_id()
+            .await
+            .map_err(err_str!(NodeStartupTaskError::Arbitrum))?;
+
+        // Derive the keychain, blinder seed, and share seed from the relayer pkey
+        let blinder_seed = derive_blinder_seed(&self.keypair)
+            .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
+        let share_seed = derive_share_seed(&self.keypair)
+            .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
+        let keychain = derive_wallet_keychain(&self.keypair, chain_id)
+            .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
+
+        // Set the node metadata entry for the relayer's wallet
+        let wallet_id = derive_wallet_id(&self.keypair)
+            .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
+
+        // Attempt to find the wallet on-chain
+        if self.find_wallet_onchain(wallet_id, blinder_seed, share_seed, keychain.clone()).await? {
+            info!("found relayer wallet on-chain");
+            return Ok(());
+        }
+
+        // Otherwise, create a new wallet
+        self.create_wallet(wallet_id, blinder_seed, share_seed, keychain).await
     }
 
     /// Manage the process to join an existing raft cluster
@@ -243,7 +351,57 @@ impl NodeStartupTask {
     /// cluster
     #[allow(clippy::unused_async)]
     async fn join_raft(&self) -> Result<(), NodeStartupTaskError> {
-        println!("joining raft cluster");
+        info!("joining raft cluster");
         Ok(())
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Attempt to fetch a wallet from on-chain
+    async fn find_wallet_onchain(
+        &self,
+        wallet_id: WalletIdentifier,
+        blinder_seed: Scalar,
+        share_seed: Scalar,
+        keychain: KeyChain,
+    ) -> Result<bool, NodeStartupTaskError> {
+        info!("Finding relayer wallet on-chain");
+        let descriptor =
+            LookupWalletTaskDescriptor::new(wallet_id, blinder_seed, share_seed, keychain)
+                .expect("infallible");
+        let res = await_task(descriptor.into(), &self.state, self.task_queue.clone()).await;
+
+        match res {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                // If the error is that the wallet was not found, return false and create a new
+                // wallet. Otherwise, propagate the error
+                if e.contains(ERR_WALLET_NOT_FOUND) {
+                    Ok(false)
+                } else {
+                    Err(NodeStartupTaskError::Setup(e))
+                }
+            },
+        }
+    }
+
+    /// Create a new wallet for the relayer
+    async fn create_wallet(
+        &self,
+        wallet_id: WalletIdentifier,
+        blinder_seed: Scalar,
+        share_seed: Scalar,
+        keychain: KeyChain,
+    ) -> Result<(), NodeStartupTaskError> {
+        info!("Creating new relayer wallet");
+        let wallet = Wallet::new_empty_wallet(wallet_id, blinder_seed, share_seed, keychain);
+        let descriptor = NewWalletTaskDescriptor::new(wallet)
+            .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
+
+        await_task(descriptor.into(), &self.state, self.task_queue.clone())
+            .await
+            .map_err(err_str!(NodeStartupTaskError::Setup))
     }
 }

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -5,7 +5,10 @@ use std::fmt::{Debug, Display};
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
 use external_api::bus_message::SystemBusMessage;
-use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use job_types::{
+    network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue,
+    task_driver::TaskDriverQueue,
+};
 use serde::{Deserialize, Serialize};
 use state::State;
 use system_bus::SystemBus;
@@ -108,6 +111,8 @@ pub struct TaskContext {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's queue
     pub proof_queue: ProofManagerQueue,
+    /// A sender back to the task driver's queue
+    pub task_queue: TaskDriverQueue,
     /// A handle on the system bus
     pub bus: SystemBus<SystemBusMessage>,
 }

--- a/workers/task-driver/src/worker.rs
+++ b/workers/task-driver/src/worker.rs
@@ -7,8 +7,9 @@ use async_trait::async_trait;
 use common::{default_wrapper::DefaultOption, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
-    network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue,
-    task_driver::TaskDriverReceiver,
+    network_manager::NetworkManagerQueue,
+    proof_manager::ProofManagerQueue,
+    task_driver::{TaskDriverQueue, TaskDriverReceiver},
 };
 use state::State;
 use system_bus::SystemBus;
@@ -28,6 +29,10 @@ pub struct TaskDriverConfig {
     pub runtime_config: RuntimeArgs,
     /// The queue on which to receive tasks
     pub task_queue: TaskDriverReceiver,
+    /// The sender to the task driver's queue
+    ///
+    /// For recursive job enqueues
+    pub task_queue_sender: TaskDriverQueue,
     /// The arbitrum client used by the system
     pub arbitrum_client: ArbitrumClient,
     /// A sender to the network manager's work queue
@@ -44,6 +49,7 @@ impl TaskDriverConfig {
     /// Create a new config with default values
     pub fn new(
         task_queue: TaskDriverReceiver,
+        task_queue_sender: TaskDriverQueue,
         arbitrum_client: ArbitrumClient,
         network_queue: NetworkManagerQueue,
         proof_queue: ProofManagerQueue,
@@ -53,6 +59,7 @@ impl TaskDriverConfig {
         Self {
             runtime_config: Default::default(),
             task_queue,
+            task_queue_sender,
             arbitrum_client,
             network_queue,
             proof_queue,


### PR DESCRIPTION
### Purpose
This PR adds protocol fee & relayer wallet lookup to the node startup task. If, after gossip warmup, a node has discovered no existing raft, it will create a new raft and lookup/create a relayer wallet. If instead the node has found an existing raft, it will do no lookup and instead learn about the relayer wallet through the replication subsystem.

### Raft Todo
- Test snapshotting
- Await promotion when joining a new cluster

### Testing
- Unit test pass
- Tested a two node cluster; both cases in which the first node online can find a wallet on-chain and when a new wallet must be created. Verified that both nodes had the wallet after the setup was finished
