### PR TITLE
renegade-metrics: gauge: add atomic gauge metric primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,6 @@ dependencies = [
  "itertools 0.12.1",
  "json",
  "lazy_static",
- "metrics",
  "mpc-plonk",
  "mpc-relation",
  "num-bigint",
@@ -295,6 +294,7 @@ dependencies = [
  "postcard",
  "rand 0.8.5",
  "renegade-crypto",
+ "renegade-metrics",
  "ruint",
  "serde",
  "serde_with",
@@ -786,6 +786,12 @@ name = "atomic_float"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62af46d040ba9df09edc6528dae9d8e49f5f3e82f55b7d2ec31a733c38dbc49d"
+
+[[package]]
+name = "atomic_float"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c4b08ed8a30ff7320117c190eb4d73d47f0ac0c930ab853b8224cef7cd9a5e7"
 
 [[package]]
 name = "atty"
@@ -6681,7 +6687,7 @@ name = "price-reporter"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "atomic_float",
+ "atomic_float 0.1.0",
  "bimap",
  "common",
  "create2",
@@ -7272,8 +7278,10 @@ dependencies = [
 name = "renegade-metrics"
 version = "0.1.0"
 dependencies = [
+ "atomic_float 1.0.0",
  "circuit-types",
  "common",
+ "lazy_static",
  "metrics",
  "num-bigint",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7276,7 +7276,6 @@ dependencies = [
  "common",
  "metrics",
  "num-bigint",
- "state",
  "tracing",
  "util",
 ]

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -10,7 +10,7 @@ integration = [
     "common/mocks",
 ]
 rand = ["dep:rand"]
-tx-metrics = ["dep:metrics"]
+tx-metrics = ["renegade-metrics/tx-metrics"]
 
 [[test]]
 name = "integration"
@@ -40,6 +40,7 @@ circuits = { path = "../circuits" }
 common = { path = "../common" }
 renegade-crypto = { path = "../renegade-crypto" }
 util = { path = "../util" }
+renegade-metrics = { path = "../renegade-metrics" }
 
 # === Serde === #
 serde = { workspace = true }
@@ -51,7 +52,6 @@ itertools = "0.12"
 lazy_static = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
-metrics = { workspace = true, optional = true }
 
 # === Contracts Repo Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -58,13 +58,6 @@ pub const BLOCK_POLLING_INTERVAL_MS: u64 = 100;
 /// The interval at which to poll for event filters
 pub const EVENT_FILTER_POLLING_INTERVAL_MS: u64 = 7000;
 
-// Metric labels
-
-/// Metric describing the number of transactions sent
-pub const NUM_TXS_SENT_METRIC: &str = "num_txs_sent";
-/// Metric describing the number of transactions submitted
-pub const NUM_TXS_SUBMITTED_METRIC: &str = "num_txs_submitted";
-
 lazy_static! {
     // ------------------------
     // | Merkle Tree Metadata |

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -16,6 +16,7 @@ use ethers::{
     contract::ContractCall,
     types::{Bytes, TransactionReceipt},
 };
+use renegade_metrics::helpers::{decr_inflight_txs, incr_inflight_txs};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -48,7 +49,7 @@ pub fn deserialize_calldata<'de, T: Deserialize<'de>>(
 pub async fn send_tx(
     tx: ContractCall<MiddlewareStack, impl Detokenize>,
 ) -> Result<TransactionReceipt, ArbitrumClientError> {
-    incr_txs_sent();
+    incr_inflight_txs();
     let res = tx
         .send()
         .await
@@ -57,7 +58,7 @@ pub async fn send_tx(
         .map_err(|e| ArbitrumClientError::ContractInteraction(e.to_string()))?
         .ok_or(ArbitrumClientError::TxDropped);
 
-    incr_txs_submitted();
+    decr_inflight_txs();
     res
 }
 
@@ -190,18 +191,4 @@ pub fn parse_shares_from_redeem_fee(
     let mut shares = statement.new_wallet_public_shares.into_iter().map(Scalar::new);
 
     Ok(SizedWalletShare::from_scalars(&mut shares))
-}
-
-/// Increment the number of transactions sent
-#[inline]
-pub fn incr_txs_sent() {
-    #[cfg(feature = "tx-metrics")]
-    metrics::counter!(NUM_TXS_SENT_METRIC).increment(1);
-}
-
-/// Increment the number of transactions submitted
-#[inline]
-pub fn incr_txs_submitted() {
-    #[cfg(feature = "tx-metrics")]
-    metrics::counter!(NUM_TXS_SUBMITTED_METRIC).increment(1);
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 default-run = "renegade-relayer"
 
 [features]
-dev-metrics = ["metered-channels", "task-queue-len", "task-metrics", "proof-metrics", "tx-metrics"]
+dev-metrics = ["task-queue-len", "task-metrics", "proof-metrics"]
 metered-channels = ["util/metered-channels"]
 task-queue-len = ["state/task-queue-len"]
 task-metrics = ["task-driver/task-metrics"]

--- a/renegade-metrics/Cargo.toml
+++ b/renegade-metrics/Cargo.toml
@@ -19,4 +19,3 @@ num-bigint = { workspace = true }
 circuit-types = { path = "../circuit-types" }
 util = { path = "../util" }
 common = { path = "../common" }
-state = { path = "../state" }

--- a/renegade-metrics/Cargo.toml
+++ b/renegade-metrics/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 task-metrics = []
 proof-metrics = []
+tx-metrics = []
 
 [dependencies]
 # === Telemetry === #
@@ -14,8 +15,12 @@ metrics = { workspace = true }
 
 # === Cryptography / Arithmetic === #
 num-bigint = { workspace = true }
+atomic_float = "1"
 
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }
 util = { path = "../util" }
 common = { path = "../common" }
+
+# === Misc === #
+lazy_static = { workspace = true }

--- a/renegade-metrics/src/gauge.rs
+++ b/renegade-metrics/src/gauge.rs
@@ -1,0 +1,55 @@
+//! An atomic gauge for recording metrics. Exposes an
+//! increment/decrement/set API that is not natively supported by StatsD.
+
+use std::sync::atomic::Ordering;
+
+use atomic_float::AtomicF64;
+
+/// Stores the value of the gauge metric
+pub struct Gauge {
+    /// The name of the gauge metric
+    name: String,
+    /// The tags associated with the gauge metric
+    tags: Vec<(String, String)>,
+    /// The value of the gauge metric
+    value: AtomicF64,
+}
+
+impl Gauge {
+    /// Create a new gauge metric with an initial value
+    pub fn new(name: String, tags: Vec<(String, String)>) -> Self {
+        Self { name, tags, value: AtomicF64::default() }
+    }
+
+    /// Increment the gauge metric by a given value
+    pub fn increment(&self, value: f64) {
+        self.value.fetch_add(value, Ordering::Relaxed);
+        self.record_gauge();
+    }
+
+    /// Decrement the gauge metric by a given value
+    pub fn decrement(&self, value: f64) {
+        self.value.fetch_sub(value, Ordering::Relaxed);
+        self.record_gauge();
+    }
+
+    /// Set the gauge metric to a given value
+    pub fn set(&self, value: f64) {
+        self.value.store(value, Ordering::Relaxed);
+        self.record_gauge();
+    }
+
+    /// Get the value of the gauge metric
+    pub fn get(&self) -> f64 {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Record the gauge metric
+    fn record_gauge(&self) {
+        metrics::gauge!(self.name.clone(), self.tags.as_slice()).set(self.get());
+    }
+}

--- a/renegade-metrics/src/global_metrics.rs
+++ b/renegade-metrics/src/global_metrics.rs
@@ -1,0 +1,19 @@
+//! Static metric instances that can be accessed from anywhere in the codebase
+
+use lazy_static::lazy_static;
+
+use crate::{
+    gauge::Gauge,
+    labels::{NUM_INFLIGHT_PROOFS_METRIC, NUM_INFLIGHT_TASKS_METRIC, NUM_INFLIGHT_TXS_METRIC},
+};
+
+lazy_static! {
+    /// In-flight tasks gauge
+    pub static ref IN_FLIGHT_TASKS: Gauge = Gauge::new(NUM_INFLIGHT_TASKS_METRIC.to_string(), vec![] /* tags */);
+
+    /// In-flight proofs gauge
+    pub static ref IN_FLIGHT_PROOFS: Gauge = Gauge::new(NUM_INFLIGHT_PROOFS_METRIC.to_string(), vec![] /* tags */);
+
+    /// In-flight Arbitrum transactions gauge
+    pub static ref IN_FLIGHT_ARBITRUM_TXS: Gauge = Gauge::new(NUM_INFLIGHT_TXS_METRIC.to_string(), vec![] /* tags */);
+}

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -5,11 +5,13 @@ use common::types::{token::Token, transfer_auth::ExternalTransferWithAuth};
 use num_bigint::BigUint;
 use util::hex::biguint_to_hex_string;
 
-use crate::labels::{
-    ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
-    MATCH_QUOTE_VOLUME_METRIC, NUM_COMPLETED_PROOFS_METRIC, NUM_COMPLETED_TASKS_METRIC,
-    NUM_DEPOSITS_METRICS, NUM_STARTED_PROOFS_METRIC, NUM_STARTED_TASKS_METRIC,
-    NUM_STOPPED_TASKS_METRIC, NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
+use crate::{
+    global_metrics::{IN_FLIGHT_ARBITRUM_TXS, IN_FLIGHT_PROOFS, IN_FLIGHT_TASKS},
+    labels::{
+        ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
+        MATCH_QUOTE_VOLUME_METRIC, NUM_COMPLETED_TASKS_METRIC, NUM_DEPOSITS_METRICS,
+        NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
+    },
 };
 
 /// Get the human-readable asset and volume of
@@ -66,18 +68,18 @@ pub fn record_relayer_fee_settlement(mint: &BigUint, amount: u128) {
     record_volume(mint, amount, FEES_COLLECTED_METRIC);
 }
 
-/// Increment the number of started tasks
+/// Increment the number of in-flight tasks by 1
 #[inline]
-pub fn incr_started_tasks() {
+pub fn incr_inflight_tasks() {
     #[cfg(feature = "task-metrics")]
-    metrics::counter!(NUM_STARTED_TASKS_METRIC).increment(1);
+    IN_FLIGHT_TASKS.increment(1.0);
 }
 
-/// Increment the number of stopped tasks by the given number of tasks
+/// Decrement the number of in-flight tasks
 #[inline]
-pub fn incr_stopped_tasks(num_tasks: usize) {
+pub fn decr_inflight_tasks(value: f64) {
     #[cfg(feature = "task-metrics")]
-    metrics::counter!(NUM_STOPPED_TASKS_METRIC).increment(num_tasks as u64);
+    IN_FLIGHT_TASKS.decrement(value);
 }
 
 /// Increment the number of completed tasks
@@ -87,16 +89,30 @@ pub fn incr_completed_tasks() {
     metrics::counter!(NUM_COMPLETED_TASKS_METRIC).increment(1);
 }
 
-/// Increment the number of started proofs
+/// Increment the number of in-flight proofs by 1
 #[inline]
-pub fn incr_started_proofs() {
+pub fn incr_inflight_proofs() {
     #[cfg(feature = "proof-metrics")]
-    metrics::counter!(NUM_STARTED_PROOFS_METRIC).increment(1);
+    IN_FLIGHT_PROOFS.increment(1.0);
 }
 
-/// Increment the number of completed proofs
+/// Decrement the number of in-flight proofs by 1
 #[inline]
-pub fn incr_completed_proofs() {
+pub fn decr_inflight_proofs() {
     #[cfg(feature = "proof-metrics")]
-    metrics::counter!(NUM_COMPLETED_PROOFS_METRIC).increment(1);
+    IN_FLIGHT_PROOFS.decrement(1.0);
+}
+
+/// Increment the number of in-flight transactions by 1
+#[inline]
+pub fn incr_inflight_txs() {
+    #[cfg(feature = "tx-metrics")]
+    IN_FLIGHT_ARBITRUM_TXS.increment(1.0);
+}
+
+/// Decrement the number of in-flight transactions by 1
+#[inline]
+pub fn decr_inflight_txs() {
+    #[cfg(feature = "tx-metrics")]
+    IN_FLIGHT_ARBITRUM_TXS.decrement(1.0);
 }

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -5,14 +5,18 @@ use common::types::{token::Token, transfer_auth::ExternalTransferWithAuth};
 use num_bigint::BigUint;
 use util::hex::biguint_to_hex_string;
 
-use crate::{
-    global_metrics::{IN_FLIGHT_ARBITRUM_TXS, IN_FLIGHT_PROOFS, IN_FLIGHT_TASKS},
-    labels::{
-        ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
-        MATCH_QUOTE_VOLUME_METRIC, NUM_COMPLETED_TASKS_METRIC, NUM_DEPOSITS_METRICS,
-        NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
-    },
+use crate::labels::{
+    ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
+    MATCH_QUOTE_VOLUME_METRIC, NUM_DEPOSITS_METRICS, NUM_WITHDRAWALS_METRICS,
+    WITHDRAWAL_VOLUME_METRIC,
 };
+
+#[cfg(feature = "tx-metrics")]
+use crate::global_metrics::IN_FLIGHT_ARBITRUM_TXS;
+#[cfg(feature = "proof-metrics")]
+use crate::global_metrics::IN_FLIGHT_PROOFS;
+#[cfg(feature = "task-metrics")]
+use crate::{global_metrics::IN_FLIGHT_TASKS, labels::NUM_COMPLETED_TASKS_METRIC};
 
 /// Get the human-readable asset and volume of
 /// the given mint and amount.
@@ -69,50 +73,43 @@ pub fn record_relayer_fee_settlement(mint: &BigUint, amount: u128) {
 }
 
 /// Increment the number of in-flight tasks by 1
-#[inline]
+#[cfg(feature = "task-metrics")]
 pub fn incr_inflight_tasks() {
-    #[cfg(feature = "task-metrics")]
     IN_FLIGHT_TASKS.increment(1.0);
 }
 
 /// Decrement the number of in-flight tasks
-#[inline]
+#[cfg(feature = "task-metrics")]
 pub fn decr_inflight_tasks(value: f64) {
-    #[cfg(feature = "task-metrics")]
     IN_FLIGHT_TASKS.decrement(value);
 }
 
 /// Increment the number of completed tasks
-#[inline]
+#[cfg(feature = "task-metrics")]
 pub fn incr_completed_tasks() {
-    #[cfg(feature = "task-metrics")]
     metrics::counter!(NUM_COMPLETED_TASKS_METRIC).increment(1);
 }
 
 /// Increment the number of in-flight proofs by 1
-#[inline]
+#[cfg(feature = "proof-metrics")]
 pub fn incr_inflight_proofs() {
-    #[cfg(feature = "proof-metrics")]
     IN_FLIGHT_PROOFS.increment(1.0);
 }
 
 /// Decrement the number of in-flight proofs by 1
-#[inline]
+#[cfg(feature = "proof-metrics")]
 pub fn decr_inflight_proofs() {
-    #[cfg(feature = "proof-metrics")]
     IN_FLIGHT_PROOFS.decrement(1.0);
 }
 
 /// Increment the number of in-flight transactions by 1
-#[inline]
+#[cfg(feature = "tx-metrics")]
 pub fn incr_inflight_txs() {
-    #[cfg(feature = "tx-metrics")]
     IN_FLIGHT_ARBITRUM_TXS.increment(1.0);
 }
 
 /// Decrement the number of in-flight transactions by 1
-#[inline]
+#[cfg(feature = "tx-metrics")]
 pub fn decr_inflight_txs() {
-    #[cfg(feature = "tx-metrics")]
     IN_FLIGHT_ARBITRUM_TXS.decrement(1.0);
 }

--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -34,19 +34,20 @@ pub const NUM_REMOTE_PEERS_METRIC: &str = "num_remote_peers";
 
 // Task metrics
 
-/// Metric describing the number of tasks started
-pub const NUM_STARTED_TASKS_METRIC: &str = "num_started_tasks";
-/// Metric describing the number of tasks stopped
-pub const NUM_STOPPED_TASKS_METRIC: &str = "num_stopped_tasks";
+/// Metric describing the number of in-flight tasks
+pub const NUM_INFLIGHT_TASKS_METRIC: &str = "num_inflight_tasks";
 /// Metric describing the number of tasks completed
 pub const NUM_COMPLETED_TASKS_METRIC: &str = "num_completed_tasks";
 
 // Proof metrics
 
-/// Metric describing the number of proof jobs started
-pub const NUM_STARTED_PROOFS_METRIC: &str = "num_started_proofs";
-/// Metric describing the number of proof jobs completed
-pub const NUM_COMPLETED_PROOFS_METRIC: &str = "num_completed_proofs";
+/// Metric describing the number of in-flight proofs
+pub const NUM_INFLIGHT_PROOFS_METRIC: &str = "num_inflight_proofs";
+
+// Transaction metrics
+
+/// Metric describing the number of in-flight Arbitrum transactions
+pub const NUM_INFLIGHT_TXS_METRIC: &str = "num_inflight_txs";
 
 // ---------------
 // | METRIC TAGS |

--- a/renegade-metrics/src/lib.rs
+++ b/renegade-metrics/src/lib.rs
@@ -7,5 +7,7 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![deny(clippy::missing_docs_in_private_items)]
 
+pub mod gauge;
+pub mod global_metrics;
 pub mod helpers;
 pub mod labels;

--- a/util/src/telemetry/metrics.rs
+++ b/util/src/telemetry/metrics.rs
@@ -14,13 +14,24 @@ use super::{
 /// The prefix to used for metrics emitted by the relayer
 pub const RELAYER_METRICS_PREFIX: &str = "renegade_relayer";
 
+/// The size (in bytes) of the buffer which metrics data must fill before being
+/// flushed out over UDP
+pub const METRICS_BUFFER_SIZE: usize = 1024;
+/// The size (in # of elements) of the queue which the metrics exporter
+/// maintains. If the queue is full, metrics data will be dropped.
+/// We effectively want an unbounded queue, but the `StatsdBuilder` doesn't
+/// support this, so we set a suffiiently large value here.
+pub const METRICS_QUEUE_SIZE: usize = 1024 * 1024 * 1024;
+
 /// Configures a statsd metrics recorder
 pub fn configure_metrics_statsd_recorder(
     datadog_enabled: bool,
     statsd_host: &str,
     statsd_port: u16,
 ) -> Result<(), TelemetrySetupError> {
-    let mut builder = StatsdBuilder::from(statsd_host, statsd_port).with_buffer_size(0);
+    let mut builder = StatsdBuilder::from(statsd_host, statsd_port)
+        .with_buffer_size(METRICS_BUFFER_SIZE)
+        .with_queue_size(METRICS_QUEUE_SIZE);
 
     if datadog_enabled {
         let UnifiedServiceTags { service, env, version } = get_unified_service_tags()?;

--- a/util/src/telemetry/metrics.rs
+++ b/util/src/telemetry/metrics.rs
@@ -21,7 +21,7 @@ pub const METRICS_BUFFER_SIZE: usize = 1024;
 /// maintains. If the queue is full, metrics data will be dropped.
 /// We effectively want an unbounded queue, but the `StatsdBuilder` doesn't
 /// support this, so we set a suffiiently large value here.
-pub const METRICS_QUEUE_SIZE: usize = 1024 * 1024 * 1024;
+pub const METRICS_QUEUE_SIZE: usize = 1024 * 1024;
 
 /// Configures a statsd metrics recorder
 pub fn configure_metrics_statsd_recorder(

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -13,11 +13,10 @@ use gossip_api::{
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use renegade_metrics::helpers::record_num_peers_metrics;
 use tracing::info;
 use util::{err_str, get_current_time_millis};
 
-use crate::{errors::GossipError, server::GossipProtocolExecutor};
+use crate::{errors::GossipError, peer_discovery::peer_metrics::record_num_peers_metrics, server::GossipProtocolExecutor};
 
 // -------------
 // | Constants |

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -16,7 +16,10 @@ use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob}
 use tracing::info;
 use util::{err_str, get_current_time_millis};
 
-use crate::{errors::GossipError, peer_discovery::peer_metrics::record_num_peers_metrics, server::GossipProtocolExecutor};
+use crate::{
+    errors::GossipError, peer_discovery::peer_metrics::record_num_peers_metrics,
+    server::GossipProtocolExecutor,
+};
 
 // -------------
 // | Constants |

--- a/workers/gossip-server/src/peer_discovery/mod.rs
+++ b/workers/gossip-server/src/peer_discovery/mod.rs
@@ -1,6 +1,7 @@
 //! Groups handlers for peer discovery and indexing
 
 pub(crate) mod expiry_window;
+pub(crate) mod peer_metrics;
 pub mod heartbeat;
 pub mod heartbeat_timer;
 pub mod peers;

--- a/workers/gossip-server/src/peer_discovery/mod.rs
+++ b/workers/gossip-server/src/peer_discovery/mod.rs
@@ -1,7 +1,7 @@
 //! Groups handlers for peer discovery and indexing
 
 pub(crate) mod expiry_window;
-pub(crate) mod peer_metrics;
 pub mod heartbeat;
 pub mod heartbeat_timer;
+pub(crate) mod peer_metrics;
 pub mod peers;

--- a/workers/gossip-server/src/peer_discovery/peer_metrics.rs
+++ b/workers/gossip-server/src/peer_discovery/peer_metrics.rs
@@ -1,0 +1,26 @@
+use renegade_metrics::labels::{NUM_LOCAL_PEERS_METRIC, NUM_REMOTE_PEERS_METRIC};
+use state::{error::StateError, State};
+use tracing::error;
+
+/// Get the number of local and remote peers the cluster is connected to
+async fn get_num_peers(state: &State) -> Result<(usize, usize), StateError> {
+    let cluster_id = state.get_cluster_id().await?;
+    let num_local_peers = state.get_cluster_peers(&cluster_id).await?.len();
+    let num_remote_peers = state.get_non_cluster_peers(&cluster_id).await?.len();
+
+    Ok((num_local_peers, num_remote_peers))
+}
+
+/// Record the number of local and remote peers the cluster is connected to
+pub async fn record_num_peers_metrics(state: &State) {
+    let (num_local_peers, num_remote_peers) = match get_num_peers(state).await {
+        Ok(peers) => peers,
+        Err(e) => {
+            error!("Error getting number of peers: {}", e);
+            return;
+        },
+    };
+
+    metrics::gauge!(NUM_LOCAL_PEERS_METRIC).set(num_local_peers as f64);
+    metrics::gauge!(NUM_REMOTE_PEERS_METRIC).set(num_remote_peers as f64);
+}

--- a/workers/gossip-server/src/peer_discovery/peer_metrics.rs
+++ b/workers/gossip-server/src/peer_discovery/peer_metrics.rs
@@ -1,3 +1,5 @@
+//! Helpers for tracking peer metrics
+
 use renegade_metrics::labels::{NUM_LOCAL_PEERS_METRIC, NUM_REMOTE_PEERS_METRIC};
 use state::{error::StateError, State};
 use tracing::error;

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -12,13 +12,12 @@ use gossip_api::{
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use renegade_metrics::helpers::record_num_peers_metrics;
 use tracing::{info, warn};
 use util::{err_str, get_current_time_millis};
 
 use crate::{errors::GossipError, server::GossipProtocolExecutor};
 
-use super::heartbeat::CLUSTER_HEARTBEAT_FAILURE_MS;
+use super::{heartbeat::CLUSTER_HEARTBEAT_FAILURE_MS, peer_metrics::record_num_peers_metrics};
 
 impl GossipProtocolExecutor {
     // --------------------

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -38,7 +38,7 @@ use circuits::{
 use common::types::{proof_bundles::ProofBundle, CancelChannel};
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
 use rayon::ThreadPool;
-use renegade_metrics::helpers::{incr_completed_proofs, incr_started_proofs};
+use renegade_metrics::helpers::{decr_inflight_proofs, incr_inflight_proofs};
 use tracing::{error, info, info_span, instrument};
 use util::err_str;
 
@@ -107,7 +107,7 @@ impl ProofManager {
 
     /// The main job handler, run by a thread in the pool
     fn handle_proof_job(job: ProofManagerJob) -> Result<(), ProofManagerError> {
-        incr_started_proofs();
+        incr_inflight_proofs();
         let proof_bundle = match job.type_ {
             ProofJob::ValidWalletCreate { witness, statement } => {
                 // Prove `VALID WALLET CREATE`
@@ -148,7 +148,7 @@ impl ProofManager {
                 Self::prove_valid_fee_redemption(witness, statement)
             },
         }?;
-        incr_completed_proofs();
+        decr_inflight_proofs();
 
         job.response_channel
             .send(proof_bundle)

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -221,7 +221,6 @@ pub fn new_mock_task_driver(
         backoff_ceiling_ms: 1_000, // 1 second
         initial_backoff_ms: 100,   // 100 milliseconds
         n_retries: 2,
-        n_threads: 5,
     };
 
     let config = TaskDriverConfig {


### PR DESCRIPTION
This PR introduces the `Gauge` struct, which manages an atomic, incrementable/decrementable gauge value from which metrics are reported. This is necessary as StatsD does not recognize the `gauge.increment()` / `gauge.decrement()` events, only `gauge.set()` - so we expose them through this wrapper.

The metrics from which in-flight tasks, proofs, and transactions were calculated were replaced with static gauges of this type.