### PR TITLE
state: replicationv2: snapshot: Fix misc bugs with snapshots

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -452,7 +452,7 @@ fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, String> {
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 
-    // Parse the price reporter URL, if ther is one
+    // Parse the price reporter URL, if there is one
     let price_reporter_url = cli_args
         .price_reporter_url
         .map(|url| Url::parse(&url).expect("Invalid price reporter URL"));

--- a/state/src/replicationv2/state_machine.rs
+++ b/state/src/replicationv2/state_machine.rs
@@ -83,18 +83,30 @@ impl StateMachine {
     }
 
     /// Get the directory at which snapshots are saved
-    pub fn snapshot_dir(&self) -> &str {
-        &self.config.snapshot_out
+    pub fn snapshot_dir(&self) -> PathBuf {
+        PathBuf::from(&self.config.snapshot_out)
     }
 
     /// Get the path of the snapshot file
     pub fn snapshot_archive_path(&self) -> PathBuf {
-        PathBuf::from(self.snapshot_dir()).join(SNAPSHOT_FILE).with_extension("gz")
+        self.snapshot_dir().join(SNAPSHOT_FILE).with_extension("gz")
     }
 
     /// Get the path to place the snapshot data at
     pub fn snapshot_data_path(&self) -> PathBuf {
-        PathBuf::from(self.snapshot_dir()).join(SNAPSHOT_FILE)
+        self.snapshot_dir().join(SNAPSHOT_FILE)
+    }
+
+    /// Create the snapshot directory if it doesn't exist
+    pub async fn create_snapshot_dir(&self) -> Result<(), ReplicationV2Error> {
+        let snap_dir = self.snapshot_dir();
+        if !snap_dir.exists() {
+            tokio::fs::create_dir_all(&snap_dir)
+                .await
+                .map_err(err_str!(ReplicationV2Error::Snapshot))?;
+        }
+
+        Ok(())
     }
 
     /// Open the file containing the snapshot
@@ -181,6 +193,7 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
         }
 
         // (Re)create it
+        self.create_snapshot_dir().await.map_err(new_snapshot_error)?;
         let file = tokio::fs::File::create(snapshot_path).await.map_err(|e| {
             RaftStorageError::from_io_error(ErrorSubject::Snapshot(None), ErrorVerb::Write, e)
         })?;
@@ -191,10 +204,9 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, Node>,
-        snapshot: Box<SnapshotData>,
+        _snapshot: Box<SnapshotData>,
     ) -> Result<(), RaftStorageError<NodeId>> {
-        let snapshot = *snapshot;
-        let snap_db = self.open_snap_db_with_file(snapshot).await.map_err(new_snapshot_error)?;
+        let snap_db = self.open_snap_db().await.map_err(new_snapshot_error)?;
         self.update_from_snapshot(meta, snap_db).await.map_err(new_snapshot_error)
     }
 

--- a/state/src/storage/cursor.rs
+++ b/state/src/storage/cursor.rs
@@ -71,6 +71,11 @@ impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
         }
     }
 
+    /// Get the key/value at the current position position without deserializing
+    pub fn get_current_raw(&mut self) -> Result<Option<(CowBuffer, CowBuffer)>, StorageError> {
+        self.inner.get_current::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)
+    }
+
     /// Position the cursor at the next key value pair
     ///
     /// Returns `true` if the cursor has reached the end of the table


### PR DESCRIPTION
### Purpose
This PR fixes a few bugs with snapshotting, namely:
1. Snapshot directory is not created by 
2. Early close on the snapshot file by the underlying `openraft` implementation. We just re-open the file in out `install_snapshot` implementation.
3. Improper double deserialization of CoW buffers

### Testing
- Tested a raft wherein the first node comes online and processes state transitions long enough to snapshot. Brought up a second node and verified through the API that the state was the same
- Unit tests pass