### PR TITLE
workers: task-driver: driver: Await task queue pause + resume

### DIFF
--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -28,7 +28,7 @@ pub async fn node_setup(
         .map_err(|_| CoordinatorError::Setup(ERR_SENDING_STARTUP_TASK.to_string()))?;
 
     // Wait for the task driver to index the task then request a notification
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(1000)).await;
     let (recv, job) = new_task_notification(id);
     task_queue
         .send(job)

--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -13,6 +13,11 @@ pub enum StateApplicatorError {
     EnqueueTask(String),
     /// Missing keys in the database necessary for a tx
     MissingEntry(&'static str),
+    /// An error indicating a state transition has been rejected
+    ///
+    /// This error will be sent directly to the listeners on a proposal and not
+    /// forwarded to the raft core
+    Rejected(String),
     /// An error interacting with storage
     Storage(StorageError),
     /// A task queue is empty when it should not be

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -84,9 +84,11 @@ impl StateApplicator {
             StateTransition::TransitionTask { task_id, state } => {
                 self.transition_task_state(task_id, state)
             },
-            StateTransition::PreemptTaskQueue { key, task } => self.preempt_task_queue(key, &task),
-            StateTransition::ResumeTaskQueue { key, success } => {
-                self.resume_task_queue(key, success)
+            StateTransition::PreemptTaskQueues { keys, task } => {
+                self.preempt_task_queues(&keys, &task)
+            },
+            StateTransition::ResumeTaskQueues { keys, success } => {
+                self.resume_task_queues(&keys, success)
             },
             StateTransition::AddMpcPreprocessingValues { cluster, values } => {
                 self.add_preprocessing_values(&cluster, &values)

--- a/state/src/applicator/return_type.rs
+++ b/state/src/applicator/return_type.rs
@@ -8,8 +8,6 @@
 
 use common::types::mpc_preprocessing::PairwiseOfflineSetup;
 
-use super::error::StateApplicatorError;
-
 /// The return type from the Applicator
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -18,8 +16,6 @@ pub enum ApplicatorReturnType {
     MpcPrep(PairwiseOfflineSetup),
     /// No return value
     None,
-    /// The application of the proposal failed in an expected manner
-    Rejected(StateApplicatorError),
 }
 
 // Downcasting conversions

--- a/state/src/interface/error.rs
+++ b/state/src/interface/error.rs
@@ -29,6 +29,8 @@ pub enum StateError {
     Runtime(String),
     /// An error deserializing a message
     Serde(String),
+    /// A state transition was rejected
+    TransitionRejected(String),
 }
 
 impl Display for StateError {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -139,9 +139,9 @@ pub enum StateTransition {
     /// Preempt the given task queue
     ///
     /// Returns any running tasks to `Queued` state and pauses the queue
-    PreemptTaskQueue { key: TaskQueueKey, task: QueuedTask },
+    PreemptTaskQueues { keys: Vec<TaskQueueKey>, task: QueuedTask },
     /// Resume the given task queue
-    ResumeTaskQueue { key: TaskQueueKey, success: bool },
+    ResumeTaskQueues { keys: Vec<TaskQueueKey>, success: bool },
 
     // --- MPC Preprocessing --- //
     /// Add a preprocessing bundle to the state


### PR DESCRIPTION
### Purpose
This task fixes a bug in which concurrent matches were allowed to process. This ends up panicking the state machine and thereby the raft as we try to pop a preemptive task twice. The root cause is that two match tasks _both_ attempt to pause the task queue. Only one succeeds, but neither waits for the pause state transition to finish before starting the task.

I changed the driver's implementation to await the preemption proposal before continuing.

While fixing this codepath, I also fixed a few other bugs that have not yet come up but will:
- We now pause/resume task queues in an "all-or-none" fashion. This mitigates a bug in which we succeed to pause one task queue and not another. We will fail the driver's loop and never resume the first wallet's task queue.
- To more easily support the above bug fix, I had the state machine return an `Err` on rejection rather than `Ok(ApplicatorReturnType::Rejected)`. This simplifies the implementation and allows us to use try operators within a tx -- so that the tx will abort if one try fails, that is, if one pause/resume is rejected

### Testing
- Unit tests pass, added tests for pausing/resuming multiple queues
- Replicated the `"expected preemptive task"` bug locally, verified that this fix mitigates it -> we fail one of the task driver jobs