### PR TITLE
state: applicator: task-queue: Do not error on missing task

### DIFF
--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -38,6 +38,11 @@ fn already_paused(id: TaskQueueKey) -> String {
     format!("task queue {id} already paused")
 }
 
+/// Error message emitted when a task id is missing
+fn missing_task_key(id: TaskIdentifier) -> String {
+    format!("task id {id} not found")
+}
+
 /// Error message emitted when the applicator attempts to preempt a conflicting
 /// committed task
 fn already_committed(id: TaskQueueKey) -> String {
@@ -156,7 +161,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
         let key = tx
             .get_queue_key_for_task(&task_id)?
-            .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_NO_KEY))?;
+            .ok_or_else(|| StateApplicatorError::Rejected(missing_task_key(task_id)))?;
 
         if tx.is_queue_paused(&key)? {
             return Err(StateApplicatorError::Rejected(already_paused(key)));


### PR DESCRIPTION
### Purpose
This PR makes two changes:
1. Do not error on missing tasks. Tasks may end up missing if their queue was cleared by a preemptive task. If this is the case, we should not error as this shuts down the raft, but instead reject the transition as the task is already completed. We saw this happen in a load test
2. Check if a queue is paused before attempting to pause it. This avoids an unnecessary rejection through raft which can be costly.

### Testing
- Unit tests pass
- Tested conflicting matches, verified that the second change took effect.