### PR TITLE
arbitrum-client: use multiple arbitrum keypairs

### DIFF
--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -9,6 +9,7 @@ integration = [
     "circuits/test_helpers",
     "common/mocks",
 ]
+rand = ["dep:rand"]
 
 [[test]]
 name = "integration"
@@ -48,6 +49,7 @@ postcard = { version = "1", features = ["alloc"] }
 itertools = "0.12"
 lazy_static = { workspace = true }
 tracing = { workspace = true }
+rand = { workspace = true, optional = true }
 
 # === Contracts Repo Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
@@ -61,5 +63,4 @@ json = "0.12"
 tokio = { workspace = true }
 colored = "2"
 inventory = "0.3"
-rand = { workspace = true }
 mpc-plonk = { workspace = true }

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -68,8 +68,5 @@ pub async fn setup_pre_allocated_state(client: &mut ArbitrumClient) -> Result<Pr
 /// w/ the default values for the leaves
 pub async fn clear_merkle(client: &ArbitrumClient) -> Result<()> {
     warn!("Clearing Merkle contract state");
-    send_tx(client.darkpool_contract.clear_merkle())
-        .await
-        .map(|_| ())
-        .map_err(|e| eyre!(e.to_string()))
+    send_tx(client.get_darkpool_client().clear_merkle()).await.map(|_| ()).map_err(|e| eyre!(e.to_string()))
 }

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -116,7 +116,7 @@ impl From<CliArgs> for IntegrationTestArgs {
         let client = block_current(ArbitrumClient::new(ArbitrumClientConfig {
             chain: Chain::Devnet,
             darkpool_addr,
-            arb_priv_key,
+            arb_priv_keys: vec![arb_priv_key],
             rpc_url: test_args.rpc_url,
             block_polling_interval_ms: 100,
         }))

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -43,7 +43,7 @@ impl ArbitrumClient {
     /// Get the current Merkle root in the contract
     #[instrument(skip_all, err)]
     pub async fn get_merkle_root(&self) -> Result<Scalar, ArbitrumClientError> {
-        self.darkpool_contract
+        self.get_darkpool_client()
             .get_root()
             .call()
             .await
@@ -55,7 +55,7 @@ impl ArbitrumClient {
     #[instrument(skip_all, err)]
     pub async fn get_protocol_fee(&self) -> Result<FixedPoint, ArbitrumClientError> {
         // The contract returns the repr of the fee as a u256
-        self.darkpool_contract
+        self.get_darkpool_client()
             .get_fee()
             .call()
             .await
@@ -67,7 +67,7 @@ impl ArbitrumClient {
     #[instrument(skip_all, err)]
     pub async fn get_protocol_pubkey(&self) -> Result<EncryptionKey, ArbitrumClientError> {
         let pubkey = self
-            .darkpool_contract
+            .get_darkpool_client()
             .get_pubkey()
             .call()
             .await
@@ -82,7 +82,7 @@ impl ArbitrumClient {
         &self,
         root: MerkleRoot,
     ) -> Result<bool, ArbitrumClientError> {
-        self.darkpool_contract
+        self.get_darkpool_client()
             .root_in_history(scalar_to_u256(&root))
             .call()
             .await
@@ -95,7 +95,7 @@ impl ArbitrumClient {
         &self,
         nullifier: Nullifier,
     ) -> Result<bool, ArbitrumClientError> {
-        self.darkpool_contract
+        self.get_darkpool_client()
             .is_nullifier_spent(scalar_to_u256(&nullifier))
             .call()
             .await
@@ -127,8 +127,7 @@ impl ArbitrumClient {
         let valid_wallet_create_statement_calldata = serialize_calldata(&contract_statement)?;
 
         let receipt = send_tx(
-            self.darkpool_contract
-                .new_wallet(proof_calldata, valid_wallet_create_statement_calldata),
+            self.get_darkpool_client().new_wallet(proof_calldata, valid_wallet_create_statement_calldata),
         )
         .await?;
 
@@ -165,7 +164,7 @@ impl ArbitrumClient {
             transfer_auth.map(to_contract_transfer_aux_data).transpose()?.unwrap_or_default();
         let transfer_aux_data_calldata = serialize_calldata(&contract_transfer_aux_data)?;
 
-        let receipt = send_tx(self.darkpool_contract.update_wallet(
+        let receipt = send_tx(self.get_darkpool_client().update_wallet(
             proof_calldata,
             valid_wallet_update_statement_calldata,
             wallet_commitment_signature.into(),
@@ -258,7 +257,7 @@ impl ArbitrumClient {
         let match_link_proofs_calldata = serialize_calldata(&match_link_proofs)?;
 
         // Call `process_match_settle` on darkpool contract
-        let receipt = send_tx(self.darkpool_contract.process_match_settle(
+        let receipt = send_tx(self.get_darkpool_client().process_match_settle(
             party_0_match_payload_calldata,
             party_1_match_payload_calldata,
             valid_match_settle_statement_calldata,
@@ -297,7 +296,7 @@ impl ArbitrumClient {
         let valid_relayer_fee_settlement_statement_calldata =
             serialize_calldata(&contract_statement)?;
 
-        let receipt = send_tx(self.darkpool_contract.settle_online_relayer_fee(
+        let receipt = send_tx(self.get_darkpool_client().settle_online_relayer_fee(
             proof_calldata,
             valid_relayer_fee_settlement_statement_calldata,
             relayer_wallet_commitment_signature.into(),
@@ -333,7 +332,7 @@ impl ArbitrumClient {
             serialize_calldata(&contract_statement)?;
 
         let receipt =
-            send_tx(self.darkpool_contract.settle_offline_fee(
+            send_tx(self.get_darkpool_client().settle_offline_fee(
                 proof_calldata,
                 valid_offline_fee_settlement_statement_calldata,
             ))
@@ -367,7 +366,7 @@ impl ArbitrumClient {
         let contract_statement = to_contract_valid_fee_redemption_statement(statement)?;
         let valid_fee_redemption_statement_calldata = serialize_calldata(&contract_statement)?;
 
-        let receipt = send_tx(self.darkpool_contract.redeem_fee(
+        let receipt = send_tx(self.get_darkpool_client().redeem_fee(
             proof_calldata,
             valid_fee_redemption_statement_calldata,
             recipient_wallet_commitment_signature.into(),

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -51,10 +51,10 @@ impl ArbitrumClient {
         &self,
         public_blinder_share: Scalar,
     ) -> Result<Option<TxHash>, ArbitrumClientError> {
-        let events = self
-            .darkpool_contract
+        let darkpool_client = self.get_darkpool_client();
+        let events = darkpool_client
             .event::<WalletUpdatedFilter>()
-            .address(self.darkpool_contract.address().into())
+            .address(darkpool_client.address().into())
             .topic1(scalar_to_u256(&public_blinder_share))
             .from_block(self.deploy_block)
             .query_with_meta()
@@ -81,7 +81,7 @@ impl ArbitrumClient {
         let (index, tx) = self.find_commitment_in_state_with_tx(commitment).await?;
         let leaf_index = BigUint::from(index);
         let tx: TransactionReceipt = self
-            .darkpool_contract
+            .get_darkpool_client()
             .client()
             .get_transaction_receipt(tx)
             .await
@@ -157,9 +157,9 @@ impl ArbitrumClient {
         commitment: Scalar,
     ) -> Result<(u128, TxHash), ArbitrumClientError> {
         let events = self
-            .darkpool_contract
+            .get_darkpool_client()
             .event::<MerkleInsertionFilter>()
-            .address(self.darkpool_contract.address().into())
+            .address(self.get_darkpool_client().address().into())
             .topic2(scalar_to_u256(&commitment))
             .from_block(self.deploy_block)
             .query_with_meta()
@@ -186,7 +186,7 @@ impl ArbitrumClient {
             .ok_or(ArbitrumClientError::BlinderNotFound)?;
 
         let tx = self
-            .darkpool_contract
+            .get_darkpool_client()
             .client()
             .get_transaction(tx_hash)
             .await

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { workspace = true }
 
 # === Workspace Dependencies === #
 api-server = { path = "../workers/api-server" }
-arbitrum-client = { path = "../arbitrum-client" }
+arbitrum-client = { path = "../arbitrum-client", features = ["rand"] }
 circuit-types = { path = "../circuit-types" }
 chain-events = { path = "../workers/chain-events" }
 common = { path = "../common" }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -148,7 +148,7 @@ async fn main() -> Result<(), CoordinatorError> {
         darkpool_addr: args.contract_address.clone(),
         chain: args.chain_id,
         rpc_url: args.rpc_url.clone().unwrap(),
-        arb_priv_key: args.arbitrum_private_key.clone(),
+        arb_priv_keys: args.arbitrum_private_keys.clone(),
         block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
     })
     .await
@@ -159,7 +159,7 @@ async fn main() -> Result<(), CoordinatorError> {
         darkpool_addr: args.contract_address.clone(),
         chain: args.chain_id,
         rpc_url: args.rpc_url.unwrap(),
-        arb_priv_key: args.arbitrum_private_key.clone(),
+        arb_priv_keys: args.arbitrum_private_keys.clone(),
         block_polling_interval_ms: EVENT_FILTER_POLLING_INTERVAL_MS,
     })
     .await

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -21,7 +21,7 @@ pub async fn node_setup(
     task_queue: TaskDriverQueue,
 ) -> Result<(), CoordinatorError> {
     // Start the node setup task and await its completion
-    let desc = NodeStartupTaskDescriptor::new(config.gossip_warmup, &config.arbitrum_private_key);
+    let desc = NodeStartupTaskDescriptor::new(config.gossip_warmup, config.relayer_arbitrum_key());
     let id = desc.id;
     task_queue
         .send(TaskDriverJob::RunImmediate { task_id: id, wallet_ids: vec![], task: desc.into() })

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -249,7 +249,7 @@ impl MockNodeController {
             darkpool_addr: self.config.contract_address.clone(),
             chain: self.config.chain_id,
             rpc_url: self.config.rpc_url.clone().unwrap(),
-            arb_priv_key: self.config.arbitrum_private_key.clone(),
+            arb_priv_keys: self.config.arbitrum_private_keys.clone(),
             block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
         };
 
@@ -537,7 +537,7 @@ mod test {
         let db_path = tmp_db_path();
         let conf = RelayerConfig {
             rpc_url: Some("http://localhost:1234".to_string()),
-            arbitrum_private_key: get_devnet_key(),
+            arbitrum_private_keys: vec![get_devnet_key()],
             raft_snapshot_path: db_path.clone(),
             db_path,
             ..Default::default()

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -105,8 +105,9 @@ impl State {
         let p2p_key = config.p2p_key.clone();
         let fee_decryption_key = config.fee_decryption_key;
         let match_take_rate = config.match_take_rate;
+
         let relayer_wallet_id =
-            derive_wallet_id(&config.arbitrum_private_key).map_err(StateError::InvalidUpdate)?;
+            derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
 
         self.with_write_tx(move |tx| {
             tx.create_table(NODE_METADATA_TABLE)?;

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -83,7 +83,7 @@ impl OnChainEventListenerExecutor {
         info!("Starting on-chain event listener from current block {starting_block_number}");
 
         // Build a filtered stream on events that the chain-events worker listens for
-        let filter = self.arbitrum_client().darkpool_contract.event::<NullifierSpentFilter>();
+        let filter = self.arbitrum_client().get_darkpool_client().event::<NullifierSpentFilter>();
         let mut event_stream = filter
             .stream()
             .await

--- a/workers/handshake-manager-tests/src/main.rs
+++ b/workers/handshake-manager-tests/src/main.rs
@@ -105,7 +105,7 @@ impl From<CliArgs> for IntegrationTestArgs {
             p2p_key,
             p2p_port: args.my_port,
             chain_id: Chain::Devnet,
-            arbitrum_private_key,
+            arbitrum_private_keys: vec![arbitrum_private_key],
             contract_address,
             rpc_url: Some(args.devnet_url.clone()),
             allow_local: true,

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -15,8 +15,7 @@ use common::{
     worker::Worker,
 };
 use constants::Scalar;
-use ethers::middleware::Middleware;
-use ethers::types::Address;
+use ethers::{middleware::Middleware, types::Address};
 use eyre::Result;
 use job_types::{
     network_manager::NetworkManagerQueue,
@@ -197,9 +196,10 @@ pub async fn authorize_transfer(
     let client = &test_args.arbitrum_client;
     let chain_id = client.chain_id().await.unwrap();
     let permit2_address = AlloyAddress::from_str(&test_args.permit2_addr)?;
-    let darkpool_address = AlloyAddress::from_slice(client.darkpool_contract.address().as_bytes());
+    let darkpool_address =
+        AlloyAddress::from_slice(client.get_darkpool_client().address().as_bytes());
 
-    let eth_client = client.darkpool_contract.client(); // Assigned to avoid dropping
+    let eth_client = client.get_darkpool_client().client(); // Assigned to avoid dropping
     let signer = eth_client.inner().signer();
 
     gen_transfer_with_auth(signer, pk_root, permit2_address, darkpool_address, chain_id, transfer)

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -113,8 +113,7 @@ pub fn new_deposit(
     amount: Amount,
     test_args: &IntegrationTestArgs,
 ) -> ExternalTransfer {
-    let client = &test_args.arbitrum_client;
-    let account_addr = biguint_from_address(client.wallet_address());
+    let account_addr = biguint_from_address(test_args.wallet_address());
     ExternalTransfer { mint, amount, direction: ExternalTransferDirection::Deposit, account_addr }
 }
 
@@ -124,8 +123,7 @@ pub fn new_withdrawal(
     amount: Amount,
     test_args: &IntegrationTestArgs,
 ) -> ExternalTransfer {
-    let client = &test_args.arbitrum_client;
-    let account_addr = biguint_from_address(client.wallet_address());
+    let account_addr = biguint_from_address(test_args.wallet_address());
     ExternalTransfer {
         mint,
         amount,


### PR DESCRIPTION
This PR tweaks the `arbitrum_client` to be configured with a list of Arbitrum keypairs, from which it will randomly select one every time a darkpool contract client is needed. This required an extra compiler flag to gate usage of the `rand` crate so that the contracts repo, which import that `arbitrum_client` crate just to make use of their conversion utilities, can still be built to WASM.
The relayer wallet is derived from the first supplied keypair.

I tested this by running a local relayer w/ 2 keys, executing a few `new-wallet` tasks, and asserting that there were transactions submitted from both associated addresses.