### PR TITLE
state: raft: Fix peer removal bugs

### DIFF
--- a/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
@@ -92,6 +92,11 @@ impl HeartbeatTimer {
             let wait_time =
                 if peers.is_empty() { wait_period } else { wait_period / (peers.len() as u32) };
 
+            // If there is only one peer (self), sleep the whole wait period
+            if peers.len() <= 1 {
+                thread::sleep(wait_time);
+            }
+
             for peer in peers.into_iter().filter(|peer| peer != &local_peer_id) {
                 if let Err(err) = job_queue.send(GossipServerJob::ExecuteHeartbeat(peer)) {
                     return Err(GossipError::TimerFailed(err.to_string()));

--- a/workers/network-manager/src/executor.rs
+++ b/workers/network-manager/src/executor.rs
@@ -205,7 +205,7 @@ impl NetworkManagerExecutor {
                             let this = self.clone();
                             tokio::spawn(async move {
                                 if let Err(err) = this.handle_inbound_message(event).await {
-                                    info!("error in network manager: {:?}", err);
+                                    error!("error in network manager: {:?}", err);
                                 }
                             });
                         },


### PR DESCRIPTION
### Purpose
This PR fixes a few peer remove bugs:
1. A deadlock bug wherein we block on the raft removal within a write tx.
2. A bug wherein concurrent removal proposals result in errors that prevent the raft from making progress.

### Testing
- Unit tests pass
- Tested removing a peer from a cluster. More edge cases that need to be covered in follow ups