### PR TITLE
task-driver: driver: Notify preemptive task senders directly

### DIFF
--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -8,7 +8,7 @@ use circuit_types::{keychain::PublicSigningKey, transfers::ExternalTransfer};
 use common::{
     types::{
         proof_bundles::mocks::dummy_valid_wallet_update_bundle,
-        tasks::{LookupWalletTaskDescriptor, TaskDescriptor, TaskIdentifier},
+        tasks::{LookupWalletTaskDescriptor, TaskDescriptor},
         transfer_auth::ExternalTransferWithAuth,
         wallet::{Wallet, WalletIdentifier},
     },
@@ -98,11 +98,7 @@ pub(crate) async fn await_immediate_task(
     task: TaskDescriptor,
     test_args: &IntegrationTestArgs,
 ) -> Result<()> {
-    let task_id = TaskIdentifier::new_v4();
-    let job = TaskDriverJob::RunImmediate { task_id, wallet_ids: modified_wallets, task };
-    test_args.task_queue.send(job).unwrap();
-
-    let (rx, job) = new_task_notification(task_id);
+    let (job, rx) = TaskDriverJob::new_immediate_with_notification(task, modified_wallets);
     test_args.task_queue.send(job).unwrap();
 
     rx.await.unwrap().map_err(|e| eyre::eyre!(e))


### PR DESCRIPTION
### Purpose
This PR changes the way in which we notify waiters about the result of a preemptive task. Instead of going through the open notifications set, we directly send a response channel alongside the `RunImmediate` job. The driver responds directly on this channel rather than looking up channels in the open notifications map.

This fixes an issue we have seen wherein the handshake manager registers a notification with the driver for an immediate task, but beats the task's registration, causing an erroneous `"task not found"` error. The handshake manager will then retry matches unnecessarily and possibly create a duplicate match which will need to be cancelled. The net effect of this is wasted work.

### Testing
- Tested a case in which two matches occur at the same time on the same wallet. Verified that it was handled cleanly