### PR TITLE
workers: handshake-manager: internal_engine: use direct pair price

### DIFF
--- a/common/src/types/wallet/keychain.rs
+++ b/common/src/types/wallet/keychain.rs
@@ -1,6 +1,7 @@
 //! Keychain helpers for the wallet
 
 use constants::Scalar;
+use contracts_common::custom_serde::BytesSerializable;
 use ethers::{
     core::k256::ecdsa::SigningKey as EthersSigningKey,
     types::{Signature, U256},
@@ -24,7 +25,7 @@ impl Wallet {
         let key = EthersSigningKey::try_from(root_key)?;
 
         // Hash the message and sign it
-        let comm_bytes = commitment.to_biguint().to_bytes_be();
+        let comm_bytes = commitment.inner().serialize_to_bytes();
         let digest = keccak256(comm_bytes);
         let (sig, recovery_id) = key
             .sign_prehash_recoverable(&digest)

--- a/workers/handshake-manager/src/error.rs
+++ b/workers/handshake-manager/src/error.rs
@@ -20,6 +20,8 @@ pub enum HandshakeManagerError {
     Multiprover(String),
     /// Necessary price data was not available for a token pair
     NoPriceData(String),
+    /// Error interacting with the price reporter
+    PriceReporter(String),
     /// Error sending a message to the network
     SendMessage(String),
     /// Error while setting up the handshake manager


### PR DESCRIPTION
This PR tweaks the `get_execution_price` method of the internal matching engine to request the order pair's price directly from the price reporter, as opposed to fetching the price vector of default pairs and looking within it for the necessary pair.

This fixes a bug wherein we could not settle matches on orders for pairs outside of the default pair list.

I tested this by running a relayer locally and successfully settling a match on the MKR-USDC pair.

Additionally, I noticed the `sign_commitments` method on the `Wallet` type was still using the wrong serialization of the commitment, so I updated that to serialize in the same way as the contracts. This was covered by my above test, as I used the CLI, which invokes this method to generate a wallet update signature. A commitment whose signature was previously getting rejected by the relayer was successfully used in an update wallet task after this change.