### PR TITLE
workers: task-driver: replace queue_key() in trace field

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -20,7 +20,7 @@ pub use update_wallet::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::gossip::WrappedPeerId;
+use crate::types::{gossip::WrappedPeerId, wallet::WalletIdentifier};
 
 /// The error message returned when a wallet's shares are invalid
 const INVALID_WALLET_SHARES: &str = "invalid wallet shares";
@@ -139,9 +139,23 @@ impl TaskDescriptor {
         }
     }
 
+    /// Returns the IDs of the wallets affected by the task
+    pub fn affected_wallets(&self) -> Vec<WalletIdentifier> {
+        match self {
+            TaskDescriptor::NewWallet(task) => vec![task.wallet.wallet_id],
+            TaskDescriptor::LookupWallet(task) => vec![task.wallet_id],
+            TaskDescriptor::OfflineFee(task) => vec![task.wallet_id],
+            TaskDescriptor::RelayerFee(task) => vec![task.wallet_id],
+            TaskDescriptor::RedeemRelayerFee(task) => vec![task.wallet_id],
+            TaskDescriptor::SettleMatch(task) => vec![task.wallet_id],
+            TaskDescriptor::SettleMatchInternal(task) => vec![task.wallet_id1, task.wallet_id2],
+            TaskDescriptor::UpdateMerkleProof(task) => vec![task.wallet.wallet_id],
+            TaskDescriptor::UpdateWallet(task) => vec![task.wallet_id],
+            TaskDescriptor::NodeStartup(_) => vec![],
+        }
+    }
+
     /// Returns whether the task is a wallet task
-    ///
-    /// Currently all tasks are wallet tasks
     pub fn is_wallet_task(&self) -> bool {
         match self {
             TaskDescriptor::NewWallet(_)

--- a/state/src/replicationv2/raft.rs
+++ b/state/src/replicationv2/raft.rs
@@ -345,7 +345,7 @@ impl RaftClient {
             let lag = my_log.saturating_sub(latest_log.index);
             if lag < self.config.learner_promotion_threshold {
                 info!("promoting {learner} to voter");
-                self.promote_learner(learner).await.unwrap();
+                self.promote_learner(learner).await?;
             }
         }
 

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -285,7 +285,7 @@ impl TaskExecutor {
     #[instrument(name = "task", skip_all, err, fields(
         task_id = %id,
         task = %task.display_description(),
-        queue_key = %task.queue_key(),
+        wallet_ids = ?task.affected_wallets(),
     ))]
     async fn start_task(
         &self,


### PR DESCRIPTION
This PR removes the call to `queue_key` in the `start_task` trace - for matches, this would cause the task driver to panic as `queue_key` is unimplemented for `SettleMatchInternal` and `SettleMatch`. Instead, we define a new method on the `TaskDescriptor`, `affected_wallets`, which returns the IDs of the wallets implicated in the given task. This is used to set the `wallet_ids` field on the trace.

Additionally, this PR tweaks the `try_promote_learners` method to not `unwrap` the call to `promote_learner`. In dev, we've seen this cause panics due to `the cluster is already undergoing a configuration change` errors