### PR TITLE
arbitrum-client: Decrease ethers polling interval for quicker tx updates

### DIFF
--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -53,6 +53,10 @@ pub const SELECTOR_LEN: usize = 4;
 pub const WALLET_UPDATED_EVENT_NAME: &str = "WalletUpdated";
 /// The abi signature for the `NullifierSpent` event
 pub const NULLIFIER_SPENT_EVENT_NAME: &str = "NullifierSpent";
+/// The interval at which to poll for pending transactions
+pub const BLOCK_POLLING_INTERVAL_MS: u64 = 100;
+/// The interval at which to poll for event filters
+pub const EVENT_FILTER_POLLING_INTERVAL_MS: u64 = 7000;
 
 lazy_static! {
     // ------------------------


### PR DESCRIPTION
This PR reduces the polling interval of the ethers provider used in the `arbitrum-client`. The default value is 7s, probably set for use on Ethereum where block times are ~12s (Arbitrum block time is ~260ms). This value is also used as the initial delay to wait before querying the chain for updates.

Tested in the fronted on local relayer, SubmittingTx now takes ~1s compared to ~4-5s before.