### PR TITLE
state: replication: raft: increase snapshot rpc timeout

### DIFF
--- a/state/src/replication/raft.rs
+++ b/state/src/replication/raft.rs
@@ -41,6 +41,8 @@ const DEFAULT_PROMOTION_TIMEOUT_MS: u64 = 5 * 60 * 1000;
 const DEFAULT_LEADER_ELECTION_TIMEOUT_MS: u64 = 30_000; // 30 seconds
 /// The default max chunk size for snapshots
 const DEFAULT_SNAPSHOT_MAX_CHUNK_SIZE: u64 = 10 * 1024 * 1024; // 10MiB
+/// The default timeout to use when sending `InstallSnapshot` RPCs
+const DEFAULT_INSTALL_SNAPSHOT_TIMEOUT_MS: u64 = 5000; // 5 seconds
 
 /// Error message emitted when there is no known leader
 const ERR_NO_LEADER: &str = "no leader";
@@ -71,6 +73,8 @@ pub struct RaftClientConfig {
     pub initial_nodes: Vec<(NodeId, RaftNode)>,
     /// The maximum size of snapshot chunks in bytes
     pub snapshot_max_chunk_size: u64,
+    /// The timeout on individual `InstallSnapshot` RPC calls
+    pub install_snapshot_timeout: u64,
 }
 
 impl Default for RaftClientConfig {
@@ -86,6 +90,7 @@ impl Default for RaftClientConfig {
             snapshot_path: "./raft-snapshots".to_string(),
             initial_nodes: vec![],
             snapshot_max_chunk_size: DEFAULT_SNAPSHOT_MAX_CHUNK_SIZE,
+            install_snapshot_timeout: DEFAULT_INSTALL_SNAPSHOT_TIMEOUT_MS,
         }
     }
 }
@@ -115,6 +120,7 @@ impl RaftClient {
             election_timeout_min: config.election_timeout_min,
             election_timeout_max: config.election_timeout_max,
             snapshot_max_chunk_size: config.snapshot_max_chunk_size,
+            install_snapshot_timeout: config.install_snapshot_timeout,
             ..Default::default()
         });
 


### PR DESCRIPTION
This PR increases the timeout that the leader uses when sending snapshot chunks to peers from the default of 200ms to 1s. Previously, the leader would time out every time it tried to send a chunk, so it would get stuck in an endless loop of trying to send the same (first) chunk of the snapshot to a learner.

This can be seen in the chunked snapshot implementation [here](https://github.com/datafuselabs/openraft/blob/v0.9.11/openraft/src/network/snapshot_transport.rs#L201-L204): upon timeout, the implementation continues to the next iteration of the loop [without incrementing the chunk offset](https://github.com/datafuselabs/openraft/blob/v0.9.11/openraft/src/network/snapshot_transport.rs#L217), never to complete.

I tested this by bringing up a relayer node, letting it build up a ~50MB snapshot, and bringing in nodes one after the other while the cluster continued to experience load. Nodes were able to successfully finish receiving the snapshot and join the cluster, as opposed to being stuck in a loop of `Done received snapshot chunk` as they would before.

I would still like to test this in `dev` in response to automatic scale-outs.