### PR TITLE
state: replication: state-machine: Recover from snapshot at startup

### DIFF
--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -24,9 +24,11 @@ use crate::{
         settleOnlineRelayerFeeCall, updateWalletCall,
     },
     client::MiddlewareStack,
-    constants::{NUM_TXS_SENT_METRIC, NUM_TXS_SUBMITTED_METRIC},
     errors::ArbitrumClientError,
 };
+
+#[cfg(feature = "tx-metrics")]
+use crate::constants::{NUM_TXS_SENT_METRIC, NUM_TXS_SUBMITTED_METRIC};
 
 /// Serializes a calldata element for a contract call
 pub fn serialize_calldata<T: Serialize>(data: &T) -> Result<Bytes, ArbitrumClientError> {

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -144,7 +144,7 @@ impl State {
         let applicator = StateApplicator::new(applicator_config).map_err(StateError::Applicator)?;
         let notifications = OpenNotifications::new();
         let sm_config = StateMachineConfig::new(config.raft_snapshot_path.clone());
-        let sm = StateMachine::new(sm_config, notifications.clone(), applicator);
+        let sm = StateMachine::new(sm_config, notifications.clone(), applicator).await?;
 
         // Start a raft
         let raft = RaftClient::new(raft_config, db.clone(), network, sm)
@@ -177,6 +177,7 @@ impl State {
             election_timeout_min: DEFAULT_MIN_ELECTION_MS,
             election_timeout_max: DEFAULT_MAX_ELECTION_MS,
             initial_nodes,
+            snapshot_path: relayer_config.raft_snapshot_path.clone(),
             ..Default::default()
         }
     }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -248,6 +248,7 @@ pub mod test_helpers {
             heartbeat_interval: 5,
             init: true,
             initial_nodes,
+            snapshot_path: relayer_config.raft_snapshot_path.clone(),
             ..Default::default()
         }
     }

--- a/state/src/replication/raft.rs
+++ b/state/src/replication/raft.rs
@@ -6,7 +6,9 @@ use std::{
     time::Duration,
 };
 
-use openraft::{ChangeMembers, Config as RaftConfig, Membership, RaftMetrics, ServerState};
+use openraft::{
+    ChangeMembers, Config as RaftConfig, Membership, RaftMetrics, ServerState, SnapshotPolicy,
+};
 use tracing::info;
 use util::err_str;
 
@@ -63,6 +65,8 @@ pub struct RaftClientConfig {
     pub election_timeout_max: u64,
     /// The length of a learner's log lag before being promoted to a follower
     pub learner_promotion_threshold: u64,
+    /// The directory at which snapshots are stored
+    pub snapshot_path: String,
     /// The nodes to initialize the membership with
     pub initial_nodes: Vec<(NodeId, RaftNode)>,
 }
@@ -77,6 +81,7 @@ impl Default for RaftClientConfig {
             election_timeout_min: DEFAULT_ELECTION_TIMEOUT_MIN,
             election_timeout_max: DEFAULT_ELECTION_TIMEOUT_MAX,
             learner_promotion_threshold: DEFAULT_LEARNER_PROMOTION_THRESHOLD,
+            snapshot_path: "./raft-snapshots".to_string(),
             initial_nodes: vec![],
         }
     }
@@ -86,7 +91,7 @@ impl Default for RaftClientConfig {
 #[derive(Clone)]
 pub struct RaftClient {
     /// The client's config
-    config: RaftClientConfig,
+    pub(crate) config: RaftClientConfig,
     /// The inner raft
     raft: Raft,
     /// The network to use for the raft client

--- a/state/src/replication/state_machine/recovery.rs
+++ b/state/src/replication/state_machine/recovery.rs
@@ -1,0 +1,47 @@
+//! Recover the state machine from a snapshot
+
+use common::types::tasks::{QueuedTask, TaskQueueKey};
+use openraft::SnapshotMeta;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::{replication::error::ReplicationV2Error, TASK_QUEUE_TABLE};
+
+use super::StateMachine;
+
+impl StateMachine {
+    /// Check for a snapshot to recover from
+    pub(crate) async fn maybe_recover_snapshot(&mut self) -> Result<(), ReplicationV2Error> {
+        if !self.snapshot_archive_path().exists() {
+            return Ok(());
+        }
+
+        // Open the snap DB and apply a dummy snapshot
+        info!("snapshot found, recovering...");
+        let snap_db = self.open_snap_db().await?;
+        let dummy_meta = SnapshotMeta {
+            last_log_id: None,
+            last_membership: Default::default(),
+            snapshot_id: "recovery".to_string(),
+        };
+
+        self.update_from_snapshot(&dummy_meta, snap_db).await?;
+        self.clear_task_queues()
+    }
+
+    /// Clear all task queues
+    ///
+    /// We do this when recovering to prevent wallets from being blocked on a
+    /// task queue that failed
+    fn clear_task_queues(&self) -> Result<(), ReplicationV2Error> {
+        let tx = self.db().new_write_tx().unwrap();
+        let cur = tx.inner().cursor::<TaskQueueKey, Vec<QueuedTask>>(TASK_QUEUE_TABLE)?;
+        for kv in cur.into_iter().keys() {
+            let queue_key: Uuid = kv?;
+            tx.clear_task_queue(&queue_key)?;
+        }
+        tx.commit()?;
+
+        Ok(())
+    }
+}

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -13,15 +13,14 @@ use openraft::{
 };
 use util::{err_str, get_current_time_millis};
 
+use crate::replication::error::{new_snapshot_error, ReplicationV2Error};
 use crate::storage::db::{DbConfig, DB};
 use crate::{
     ALL_TABLES, CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, PEER_INFO_TABLE, RAFT_LOGS_TABLE,
     RAFT_METADATA_TABLE,
 };
 
-use super::error::{new_snapshot_error, ReplicationV2Error};
-use super::state_machine::StateMachine;
-use super::{Node, NodeId, TypeConfig};
+use super::{Node, NodeId, StateMachine, TypeConfig};
 
 /// The MDBX data file
 const MDBX_DATA_FILE: &str = "mdbx.dat";
@@ -299,7 +298,7 @@ mod tests {
         const TABLE: &str = "test-table";
         let (k, v) = ("key".to_string(), "value".to_string());
 
-        let state_machine = mock_state_machine();
+        let state_machine = mock_state_machine().await;
 
         // Write to the DB
         let db = state_machine.db();
@@ -322,7 +321,7 @@ mod tests {
         let (k1, v1) = ("key1".to_string(), "value1".to_string());
         let (k2, v2) = ("key2".to_string(), "value2".to_string());
 
-        let state_machine = mock_state_machine();
+        let state_machine = mock_state_machine().await;
         let db = state_machine.db();
 
         // Write to the DB
@@ -352,7 +351,7 @@ mod tests {
     #[tokio::test]
     async fn test_snapshot_overwrite() {
         const TABLE: &str = "test-table";
-        let state_machine = mock_state_machine();
+        let state_machine = mock_state_machine().await;
         let db = state_machine.db();
 
         let (k, v1) = ("key".to_string(), "value".to_string());
@@ -422,7 +421,7 @@ mod tests {
         let (k1, v1) = ("key1".to_string(), "value1".to_string());
         let (k2, v2) = ("key2".to_string(), "value2".to_string());
 
-        let mut state_machine = mock_state_machine();
+        let mut state_machine = mock_state_machine().await;
         let snapshot_db = mock_db();
         let meta = SnapshotMeta::default();
 

--- a/state/src/storage/cursor.rs
+++ b/state/src/storage/cursor.rs
@@ -90,6 +90,13 @@ impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
         Ok(end)
     }
 
+    /// Position the cursor at the next keypair without filtering
+    ///
+    /// Returns `true` if the cursor has reached the end of the table
+    pub fn seek_next_raw(&mut self) -> Result<bool, StorageError> {
+        Ok(self.inner.next::<CowBuffer, CowBuffer>().map_err(StorageError::TxOp)?.is_none())
+    }
+
     /// Position the cursor at the previous key value pair
     ///
     /// Returns `true` if the cursor has reached the start of the table

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -352,7 +352,7 @@ impl<'db> DbTxn<'db, RW> {
         table_name: &str,
         mut cursor: DbCursor<'_, T, CowBuffer, CowBuffer>,
     ) -> Result<(), StorageError> {
-        while !cursor.seek_next()? {
+        while !cursor.seek_next_raw()? {
             let (k, v) = cursor.get_current_raw()?.unwrap();
             self.write_raw(table_name, &k, &v)?;
         }


### PR DESCRIPTION
### Purpose
This PR changes the state machine to check for a snapshot at startup and recover from the snapshot if it is present. This also involves cleanup logic -- which for now is just clearing all task queues so that wallets are not stuck. 

### Todo
- In the node startup task, check all wallets on-chain for updates since the snapshot was taken

### Testing
- Unit tests pass
- Tested recovering a node from a snapshot with a wallet in the state, verified that the state held the wallet without any lookup task