### PR TITLE
state: replication: raft: tweak initialization check & snapshot installation

### DIFF
--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -179,7 +179,7 @@ impl State {
         // Only add learners if a raft is setup
         // Before a raft is setup, we only want to populate the peer index, and not
         // attempt to form a raft
-        if self.raft.is_initialized() {
+        if self.raft.is_initialized().await? {
             for (raft_id, info) in learners.into_iter() {
                 this.raft.add_learner(raft_id, info).await?;
             }

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -24,8 +24,8 @@ impl State {
     }
 
     /// Whether the raft is initialized (has non-empty voters)
-    pub fn is_raft_initialized(&self) -> bool {
-        self.raft.is_initialized()
+    pub async fn is_raft_initialized(&self) -> Result<bool, StateError> {
+        self.raft.is_initialized().await.map_err(StateError::Replication)
     }
 
     /// Whether the local node is the leader

--- a/state/src/replication/raft.rs
+++ b/state/src/replication/raft.rs
@@ -34,11 +34,13 @@ const DEFAULT_ELECTION_TIMEOUT_MAX: u64 = 15000; // 15 seconds
 const DEFAULT_LEARNER_PROMOTION_THRESHOLD: u64 = 20; // 20 log entries
 /// The amount of time to await promotion before timing out
 ///
-/// Set to two minutes; giving enough time to receive snapshots and catch up to
+/// Set to five minutes; giving enough time to receive snapshots and catch up to
 /// logs
-const DEFAULT_PROMOTION_TIMEOUT_MS: u64 = 2 * 60 * 1000;
+const DEFAULT_PROMOTION_TIMEOUT_MS: u64 = 5 * 60 * 1000;
 /// The amount of time to await a leader election before timing out
 const DEFAULT_LEADER_ELECTION_TIMEOUT_MS: u64 = 30_000; // 30 seconds
+/// The default max chunk size for snapshots
+const DEFAULT_SNAPSHOT_MAX_CHUNK_SIZE: u64 = 10 * 1024 * 1024; // 10MiB
 
 /// Error message emitted when there is no known leader
 const ERR_NO_LEADER: &str = "no leader";
@@ -67,6 +69,8 @@ pub struct RaftClientConfig {
     pub snapshot_path: String,
     /// The nodes to initialize the membership with
     pub initial_nodes: Vec<(NodeId, RaftNode)>,
+    /// The maximum size of snapshot chunks in bytes
+    pub snapshot_max_chunk_size: u64,
 }
 
 impl Default for RaftClientConfig {
@@ -81,6 +85,7 @@ impl Default for RaftClientConfig {
             learner_promotion_threshold: DEFAULT_LEARNER_PROMOTION_THRESHOLD,
             snapshot_path: "./raft-snapshots".to_string(),
             initial_nodes: vec![],
+            snapshot_max_chunk_size: DEFAULT_SNAPSHOT_MAX_CHUNK_SIZE,
         }
     }
 }
@@ -109,6 +114,7 @@ impl RaftClient {
             heartbeat_interval: config.heartbeat_interval,
             election_timeout_min: config.election_timeout_min,
             election_timeout_max: config.election_timeout_max,
+            snapshot_max_chunk_size: config.snapshot_max_chunk_size,
             ..Default::default()
         });
 

--- a/state/src/replication/raft.rs
+++ b/state/src/replication/raft.rs
@@ -145,12 +145,8 @@ impl RaftClient {
     }
 
     /// Whether the raft is initialized
-    ///
-    /// This is equivalent to whether the raft has non-empty voters list. A
-    /// non-empty set of voters implies a leader exists or will soon be elected
-    pub fn is_initialized(&self) -> bool {
-        let members = self.membership();
-        members.voter_ids().count() > 0
+    pub async fn is_initialized(&self) -> Result<bool, ReplicationV2Error> {
+        self.raft.is_initialized().await.map_err(err_str!(ReplicationV2Error::Raft))
     }
 
     /// Get a copy of the raft metrics

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -304,7 +304,7 @@ impl NodeStartupTask {
             .map_err(|_| NodeStartupTaskError::Enqueue(ERR_SEND_JOB.to_string()))?;
 
         // After warmup, check for an existing raft cluster
-        if self.state.is_raft_initialized() {
+        if self.state.is_raft_initialized().await.map_err(err_str!(NodeStartupTaskError::State))? {
             self.task_state = NodeStartupTaskState::JoinRaft;
         } else {
             self.task_state = NodeStartupTaskState::InitializeRaft;


### PR DESCRIPTION
This PR aims to stabilize the onboarding of a new Raft node that needs to install a snapshot from the leader. In the case of a large snapshot, it takes significantly longer than the gossip warmup period to download it. As such our current initialization check fails, and we attempt to initialize a new Raft. As such, this PR:
1. Defers the initialization check to `openraft`'s `is_initialized()` method for consistency
2. Increases the snapshot chunk size from a default of `3MiB` -> `10MiB` to speed up snapshot download
3. Increases the learner promotion timeout to 5 minutes to allow more time for snapshot download

This is currently being tested in dev