### PR TITLE
state: applicator: Reassign tasks when cluster peer removed

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -71,6 +71,7 @@ impl QueuedTaskState {
     /// Whether the task is running
     pub fn is_running(&self) -> bool {
         matches!(self, QueuedTaskState::Running { .. })
+            || matches!(self, QueuedTaskState::Preemptive)
     }
 
     /// Whether the task is committed

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -90,6 +90,7 @@ impl StateApplicator {
             StateTransition::ResumeTaskQueues { keys, success } => {
                 self.resume_task_queues(&keys, success)
             },
+            StateTransition::ReassignTasks { from, to } => self.reassign_tasks(&from, &to),
             StateTransition::AddMpcPreprocessingValues { cluster, values } => {
                 self.add_preprocessing_values(&cluster, &values)
             },

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -223,7 +223,8 @@ impl State {
 
         if is_cluster_peer {
             let raft_id = get_raft_id(&peer_id);
-            this.raft.remove_peer(raft_id).await?;
+            self.raft.remove_peer(raft_id).await?;
+            self.reassign_tasks(&peer_id).await?;
         }
 
         Ok(())

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -145,6 +145,8 @@ pub enum StateTransition {
     PreemptTaskQueues { keys: Vec<TaskQueueKey>, task: QueuedTask, executor: WrappedPeerId },
     /// Resume the given task queue
     ResumeTaskQueues { keys: Vec<TaskQueueKey>, success: bool},
+    /// Reassign all tasks from one peer to another peer
+    ReassignTasks { from: WrappedPeerId, to: WrappedPeerId },
 
     // --- MPC Preprocessing --- //
     /// Add a preprocessing bundle to the state

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -128,7 +128,7 @@ impl<'db> StateTxn<'db, RW> {
         // Check if the value is already in the set
         if !set.contains(value) {
             set.push(value.clone());
-            self.inner().write(table_name, key, &set)?;
+            self.write_set(table_name, key, &set)?;
         }
 
         Ok(())
@@ -150,9 +150,18 @@ impl<'db> StateTxn<'db, RW> {
         set.retain(|v| v != value);
 
         // Write the updated set back to the database
-        self.inner().write(table_name, key, &set)?;
-
+        self.write_set(table_name, key, &set)?;
         Ok(())
+    }
+
+    /// Write a set type to the database
+    pub(crate) fn write_set<K: Key, V: Value>(
+        &self,
+        table_name: &str,
+        key: &K,
+        value: &Vec<V>,
+    ) -> Result<(), StorageError> {
+        self.inner().write(table_name, key, value)
     }
 
     // ----------


### PR DESCRIPTION
### Purpose
This PR adds a `ReassignTasks` state transition that is appended to the log when a peer is removed from the cluster. This task reassigns all tasks on a failed node to the log proposer.

### Testing
- Unit tests pass
- Killed a node while it was executing a task; verified that its task was reassigned and executed.
- Killed a node with a queued (not yet executing task). Verified that the task was dequeued and executed on one of the remaining nodes