### PR TITLE
state: replicationv2: raft: Periodically check raft core for panicks

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -19,7 +19,7 @@ use api_server::worker::{ApiServer, ApiServerConfig};
 use arbitrum_client::client::{ArbitrumClient, ArbitrumClientConfig};
 use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::default_wrapper::default_option;
-use common::worker::{watch_worker, Worker};
+use common::worker::{new_worker_failure_channel, watch_worker, Worker};
 use constants::VERSION;
 use external_api::bus_message::SystemBusMessage;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
@@ -41,10 +41,7 @@ use system_bus::SystemBus;
 use error::CoordinatorError;
 use system_clock::SystemClock;
 use task_driver::worker::{TaskDriver, TaskDriverConfig};
-use tokio::{
-    select,
-    sync::{mpsc, watch},
-};
+use tokio::{select, sync::watch};
 use tracing::info;
 use util::{err_str, telemetry::configure_telemetry};
 
@@ -116,6 +113,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (task_sender, task_receiver) = new_task_driver_queue();
 
     // Construct a global state
+    let (state_failure_send, mut state_failure_recv) = new_worker_failure_channel();
     let global_state = State::new(
         &args,
         network_sender.clone(),
@@ -123,6 +121,7 @@ async fn main() -> Result<(), CoordinatorError> {
         handshake_worker_sender.clone(),
         system_bus.clone(),
         system_clock,
+        state_failure_send,
     )
     .await?;
 
@@ -173,7 +172,7 @@ async fn main() -> Result<(), CoordinatorError> {
     task_driver.start().expect("failed to start task driver");
 
     let (task_driver_failure_sender, mut task_driver_failure_receiver) =
-        mpsc::channel(1 /* buffer_size */);
+        new_worker_failure_channel();
     watch_worker::<TaskDriver>(&mut task_driver, &task_driver_failure_sender);
 
     // Start the proof generation module
@@ -186,7 +185,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .expect("failed to build proof generation module");
     proof_manager.start().expect("failed to start proof generation module");
     let (proof_manager_failure_sender, mut proof_manager_failure_receiver) =
-        mpsc::channel(1 /* buffer_size */);
+        new_worker_failure_channel();
     watch_worker::<ProofManager>(&mut proof_manager, &proof_manager_failure_sender);
 
     // Start the network manager
@@ -209,8 +208,7 @@ async fn main() -> Result<(), CoordinatorError> {
         NetworkManager::new(network_manager_config).await.expect("failed to build network manager");
     network_manager.start().expect("failed to start network manager");
 
-    let (network_failure_sender, mut network_failure_receiver) =
-        mpsc::channel(1 /* buffer size */);
+    let (network_failure_sender, mut network_failure_receiver) = new_worker_failure_channel();
     watch_worker::<NetworkManager>(&mut network_manager, &network_failure_sender);
 
     // Start the gossip server
@@ -230,8 +228,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .await
     .expect("failed to build gossip server");
     gossip_server.start().expect("failed to start gossip server");
-    let (gossip_failure_sender, mut gossip_failure_receiver) =
-        mpsc::channel(1 /* buffer size */);
+    let (gossip_failure_sender, mut gossip_failure_receiver) = new_worker_failure_channel();
     watch_worker::<GossipServer>(&mut gossip_server, &gossip_failure_sender);
 
     // Once the minimal set of workers are running, run the setup task
@@ -258,8 +255,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .await
     .expect("failed to build handshake manager");
     handshake_manager.start().expect("failed to start handshake manager");
-    let (handshake_failure_sender, mut handshake_failure_receiver) =
-        mpsc::channel(1 /* buffer size */);
+    let (handshake_failure_sender, mut handshake_failure_receiver) = new_worker_failure_channel();
     watch_worker::<HandshakeManager>(&mut handshake_manager, &handshake_failure_sender);
 
     // Start the price reporter manager
@@ -281,7 +277,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .expect("failed to build price reporter manager");
     price_reporter_manager.start().expect("failed to start price reporter manager");
     let (price_reporter_failure_sender, mut price_reporter_failure_receiver) =
-        mpsc::channel(1 /* buffer size */);
+        new_worker_failure_channel();
     watch_worker::<PriceReporter>(&mut price_reporter_manager, &price_reporter_failure_sender);
 
     // Start the on-chain event listener
@@ -299,7 +295,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .expect("failed to build on-chain event listener");
     chain_listener.start().expect("failed to start on-chain event listener");
     let (chain_listener_failure_sender, mut chain_listener_failure_receiver) =
-        mpsc::channel(1 /* buffer_size */);
+        new_worker_failure_channel();
     watch_worker::<OnChainEventListener>(&mut chain_listener, &chain_listener_failure_sender);
 
     // Start the API server
@@ -317,7 +313,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .await
     .expect("failed to build api server");
     api_server.start().expect("failed to start api server");
-    let (api_failure_sender, mut api_failure_receiver) = mpsc::channel(1 /* buffer_size */);
+    let (api_failure_sender, mut api_failure_receiver) = new_worker_failure_channel();
     watch_worker::<ApiServer>(&mut api_server, &api_failure_sender);
 
     // Await module termination, and send a cancel signal for any modules that
@@ -325,6 +321,9 @@ async fn main() -> Result<(), CoordinatorError> {
     let recovery_loop = || async {
         loop {
             select! {
+                _ = state_failure_recv.recv() => {
+                    return Err(CoordinatorError::State("state submodule failed".to_string()));
+                },
                 _ = task_driver_failure_receiver.recv() => {
                     task_driver = recover_worker(task_driver)?;
                 }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -16,7 +16,7 @@ use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::{
     default_wrapper::{default_option, DefaultOption},
     types::Price,
-    worker::Worker,
+    worker::{new_worker_failure_channel, Worker},
 };
 use config::RelayerConfig;
 use ed25519_dalek::Keypair;
@@ -264,6 +264,7 @@ impl MockNodeController {
         let handshake_queue = self.handshake_queue.0.clone();
         let bus = self.bus.clone();
         let clock = self.clock.clone();
+        let (failure_send, failure_recv) = new_worker_failure_channel();
 
         let state = run_fut(State::new(
             &self.config,
@@ -272,8 +273,10 @@ impl MockNodeController {
             handshake_queue,
             bus,
             clock,
+            failure_send,
         ))
         .expect("Failed to create state instance");
+        std::mem::forget(failure_recv); // forget to avoid closing
 
         self.state = Some(state);
         self

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -178,6 +178,7 @@ pub mod test_helpers {
     //! Test helpers for the state crate
     use std::{mem, time::Duration};
 
+    use common::worker::new_worker_failure_channel;
     use config::RelayerConfig;
     use job_types::{
         handshake_manager::new_handshake_manager_queue,
@@ -272,6 +273,7 @@ pub mod test_helpers {
         let raft = MockRaft::create_raft(2 /* n_nodes */, false /* init */).await;
         let net = raft.new_network_client();
         let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
+        let (failure_send, _failure_recv) = new_worker_failure_channel();
         let state = State::new_with_network(
             config,
             mock_raft_config(config),
@@ -280,6 +282,7 @@ pub mod test_helpers {
             handshake_manager_queue,
             SystemBus::new(),
             SystemClock::new().await,
+            failure_send,
         )
         .await
         .unwrap();

--- a/state/src/replicationv2/raft.rs
+++ b/state/src/replicationv2/raft.rs
@@ -181,6 +181,14 @@ impl RaftClient {
         metrics.membership_config.membership().learner_ids().collect()
     }
 
+    /// Check for a panic in the raft core
+    ///
+    /// Returns `true` if the raft core panicked
+    pub async fn raft_core_panicked(&self) -> bool {
+        // The raft state method will return a `Fatal` error iff the core panicked
+        self.raft.with_raft_state(|_| ()).await.is_err()
+    }
+
     /// Shutdown the raft
     pub async fn shutdown(&self) -> Result<(), ReplicationV2Error> {
         self.raft.shutdown().await.map_err(err_str!(ReplicationV2Error::RaftTeardown))


### PR DESCRIPTION
### Purpose
This PR adds a timer event to the `SystemClock` to periodically check for raft core panicks. The core does not expose a direct way of measuring or awaiting this, so we attempt to read the server state of the raft. If it has panicked, this will return with a `Fatal` error.

### Testing
- Unit tests pass
- Simulated a panic in the state machine as we've seen in `dev`, node shut down