### PR TITLE
workers: task-driver: helpers: Allow zero'd balances to be overwritten

### DIFF
--- a/workers/task-driver/src/helpers.rs
+++ b/workers/task-driver/src/helpers.rs
@@ -269,7 +269,7 @@ fn find_or_augment_balance(
                 .balances
                 .iter()
                 .enumerate()
-                .find(|(_ind, balance)| balance.mint.eq(&BigUint::from(0u8)))
+                .find(|(_ind, balance)| balance.is_zero())
                 .map(|(ind, _balance)| ind)?;
 
             wallet.balances[empty_balance_ind] = Balance::new_from_mint(mint.clone());


### PR DESCRIPTION
### Purpose
This PR changes the criterion for a balance being overwritten from `mint == 0` to `balance.is_zerod()`. The `Balance::is_zerod` method is explicitly: `balance.amount == 0 && balance.protocol_fee_balance == 0 && balance.relayer_fee_balance == 0`. Effectively, this PR allows balances to be overwritten by augmentations if only the mint is non-zero. This is already explicitly allowed in the circuits.

### Testing
- Unit tests pass
- @sehyunc will test integration with a bug he's seeing