### PR TITLE
network-manager: Spawn request authentication on blocking thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5738,6 +5738,7 @@ dependencies = [
  "system-bus",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "util",
  "uuid 1.8.0",
 ]

--- a/gossip-api/src/lib.rs
+++ b/gossip-api/src/lib.rs
@@ -8,6 +8,8 @@
 
 use ed25519_dalek::{Digest, Keypair, PublicKey, Sha512, Signature, SignatureError};
 use serde::Serialize;
+use tracing::instrument;
+use util::telemetry::helpers::backfill_trace_field;
 
 pub mod pubsub;
 pub mod request_response;
@@ -17,22 +19,30 @@ pub mod request_response;
 // -----------
 
 /// Sign a request body with the given key
+#[instrument(name = "sign_message", skip_all, fields(req_size))]
 pub fn sign_message<M: Serialize>(req: &M, key: &Keypair) -> Result<Vec<u8>, SignatureError> {
+    let buf = serde_json::to_vec(req).unwrap();
+    backfill_trace_field("req_size", buf.len());
+
     let mut hash_digest = Sha512::new();
-    hash_digest.update(&serde_json::to_vec(req).unwrap());
+    hash_digest.update(&buf);
     let sig_bytes = key.sign_prehashed(hash_digest, None /* context */)?.to_bytes();
 
     Ok(sig_bytes.to_vec())
 }
 
 /// Check a signature on a request body with the given key
+#[instrument(name = "check_signature", skip_all)]
 pub fn check_signature<M: Serialize>(
     req: &M,
     sig: &[u8],
     key: &PublicKey,
 ) -> Result<(), SignatureError> {
+    let buf = serde_json::to_vec(req).unwrap();
+    backfill_trace_field("req_size", buf.len());
+
     let mut hash_digest = Sha512::new();
-    hash_digest.update(&serde_json::to_vec(req).unwrap());
+    hash_digest.update(&buf);
     let sig = Signature::from_bytes(sig)?;
 
     key.verify_prehashed(hash_digest, None /* context */, &sig)

--- a/state/src/replication/network/gossip.rs
+++ b/state/src/replication/network/gossip.rs
@@ -64,7 +64,7 @@ impl P2PRaftNetwork for GossipNetwork {
     #[allow(clippy::blocks_in_conditions)]
     #[instrument(
         name = "send_raft_request", 
-        skip_all, err, 
+        skip_all, err
         fields(req_type = %request.type_str())
     )]
     async fn send_request(

--- a/state/src/replication/network/mod.rs
+++ b/state/src/replication/network/mod.rs
@@ -42,12 +42,14 @@ pub enum RaftRequest {
 
 impl RaftRequest {
     /// Get a string representing the request type
-    pub fn type_str(&self) -> &'static str {
+    pub fn type_str(&self) -> String {
         match self {
-            RaftRequest::AppendEntries(_) => "append_entries",
-            RaftRequest::InstallSnapshot(_) => "install_snapshot",
-            RaftRequest::Vote(_) => "vote",
-            RaftRequest::ForwardedProposal(_) => "forwarded_proposal",
+            RaftRequest::AppendEntries(req) => {
+                format!("append_entries (len = {})", req.entries.len())
+            },
+            RaftRequest::InstallSnapshot(_) => "install_snapshot".to_string(),
+            RaftRequest::Vote(_) => "vote".to_string(),
+            RaftRequest::ForwardedProposal(_) => "forwarded_proposal".to_string(),
         }
     }
 }

--- a/workers/network-manager/Cargo.toml
+++ b/workers/network-manager/Cargo.toml
@@ -36,4 +36,5 @@ util = { path = "../../util" }
 itertools = "0.11"
 serde_json = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = "0.22"
 uuid = "1.1.2"

--- a/workers/network-manager/src/executor.rs
+++ b/workers/network-manager/src/executor.rs
@@ -240,7 +240,7 @@ impl NetworkManagerExecutor {
             },
             ComposedProtocolEvent::PubSub(msg) => {
                 if let GossipsubEvent::Message { message, .. } = msg {
-                    self.handle_inbound_pubsub_message(message)?;
+                    self.handle_inbound_pubsub_message(message).await?;
                 }
 
                 Ok(())


### PR DESCRIPTION
### Purpose
This PR changes the `network-manager` to spawn all authentication tasks on the blocking pool rather than directly calling them. This prevents the async pool from being drained under heavy load with large payloads. 

A follow-up will change the cluster auth mechanism to use a symmetric scheme to further speed up these blocking operations.

### Testing
- Reproduced a bug wherein `AppendEntries` messages continuously timeout and nodes begin expiring one another. Verified that the node was much more stable after this change. Symmetric auth will further reduce this issue.