### PR TITLE
gossip-server: peer-discovery: Send expiry updates through pubsub

### DIFF
--- a/gossip-api/src/pubsub/cluster.rs
+++ b/gossip-api/src/pubsub/cluster.rs
@@ -40,4 +40,17 @@ pub enum ClusterManagementMessageType {
     /// If no rejection is seen in a reasonable amount of time, the peer will
     /// be removed from the cluster
     ProposeExpiry(WrappedPeerId),
+    /// Reject a peer expiry proposal
+    ///
+    /// Peers will check the last heartbeat they received from the expiry
+    /// candidate. If it is within some threshold they will reject the expiry.
+    /// If no rejection is seen in a reasonable amount of time, the peer will
+    /// be removed from the cluster
+    RejectExpiry {
+        /// The peer id of the node that is proposing to expire
+        peer_id: WrappedPeerId,
+        /// The timestamp of the last heartbeat the sender received from the
+        /// expiry candidate
+        last_heartbeat: u64,
+    },
 }

--- a/gossip-api/src/pubsub/mod.rs
+++ b/gossip-api/src/pubsub/mod.rs
@@ -99,7 +99,8 @@ impl PubsubMessage {
         match self {
             PubsubMessage::Cluster(ClusterManagementMessage { message_type, .. }) => {
                 match message_type {
-                    ClusterManagementMessageType::ProposeExpiry(..) => {
+                    ClusterManagementMessageType::ProposeExpiry(..)
+                    | ClusterManagementMessageType::RejectExpiry { .. } => {
                         GossipDestination::GossipServer
                     },
                     _ => GossipDestination::HandshakeManager,

--- a/gossip-api/src/request_response/heartbeat.rs
+++ b/gossip-api/src/request_response/heartbeat.rs
@@ -37,13 +37,3 @@ pub struct PeerInfoResponse {
     /// The peer info for the requested peers
     pub peer_info: Vec<PeerInfo>,
 }
-
-/// Defines a request to reject a peer's proposal to expire a node
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RejectExpiryRequest {
-    /// The peer id of the node that is proposing to expire
-    pub peer_id: WrappedPeerId,
-    /// The timestamp of the last heartbeat the sender received from the expiry
-    /// candidate
-    pub last_heartbeat: u64,
-}

--- a/gossip-api/src/request_response/mod.rs
+++ b/gossip-api/src/request_response/mod.rs
@@ -7,9 +7,7 @@ use crate::{check_signature, sign_message, GossipDestination};
 
 use self::{
     handshake::HandshakeMessage,
-    heartbeat::{
-        BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse, RejectExpiryRequest,
-    },
+    heartbeat::{BootstrapRequest, HeartbeatMessage, PeerInfoRequest, PeerInfoResponse},
     orderbook::{OrderInfoRequest, OrderInfoResponse},
 };
 
@@ -72,8 +70,6 @@ pub enum GossipRequest {
     Heartbeat(HeartbeatMessage),
     /// A request for peer info
     PeerInfo(PeerInfoRequest),
-    /// Reject a proposal to expire a peer
-    RejectExpiry(RejectExpiryRequest),
 
     // --- Handshakes --- //
     /// A request from a peer communicating about a potential handshake
@@ -105,7 +101,6 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => false,
             GossipRequest::Heartbeat(..) => false,
             GossipRequest::PeerInfo(..) => false,
-            GossipRequest::RejectExpiry(..) => true,
             GossipRequest::Handshake { .. } => false,
             GossipRequest::OrderInfo(..) => false,
         }
@@ -120,7 +115,6 @@ impl GossipRequest {
             GossipRequest::Bootstrap(..) => GossipDestination::GossipServer,
             GossipRequest::Heartbeat(..) => GossipDestination::GossipServer,
             GossipRequest::PeerInfo(..) => GossipDestination::GossipServer,
-            GossipRequest::RejectExpiry(..) => GossipDestination::GossipServer,
             GossipRequest::OrderInfo(..) => GossipDestination::GossipServer,
             GossipRequest::Handshake { .. } => GossipDestination::HandshakeManager,
         }

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -1,9 +1,15 @@
 //! Handles bootstrap requests and responses
 
 use common::types::gossip::{PeerInfo, WrappedPeerId};
-use gossip_api::request_response::{
-    heartbeat::{BootstrapRequest, PeerInfoResponse, RejectExpiryRequest},
-    GossipRequest, GossipResponse,
+use gossip_api::{
+    pubsub::{
+        cluster::{ClusterManagementMessage, ClusterManagementMessageType},
+        PubsubMessage,
+    },
+    request_response::{
+        heartbeat::{BootstrapRequest, PeerInfoResponse},
+        GossipResponse,
+    },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
 use renegade_metrics::helpers::record_num_peers_metrics;
@@ -72,38 +78,48 @@ impl GossipProtocolExecutor {
             info!("rejecting expiry of {peer_id} from {sender}, last heartbeat was {time_since_last_heartbeat}ms ago");
 
             // The peer should not expire yet, send a rejection
-            let msg = GossipRequest::RejectExpiry(RejectExpiryRequest {
+            let cluster_id = self.state.get_cluster_id().await?;
+            let topic = cluster_id.get_management_topic();
+            let message_type = ClusterManagementMessageType::RejectExpiry {
                 peer_id,
                 last_heartbeat: info.last_heartbeat,
-            });
+            };
 
-            let job = NetworkManagerJob::request(sender, msg);
+            let msg = PubsubMessage::Cluster(ClusterManagementMessage { cluster_id, message_type });
+            let job = NetworkManagerJob::pubsub(topic, msg);
             self.network_channel.send(job).map_err(err_str!(GossipError::SendMessage))?;
+        } else {
+            // If we do not reject the expiry, begin expiring on the local node
+            info!("received expiry request, marking {peer_id} as expiry candidate");
+            self.expiry_buffer.mark_expiry_candidate(peer_id).await;
         }
 
         Ok(())
     }
 
     /// Handle a request to reject expiry
-    pub async fn handle_reject_expiry_req(
+    pub async fn handle_reject_expiry(
         &self,
-        req: RejectExpiryRequest,
-    ) -> Result<GossipResponse, GossipError> {
+        peer_id: WrappedPeerId,
+        last_heartbeat: u64,
+    ) -> Result<(), GossipError> {
         info!("received reject expiry request");
         // Remove from the expiry buffer if present
-        let id = req.peer_id;
-        self.expiry_buffer.remove_expiry_candidate(id).await;
+        self.expiry_buffer.remove_expiry_candidate(peer_id).await;
 
         // Update the latest heartbeat for the peer
-        let maybe_info = self.state.get_peer_info(&id).await?;
+        let maybe_info = self.state.get_peer_info(&peer_id).await?;
         let mut info = match maybe_info {
             Some(info) => info,
-            None => return Ok(GossipResponse::Ack),
+            None => return Ok(()),
         };
-        info.last_heartbeat = req.last_heartbeat;
-        self.state.set_peer_info(info).await?;
 
-        Ok(GossipResponse::Ack)
+        if info.last_heartbeat < last_heartbeat {
+            info.last_heartbeat = last_heartbeat;
+            self.state.set_peer_info(info).await?;
+        }
+
+        Ok(())
     }
 
     // ---------------------


### PR DESCRIPTION
### Purpose
This PR sends all expiry rejections through pubsub to ensure that all cluster peers hear about a rejection. This allows us to also safely place a proposed expiry candidate in the candidate state on all nodes that _do not_ reject.

### Testing
- Unit tests pass
- Tested expiry on a small cluster, including forcing a rejection