### PR TITLE
state: state-machine: recovery: Do not error on empty snapshot

### DIFF
--- a/state/src/replication/state_machine/mod.rs
+++ b/state/src/replication/state_machine/mod.rs
@@ -14,6 +14,7 @@ use openraft::{
     Snapshot, SnapshotMeta, StorageError as RaftStorageError, StoredMembership,
 };
 use tokio::fs::File;
+use tracing::error;
 use util::{err_str, res_some};
 
 use crate::{
@@ -94,7 +95,11 @@ impl StateMachine {
             applicator,
         };
 
-        this.maybe_recover_snapshot().await?;
+        // Do not error on an invalid snapshot
+        if let Err(e) = this.maybe_recover_snapshot().await {
+            error!("Failed to recover from snapshot: {e:?}");
+        }
+
         Ok(this)
     }
 


### PR DESCRIPTION
### Purpose
This PR makes two changes to the recovery logic:
1. Do not fail the node if snapshot recovery fails. This is more generally the desired behavior in the case of an invalid snapshot
2. Do not attempt recovery if the snapshot file length is zero. This may happen if a dummy snapshot was created ahead of time; e.g. in the snapshot sidecar

### Testing
- Tested creating a dummy snap with the sidecar, verified that the snapshot was skipped