### PR TITLE
common: wallet: Make order matchable only if receive balance available

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -74,6 +74,12 @@ impl Wallet {
         self.balances.values().any(|balance| balance.fees().total() > 0)
     }
 
+    /// Whether the wallet has any zero'd balances that may be used for
+    /// receiving a new mint
+    pub fn has_empty_balance(&self) -> bool {
+        self.balances.values().any(|balance| balance.is_zero())
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -62,7 +62,14 @@ impl Wallet {
                     None => false,
                 };
 
-                !order.is_zero() && has_balance
+                let receive_mint = order.receive_mint();
+                let has_receive_balance = match self.get_balance(receive_mint) {
+                    Some(balance) => balance.amount > 0,
+                    // If no receive balance exists, there must be an open balance to overwrite
+                    None => self.has_empty_balance(),
+                };
+
+                !order.is_zero() && has_balance && has_receive_balance
             })
             .cloned()
             .collect_vec()


### PR DESCRIPTION
### Purpose
This PR adds a check for an open augmentation or existing receive balance in the `get_matchable_orders` method on the `Wallet`. This resolves a bug wherein the balances for a wallet are full and the `UpdateValidityProofs` step in each task fails as no receive balance is available for an order that we're attempting to prove validity for.

### Testing
- Reproduced the bug locally, verified that this change fixed it