### PR TITLE
gossip-api: Use `bincode` to serialize requests for hmac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,12 +3735,12 @@ dependencies = [
 name = "gossip-api"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "circuit-types",
  "common",
  "hmac",
  "libp2p",
  "openraft",
- "protobuf",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -6872,12 +6872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
 name = "quanta"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8059,6 +8053,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/gossip-api/Cargo.toml
+++ b/gossip-api/Cargo.toml
@@ -6,18 +6,20 @@ edition = "2021"
 [dependencies]
 # === Cryptography === #
 hmac = "0.12"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["asm"] }
 
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }
 common = { path = "../common" }
 util = { path = "../util" }
 
+# === Serialization === #
+bincode = "1.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+
 # === Misc Dependencies === #
 libp2p = { workspace = true }
 openraft = "0.9"
-protobuf = "2.0"
-serde = { workspace = true }
-serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/gossip-api/src/lib.rs
+++ b/gossip-api/src/lib.rs
@@ -26,7 +26,7 @@ pub type HmacSha256 = hmac::Hmac<Sha256>;
 /// Sign a request body with the given key
 #[instrument(name = "sign_message", skip_all, fields(req_size))]
 pub fn create_hmac<M: Serialize>(req: &M, key: &ClusterSymmetricKey) -> Vec<u8> {
-    let buf = serde_json::to_vec(req).unwrap();
+    let buf = bincode::serialize(req).unwrap();
     backfill_trace_field("req_size", buf.len());
 
     let mut hmac = HmacSha256::new_from_slice(key).expect("hmac can handle all slice lengths");
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn test_hmac() {
-        const SIZE: usize = 1_000;
+        const SIZE: usize = 10_000;
         let key = [20u8; 32];
 
         let body = vec![0u8; SIZE];


### PR DESCRIPTION
### Purpose
This PR changes the serialization backend in gossip HMACs to `bincode` from `serde_json`. This results in approximately a 2x speedup.

### Testing
- Unit tests pass
- Tested a cluster with this change