### PR TITLE
common: wallet: balances: Allow empty balances in validity proofs

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -77,7 +77,8 @@ impl Wallet {
     /// Whether the wallet has any zero'd balances that may be used for
     /// receiving a new mint
     pub fn has_empty_balance(&self) -> bool {
-        self.balances.values().any(|balance| balance.is_zero())
+        self.balances.len() < MAX_BALANCES
+            || self.balances.values().any(|balance| balance.is_zero())
     }
 
     // -----------

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -63,11 +63,8 @@ impl Wallet {
                 };
 
                 let receive_mint = order.receive_mint();
-                let has_receive_balance = match self.get_balance(receive_mint) {
-                    Some(balance) => balance.amount > 0,
-                    // If no receive balance exists, there must be an open balance to overwrite
-                    None => self.has_empty_balance(),
-                };
+                let has_receive_balance =
+                    self.get_balance(receive_mint).is_some() || self.has_empty_balance();
 
                 !order.is_zero() && has_balance && has_receive_balance
             })


### PR DESCRIPTION
### Purpose
This PR fixes a bug wherein new wallets or wallets with unused balances would fail to attempt validity proofs on new orders. This was because of an overly-restrictive condition in `get_matchable_orders`

### Testing
- Unit tests pass
- Tested new wallet flows locally