### PR TITLE
gossip-api: trace gossip requests across network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,8 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_json",
+ "tracing",
+ "util",
  "uuid 1.8.0",
 ]
 
@@ -8396,9 +8398,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d08e5e1748192713cc281da8b16924fb46be7b0c2431854eadc785823e5696e"
+checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
 dependencies = [
  "approx",
  "lazy_static",
@@ -8443,11 +8445,11 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/gossip-api/Cargo.toml
+++ b/gossip-api/Cargo.toml
@@ -10,6 +10,7 @@ ed25519-dalek = { version = "1.0.1" }
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }
 common = { path = "../common" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 libp2p = { workspace = true }
@@ -17,4 +18,5 @@ openraft = "0.9"
 protobuf = "2.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use common::types::gossip::WrappedPeerId;
+use tracing::instrument;
 use util::err_str;
 
 use crate::{
@@ -71,6 +72,7 @@ impl State {
     /// Handle a raft request from a peer
     ///
     /// We (de)serialize at the raft layer to avoid dependency leak
+    #[instrument(name = "handle_raft_request", skip_all, err)]
     pub async fn handle_raft_req(&self, msg_bytes: Vec<u8>) -> Result<RaftResponse, StateError> {
         let msg: RaftRequest =
             bincode::deserialize(&msg_bytes).map_err(err_str!(StateError::Serde))?;

--- a/state/src/replication/network/mod.rs
+++ b/state/src/replication/network/mod.rs
@@ -40,6 +40,18 @@ pub enum RaftRequest {
     ForwardedProposal(Proposal),
 }
 
+impl RaftRequest {
+    /// Get a string representing the request type
+    pub fn type_str(&self) -> &'static str {
+        match self {
+            RaftRequest::AppendEntries(_) => "append_entries",
+            RaftRequest::InstallSnapshot(_) => "install_snapshot",
+            RaftRequest::Vote(_) => "vote",
+            RaftRequest::ForwardedProposal(_) => "forwarded_proposal",
+        }
+    }
+}
+
 /// The response type a raft node may send to another
 #[derive(Debug, Serialize, Deserialize)]
 pub enum RaftResponse {

--- a/util/src/telemetry/mod.rs
+++ b/util/src/telemetry/mod.rs
@@ -10,6 +10,7 @@ pub mod datadog;
 pub mod helpers;
 pub mod metrics;
 pub mod otlp_tracer;
+pub mod propagation;
 
 /// Possible errors that occur when setting up telemetry
 /// for the relayer

--- a/util/src/telemetry/propagation.rs
+++ b/util/src/telemetry/propagation.rs
@@ -1,0 +1,63 @@
+//! Helpers for propagating tracing information across processes
+use std::collections::HashMap;
+
+use opentelemetry::{
+    global,
+    propagation::{Extractor, Injector},
+    Context,
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Represents the context of a trace
+pub type TraceContextHeaders = HashMap<String, String>;
+
+/// Helper struct for injecting tracing context into a TraceContextHeaders
+pub struct TraceContextHeadersInjector<'a>(&'a mut TraceContextHeaders);
+/// Helper struct for extracting tracing context from a TraceContextHeaders
+pub struct TraceContextHeadersExtractor<'a>(&'a TraceContextHeaders);
+
+impl<'a> Injector for TraceContextHeadersInjector<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_string(), value);
+    }
+}
+
+impl<'a> Extractor for TraceContextHeadersExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}
+
+/// Create a new TraceContextHeaders containing string-keyed trace context
+pub fn trace_context_headers() -> TraceContextHeaders {
+    let mut trace_context = TraceContextHeaders::new();
+    global::get_text_map_propagator(|prop| {
+        prop.inject_context(
+            &tracing::Span::current().context(),
+            &mut TraceContextHeadersInjector(&mut trace_context),
+        )
+    });
+
+    trace_context
+}
+
+/// Extract trace context from a TraceContextHeaders
+pub fn trace_context_from_headers(headers: &TraceContextHeaders) -> Context {
+    let extractor = TraceContextHeadersExtractor(headers);
+    global::get_text_map_propagator(|prop| prop.extract(&extractor))
+}
+
+/// Set the parent span from a TraceContextHeaders context
+pub fn set_parent_span_from_headers(headers: &TraceContextHeaders) {
+    let context = if headers.is_empty() {
+        tracing::Span::current().context().clone()
+    } else {
+        trace_context_from_headers(headers)
+    };
+
+    tracing::Span::current().set_parent(context);
+}

--- a/workers/gossip-server/src/orderbook.rs
+++ b/workers/gossip-server/src/orderbook.rs
@@ -18,7 +18,7 @@ use common::types::{
 use futures::executor::block_on;
 use gossip_api::{
     pubsub::orderbook::OrderBookManagementMessage,
-    request_response::{orderbook::OrderInfoResponse, GossipResponse},
+    request_response::{orderbook::OrderInfoResponse, GossipResponseType},
 };
 use tracing::debug;
 use util::err_str;
@@ -40,12 +40,12 @@ impl GossipProtocolExecutor {
     pub(crate) async fn handle_order_info_request(
         &self,
         order_ids: &[OrderIdentifier],
-    ) -> Result<GossipResponse, GossipError> {
+    ) -> Result<GossipResponseType, GossipError> {
         let info = self.state.get_orders_batch(order_ids).await?;
         let order_info = info.into_iter().flatten().collect();
 
         let resp = OrderInfoResponse { order_info };
-        Ok(GossipResponse::OrderInfo(resp))
+        Ok(GossipResponseType::OrderInfo(resp))
     }
 
     // ---------------------

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -9,7 +9,7 @@ use gossip_api::{
     request_response::{
         heartbeat::{HeartbeatMessage, PeerInfoRequest},
         orderbook::OrderInfoRequest,
-        GossipRequest,
+        GossipRequestType,
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
@@ -55,7 +55,7 @@ impl GossipProtocolExecutor {
         }
 
         let heartbeat_message = self.state.construct_heartbeat().await?;
-        let msg = GossipRequest::Heartbeat(heartbeat_message);
+        let msg = GossipRequestType::Heartbeat(heartbeat_message);
         let job = NetworkManagerJob::request(recipient_peer_id, msg);
 
         self.network_channel.send(job).map_err(err_str!(GossipError::SendMessage))?;
@@ -87,7 +87,7 @@ impl GossipProtocolExecutor {
         message: &HeartbeatMessage,
     ) -> Result<(), GossipError> {
         let missing_orders = self.state.get_missing_orders(&message.known_orders).await?;
-        let req = GossipRequest::OrderInfo(OrderInfoRequest { order_ids: missing_orders });
+        let req = GossipRequestType::OrderInfo(OrderInfoRequest { order_ids: missing_orders });
         self.network_channel
             .send(NetworkManagerJob::request(*peer, req))
             .map_err(err_str!(GossipError::SendMessage))
@@ -100,7 +100,7 @@ impl GossipProtocolExecutor {
         message: &HeartbeatMessage,
     ) -> Result<(), GossipError> {
         let missing_peers = self.state.get_missing_peers(&message.known_peers).await?;
-        let req = GossipRequest::PeerInfo(PeerInfoRequest { peer_ids: missing_peers });
+        let req = GossipRequestType::PeerInfo(PeerInfoRequest { peer_ids: missing_peers });
         self.network_channel
             .send(NetworkManagerJob::request(*peer, req))
             .map_err(err_str!(GossipError::SendMessage))

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -8,7 +8,7 @@ use gossip_api::{
     },
     request_response::{
         heartbeat::{BootstrapRequest, PeerInfoResponse},
-        GossipResponse,
+        GossipResponseType,
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
@@ -29,7 +29,7 @@ impl GossipProtocolExecutor {
     pub async fn handle_peer_info_req(
         &self,
         peers: Vec<WrappedPeerId>,
-    ) -> Result<GossipResponse, GossipError> {
+    ) -> Result<GossipResponseType, GossipError> {
         let peer_info = self.state.get_peer_info_map().await?;
 
         let mut res = Vec::new();
@@ -39,7 +39,7 @@ impl GossipProtocolExecutor {
             }
         }
 
-        let resp = GossipResponse::PeerInfo(PeerInfoResponse { peer_info: res });
+        let resp = GossipResponseType::PeerInfo(PeerInfoResponse { peer_info: res });
         Ok(resp)
     }
 
@@ -47,12 +47,12 @@ impl GossipProtocolExecutor {
     pub async fn handle_bootstrap_req(
         &self,
         req: BootstrapRequest,
-    ) -> Result<GossipResponse, GossipError> {
+    ) -> Result<GossipResponseType, GossipError> {
         // Add the peer to the index
         self.add_new_peers(vec![req.peer_info]).await?;
         let resp = self.build_heartbeat().await?;
 
-        Ok(GossipResponse::Heartbeat(resp))
+        Ok(GossipResponseType::Heartbeat(resp))
     }
 
     /// Handle a proposed expiry from a peer

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -29,7 +29,8 @@ use gossip_api::{
         PubsubMessage,
     },
     request_response::{
-        handshake::HandshakeMessage, AuthenticatedGossipResponse, GossipRequest, GossipResponse,
+        handshake::HandshakeMessage, AuthenticatedGossipResponse, GossipRequestType,
+        GossipResponseType,
     },
 };
 use job_types::{
@@ -354,9 +355,9 @@ impl HandshakeExecutor {
         response_channel: Option<ResponseChannel<AuthenticatedGossipResponse>>,
     ) -> Result<(), HandshakeManagerError> {
         let job = if let Some(channel) = response_channel {
-            NetworkManagerJob::response(GossipResponse::Ack, channel)
+            NetworkManagerJob::response(GossipResponseType::Ack, channel)
         } else {
-            NetworkManagerJob::request(*peer_id, GossipRequest::Ack)
+            NetworkManagerJob::request(*peer_id, GossipRequestType::Ack)
         };
 
         self.network_channel.send(job).map_err(err_str!(HandshakeManagerError::SendMessage))
@@ -376,9 +377,9 @@ impl HandshakeExecutor {
         response_channel: Option<ResponseChannel<AuthenticatedGossipResponse>>,
     ) -> Result<(), HandshakeManagerError> {
         let job = if let Some(channel) = response_channel {
-            NetworkManagerJob::response(GossipResponse::Handshake(response), channel)
+            NetworkManagerJob::response(GossipResponseType::Handshake(response), channel)
         } else {
-            NetworkManagerJob::request(peer_id, GossipRequest::Handshake(response))
+            NetworkManagerJob::request(peer_id, GossipRequestType::Handshake(response))
         };
 
         self.network_channel.send(job).map_err(err_str!(HandshakeManagerError::SendMessage))

--- a/workers/job-types/src/network_manager.rs
+++ b/workers/job-types/src/network_manager.rs
@@ -3,7 +3,10 @@
 use common::types::{gossip::WrappedPeerId, handshake::ConnectionRole};
 use gossip_api::{
     pubsub::PubsubMessage,
-    request_response::{AuthenticatedGossipResponse, GossipRequest, GossipResponse},
+    request_response::{
+        AuthenticatedGossipResponse, GossipRequest, GossipRequestType, GossipResponse,
+        GossipResponseType,
+    },
 };
 use libp2p::request_response::ResponseChannel;
 use libp2p_core::Multiaddr;
@@ -63,25 +66,25 @@ impl NetworkManagerJob {
     }
 
     /// Construct a new gossip request
-    pub fn request(peer_id: WrappedPeerId, request: GossipRequest) -> Self {
-        Self::Request(peer_id, request, None)
+    pub fn request(peer_id: WrappedPeerId, request: GossipRequestType) -> Self {
+        Self::Request(peer_id, request.into(), None)
     }
 
     /// Construct a new gossip request with a response channel
     pub fn request_with_response(
         peer_id: WrappedPeerId,
-        request: GossipRequest,
+        request: GossipRequestType,
     ) -> (Self, NetworkResponseReceiver) {
         let (send, recv) = new_response_channel();
-        (Self::Request(peer_id, request, Some(send)), recv)
+        (Self::Request(peer_id, request.into(), Some(send)), recv)
     }
 
     /// Construct a new gossip response
     pub fn response(
-        response: GossipResponse,
+        response: GossipResponseType,
         channel: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Self {
-        Self::Response(response, channel)
+        Self::Response(response.into(), channel)
     }
 
     /// Construct a new internal network manager control signal


### PR DESCRIPTION
### Purpose
This PR adds basic tracing to the network manager and propagates the traces across nodes sending/receiving a message. I added a layer of encapsulation to the `GossipRequest` and `GossipResponse` to permit adding tracing headers to these types. 

### Testing
- Deployed to dev, verified that I was able to see request/response handlers together in a trace