### PR TITLE
state: applicator, storage: Track task executor via `task-assignments` table

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -20,7 +20,7 @@ pub use update_wallet::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{gossip::WrappedPeerId, wallet::WalletIdentifier};
+use crate::types::wallet::WalletIdentifier;
 
 /// The error message returned when a wallet's shares are invalid
 const INVALID_WALLET_SHARES: &str = "invalid wallet shares";
@@ -36,8 +36,6 @@ pub type TaskQueueKey = Uuid;
 pub struct QueuedTask {
     /// The ID of the task
     pub id: TaskIdentifier,
-    /// The peer assigned to the task
-    pub executor: WrappedPeerId,
     /// The state of the task
     pub state: QueuedTaskState,
     /// The task descriptor
@@ -202,10 +200,7 @@ pub mod mocks {
     use k256::ecdsa::SigningKey as K256SigningKey;
     use util::get_current_time_millis;
 
-    use crate::types::{
-        gossip::mocks::mock_peer, tasks::TaskIdentifier, wallet::Wallet,
-        wallet_mocks::mock_empty_wallet,
-    };
+    use crate::types::{tasks::TaskIdentifier, wallet::Wallet, wallet_mocks::mock_empty_wallet};
 
     use super::{
         NewWalletTaskDescriptor, QueuedTask, QueuedTaskState, TaskDescriptor, TaskQueueKey,
@@ -232,7 +227,6 @@ pub mod mocks {
     pub fn mock_queued_task(queue_key: TaskQueueKey) -> super::QueuedTask {
         QueuedTask {
             id: TaskIdentifier::new_v4(),
-            executor: mock_peer().peer_id,
             state: QueuedTaskState::Queued,
             descriptor: mock_task_descriptor(queue_key),
             created_at: get_current_time_millis(),

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -79,13 +79,13 @@ impl StateApplicator {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
-            StateTransition::AppendTask { task } => self.append_task(&task),
+            StateTransition::AppendTask { task, executor } => self.append_task(&task, &executor),
             StateTransition::PopTask { task_id, success } => self.pop_task(task_id, success),
             StateTransition::TransitionTask { task_id, state } => {
                 self.transition_task_state(task_id, state)
             },
-            StateTransition::PreemptTaskQueues { keys, task } => {
-                self.preempt_task_queues(&keys, &task)
+            StateTransition::PreemptTaskQueues { keys, task, executor } => {
+                self.preempt_task_queues(&keys, &task, &executor)
             },
             StateTransition::ResumeTaskQueues { keys, success } => {
                 self.resume_task_queues(&keys, success)

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -141,13 +141,13 @@ impl State {
         let task = QueuedTask {
             id,
             state: QueuedTaskState::Queued,
-            executor: self_id,
             descriptor: task,
             created_at: get_current_time_millis(),
         };
 
         // Propose the task to the task queue
-        let waiter = self.send_proposal(StateTransition::AppendTask { task }).await?;
+        let proposal = StateTransition::AppendTask { task, executor: self_id };
+        let waiter = self.send_proposal(proposal).await?;
         Ok((id, waiter))
     }
 
@@ -195,12 +195,12 @@ impl State {
         let task = QueuedTask {
             id: task_id,
             state: QueuedTaskState::Preemptive,
-            executor: self_id,
             descriptor: task,
             created_at: get_current_time_millis(),
         };
 
-        self.send_proposal(StateTransition::PreemptTaskQueues { keys, task }).await
+        let proposal = StateTransition::PreemptTaskQueues { keys, task, executor: self_id };
+        self.send_proposal(proposal).await
     }
 
     /// Resume a task queue

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -134,7 +134,7 @@ pub enum StateTransition {
 
     // --- Task Queue --- //
     /// Add a task to the task queue
-    AppendTask { task: QueuedTask },
+    AppendTask { task: QueuedTask, executor: WrappedPeerId },
     /// Pop the top task from the task queue
     PopTask { task_id: TaskIdentifier, success: bool },
     /// Transition the state of the top task in the task queue
@@ -142,9 +142,9 @@ pub enum StateTransition {
     /// Preempt the given task queue
     ///
     /// Returns any running tasks to `Queued` state and pauses the queue
-    PreemptTaskQueues { keys: Vec<TaskQueueKey>, task: QueuedTask },
+    PreemptTaskQueues { keys: Vec<TaskQueueKey>, task: QueuedTask, executor: WrappedPeerId },
     /// Resume the given task queue
-    ResumeTaskQueues { keys: Vec<TaskQueueKey>, success: bool },
+    ResumeTaskQueues { keys: Vec<TaskQueueKey>, success: bool},
 
     // --- MPC Preprocessing --- //
     /// Add a preprocessing bundle to the state

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -44,7 +44,7 @@ use uuid::Uuid;
 // -------------
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 14;
+const NUM_TABLES: usize = 15;
 
 /// The name of the db table that stores node metadata
 pub(crate) const NODE_METADATA_TABLE: &str = "node-metadata";
@@ -70,6 +70,8 @@ pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
 /// The name of the db table that maps tasks to their queue key
 pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
+/// The name of the db table that maps nodes to their assigned tasks
+pub(crate) const TASK_ASSIGNMENT_TABLE: &str = "task-assignments";
 /// The name of the db table that stores historical task information
 pub(crate) const TASK_HISTORY_TABLE: &str = "task-history";
 
@@ -92,6 +94,7 @@ pub const ALL_TABLES: [&str; NUM_TABLES] = [
     WALLETS_TABLE,
     TASK_QUEUE_TABLE,
     TASK_TO_KEY_TABLE,
+    TASK_ASSIGNMENT_TABLE,
     TASK_HISTORY_TABLE,
     MPC_PREPROCESSING_TABLE,
     RAFT_METADATA_TABLE,

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -12,6 +12,7 @@ pub mod order_book;
 pub mod order_history;
 pub mod peer_index;
 pub mod raft_log;
+pub mod task_assignments;
 pub mod task_history;
 pub mod task_queue;
 pub mod wallet_index;

--- a/state/src/storage/tx/task_assignments.rs
+++ b/state/src/storage/tx/task_assignments.rs
@@ -1,0 +1,136 @@
+//! Handles storage operations on the table that tracks the assignment of tasks
+//! to nodes
+
+// -----------
+// | Getters |
+// -----------
+
+use common::types::{gossip::WrappedPeerId, tasks::TaskIdentifier};
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, TASK_ASSIGNMENT_TABLE};
+
+use super::StateTxn;
+
+/// Get the key for the list of tasks assigned to a node
+fn node_tasks_key(id: &WrappedPeerId) -> String {
+    format!("assigned-tasks-{id}")
+}
+
+/// Get the key for a task's assignment
+fn task_assignment_key(task_id: &TaskIdentifier) -> String {
+    format!("task-assignment-{task_id}")
+}
+
+/// Create a key not found error for a task assignment
+fn task_not_found_err(task_id: &TaskIdentifier) -> StorageError {
+    StorageError::NotFound(format!("Task {task_id} not found"))
+}
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the tasks assigned to a node
+    pub fn get_assigned_tasks(
+        &self,
+        peer_id: &WrappedPeerId,
+    ) -> Result<Vec<TaskIdentifier>, StorageError> {
+        let key = node_tasks_key(peer_id);
+        self.read_set(TASK_ASSIGNMENT_TABLE, &key)
+    }
+
+    /// Get the node assigned to a given task
+    pub fn get_task_assignment(
+        &self,
+        task_id: &TaskIdentifier,
+    ) -> Result<WrappedPeerId, StorageError> {
+        let key = task_assignment_key(task_id);
+        let value = self
+            .inner()
+            .read(TASK_ASSIGNMENT_TABLE, &key)?
+            .ok_or_else(|| task_not_found_err(task_id))?;
+
+        Ok(value)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Push a task to the list of assigned tasks for a node
+    pub fn add_assigned_tasks(
+        &self,
+        peer_id: &WrappedPeerId,
+        task_id: &TaskIdentifier,
+    ) -> Result<(), StorageError> {
+        let key = node_tasks_key(peer_id);
+        self.add_to_set(TASK_ASSIGNMENT_TABLE, &key, task_id)?;
+
+        // Set the inverse assignment
+        self.assign_task_to_node(task_id, peer_id)
+    }
+
+    /// Remove a task from the list of assigned tasks for a node
+    pub fn remove_assigned_task(
+        &self,
+        peer_id: &WrappedPeerId,
+        task_id: &TaskIdentifier,
+    ) -> Result<(), StorageError> {
+        let key = node_tasks_key(peer_id);
+        self.remove_from_set(TASK_ASSIGNMENT_TABLE, &key, task_id)?;
+
+        // Delete the assignment
+        let key = task_assignment_key(task_id);
+        self.inner().delete(TASK_ASSIGNMENT_TABLE, &key)?;
+        Ok(())
+    }
+
+    /// Add an assignment from a task id to a node
+    fn assign_task_to_node(
+        &self,
+        task_id: &TaskIdentifier,
+        peer_id: &WrappedPeerId,
+    ) -> Result<(), StorageError> {
+        let key = task_assignment_key(task_id);
+        self.inner().write(TASK_ASSIGNMENT_TABLE, &key, peer_id)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use common::types::{gossip::mocks::mock_peer, tasks::TaskIdentifier};
+
+    use crate::test_helpers::mock_db;
+
+    /// Tests the basic flow of adding and removing task assignments
+    #[test]
+    fn test_assignments() {
+        let db = mock_db();
+        let peer_id = mock_peer().get_peer_id();
+        let task_id = TaskIdentifier::new_v4();
+        let tx = db.new_write_tx().unwrap();
+
+        // First check the assigned tasks => should be empty
+        let assigned_tasks = tx.get_assigned_tasks(&peer_id).unwrap();
+        assert_eq!(assigned_tasks, vec![]);
+
+        // Add the task to the assigned tasks
+        tx.add_assigned_tasks(&peer_id, &task_id).unwrap();
+
+        // Check the assigned tasks => should be empty
+        let assigned_tasks = tx.get_assigned_tasks(&peer_id).unwrap();
+        let task_assignment = tx.get_task_assignment(&task_id).unwrap();
+        assert_eq!(assigned_tasks, vec![task_id]);
+        assert_eq!(task_assignment, peer_id);
+
+        // Remove the task from the assigned tasks
+        tx.remove_assigned_task(&peer_id, &task_id).unwrap();
+
+        // Check the assigned tasks => should be empty
+        let assigned_tasks = tx.get_assigned_tasks(&peer_id).unwrap();
+        let task_assignment = tx.get_task_assignment(&task_id);
+        assert_eq!(assigned_tasks, vec![]);
+        assert!(task_assignment.is_err());
+    }
+}


### PR DESCRIPTION
### Purpose
This PR removes the `executor` field on each task in favor of tracking this information in a `task-assignments` table. Doing so will allow us to re-assign tasks when a node goes down in a simpler manner. I.e. by updating this index.

### Testing
- Unit tests pass; more will come in reassignment PR
- Tested the basic task flows 