### PR TITLE
state: replication: raft: Campaign before expiring leader

### DIFF
--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -68,5 +68,8 @@ pub async fn setup_pre_allocated_state(client: &mut ArbitrumClient) -> Result<Pr
 /// w/ the default values for the leaves
 pub async fn clear_merkle(client: &ArbitrumClient) -> Result<()> {
     warn!("Clearing Merkle contract state");
-    send_tx(client.get_darkpool_client().clear_merkle()).await.map(|_| ()).map_err(|e| eyre!(e.to_string()))
+    send_tx(client.get_darkpool_client().clear_merkle())
+        .await
+        .map(|_| ())
+        .map_err(|e| eyre!(e.to_string()))
 }

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -127,7 +127,8 @@ impl ArbitrumClient {
         let valid_wallet_create_statement_calldata = serialize_calldata(&contract_statement)?;
 
         let receipt = send_tx(
-            self.get_darkpool_client().new_wallet(proof_calldata, valid_wallet_create_statement_calldata),
+            self.get_darkpool_client()
+                .new_wallet(proof_calldata, valid_wallet_create_statement_calldata),
         )
         .await?;
 

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -20,7 +20,11 @@ use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use clap::Parser;
 use common::types::token::{ADDR_DECIMALS_MAP, TOKEN_REMAPS};
 use crossbeam::channel::Sender as CrossbeamSender;
-use ethers::{middleware::Middleware, signers::{LocalWallet, Signer}, types::Address};
+use ethers::{
+    middleware::Middleware,
+    signers::{LocalWallet, Signer},
+    types::Address,
+};
 use helpers::new_mock_task_driver;
 use job_types::{
     network_manager::{new_network_manager_queue, NetworkManagerReceiver},


### PR DESCRIPTION
### Purpose
This PR changes the proposal logic for removing a raft leader from the cluster. When doing so the proposing node first campaigns for election, then proposes the removal. This prevents a bug wherein the proposal is forwarded to a raft leader that no longer exists and is lost.

### Testing
- Unit tests pass
- Expired the leader on a local cluster, verified that the cluster recovered quickly