### PR TITLE
task-driver: node-startup: Refresh wallets if recovering from snap

### DIFF
--- a/common/src/types/wallet/shares.rs
+++ b/common/src/types/wallet/shares.rs
@@ -44,6 +44,19 @@ impl Wallet {
         compute_wallet_share_nullifier(self.get_wallet_share_commitment(), self.blinder)
     }
 
+    /// Get the private share of the blinder
+    pub fn private_blinder_share(&self) -> Scalar {
+        self.private_shares.blinder
+    }
+
+    /// Get the last non-blinder wallet share
+    pub fn get_last_private_share(&self) -> Scalar {
+        let shares = self.private_shares.to_scalars();
+
+        // The last share is the blinder, so take the second to last
+        shares[shares.len() - 2]
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -18,6 +18,11 @@ use crate::{
 impl State {
     // --- Raft State --- //
 
+    /// Whether the state machine was recovered from a snapshot
+    pub fn was_recovered_from_snapshot(&self) -> bool {
+        self.recovered_from_snapshot
+    }
+
     /// Whether the raft is initialized (has non-empty voters)
     pub fn is_raft_initialized(&self) -> bool {
         self.raft.is_initialized()

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -321,6 +321,7 @@ pub mod test_helpers {
             raft: client,
             bus: SystemBus::new(),
             notifications: OpenNotifications::new(),
+            recovered_from_snapshot: false,
         };
 
         // Configure the node

--- a/state/src/replication/state_machine/mod.rs
+++ b/state/src/replication/state_machine/mod.rs
@@ -64,6 +64,8 @@ impl StateMachineConfig {
 /// The state machine for the raft node
 #[derive(Clone)]
 pub struct StateMachine {
+    /// Whether the state machine recovered from a snapshot
+    pub(crate) recovered_from_snapshot: bool,
     /// The index of the last applied log
     pub(crate) last_applied_log: Option<LogId<NodeId>>,
     /// The last cluster membership config
@@ -84,6 +86,7 @@ impl StateMachine {
         applicator: StateApplicator,
     ) -> Result<Self, ReplicationV2Error> {
         let mut this = Self {
+            recovered_from_snapshot: false,
             last_applied_log: None,
             last_membership: Default::default(),
             config,

--- a/state/src/replication/state_machine/recovery.rs
+++ b/state/src/replication/state_machine/recovery.rs
@@ -18,6 +18,7 @@ impl StateMachine {
 
         // Open the snap DB and apply a dummy snapshot
         info!("snapshot found, recovering...");
+        self.recovered_from_snapshot = true;
         let snap_db = self.open_snap_db().await?;
         let dummy_meta = SnapshotMeta {
             last_log_id: None,


### PR DESCRIPTION
### Purpose
This PR refreshes all recovered wallets when recovering from a snapshot. That is, for each wallet found in the snapshot, the relayer will check if the wallet's nullifier has been used. If so, the relayer will run a lookup wallet task to refresh the wallet state from on-chain.

### Testing
- Unit tests pass
- Setup a wallet in a snapshot. Used another relayer to update the wallet. Ran the original relayer with its snapshot in place and verified that the relayer looked up the most recent version.