### PR TITLE
state: applicator: task_queue: record task queue lengths

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v5
         env:
           IMAGE: ${{ steps.login-ecr.outputs.registry }}/relayer-${{ github.ref_name }}
-          CARGO_FEATURES: ${{ github.ref_name == 'dev' && 'metered-channels' || 'default' }}
+          CARGO_FEATURES: ${{ github.ref_name == 'dev' && 'metered-channels task-queue-len' || 'default' }}
         with:
           platforms: linux/arm64
           context: .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7697,6 +7697,7 @@ dependencies = [
  "lazy_static",
  "libmdbx",
  "libp2p",
+ "metrics",
  "multiaddr",
  "num-bigint",
  "openraft",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ default-run = "renegade-relayer"
 
 [features]
 metered-channels = ["util/metered-channels"]
+task-queue-len = ["state/task-queue-len"]
 
 [dependencies]
 # === Runtime + Async === #

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -53,6 +53,7 @@ tracing-slog = "0.2"
 tui = "0.19"
 tui-logger = "0.8"
 uuid = "1.1.2"
+metrics = { workspace = true }
 
 [dev-dependencies]
 multiaddr = "0.17"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # Used to enable mocks from other crates in tests
 all-tests = ["common/mocks"]
 mocks = ["dep:tempfile", "dep:test-helpers"]
+task-queue-len = ["dep:metrics"]
 
 [dependencies]
 
@@ -53,7 +54,7 @@ tracing-slog = "0.2"
 tui = "0.19"
 tui-logger = "0.8"
 uuid = "1.1.2"
-metrics = { workspace = true }
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 multiaddr = "0.17"


### PR DESCRIPTION
This PR adds metrics gauging the lengths of tasks queues in the relayer. We do this in the applicator, despite the fact that metrics will be emitted from all nodes in the cluster - this can be easily deduplicated in DataDog. We don't record these metrics in the interface layer (i.e. when proposing state transitions) because we would be unable to accurately capture queue lengths when preemptive tasks are added / queues are cleared due to task failure.