### PR TITLE
api-server: Add `/v0/admin/is-leader` endpoint

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -1,0 +1,17 @@
+//! Request/response types for the admin api
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+use serde::{Deserialize, Serialize};
+
+/// Check whether the target node is a raft leader
+pub const IS_LEADER_ROUTE: &str = "/v0/admin/is-leader";
+
+/// The response to an "is leader" request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IsLeaderResponse {
+    /// Whether the target node is a raft leader
+    pub leader: bool,
+}

--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod admin;
 pub mod network;
 pub mod order_book;
 pub mod price_report;

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -23,6 +23,14 @@ impl State {
         self.raft.is_initialized()
     }
 
+    /// Whether the local node is the leader
+    pub fn is_leader(&self) -> bool {
+        match self.raft.leader_info() {
+            Some((leader_id, _)) => self.raft.node_id() == leader_id,
+            None => false,
+        }
+    }
+
     /// Get the leader of the raft
     pub fn get_leader(&self) -> Option<WrappedPeerId> {
         let (_raft_id, info) = self.raft.leader_info()?;

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -1,0 +1,45 @@
+//! Route handlers for the admin API
+
+// ------------------------
+// | Admin Route Handlers |
+// ------------------------
+
+use async_trait::async_trait;
+use external_api::{http::admin::IsLeaderResponse, EmptyRequestResponse};
+use hyper::HeaderMap;
+use state::State;
+
+use crate::{
+    error::ApiServerError,
+    router::{QueryParams, TypedHandler, UrlParams},
+};
+
+/// Handler for the GET /v0/admin/is-leader route
+pub struct IsLeaderHandler {
+    /// A handle to the relayer state
+    state: State,
+}
+
+impl IsLeaderHandler {
+    /// Constructor
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for IsLeaderHandler {
+    type Request = EmptyRequestResponse;
+    type Response = IsLeaderResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        _req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let leader = self.state.is_leader();
+        Ok(IsLeaderResponse { leader })
+    }
+}


### PR DESCRIPTION
### Purpose
This PR initializes the `/admin` api with an `is-leader` endpoint that returns true iff the node is a raft leader. This will be used by the snapshot sidecar to determine if a new snapshot should be written to s3.

### Testing
- Unit tests pass