### PR TITLE
workers: gossip-server: Track expiry candidates and invisibility window

### DIFF
--- a/gossip-api/src/pubsub/cluster.rs
+++ b/gossip-api/src/pubsub/cluster.rs
@@ -40,4 +40,17 @@ pub enum ClusterManagementMessageType {
     /// If no rejection is seen in a reasonable amount of time, the peer will
     /// be removed from the cluster
     ProposeExpiry(WrappedPeerId),
+    /// Reject a peer expiry proposal
+    ///
+    /// Peers will check the last heartbeat they received from the expiry
+    /// candidate. If it is within some threshold they will reject the expiry.
+    /// If no rejection is seen in a reasonable amount of time, the peer will
+    /// be removed from the cluster
+    RejectExpiry {
+        /// The peer id of the node that is proposing to expire
+        peer_id: WrappedPeerId,
+        /// The timestamp of the last heartbeat the sender received from the
+        /// expiry candidate
+        last_heartbeat: u64,
+    },
 }

--- a/gossip-api/src/pubsub/mod.rs
+++ b/gossip-api/src/pubsub/mod.rs
@@ -99,7 +99,8 @@ impl PubsubMessage {
         match self {
             PubsubMessage::Cluster(ClusterManagementMessage { message_type, .. }) => {
                 match message_type {
-                    ClusterManagementMessageType::ProposeExpiry(..) => {
+                    ClusterManagementMessageType::ProposeExpiry(..)
+                    | ClusterManagementMessageType::RejectExpiry { .. } => {
                         GossipDestination::GossipServer
                     },
                     _ => GossipDestination::HandshakeManager,

--- a/gossip-api/src/request_response/heartbeat.rs
+++ b/gossip-api/src/request_response/heartbeat.rs
@@ -37,13 +37,3 @@ pub struct PeerInfoResponse {
     /// The peer info for the requested peers
     pub peer_info: Vec<PeerInfo>,
 }
-
-/// Defines a request to reject a peer's proposal to expire a node
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RejectExpiryRequest {
-    /// The peer id of the node that is proposing to expire
-    pub peer_id: WrappedPeerId,
-    /// The timestamp of the last heartbeat the sender received from the expiry
-    /// candidate
-    pub last_heartbeat: u64,
-}

--- a/gossip-api/src/request_response/mod.rs
+++ b/gossip-api/src/request_response/mod.rs
@@ -7,9 +7,7 @@ use crate::{check_signature, sign_message, GossipDestination};
 
 use self::{
     handshake::HandshakeMessage,
-    heartbeat::{
-        BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse, RejectExpiryRequest,
-    },
+    heartbeat::{BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse},
     orderbook::{OrderInfoRequest, OrderInfoResponse},
 };
 
@@ -72,8 +70,6 @@ pub enum GossipRequest {
     Heartbeat(HeartbeatMessage),
     /// A request for peer info
     PeerInfo(PeerInfoRequest),
-    /// Reject a proposal to expire a peer
-    RejectExpiry(RejectExpiryRequest),
 
     // --- Handshakes --- //
     /// A request from a peer communicating about a potential handshake
@@ -105,7 +101,6 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => false,
             GossipRequest::Heartbeat(..) => false,
             GossipRequest::PeerInfo(..) => false,
-            GossipRequest::RejectExpiry(..) => true,
             GossipRequest::Handshake { .. } => false,
             GossipRequest::OrderInfo(..) => false,
         }
@@ -120,7 +115,6 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => GossipDestination::GossipServer,
             GossipRequest::Heartbeat(..) => GossipDestination::GossipServer,
             GossipRequest::PeerInfo(..) => GossipDestination::GossipServer,
-            GossipRequest::RejectExpiry(..) => GossipDestination::GossipServer,
             GossipRequest::OrderInfo(..) => GossipDestination::GossipServer,
             GossipRequest::Handshake { .. } => GossipDestination::HandshakeManager,
         }

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -188,6 +188,15 @@ impl State {
         Ok(())
     }
 
+    /// Write the peer info for a peer directly
+    pub async fn set_peer_info(&self, peer: PeerInfo) -> Result<(), StateError> {
+        self.with_write_tx(move |tx| {
+            tx.write_peer(&peer)?;
+            Ok(())
+        })
+        .await
+    }
+
     /// Remove a peer that has been expired
     pub async fn remove_peer(&self, peer_id: WrappedPeerId) -> Result<(), StateError> {
         let this = self.clone();

--- a/workers/gossip-server/src/peer_discovery/expiry_window.rs
+++ b/workers/gossip-server/src/peer_discovery/expiry_window.rs
@@ -1,0 +1,169 @@
+//! Defines a windowed buffer that manages the state transitions of peers in the
+//! network
+
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    time::{Duration, Instant},
+};
+
+use common::{new_async_shared, types::gossip::WrappedPeerId, AsyncShared};
+use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+/// The amount of time other cluster peers are allowed to give liveness
+/// attestations for an expiry candidate
+pub(crate) const EXPIRY_CANDIDATE_WINDOW_MS: u64 = 10_000; // 10 seconds
+/// The minimum amount of time between a peer's expiry and when it can be
+/// added back to the peer info
+pub(crate) const EXPIRY_INVISIBILITY_WINDOW_MS: u64 = 30_000; // 30 seconds
+
+/// A buffer of time windows
+#[derive(Clone)]
+pub struct TimeWindowBuffer<T: Hash + Eq + PartialEq> {
+    /// The set of time windows; maps a key to the time at which it should exit
+    /// the buffer
+    ///
+    /// Thread safe
+    pub windows: AsyncShared<HashMap<T, Instant>>,
+}
+
+impl<T: Hash + Eq + PartialEq> TimeWindowBuffer<T> {
+    /// Constructor
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self { windows: new_async_shared(HashMap::new()) }
+    }
+
+    /// Acquire a read lock on the windows
+    async fn read_windows(&self) -> RwLockReadGuard<'_, HashMap<T, Instant>> {
+        self.windows.read().await
+    }
+
+    /// Acquire a write lock on the windows
+    async fn write_windows(&self) -> RwLockWriteGuard<'_, HashMap<T, Instant>> {
+        self.windows.write().await
+    }
+
+    /// Cleanup all expired windows
+    async fn cleanup(&self) {
+        let mut this = self.write_windows().await;
+        this.retain(|_, expiry_time| *expiry_time > Instant::now());
+    }
+
+    /// Whether or not the given key is present in the buffer
+    pub async fn contains(&self, key: &T) -> bool {
+        let this = self.read_windows().await;
+        this.contains_key(key)
+    }
+
+    /// Check whether the window for a key has expired
+    pub async fn is_expired(&self, key: &T) -> bool {
+        let this = self.read_windows().await;
+        match this.get(key) {
+            Some(expiry_time) => *expiry_time < Instant::now(),
+            None => true,
+        }
+    }
+
+    /// Adds a key to the buffer
+    pub async fn add(&self, key: T, dur: Duration) {
+        let expiry_time = Instant::now() + dur;
+        let mut this = self.write_windows().await;
+        this.entry(key).or_insert(expiry_time);
+        drop(this); // unlock
+
+        self.cleanup().await;
+    }
+
+    /// Remove a key from the buffer
+    pub async fn remove(&self, key: T) {
+        let mut this = self.write_windows().await;
+        this.remove(&key);
+        drop(this); // unlock
+
+        self.cleanup().await;
+    }
+}
+
+/// A buffer that contains expiry windows for the nodes in the network
+///
+/// Within the context of peer expiry, a remote node may be in one of two
+/// states:
+/// - Expiry Candidate: a cluster peer has been deemed a candidate for expiry,
+///   and will be expired if no _other_ cluster peers attest to its liveness.
+///   Note that only intra-cluster peers may be in this state, inter-cluster
+///   peering is expired immediately. This means that a node from another
+///   cluster will be immediately placed in the invisibility window when
+///   expired.
+/// - Expiry Invisibility: a (possibly non-cluster) peer has been expired, and
+///   enters an invisibility window, during which they may not be added back to
+///   the network. This allows time for expiry to sync across nodes
+///
+/// The buffer manages the state transitions of these two windows
+#[derive(Clone)]
+pub struct PeerExpiryWindows {
+    /// The buffer of candidates awaiting expiry or liveness attestation
+    pub candidates: TimeWindowBuffer<WrappedPeerId>,
+    /// The buffer of peers that have been expired and are in their invisibility
+    /// window
+    pub invisibility: TimeWindowBuffer<WrappedPeerId>,
+}
+
+impl PeerExpiryWindows {
+    /// Constructor
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self { candidates: TimeWindowBuffer::new(), invisibility: TimeWindowBuffer::new() }
+    }
+
+    /// Check the expiry candidacy of a peer
+    pub async fn is_expiry_candidate(&self, peer_id: &WrappedPeerId) -> bool {
+        self.candidates.contains(peer_id).await
+    }
+
+    /// Whether the peer should be expired
+    ///
+    /// `true` if the remote peer is in the expiry candidate list and the
+    /// timeout has elapsed
+    pub async fn should_expire(&self, peer_id: &WrappedPeerId) -> bool {
+        self.candidates.is_expired(peer_id).await
+    }
+
+    /// Whether either the expiry candidate list or the invisibility window
+    /// contains the given peer
+    pub async fn contains(&self, peer_id: &WrappedPeerId) -> bool {
+        self.candidates.contains(peer_id).await || self.invisibility.contains(peer_id).await
+    }
+
+    /// Add a peer to the expiry candidate list
+    async fn add_expiry_candidate(&self, peer_id: WrappedPeerId) {
+        let dur = Duration::from_millis(EXPIRY_CANDIDATE_WINDOW_MS);
+        self.candidates.add(peer_id, dur).await;
+    }
+
+    /// Add a peer to the invisibility window
+    async fn mark_invisible(&self, peer_id: WrappedPeerId) {
+        let dur = Duration::from_millis(EXPIRY_INVISIBILITY_WINDOW_MS);
+        self.invisibility.add(peer_id, dur).await;
+    }
+
+    /// Mark a peer as a candidate for expiry
+    ///
+    /// The candidate is added to both the expiry candidate list and the
+    /// invisibility window to prevent the peer from being added back to the
+    /// network while multiple nodes may be expiring it
+    pub async fn mark_expiry_candidate(&self, peer_id: WrappedPeerId) {
+        self.add_expiry_candidate(peer_id).await;
+        self.mark_invisible(peer_id).await;
+    }
+
+    /// Remove a candidate from the expiry candidate list
+    pub async fn remove_expiry_candidate(&self, peer_id: WrappedPeerId) {
+        self.candidates.remove(peer_id).await;
+    }
+
+    /// Mark a peer as expired, adding it to the invisibility window
+    pub async fn mark_expired(&self, peer_id: WrappedPeerId) {
+        self.mark_invisible(peer_id).await;
+    }
+}

--- a/workers/gossip-server/src/peer_discovery/mod.rs
+++ b/workers/gossip-server/src/peer_discovery/mod.rs
@@ -1,5 +1,6 @@
 //! Groups handlers for peer discovery and indexing
 
+pub(crate) mod expiry_window;
 pub mod heartbeat;
 pub mod heartbeat_timer;
 pub mod peers;

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -1,9 +1,15 @@
 //! Handles bootstrap requests and responses
 
 use common::types::gossip::{PeerInfo, WrappedPeerId};
-use gossip_api::request_response::{
-    heartbeat::{BootstrapRequest, PeerInfoResponse, RejectExpiryRequest},
-    GossipRequest, GossipResponse,
+use gossip_api::{
+    pubsub::{
+        cluster::{ClusterManagementMessage, ClusterManagementMessageType},
+        PubsubMessage,
+    },
+    request_response::{
+        heartbeat::{BootstrapRequest, PeerInfoResponse},
+        GossipResponse,
+    },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
 use renegade_metrics::helpers::record_num_peers_metrics;
@@ -72,38 +78,48 @@ impl GossipProtocolExecutor {
             info!("rejecting expiry of {peer_id} from {sender}, last heartbeat was {time_since_last_heartbeat}ms ago");
 
             // The peer should not expire yet, send a rejection
-            let msg = GossipRequest::RejectExpiry(RejectExpiryRequest {
+            let cluster_id = self.state.get_cluster_id().await?;
+            let topic = cluster_id.get_management_topic();
+            let message_type = ClusterManagementMessageType::RejectExpiry {
                 peer_id,
                 last_heartbeat: info.last_heartbeat,
-            });
+            };
 
-            let job = NetworkManagerJob::request(sender, msg);
+            let msg = PubsubMessage::Cluster(ClusterManagementMessage { cluster_id, message_type });
+            let job = NetworkManagerJob::pubsub(topic, msg);
             self.network_channel.send(job).map_err(err_str!(GossipError::SendMessage))?;
+        } else {
+            // If we do not reject the expiry, begin expiring on the local node
+            info!("received expiry request, marking {peer_id} as expiry candidate");
+            self.expiry_buffer.mark_expiry_candidate(peer_id).await;
         }
 
         Ok(())
     }
 
     /// Handle a request to reject expiry
-    pub async fn handle_reject_expiry_req(
+    pub async fn handle_reject_expiry(
         &self,
-        req: RejectExpiryRequest,
-    ) -> Result<GossipResponse, GossipError> {
+        peer_id: WrappedPeerId,
+        last_heartbeat: u64,
+    ) -> Result<(), GossipError> {
         info!("received reject expiry request");
         // Remove from the expiry buffer if present
-        let id = req.peer_id;
-        self.expiry_buffer.remove_expiry_candidate(id).await;
+        self.expiry_buffer.remove_expiry_candidate(peer_id).await;
 
         // Update the latest heartbeat for the peer
-        let maybe_info = self.state.get_peer_info(&id).await?;
+        let maybe_info = self.state.get_peer_info(&peer_id).await?;
         let mut info = match maybe_info {
             Some(info) => info,
-            None => return Ok(GossipResponse::Ack),
+            None => return Ok(()),
         };
-        info.last_heartbeat = req.last_heartbeat;
-        self.state.set_peer_info(info).await?;
 
-        Ok(GossipResponse::Ack)
+        if info.last_heartbeat < last_heartbeat {
+            info.last_heartbeat = last_heartbeat;
+            self.state.set_peer_info(info).await?;
+        }
+
+        Ok(())
     }
 
     // ---------------------


### PR DESCRIPTION
### Purpose
This PR adds a `PeerExpiryWindows` struct that tracks both the expiry candidacy and invisibility windows. These windows are updated through the expiry gossip protocol.

### Todo
- Move expiry rejection to pubsub and transition peers to expiry candidates locally when not rejecting an expiry proposal

### Testing
- Unit tests pass
- Tested expiry of a node; verified that it went into the candidate state and waited the appropriate time before expiry.