### PR TITLE
state: Fix flakey unit tests

### DIFF
--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -19,7 +19,6 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
     ops::Deref,
     str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use util::{get_current_time_millis, networking::is_dialable_multiaddr};
 
@@ -77,7 +76,7 @@ impl PeerInfo {
             peer_id,
             cluster_id,
             cluster_auth_signature,
-            last_heartbeat: current_time_seconds(),
+            last_heartbeat: get_current_time_millis(),
         }
     }
 
@@ -283,11 +282,6 @@ impl FromStr for ClusterId {
 // -----------
 // | Helpers |
 // -----------
-
-/// Returns a u64 representing the current unix timestamp in seconds
-fn current_time_seconds() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_secs()
-}
 
 #[cfg(feature = "mocks")]
 pub mod mocks {

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -123,8 +123,8 @@ pub mod test_helpers {
         // All timeouts in ms
         RaftClientConfig {
             cluster_name: "mock-cluster".to_string(),
-            election_timeout_min: 10,
-            election_timeout_max: 15,
+            election_timeout_min: 20,
+            election_timeout_max: 25,
             heartbeat_interval: 5,
             initial_nodes,
             ..Default::default()
@@ -621,7 +621,7 @@ mod test {
         for i in 0..N - SCALE_TO {
             let removed_nid = N - i - 1;
             client.remove_peer(removed_nid as u64).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
         // Propose a state transition and ensure consensus is reached

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -248,6 +248,7 @@ impl StateMachine {
     ) -> Result<(), ReplicationV2Error> {
         self.last_applied_log = meta.last_log_id;
         self.last_membership = meta.last_membership.clone();
+        self.write_snapshot_metadata(meta)?;
 
         let db_clone = self.db_owned();
         let jh = tokio::task::spawn_blocking(move || Self::copy_db_data(&snapshot_db, &db_clone));


### PR DESCRIPTION
### Purpose
This PR fixes a few flakey and incorrect unit tests in the `state` crate. Some tests are still somewhat flakey, but they now are all passable.