### PR TITLE
workers: gossip-server: Notify cluster peers before expiring

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -44,6 +44,11 @@ required-features = ["test_helpers"]
 name = "full_match"
 harness = false
 required-features = ["test_helpers"]
+    
+[[bench]]
+name = "internal_match_settlement"
+harness = false
+required-features = ["test_helpers"]
 
 [[bench]]
 name = "valid_relayer_fee_settlement"

--- a/circuits/benches/internal_match_settlement.rs
+++ b/circuits/benches/internal_match_settlement.rs
@@ -1,0 +1,182 @@
+//! Benchmarks internal match settlement
+#![allow(incomplete_features)]
+#![allow(missing_docs)]
+#![feature(generic_const_exprs)]
+
+use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
+use circuit_types::PlonkCircuit;
+use circuits::zk_circuits::valid_match_settle::test_helpers::dummy_witness_and_statement;
+use circuits::zk_circuits::valid_match_settle::ValidMatchSettle;
+use circuits::{singleprover_prove, verify_singleprover_proof};
+use constants::{MAX_BALANCES, MAX_ORDERS};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use mpc_relation::proof_linking::LinkableCircuit;
+
+/// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS,
+/// MERKLE_HEIGHT)
+const SMALL_PARAM_SET: (usize, usize) = (2, 2);
+/// The parameter set for the large sized circuit
+const LARGE_PARAM_SET: (usize, usize) = (MAX_BALANCES, MAX_ORDERS);
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Tests the time taken to apply the constraints of `VALID MATCH SETTLE`
+/// circuit
+pub fn bench_apply_constraints_with_sizes<const MAX_BALANCES: usize, const MAX_ORDERS: usize>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    let mut group = c.benchmark_group("valid_match_settle");
+    let benchmark_id =
+        BenchmarkId::new("constraint-generation", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) = dummy_witness_and_statement::<MAX_BALANCES, MAX_ORDERS>();
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+
+        // Add proof linking groups to the circuit
+        let layout = ValidMatchSettle::<MAX_BALANCES, MAX_ORDERS>::get_circuit_layout().unwrap();
+        for (id, layout) in layout.group_layouts.into_iter() {
+            cs.create_link_group(id, Some(layout));
+        }
+
+        let witness_var = witness.create_witness(&mut cs);
+        let statement_var = statement.create_public_var(&mut cs);
+
+        b.iter(|| {
+            ValidMatchSettle::apply_constraints(
+                witness_var.clone(),
+                statement_var.clone(),
+                &mut cs,
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Tests the time taken to prove `VALID MATCH SETTLE`
+pub fn bench_prover_with_sizes<const MAX_BALANCES: usize, const MAX_ORDERS: usize>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    let mut group = c.benchmark_group("valid_match_settle");
+    let benchmark_id = BenchmarkId::new("prover", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) = dummy_witness_and_statement::<MAX_BALANCES, MAX_ORDERS>();
+
+        b.iter(|| {
+            singleprover_prove::<ValidMatchSettle<MAX_BALANCES, MAX_ORDERS>>(
+                witness.clone(),
+                statement.clone(),
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Tests the time taken to verify `VALID MATCH SETTLE`
+pub fn bench_verifier_with_sizes<const MAX_BALANCES: usize, const MAX_ORDERS: usize>(
+    c: &mut Criterion,
+) where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    let mut group = c.benchmark_group("valid_match_settle");
+    let benchmark_id = BenchmarkId::new("verifier", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // First generate a proof that will be verified multiple times
+        let (witness, statement) = dummy_witness_and_statement::<MAX_BALANCES, MAX_ORDERS>();
+
+        let proof = singleprover_prove::<ValidMatchSettle<MAX_BALANCES, MAX_ORDERS>>(
+            witness,
+            statement.clone(),
+        )
+        .unwrap();
+
+        b.iter(|| {
+            verify_singleprover_proof::<ValidMatchSettle<MAX_BALANCES, MAX_ORDERS>>(
+                statement.clone(),
+                &proof,
+            )
+            .unwrap();
+        });
+    });
+}
+
+// --------------
+// | Benchmarks |
+// --------------
+
+/// Tests the time taken to apply the constraints of a small `VALID MATCH
+/// SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__small_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<{ SMALL_PARAM_SET.0 }, { SMALL_PARAM_SET.1 }>(c);
+}
+
+/// Tests the time taken to prove a small `VALID MATCH SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__small_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<{ SMALL_PARAM_SET.0 }, { SMALL_PARAM_SET.1 }>(c);
+}
+
+/// Tests the time taken verify a small `VALID MATCH SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__small_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<{ SMALL_PARAM_SET.0 }, { SMALL_PARAM_SET.1 }>(c);
+}
+
+/// Tests the time taken to apply the constraints of a large `VALID MATCH
+/// SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_apply_constraints__large_circuit(c: &mut Criterion) {
+    bench_apply_constraints_with_sizes::<{ LARGE_PARAM_SET.0 }, { LARGE_PARAM_SET.1 }>(c);
+}
+
+/// Tests the time taken to prove a large `VALID MATCH SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_prover__large_circuit(c: &mut Criterion) {
+    bench_prover_with_sizes::<{ LARGE_PARAM_SET.0 }, { LARGE_PARAM_SET.1 }>(c);
+}
+
+/// Tests the time taken verify a large `VALID MATCH SETTLE` circuit
+#[allow(non_snake_case)]
+pub fn bench_verifier__large_circuit(c: &mut Criterion) {
+    bench_verifier_with_sizes::<{ LARGE_PARAM_SET.0 }, { LARGE_PARAM_SET.1 }>(c);
+}
+
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+#[cfg(feature = "large_benchmarks")]
+criterion_group! {
+    name = internal_match_settle;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+        bench_apply_constraints__large_circuit,
+        bench_prover__large_circuit,
+        bench_verifier__large_circuit,
+}
+
+#[cfg(not(feature = "large_benchmarks"))]
+criterion_group! {
+    name = internal_match_settle;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints__small_circuit,
+        bench_prover__small_circuit,
+        bench_verifier__small_circuit,
+}
+
+criterion_main!(internal_match_settle);

--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -21,7 +21,7 @@ use std::{
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
-use util::networking::is_dialable_multiaddr;
+use util::{get_current_time_millis, networking::is_dialable_multiaddr};
 
 /// The topic prefix for the cluster management pubsub topic
 ///
@@ -125,7 +125,7 @@ impl PeerInfo {
 
     /// Records a successful heartbeat
     pub fn successful_heartbeat(&mut self) {
-        self.last_heartbeat = current_time_seconds();
+        self.last_heartbeat = get_current_time_millis();
     }
 
     /// Get the last time a heartbeat was recorded for this peer

--- a/gossip-api/src/pubsub/cluster.rs
+++ b/gossip-api/src/pubsub/cluster.rs
@@ -1,6 +1,9 @@
 //! Cluster communications broadcast via Pubsub
 
-use common::types::{gossip::ClusterId, wallet::OrderIdentifier};
+use common::types::{
+    gossip::{ClusterId, WrappedPeerId},
+    wallet::OrderIdentifier,
+};
 use serde::{Deserialize, Serialize};
 
 /// A message from one cluster peer to the rest indicating cluster management
@@ -30,4 +33,11 @@ pub enum ClusterManagementMessageType {
     /// The peers should cache this order pair as completed, and not initiate
     /// handshakes with other peers on this order
     CacheSync(OrderIdentifier, OrderIdentifier),
+    /// Propose a peer expiry to the cluster
+    ///
+    /// Peers will check the last heartbeat they received from the expiry
+    /// candidate. If it is within some threshold they will reject the expiry.
+    /// If no rejection is seen in a reasonable amount of time, the peer will
+    /// be removed from the cluster
+    ProposeExpiry(WrappedPeerId),
 }

--- a/gossip-api/src/request_response/heartbeat.rs
+++ b/gossip-api/src/request_response/heartbeat.rs
@@ -37,3 +37,13 @@ pub struct PeerInfoResponse {
     /// The peer info for the requested peers
     pub peer_info: Vec<PeerInfo>,
 }
+
+/// Defines a request to reject a peer's proposal to expire a node
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RejectExpiryRequest {
+    /// The peer id of the node that is proposing to expire
+    pub peer_id: WrappedPeerId,
+    /// The timestamp of the last heartbeat the sender received from the expiry
+    /// candidate
+    pub last_heartbeat: u64,
+}

--- a/gossip-api/src/request_response/mod.rs
+++ b/gossip-api/src/request_response/mod.rs
@@ -7,7 +7,9 @@ use crate::{check_signature, sign_message, GossipDestination};
 
 use self::{
     handshake::HandshakeMessage,
-    heartbeat::{BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse},
+    heartbeat::{
+        BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse, RejectExpiryRequest,
+    },
     orderbook::{OrderInfoRequest, OrderInfoResponse},
 };
 
@@ -70,6 +72,8 @@ pub enum GossipRequest {
     Heartbeat(HeartbeatMessage),
     /// A request for peer info
     PeerInfo(PeerInfoRequest),
+    /// Reject a proposal to expire a peer
+    RejectExpiry(RejectExpiryRequest),
 
     // --- Handshakes --- //
     /// A request from a peer communicating about a potential handshake
@@ -101,6 +105,7 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => false,
             GossipRequest::Heartbeat(..) => false,
             GossipRequest::PeerInfo(..) => false,
+            GossipRequest::RejectExpiry(..) => true,
             GossipRequest::Handshake { .. } => false,
             GossipRequest::OrderInfo(..) => false,
         }
@@ -115,6 +120,7 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => GossipDestination::GossipServer,
             GossipRequest::Heartbeat(..) => GossipDestination::GossipServer,
             GossipRequest::PeerInfo(..) => GossipDestination::GossipServer,
+            GossipRequest::RejectExpiry(..) => GossipDestination::GossipServer,
             GossipRequest::OrderInfo(..) => GossipDestination::GossipServer,
             GossipRequest::Handshake { .. } => GossipDestination::HandshakeManager,
         }

--- a/workers/job-types/src/gossip_server.rs
+++ b/workers/job-types/src/gossip_server.rs
@@ -34,5 +34,7 @@ pub enum GossipServerJob {
     /// An incoming gossip response
     NetworkResponse(WrappedPeerId, GossipResponse),
     /// An incoming pubsub message
-    Pubsub(PubsubMessage),
+    ///
+    /// Arguments are (sender, msg)
+    Pubsub(WrappedPeerId, PubsubMessage),
 }


### PR DESCRIPTION
### Purpose
This PR is the first of two that improves the way in which we expire peers. Specifically, we implement a [SWIM](https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf) inspired propose/reject protocol wherein:
1. A node believes another to have failed, by timing out on heartbeats. This node sends a pubsub message to the cluster proposing that the cluster expire the candidate peer.
2. Each recipient of the pubsub message checks their own last known heartbeat, if it is within some tolerance they reject the proposal
3. If no rejections are sent within some time window, the cluster expires the peer

This PR implements the messaging half of that, but not the timeout, rejection, expiry logic.

### Testing
- Ran a cluster and killed a node, verified that the messages were sent correctly