### PR TITLE
network-manager: properly configure local addr

### DIFF
--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -134,7 +134,7 @@ impl GossipProtocolExecutor {
         }
 
         // Remove expired peer from global state & DHT
-        info!("Expiring peer {peer_id}");
+        info!("Expiring peer {peer_id} last heartbeat was {last_heartbeat} seconds ago");
         self.global_state.remove_peer(peer_id).await?;
         self.network_channel
             .send(NetworkManagerJob::internal(NetworkManagerControlSignal::PeerExpired { peer_id }))

--- a/workers/network-manager/src/worker.rs
+++ b/workers/network-manager/src/worker.rs
@@ -164,9 +164,10 @@ impl Worker for NetworkManager {
             .unwrap_or_else(|| Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)));
 
         let local_addr = Multiaddr::empty()
-            .with(Protocol::P2p(local_peer_id.0.into()))
-            .with(Protocol::Tcp(config.port))
-            .with(ip_protoc);
+            .with(ip_protoc)
+            .with(Protocol::Udp(config.port))
+            .with(Protocol::QuicV1)
+            .with(Protocol::P2p(local_peer_id.0.into()));
 
         // Write the local peer's info to the global state once we know the bind addr
         let info = PeerInfo::new_with_cluster_secret_key(


### PR DESCRIPTION
### Purpose
This PR fixes a bug wherein a peer reports its own multiaddr incorrectly. Specifically, peers must end the multiaddr with their p2p protocol, i.e. `/p2p/{peer_id}`. 

Instead, peers reordered the `QuicV1` and `P2p` protocols, appending `quic-v1`. This causes the DHT layer to incorrect address the nodes by adding an extra `p2p` entry, e.g: `p2p/{peer_id}/quic-v1/p2p/{peer_id}`. This prevented the transport from dialing properly, and ultimately led to spurious peer expiry.

### Testing
- Unit tests pass
- Ran a multi-node cluster with a few tasks, verified that the peers stopped expiring each other after the fix. Was able to run tasks on the cluster.