### PR TITLE
docker: release: Run snapshot sidecar in relayer container

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -162,7 +162,13 @@ pub struct Cli {
     /// Multiple keys can be provided to mitigate nonce contention across a node / cluster.
     /// 
     /// Defaults to the devnet pre-funded key
-    #[clap(long = "arbitrum-pkeys", value_parser, default_values_t = ["0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659".to_string()])]
+    #[clap(
+        value_parser,
+        long = "arbitrum-pkeys",  
+        default_values_t = ["0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659".to_string()],
+        num_args = 1..,
+        value_delimiter = ' ',
+    )]
     pub arbitrum_private_keys: Vec<String>,
     /// The key used to decrypt fee payments
     #[clap(long = "fee-decryption-key", value_parser)]

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -166,7 +166,8 @@ fn config_file_args(cli_args: &[String]) -> Result<Vec<String>, String> {
 
 /// Parse a config entirely from a file
 pub fn parse_config_from_file(path: &str) -> Result<RelayerConfig, String> {
-    let file_args = read_config_file(path)?;
+    let mut file_args = read_config_file(path)?;
+    file_args.insert(0, "dummy-program-name".to_string());
     let cli = Cli::parse_from(file_args);
     let config = parse_config_from_args(cli)?;
     validate_config(&config)?;

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -36,8 +36,11 @@ ARG CARGO_FEATURES="default"
 # Build only the dependencies to cache them in this layer
 RUN cargo chef cook --release --recipe-path recipe.json --features "$CARGO_FEATURES"
 
-# Build the relayer
+# Build the snapshot sidecar
 COPY . .
+RUN cargo build --release --package snapshot-sidecar
+
+# Build the relayer
 RUN cargo build --release --features "$CARGO_FEATURES"
 
 # Release stage
@@ -48,7 +51,8 @@ RUN apt-get update && \
     apt-get install -y ca-certificates && \
     apt-get install -y awscli
 
-# Copy the binary from the build stage
+# Copy the binaries from the build stage
+COPY --from=builder /build/target/release/snapshot-sidecar /bin/snapshot-sidecar
 COPY --from=builder /build/target/release/renegade-relayer /bin/renegade-relayer
 
 # Copy the bootloader script & make it executable

--- a/docker/release/bootloader.sh
+++ b/docker/release/bootloader.sh
@@ -2,12 +2,13 @@
 
 # Expects the following environment variables to be passed to the container:
 # CONFIG_BUCKET: The S3 bucket containing the configs
+# SNAPSHOT_BUCKET: The S3 bucket to save state snapshots to
 # CONFIG_FILE: The name of the config file
 # HTTP_PORT: The port to use for HTTP traffic
 # WEBSOCKET_PORT: The port to use for WebSocket traffic
 # P2P_PORT: The port to use for gossip traffic
 # PUBLIC_IP: The public IP address of the node (optional)
-
+set -e
 
 config_path="/config.toml"
 
@@ -23,6 +24,9 @@ echo "p2p-port = $P2P_PORT" >> $config_path
 if [ -n "$PUBLIC_IP" ]; then
   echo "public-ip = \"$PUBLIC_IP:$P2P_PORT\"" >> $config_path
 fi
+
+# Run the snapshot sidecar
+/bin/snapshot-sidecar --config-path $config_path --bucket $SNAPSHOT_BUCKET &
 
 # Run the relayer
 /bin/renegade-relayer --config-file $config_path


### PR DESCRIPTION
### Purpose
This PR adds the `snapshot-sidecar` to the release build and runs it in the container with the relayer. 

### Testing
- Unit tests pass
- Ran the relayer dockerfile locally using a dummy config I placed on s3. Turned the snapshot frequency up to once every five logs, then created a new wallet and added an order. Verified that the relayer's snapshot was sent to s3