### PR TITLE
state: storage: order-book: Update nullifier set before order info

### DIFF
--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -118,6 +118,7 @@ impl From<CliArgs> for IntegrationTestArgs {
             darkpool_addr,
             arb_priv_key,
             rpc_url: test_args.rpc_url,
+            block_polling_interval_ms: 100,
         }))
         .unwrap();
 

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -117,7 +117,6 @@ impl StateApplicator {
             tx.mark_order_local(&id)?;
             tx.write_order_priority(&net_order)?;
             tx.write_order(&net_order)?;
-            tx.update_order_nullifier_set(&id, nullifier)?;
         }
 
         Ok(())

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -245,7 +245,6 @@ impl State {
         order.local = false;
         tx.write_order_priority(&order)?;
         tx.write_order(&order)?;
-        tx.update_order_nullifier_set(&order.id, order.public_share_nullifier)?;
 
         Ok(tx.commit()?)
     }

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -24,7 +24,8 @@ pub enum PriceReporterJob {
     /// If using the external executor, this will send a subscription request
     /// for the pair across all exchanges.
     ///
-    /// If using the native executor, this will create and start a new PriceReporter for the pair.
+    /// If using the native executor, this will create and start a new
+    /// PriceReporter for the pair.
     ///
     /// If the PriceReporter does not yet exist, spawn it and begin publication
     /// to the global system bus. If the PriceReporter already exists and id

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -177,6 +177,7 @@ fn setup_arbitrum_client_mock(test_args: &CliArgs) -> ArbitrumClient {
         darkpool_addr,
         arb_priv_key,
         rpc_url: test_args.devnet_url.clone(),
+        block_polling_interval_ms: 100,
     }))
     .unwrap()
 }


### PR DESCRIPTION
### Purpose
This PR fixes a bug with order indexing wherein the nullifier set is incorrectly updated. Previously we were updating order info before removing an order from its old nullifier set. This causes the nullifier update to instead remove the order from the _current_ set, then immediately add it back. Further, this prevents the order from being removed from its _old_ nullifier set. This caused spurious nullification of valid orders in `dev`

I moved the calls to update the nullifier set to the `write_order` method to avoid leaking these ordering details across the storage interface.

### Testing
- Replicated the spurious nullification "Order not found" bug locally
- Verified that the fix does prevent this case