### PR TITLE
state: interface, replication: add timer for syncing missed raft learners

### DIFF
--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -59,8 +59,6 @@ const LEARNER_PROMOTION_MS: u64 = 5_000; // 5 seconds
 const PANIC_CHECK_MS: u64 = 10_000; // 10 seconds
 /// The frequency with which to check for missed expiry
 const EXPIRY_CHECK_MS: u64 = 10_000; // 10 seconds
-/// The frequency with which to attempt syncing missed learners
-const MISSED_LEARNERS_MS: u64 = 5_000; // 5 seconds
 
 /// A type alias for a proposal queue of state transitions
 pub type ProposalQueue = UnboundedSender<Proposal>;
@@ -172,7 +170,6 @@ impl State {
         this.setup_learner_promotion_timer(&system_clock).await?;
         this.setup_core_panic_timer(&system_clock, failure_send).await?;
         this.setup_expiry_timer(&system_clock).await?;
-        this.setup_missed_learners_timer(&system_clock).await?;
 
         Ok(this)
     }
@@ -259,39 +256,7 @@ impl State {
                         tx.get_cluster_peers(&cluster_id).map_err(raw_err_str!("{}"))?;
                     tx.commit().map_err(raw_err_str!("{}"))?;
 
-                    client.check_expired_nodes(known_cluster_peers).await.map_err(|e| e.to_string())
-                }
-            })
-            .await
-            .map_err(StateError::Clock)
-    }
-
-    /// Periodically checks for missed raft peers, i.e. nodes that have been
-    /// added as cluster peers at the gossip layer but are not a part of the
-    /// raft membership
-    async fn setup_missed_learners_timer(&self, clock: &SystemClock) -> Result<(), StateError> {
-        let duration = Duration::from_millis(MISSED_LEARNERS_MS);
-        let name = "raft-missed-learners-loop".to_string();
-        let client = self.raft.clone();
-        let db = self.db.clone();
-        let my_cluster = self.get_cluster_id().await?;
-
-        clock
-            .add_async_timer(name, duration, move || {
-                let db = db.clone();
-                let client = client.clone();
-                let cluster_id = my_cluster.clone();
-
-                async move {
-                    let tx = db.new_read_tx().map_err(raw_err_str!("{}"))?;
-                    let known_cluster_peers =
-                        tx.get_cluster_peers(&cluster_id).map_err(raw_err_str!("{}"))?;
-                    tx.commit().map_err(raw_err_str!("{}"))?;
-
-                    client
-                        .sync_missed_learners(known_cluster_peers)
-                        .await
-                        .map_err(|e| e.to_string())
+                    client.sync_membership(known_cluster_peers).await.map_err(|e| e.to_string())
                 }
             })
             .await

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -180,9 +180,7 @@ impl State {
         // Before a raft is setup, we only want to populate the peer index, and not
         // attempt to form a raft
         if self.raft.is_initialized().await? {
-            for (raft_id, info) in learners.into_iter() {
-                this.raft.add_learner(raft_id, info).await?;
-            }
+            this.raft.add_learners(learners).await?;
         }
 
         Ok(())

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -162,7 +162,7 @@ pub enum StateTransition {
     /// Add a raft learner to the cluster
     AddRaftLearners { learners: Vec<(NodeId, RaftNode)> },
     /// Add a raft peer to the local consensus cluster
-    AddRaftVoter { peer_id: NodeId },
+    AddRaftVoters { peer_ids: Vec<NodeId> },
     /// Remove a raft peer from the local consensus cluster
     RemoveRaftPeer { peer_id: NodeId },
 }
@@ -305,7 +305,7 @@ pub mod test_helpers {
             tokio::time::sleep(Duration::from_millis(20)).await;
 
             // Add the node as a voter
-            let prop = StateTransition::AddRaftVoter { peer_id: *id };
+            let prop = StateTransition::AddRaftVoters { peer_id: *id };
             state.send_proposal(prop).await.unwrap();
             tokio::time::sleep(Duration::from_millis(20)).await;
         }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -160,7 +160,7 @@ pub enum StateTransition {
 
     // --- Raft --- //
     /// Add a raft learner to the cluster
-    AddRaftLearner { peer_id: NodeId, info: RaftNode },
+    AddRaftLearners { learners: Vec<(NodeId, RaftNode)> },
     /// Add a raft peer to the local consensus cluster
     AddRaftVoter { peer_id: NodeId },
     /// Remove a raft peer from the local consensus cluster
@@ -300,7 +300,7 @@ pub mod test_helpers {
 
             // Add the node as a learner
             let info = RaftNode::default();
-            let prop = StateTransition::AddRaftLearner { peer_id: *id, info };
+            let prop = StateTransition::AddRaftLearners { peer_id: *id, info };
             state.send_proposal(prop).await.unwrap();
             tokio::time::sleep(Duration::from_millis(20)).await;
 

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -451,7 +451,7 @@ mod test {
         assert!(wallet.is_some());
 
         // Promote the learner, propose a new wallet, ensure consensus is reached
-        client.promote_learner(new_nid).await.unwrap();
+        client.promote_learners(new_nid).await.unwrap();
         let wallet = mock_empty_wallet();
         let wallet_id = wallet.wallet_id;
         let update = Proposal::from(StateTransition::AddWallet { wallet });
@@ -482,7 +482,7 @@ mod test {
         let new_nid = N as u64 + 1;
         raft.add_node(new_nid).await;
         client.add_learners(new_nid, RaftNode::default()).await.unwrap();
-        client.promote_learner(new_nid).await.unwrap();
+        client.promote_learners(new_nid).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Propose a new state transition
@@ -519,7 +519,7 @@ mod test {
             let new_nid = i as u64;
             raft.add_node(new_nid).await;
             client.add_learners(new_nid, RaftNode::default()).await.unwrap();
-            client.promote_learner(new_nid).await.unwrap();
+            client.promote_learners(new_nid).await.unwrap();
         }
 
         // Propose a new wallet and check that each node in the cluster has the wallet

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -442,7 +442,7 @@ mod test {
         raft.add_node(new_nid).await;
 
         // Add the node as a learner
-        client.add_learner(new_nid, RaftNode::default()).await.unwrap();
+        client.add_learners(new_nid, RaftNode::default()).await.unwrap();
 
         // Check the DB of the new node
         let db = raft.get_db(new_nid).await;
@@ -481,7 +481,7 @@ mod test {
         // Add a new node as a learner
         let new_nid = N as u64 + 1;
         raft.add_node(new_nid).await;
-        client.add_learner(new_nid, RaftNode::default()).await.unwrap();
+        client.add_learners(new_nid, RaftNode::default()).await.unwrap();
         client.promote_learner(new_nid).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -518,7 +518,7 @@ mod test {
         for i in 1..N {
             let new_nid = i as u64;
             raft.add_node(new_nid).await;
-            client.add_learner(new_nid, RaftNode::default()).await.unwrap();
+            client.add_learners(new_nid, RaftNode::default()).await.unwrap();
             client.promote_learner(new_nid).await.unwrap();
         }
 


### PR DESCRIPTION
This PR adds a timer loop checking whether any peers indexed through gossip have failed to be added to the raft, and if so, adds them as learners. The learner promotion loop will ensure they are promoted to voters when appropriate.

This helps to alleviate situations in which learner additions are missed, e.g. if the cluster is simultaneously going through another configuration change. This is presumed to be the reason why some nodes initialize a fresh raft when the cluster is scaling out.

I tested this by triggering a cluster upgrade in dev. There, we did still see a node initialize a fresh raft, unfortunately - however, the node still ceded leadership when it saw a greater log from the actual leader, and this loop ensured that the leader added this node as a learner (& subsequently promoted it to a voter), stabilizing the raft.