### PR TITLE
util: metered_channels: create metered receivers for worker queues

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -35,10 +35,13 @@ jobs:
         uses: docker/build-push-action@v5
         env:
           IMAGE: ${{ steps.login-ecr.outputs.registry }}/relayer-${{ github.ref_name }}
+          CARGO_FEATURES: ${{ github.ref_name == 'dev' && 'metered-channels' || 'default' }}
         with:
           platforms: linux/arm64
           context: .
           file: ./docker/release/Dockerfile
+          build-args: |
+            CARGO_FEATURES=${{ env.CARGO_FEATURES }}
           push: true
           tags: ${{ env.IMAGE }}:${{ github.sha }},${{ env.IMAGE }}:latest
           cache-from: type=gha

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8798,6 +8798,7 @@ dependencies = [
  "chrono",
  "circuit-types",
  "constants",
+ "crossbeam",
  "eyre",
  "futures",
  "hex 0.4.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,6 +4107,7 @@ dependencies = [
  "libp2p",
  "libp2p-core",
  "tokio",
+ "util",
  "uuid 1.8.0",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2018"
 default-run = "renegade-relayer"
 
+[features]
+metered-channels = ["util/metered-channels"]
+
 [dependencies]
 # === Runtime + Async === #
 crossbeam = { workspace = true }

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -31,12 +31,14 @@ RUN apt-get update && \
 ENV RUSTFLAGS=-Awarnings
 ENV RUST_BACKTRACE=1
 
+ARG CARGO_FEATURES="default"
+
 # Build only the dependencies to cache them in this layer
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --features "$CARGO_FEATURES"
 
 # Build the relayer
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --features "$CARGO_FEATURES"
 
 # Release stage
 FROM --platform=arm64 debian:bookworm-slim

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -401,7 +401,7 @@ mod test {
         ); // should be started
 
         // Check the task was started
-        assert!(!task_recv.inner().is_empty());
+        assert!(!task_recv.is_empty());
         let task = task_recv.recv().unwrap();
 
         if let TaskDriverJob::Run(queued_task) = task {
@@ -433,7 +433,7 @@ mod test {
         tx.commit().unwrap();
 
         assert_eq!(tasks.len(), 1);
-        assert!(task_recv.inner().is_empty());
+        assert!(task_recv.is_empty());
     }
 
     /// Tests the case in which a task is added to a non-empty queue
@@ -466,7 +466,7 @@ mod test {
         assert_eq!(tasks[1].state, QueuedTaskState::Queued);
 
         // Ensure that the task queue is empty (no task is marked as running)
-        assert!(task_recv.inner().is_empty());
+        assert!(task_recv.is_empty());
     }
 
     /// Test popping from a task queue of length one
@@ -498,7 +498,7 @@ mod test {
         assert_eq!(tasks.len(), 0);
 
         // Ensure no task was started
-        assert!(task_recv.inner().is_empty());
+        assert!(task_recv.is_empty());
     }
 
     /// Tests popping from a queue of length two in which the local peer is not
@@ -538,7 +538,7 @@ mod test {
         ); // should be started
 
         // Ensure no task was started
-        assert!(task_recv.inner().is_empty());
+        assert!(task_recv.is_empty());
     }
 
     /// Tests popping from a queue of length two in which the local peer is the
@@ -578,7 +578,7 @@ mod test {
         ); // should be started
 
         // Ensure the second task was started
-        assert!(!task_recv.inner().is_empty());
+        assert!(!task_recv.is_empty());
         let task = task_recv.recv().unwrap();
 
         if let TaskDriverJob::Run(queued_task) = task {
@@ -673,7 +673,7 @@ mod test {
         let tasks = tx.get_queued_tasks(&task_queue_key).unwrap();
         tx.commit().unwrap();
 
-        assert!(task_recv.inner().is_empty());
+        assert!(task_recv.is_empty());
         assert_eq!(tasks.len(), 2); // Includes the preemptive task
         assert_eq!(tasks[0].state, QueuedTaskState::Preemptive);
         assert_eq!(tasks[1].state, QueuedTaskState::Queued);
@@ -686,7 +686,7 @@ mod test {
         tx.commit().unwrap();
         assert_eq!(task.unwrap().id, task_id);
 
-        assert!(!task_recv.inner().is_empty());
+        assert!(!task_recv.is_empty());
 
         let task = task_recv.recv().unwrap();
         if let TaskDriverJob::Run(queued_task) = task {
@@ -748,7 +748,7 @@ mod test {
         assert!(task.is_some());
         assert_eq!(task.unwrap().id, task_id);
 
-        assert!(!task_recv.inner().is_empty());
+        assert!(!task_recv.is_empty());
         let job = task_recv.recv().unwrap();
         if let TaskDriverJob::Run(queued_task) = job {
             assert_eq!(queued_task.id, task_id);

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -401,7 +401,7 @@ mod test {
         ); // should be started
 
         // Check the task was started
-        assert!(!task_recv.is_empty());
+        assert!(!task_recv.inner().is_empty());
         let task = task_recv.recv().unwrap();
 
         if let TaskDriverJob::Run(queued_task) = task {
@@ -433,7 +433,7 @@ mod test {
         tx.commit().unwrap();
 
         assert_eq!(tasks.len(), 1);
-        assert!(task_recv.is_empty());
+        assert!(task_recv.inner().is_empty());
     }
 
     /// Tests the case in which a task is added to a non-empty queue
@@ -466,7 +466,7 @@ mod test {
         assert_eq!(tasks[1].state, QueuedTaskState::Queued);
 
         // Ensure that the task queue is empty (no task is marked as running)
-        assert!(task_recv.is_empty());
+        assert!(task_recv.inner().is_empty());
     }
 
     /// Test popping from a task queue of length one
@@ -498,7 +498,7 @@ mod test {
         assert_eq!(tasks.len(), 0);
 
         // Ensure no task was started
-        assert!(task_recv.is_empty());
+        assert!(task_recv.inner().is_empty());
     }
 
     /// Tests popping from a queue of length two in which the local peer is not
@@ -538,7 +538,7 @@ mod test {
         ); // should be started
 
         // Ensure no task was started
-        assert!(task_recv.is_empty());
+        assert!(task_recv.inner().is_empty());
     }
 
     /// Tests popping from a queue of length two in which the local peer is the
@@ -578,7 +578,7 @@ mod test {
         ); // should be started
 
         // Ensure the second task was started
-        assert!(!task_recv.is_empty());
+        assert!(!task_recv.inner().is_empty());
         let task = task_recv.recv().unwrap();
 
         if let TaskDriverJob::Run(queued_task) = task {
@@ -673,7 +673,7 @@ mod test {
         let tasks = tx.get_queued_tasks(&task_queue_key).unwrap();
         tx.commit().unwrap();
 
-        assert!(task_recv.is_empty());
+        assert!(task_recv.inner().is_empty());
         assert_eq!(tasks.len(), 2); // Includes the preemptive task
         assert_eq!(tasks[0].state, QueuedTaskState::Preemptive);
         assert_eq!(tasks[1].state, QueuedTaskState::Queued);
@@ -686,7 +686,7 @@ mod test {
         tx.commit().unwrap();
         assert_eq!(task.unwrap().id, task_id);
 
-        assert!(!task_recv.is_empty());
+        assert!(!task_recv.inner().is_empty());
 
         let task = task_recv.recv().unwrap();
         if let TaskDriverJob::Run(queued_task) = task {
@@ -748,7 +748,7 @@ mod test {
         assert!(task.is_some());
         assert_eq!(task.unwrap().id, task_id);
 
-        assert!(!task_recv.is_empty());
+        assert!(!task_recv.inner().is_empty());
         let job = task_recv.recv().unwrap();
         if let TaskDriverJob::Run(queued_task) = job {
             assert_eq!(queued_task.id, task_id);

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -20,6 +20,7 @@ libp2p = { workspace = true }
 # === Runtime === #
 futures = { workspace = true }
 tokio = { workspace = true }
+crossbeam = { workspace = true }
 
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 mocks = []
+metered-channels = []
 
 [dependencies]
 # === Arithmetic === #

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -15,6 +15,7 @@ pub mod matching_engine;
 pub mod networking;
 pub mod runtime;
 pub mod telemetry;
+pub mod metered_channels;
 
 /// Returns the current unix timestamp in seconds, represented as u64
 pub fn get_current_time_seconds() -> u64 {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -12,10 +12,10 @@ pub mod arbitrum;
 pub mod errors;
 pub mod hex;
 pub mod matching_engine;
+pub mod metered_channels;
 pub mod networking;
 pub mod runtime;
 pub mod telemetry;
-pub mod metered_channels;
 
 /// Returns the current unix timestamp in seconds, represented as u64
 pub fn get_current_time_seconds() -> u64 {

--- a/util/src/metered_channels.rs
+++ b/util/src/metered_channels.rs
@@ -1,0 +1,35 @@
+//! A simple wrapper around channel receiver types used throughout the codebase
+//! which records message queue lengths.
+
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// Metric describing the length of a worker's job queue
+pub const QUEUE_LENGTH_METRIC: &str = "queue_length";
+
+/// A wrapper around an [`UnboundedReceiver`] which records the message queue
+/// length when a message is received.
+pub struct MeteredUnboundedReceiver<T> {
+    /// The inner receiver
+    inner: UnboundedReceiver<T>,
+    /// The name of the channel
+    name: String,
+}
+
+impl<T> MeteredUnboundedReceiver<T> {
+    /// Create a new metered receiver with the given name
+    pub fn new(inner: UnboundedReceiver<T>, name: String) -> Self {
+        Self { inner, name }
+    }
+
+    /// Receive a message from the channel, recording the queue length
+    pub async fn recv(&mut self) -> Option<T> {
+        #[cfg(feature = "metered-channels")]
+        {
+            let metric_name = format!("{}_{}", self.name, QUEUE_LENGTH_METRIC);
+            let queue_len = self.inner.len();
+            metrics::gauge!(metric_name).set(queue_len as f64);
+        }
+
+        self.inner.recv().await
+    }
+}

--- a/util/src/metered_channels.rs
+++ b/util/src/metered_channels.rs
@@ -13,7 +13,9 @@ pub const QUEUE_LENGTH_METRIC: &str = "queue_length";
 pub struct MeteredTokioReceiver<T> {
     /// The inner receiver
     inner: UnboundedReceiver<T>,
+
     /// The name of the channel
+    #[cfg_attr(not(feature = "metered-channels"), allow(dead_code))]
     name: &'static str,
 }
 
@@ -52,9 +54,9 @@ impl<T> MeteredCrossbeamReceiver<T> {
         Self { inner, name }
     }
 
-    /// Get a reference to the inner receiver
-    pub fn inner(&self) -> &Receiver<T> {
-        &self.inner
+    /// Check if the channel is empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     /// Receive a message from the channel, recording the queue length
@@ -72,9 +74,6 @@ impl<T> MeteredCrossbeamReceiver<T> {
 
 impl<T> Clone for MeteredCrossbeamReceiver<T> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            name: self.name,
-        }
+        Self { inner: self.inner.clone(), name: self.name }
     }
 }

--- a/util/src/metered_channels.rs
+++ b/util/src/metered_channels.rs
@@ -8,16 +8,17 @@ pub const QUEUE_LENGTH_METRIC: &str = "queue_length";
 
 /// A wrapper around an [`UnboundedReceiver`] which records the message queue
 /// length when a message is received.
+#[derive(Debug)]
 pub struct MeteredUnboundedReceiver<T> {
     /// The inner receiver
     inner: UnboundedReceiver<T>,
     /// The name of the channel
-    name: String,
+    name: &'static str,
 }
 
 impl<T> MeteredUnboundedReceiver<T> {
     /// Create a new metered receiver with the given name
-    pub fn new(inner: UnboundedReceiver<T>, name: String) -> Self {
+    pub fn new(inner: UnboundedReceiver<T>, name: &'static str) -> Self {
         Self { inner, name }
     }
 

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -17,6 +17,7 @@ circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
 constants = { path = "../../constants" }
 gossip-api = { path = "../../gossip-api" }
+util = { path = "../../util" }
 
 # === Misc === #
 crossbeam = { workspace = true }

--- a/workers/job-types/src/gossip_server.rs
+++ b/workers/job-types/src/gossip_server.rs
@@ -7,10 +7,8 @@ use gossip_api::{
     request_response::{AuthenticatedGossipResponse, GossipRequest, GossipResponse},
 };
 use libp2p::request_response::ResponseChannel;
-use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedSender as TokioSender,
-};
-use util::metered_channels::MeteredUnboundedReceiver;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioSender};
+use util::metered_channels::MeteredTokioReceiver;
 
 /// The name of the gossip server queue, used to label queue length metrics
 const GOSSIP_SERVER_QUEUE_NAME: &str = "gossip_server";
@@ -18,12 +16,12 @@ const GOSSIP_SERVER_QUEUE_NAME: &str = "gossip_server";
 /// The queue sender type to send jobs to the gossip server
 pub type GossipServerQueue = TokioSender<GossipServerJob>;
 /// The queue receiver type to receive jobs from the gossip server
-pub type GossipServerReceiver = MeteredUnboundedReceiver<GossipServerJob>;
+pub type GossipServerReceiver = MeteredTokioReceiver<GossipServerJob>;
 
 /// Create a new gossip server queue and receiver
 pub fn new_gossip_server_queue() -> (GossipServerQueue, GossipServerReceiver) {
     let (send, recv) = unbounded_channel();
-    (send, MeteredUnboundedReceiver::new(recv, GOSSIP_SERVER_QUEUE_NAME))
+    (send, MeteredTokioReceiver::new(recv, GOSSIP_SERVER_QUEUE_NAME))
 }
 
 /// Defines a heartbeat job that can be enqueued by other workers in a relayer

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -6,10 +6,8 @@ use common::types::{gossip::WrappedPeerId, wallet::OrderIdentifier};
 use constants::SystemCurveGroup;
 use gossip_api::request_response::{handshake::HandshakeMessage, AuthenticatedGossipResponse};
 use libp2p::request_response::ResponseChannel;
-use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedSender as TokioSender,
-};
-use util::metered_channels::MeteredUnboundedReceiver;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioSender};
+use util::metered_channels::MeteredTokioReceiver;
 use uuid::Uuid;
 
 /// The name of the handshake manager queue, used to label queue length metrics
@@ -18,12 +16,12 @@ const HANDSHAKE_MANAGER_QUEUE_NAME: &str = "handshake_manager";
 /// The job queue for the handshake manager
 pub type HandshakeManagerQueue = TokioSender<HandshakeExecutionJob>;
 /// The job queue receiver for the handshake manager
-pub type HandshakeManagerReceiver = MeteredUnboundedReceiver<HandshakeExecutionJob>;
+pub type HandshakeManagerReceiver = MeteredTokioReceiver<HandshakeExecutionJob>;
 
 /// Create a new handshake manager queue and receiver
 pub fn new_handshake_manager_queue() -> (HandshakeManagerQueue, HandshakeManagerReceiver) {
     let (send, recv) = unbounded_channel();
-    (send, MeteredUnboundedReceiver::new(recv, HANDSHAKE_MANAGER_QUEUE_NAME))
+    (send, MeteredTokioReceiver::new(recv, HANDSHAKE_MANAGER_QUEUE_NAME))
 }
 
 /// Represents a job for the handshake manager's thread pool to execute

--- a/workers/job-types/src/network_manager.rs
+++ b/workers/job-types/src/network_manager.rs
@@ -11,7 +11,7 @@ use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender as TokioSender},
     oneshot::{channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender},
 };
-use util::metered_channels::MeteredUnboundedReceiver;
+use util::metered_channels::MeteredTokioReceiver;
 use uuid::Uuid;
 
 /// The name of the network manager queue, used to label queue length metrics
@@ -20,7 +20,7 @@ const NETWORK_MANAGER_QUEUE_NAME: &str = "network_manager";
 /// The task queue type for the network manager
 pub type NetworkManagerQueue = TokioSender<NetworkManagerJob>;
 /// The task queue receiver type for the network manager
-pub type NetworkManagerReceiver = MeteredUnboundedReceiver<NetworkManagerJob>;
+pub type NetworkManagerReceiver = MeteredTokioReceiver<NetworkManagerJob>;
 /// The channel type on which the network manager forwards a response to a
 /// particular request
 pub type NetworkResponseChannel = OneshotSender<GossipResponse>;
@@ -31,7 +31,7 @@ pub type NetworkResponseReceiver = OneshotReceiver<GossipResponse>;
 /// Create a new network manager queue and receiver
 pub fn new_network_manager_queue() -> (NetworkManagerQueue, NetworkManagerReceiver) {
     let (send, recv) = unbounded_channel();
-    (send, MeteredUnboundedReceiver::new(recv, NETWORK_MANAGER_QUEUE_NAME))
+    (send, MeteredTokioReceiver::new(recv, NETWORK_MANAGER_QUEUE_NAME))
 }
 /// Create a new response channel for a request
 pub fn new_response_channel() -> (NetworkResponseChannel, NetworkResponseReceiver) {

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc::{
     UnboundedSender as TokioUnboundedSender,
 };
 use tokio::sync::oneshot::Sender as TokioSender;
-use util::metered_channels::MeteredUnboundedReceiver;
+use util::metered_channels::MeteredTokioReceiver;
 
 /// The name of the price reporter queue, used to label queue length metrics
 const PRICE_REPORTER_QUEUE_NAME: &str = "price_reporter";
@@ -13,12 +13,12 @@ const PRICE_REPORTER_QUEUE_NAME: &str = "price_reporter";
 /// The queue type for the price reporter
 pub type PriceReporterQueue = TokioUnboundedSender<PriceReporterJob>;
 /// The queue receiver type for the price reporter
-pub type PriceReporterReceiver = MeteredUnboundedReceiver<PriceReporterJob>;
+pub type PriceReporterReceiver = MeteredTokioReceiver<PriceReporterJob>;
 
 /// Create a new price reporter queue and receiver
 pub fn new_price_reporter_queue() -> (PriceReporterQueue, PriceReporterReceiver) {
     let (send, recv) = unbounded_channel();
-    (send, MeteredUnboundedReceiver::new(recv, PRICE_REPORTER_QUEUE_NAME))
+    (send, MeteredTokioReceiver::new(recv, PRICE_REPORTER_QUEUE_NAME))
 }
 
 /// All possible jobs that the PriceReporter accepts.

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -1,9 +1,6 @@
 //! Defines all possible jobs for the PriceReporter.
 use common::types::{exchange::PriceReporterState, token::Token};
-use tokio::sync::mpsc::{
-    unbounded_channel,
-    UnboundedSender as TokioUnboundedSender,
-};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioUnboundedSender};
 use tokio::sync::oneshot::Sender as TokioSender;
 use util::metered_channels::MeteredTokioReceiver;
 

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -23,7 +23,7 @@ use crossbeam::channel::{unbounded, Sender as CrossbeamSender};
 use ethers::signers::LocalWallet;
 use helpers::new_mock_task_driver;
 use job_types::{
-    network_manager::NetworkManagerReceiver,
+    network_manager::{new_network_manager_queue, NetworkManagerReceiver},
     proof_manager::ProofManagerJob,
     task_driver::{new_task_driver_queue, TaskDriverQueue},
 };
@@ -38,7 +38,6 @@ use test_helpers::{
     integration_test_main,
     types::TestVerbosity,
 };
-use tokio::sync::mpsc::unbounded_channel;
 use util::{
     arbitrum::{
         parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY, DUMMY_ERC20_0_CONTRACT_KEY,
@@ -110,7 +109,7 @@ struct IntegrationTestArgs {
 impl From<CliArgs> for IntegrationTestArgs {
     fn from(test_args: CliArgs) -> Self {
         // Create a mock network sender and receiver
-        let (network_sender, network_receiver) = unbounded_channel();
+        let (network_sender, network_receiver) = new_network_manager_queue();
 
         // Create a mock proof generation module
         let (proof_job_queue, job_receiver) = unbounded();

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -19,12 +19,12 @@ use arbitrum_client::{
 use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use clap::Parser;
 use common::types::token::{ADDR_DECIMALS_MAP, TOKEN_REMAPS};
-use crossbeam::channel::{unbounded, Sender as CrossbeamSender};
+use crossbeam::channel::Sender as CrossbeamSender;
 use ethers::signers::LocalWallet;
 use helpers::new_mock_task_driver;
 use job_types::{
     network_manager::{new_network_manager_queue, NetworkManagerReceiver},
-    proof_manager::ProofManagerJob,
+    proof_manager::{new_proof_manager_queue, ProofManagerJob},
     task_driver::{new_task_driver_queue, TaskDriverQueue},
 };
 use proof_manager::mock::MockProofManager;
@@ -112,7 +112,7 @@ impl From<CliArgs> for IntegrationTestArgs {
         let (network_sender, network_receiver) = new_network_manager_queue();
 
         // Create a mock proof generation module
-        let (proof_job_queue, job_receiver) = unbounded();
+        let (proof_job_queue, job_receiver) = new_proof_manager_queue();
         MockProofManager::start(job_receiver);
 
         // Create a mock arbitrum client


### PR DESCRIPTION
This PR introduces the `MeteredTokioReceiver` and `MeteredCrossbeamReceiver` wrapper types, which augment the underlying channel primitives by recording message queue lengths every time a message is pulled from the queue. This is guarded behind a compiler flag to remove the queueing overhead when necessary.

I tested this by running a relayer locally w/ a local Datadog agent and ensuring that metrics show up in Datadog.