### PR TITLE
state: applicator: handle expected application failures

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -92,11 +92,10 @@ impl StateApplicator {
                 self.add_preprocessing_values(&cluster, &values)
             },
             StateTransition::ConsumePreprocessingValues { recipient, cluster, request } => {
-                return self.consume_preprocessing_values(recipient, &cluster, &request);
+                self.consume_preprocessing_values(recipient, &cluster, &request)
             },
             _ => unimplemented!("Unsupported state transition forwarded to applicator"),
         }
-        .map(|_| ApplicatorReturnType::None)
     }
 
     /// Get a reference to the db

--- a/state/src/applicator/mpc_preprocessing.rs
+++ b/state/src/applicator/mpc_preprocessing.rs
@@ -13,12 +13,12 @@ impl StateApplicator {
         &self,
         cluster: &ClusterId,
         value: &PairwiseOfflineSetup,
-    ) -> Result<(), StateApplicatorError> {
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
         let tx = self.db().new_write_tx()?;
         tx.append_mpc_prep_values(cluster, value)?;
         tx.commit()?;
 
-        Ok(())
+        Ok(ApplicatorReturnType::None)
     }
 
     /// Consume values from the preprocessing state for a given cluster

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::applicator::error::StateApplicatorError;
 
-use super::{Result, StateApplicator};
+use super::{return_type::ApplicatorReturnType, Result, StateApplicator};
 
 // -------------
 // | Constants |
@@ -74,7 +74,7 @@ impl StateApplicator {
         order_id: OrderIdentifier,
         proof: OrderValidityProofBundle,
         witness: OrderValidityWitnessBundle,
-    ) -> Result<()> {
+    ) -> Result<ApplicatorReturnType> {
         let tx = self.db().new_write_tx()?;
 
         tx.attach_validity_proof(&order_id, proof)?;
@@ -103,7 +103,7 @@ impl StateApplicator {
             ORDER_STATE_CHANGE_TOPIC.to_string(),
             SystemBusMessage::OrderStateChange { order: order_info },
         );
-        Ok(())
+        Ok(ApplicatorReturnType::None)
     }
 }
 

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::tx::StateTxn;
 
-use super::{error::StateApplicatorError, StateApplicator};
+use super::{error::StateApplicatorError, return_type::ApplicatorReturnType, StateApplicator};
 use common::types::wallet::order_metadata::OrderMetadata;
 use external_api::bus_message::{wallet_order_history_topic, SystemBusMessage};
 use libmdbx::RW;
@@ -12,13 +12,16 @@ const ERR_MISSING_WALLET: &str = "wallet not found";
 
 impl StateApplicator {
     /// Handle an update to an order's metadata
-    pub fn update_order_metadata(&self, meta: OrderMetadata) -> Result<(), StateApplicatorError> {
+    pub fn update_order_metadata(
+        &self,
+        meta: OrderMetadata,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
         // Update the state
         let tx = self.db().new_write_tx()?;
         self.update_order_metadata_with_tx(meta, &tx)?;
         tx.commit()?;
 
-        Ok(())
+        Ok(ApplicatorReturnType::None)
     }
 
     /// Update the state of an order's metadata given a transaction

--- a/state/src/applicator/return_type.rs
+++ b/state/src/applicator/return_type.rs
@@ -8,14 +8,18 @@
 
 use common::types::mpc_preprocessing::PairwiseOfflineSetup;
 
+use super::error::StateApplicatorError;
+
 /// The return type from the Applicator
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ApplicatorReturnType {
     /// A set of MPC preprocessing values that are ready to be used
     MpcPrep(PairwiseOfflineSetup),
     /// No return value
     None,
+    /// The application of the proposal failed in an expected manner
+    Rejected(StateApplicatorError),
 }
 
 // Downcasting conversions

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -13,7 +13,9 @@ use libmdbx::RW;
 
 use crate::storage::tx::StateTxn;
 
-use super::{error::StateApplicatorError, Result, StateApplicator};
+use super::{
+    error::StateApplicatorError, return_type::ApplicatorReturnType, Result, StateApplicator,
+};
 
 /// Error message emitted when metadata for an order is not found
 const ERR_NO_METADATA: &str = "metadata not found for order";
@@ -27,7 +29,7 @@ impl StateApplicator {
     ///
     /// This may happen, for example, when a new wallet is created by
     /// a user on one cluster node, and the others must replicate it
-    pub fn add_wallet(&self, wallet: &Wallet) -> Result<()> {
+    pub fn add_wallet(&self, wallet: &Wallet) -> Result<ApplicatorReturnType> {
         // Add the wallet to the wallet indices
         let tx = self.db().new_write_tx()?;
         tx.write_wallet(wallet)?;
@@ -40,7 +42,7 @@ impl StateApplicator {
             SystemBusMessage::WalletUpdate { wallet: Box::new(wallet.clone().into()) },
         );
 
-        Ok(())
+        Ok(ApplicatorReturnType::None)
     }
 
     /// Update a wallet in the state
@@ -52,7 +54,7 @@ impl StateApplicator {
     /// on-chain before this method is called. That is, we maintain the
     /// invariant that the state stored by this module is valid -- but
     /// possibly stale -- contract state
-    pub fn update_wallet(&self, wallet: &Wallet) -> Result<()> {
+    pub fn update_wallet(&self, wallet: &Wallet) -> Result<ApplicatorReturnType> {
         let tx = self.db().new_write_tx()?;
 
         // Index the orders in the wallet
@@ -69,7 +71,7 @@ impl StateApplicator {
             SystemBusMessage::WalletUpdate { wallet: Box::new(wallet.clone().into()) },
         );
 
-        Ok(())
+        Ok(ApplicatorReturnType::None)
     }
 
     // -----------


### PR DESCRIPTION
This PR enables the state machine to gracefully handle expected failures, dubbed "rejections", of proposal applications. This is achieved by adding the `ApplicationRejected` variant to the `ApplicatorReturnType`, which is returned by the applicator in a few choice scenarios.

Currently, we only return a rejection in the following cases:
1. Attempting to pop a task when the queue is paused
2. Attempting to transition a task when the queue is paused
3. Attempting to preempt a task queue when some task on it has already committed
4. Attempting to preempt a task queue when it is already paused

I have tested this locally by running a relayer in which the `append_task` state transition returns an `Ok(ApplicatorReturnType::ApplicationRejected(..))`, and one in which it returns an `Err(..)`, and have confirmed that only in the latter case does the error propagate to the Raft core.

Currently deploying this to dev for testing at scale.