### PR TITLE
workers: handshake-manager: Do not use blocking pool for internal engine

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -258,7 +258,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (handshake_cancel_sender, handshake_cancel_receiver) = watch::channel(());
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
         mutual_exclusion_list: args.match_mutual_exclusion_list,
-        global_state: global_state.clone(),
+        state: global_state.clone(),
         network_channel: network_sender.clone(),
         price_reporter_job_queue: price_reporter_worker_sender.clone(),
         job_receiver: Some(handshake_worker_receiver),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -375,7 +375,7 @@ impl MockNodeController {
 
     /// Add a handshake manager to the mock node
     pub fn with_handshake_manager(mut self) -> Self {
-        let global_state = self.state.clone().expect("State not initialized");
+        let state = self.state.clone().expect("State not initialized");
         let network_channel = self.network_queue.0.clone();
         let price_reporter_job_queue = self.price_queue.0.clone();
         let job_sender = self.handshake_queue.0.clone();
@@ -386,7 +386,7 @@ impl MockNodeController {
 
         let conf = HandshakeManagerConfig {
             mutual_exclusion_list: HashSet::new(),
-            global_state,
+            state,
             network_channel,
             price_reporter_job_queue,
             job_sender,

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -19,6 +19,12 @@ impl State {
         Ok(key.is_some())
     }
 
+    /// Whether a task queue is paused
+    pub async fn is_queue_paused(&self, key: &TaskQueueKey) -> Result<bool, StateError> {
+        let key = *key;
+        self.with_read_tx(move |tx| Ok(tx.is_queue_paused(&key)?)).await
+    }
+
     /// Get the length of the task queue
     pub async fn get_task_queue_len(&self, key: &TaskQueueKey) -> Result<usize, StateError> {
         let key = *key;

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -121,7 +121,7 @@ impl HandshakeExecutor {
         // fee pair Use the linkable commitments from this witness to commit to
         // values in `VALID MATCH MPC`
         let proof_witnesses = self
-            .global_state
+            .state
             .get_validity_proof_witness(&handshake_state.local_order_id)
             .await?
             .ok_or_else(|| {

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -23,7 +23,7 @@ pub struct HandshakeScheduler {
     /// The UnboundedSender to enqueue jobs on
     job_sender: HandshakeManagerQueue,
     /// A copy of the relayer-global state
-    global_state: State,
+    state: State,
     /// The cancel channel to receive cancel signals on
     cancel: CancelChannel,
 }
@@ -32,10 +32,10 @@ impl HandshakeScheduler {
     /// Construct a new timer
     pub fn new(
         job_sender: HandshakeManagerQueue,
-        global_state: State,
+        state: State,
         cancel: CancelChannel,
     ) -> Self {
-        Self { job_sender, global_state, cancel }
+        Self { job_sender, state, cancel }
     }
 
     /// The execution loop of the timer, periodically enqueues handshake jobs
@@ -50,7 +50,7 @@ impl HandshakeScheduler {
                 // Enqueue handshakes periodically according to a timer
                 _ = tokio::time::sleep(refresh_interval) => {
                     // Enqueue a job to handshake with the randomly selected peer
-                    if let Some(order) = self.global_state.choose_handshake_order().await.ok().flatten() {
+                    if let Some(order) = self.state.choose_handshake_order().await.ok().flatten() {
                         if let Err(e) = self
                             .job_sender
                             .send(HandshakeExecutionJob::PerformHandshake { order })

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -30,11 +30,7 @@ pub struct HandshakeScheduler {
 
 impl HandshakeScheduler {
     /// Construct a new timer
-    pub fn new(
-        job_sender: HandshakeManagerQueue,
-        state: State,
-        cancel: CancelChannel,
-    ) -> Self {
+    pub fn new(job_sender: HandshakeManagerQueue, state: State, cancel: CancelChannel) -> Self {
         Self { job_sender, state, cancel }
     }
 

--- a/workers/handshake-manager/src/state.rs
+++ b/workers/handshake-manager/src/state.rs
@@ -31,16 +31,16 @@ pub struct HandshakeStateIndex {
     /// A mapping from nullifier to a set of request_ids on that nullifier
     nullifier_map: AsyncShared<HashMap<Scalar, HashSet<Uuid>>>,
     /// A copy of the relayer global state
-    global_state: State,
+    state: State,
 }
 
 impl HandshakeStateIndex {
     /// Creates a new instance of the state index
-    pub fn new(global_state: State) -> Self {
+    pub fn new(state: State) -> Self {
         Self {
             state_map: new_async_shared(HashMap::new()),
             nullifier_map: new_async_shared(HashMap::new()),
-            global_state,
+            state,
         }
     }
 
@@ -60,7 +60,7 @@ impl HandshakeStateIndex {
         execution_price: FixedPoint,
     ) -> Result<(), HandshakeManagerError> {
         // Lookup the public share nullifiers for the order
-        let state = &self.global_state;
+        let state = &self.state;
         let local_nullifier = state
             .get_nullifier_for_order(&local_order_id)
             .await?

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -35,7 +35,7 @@ pub struct HandshakeManagerConfig {
     /// the node
     pub mutual_exclusion_list: HashSet<WalletIdentifier>,
     /// The relayer-global state
-    pub global_state: State,
+    pub state: State,
     /// The channel on which to send outbound network requests
     pub network_channel: NetworkManagerQueue,
     /// The price reporter's job queue
@@ -64,7 +64,7 @@ impl Worker for HandshakeManager {
         // peers
         let scheduler = HandshakeScheduler::new(
             config.job_sender.clone(),
-            config.global_state.clone(),
+            config.state.clone(),
             config.cancel_channel.clone(),
         );
         let executor = HandshakeExecutor::new(
@@ -72,7 +72,7 @@ impl Worker for HandshakeManager {
             config.job_receiver.take().unwrap(),
             config.network_channel.clone(),
             config.price_reporter_job_queue.clone(),
-            config.global_state.clone(),
+            config.state.clone(),
             config.task_queue.clone(),
             config.system_bus.clone(),
             config.cancel_channel.clone(),


### PR DESCRIPTION
### Purpose
This PR changes the implementation of the internal matching engine to run on the non-blocking Tokio pool. We observed a deadlock in the matching engine when running a relayer under intense load. This deadlock occurs on the blocking Tokio pool when spawning too many internal engine tasks at one; which themselves spawn blocking tasks for DB access. Eventually we exhaust the blocking pool's ability to spawn new tasks or await blocking tasks as these two granularities of blocking tasks get interleaved and exhaust the pool, preventing one another from making progress.

The internal engine is now implemented `async` anyways with the blocking components themselves spawned onto the blocking pool, so it is fine to run the engine `async`. 

I additionally added early exit conditions to the matching engine that we see under heavy load; i.e. a match from elsewhere in the relayer pauses a queue, or an update is interleaved making the wallet invalid. This check catches both cases and ensures we do not continue attempting to match on a stale wallet.

### Todo
- Improve task notifications to be more direct.

### Testing
- Reproduced some of the pool deadlock behavior locally using the DB of the load tested node, verified that it made progress after this fix was implemented.