### PR TITLE
task-driver: tasks: refresh-wallet: Implement wallet refresh task

### DIFF
--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -90,6 +90,8 @@ impl ArbitrumClient {
     }
 
     /// Check whether the given nullifier is used
+    ///
+    /// Returns `true` if the nullifier is used, `false` otherwise
     #[instrument(skip_all, err, fields(nullifier = %nullifier))]
     pub async fn check_nullifier_used(
         &self,

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -4,6 +4,7 @@ mod new_wallet;
 mod node_startup;
 mod pay_fees;
 mod redeem_fees;
+mod refresh_wallet;
 mod settle_match;
 mod update_merkle_proof;
 mod update_wallet;
@@ -13,6 +14,7 @@ pub use new_wallet::*;
 pub use node_startup::*;
 pub use pay_fees::*;
 pub use redeem_fees::*;
+pub use refresh_wallet::*;
 pub use settle_match::*;
 pub use update_merkle_proof::*;
 pub use update_wallet::*;
@@ -99,6 +101,8 @@ pub enum TaskDescriptor {
     NewWallet(NewWalletTaskDescriptor),
     /// The task descriptor for the `LookupWallet` task
     LookupWallet(LookupWalletTaskDescriptor),
+    /// The task descriptor for the `RefreshWallet` task
+    RefreshWallet(RefreshWalletTaskDescriptor),
     /// The task descriptor for the `PayProtocolFee` task
     OfflineFee(PayOfflineFeeTaskDescriptor),
     /// The task descriptor for the `PayRelayerFee` task
@@ -123,6 +127,7 @@ impl TaskDescriptor {
         match self {
             TaskDescriptor::NewWallet(task) => task.wallet.wallet_id,
             TaskDescriptor::LookupWallet(task) => task.wallet_id,
+            TaskDescriptor::RefreshWallet(task) => task.wallet_id,
             TaskDescriptor::OfflineFee(task) => task.wallet_id,
             TaskDescriptor::RelayerFee(task) => task.wallet_id,
             TaskDescriptor::RedeemRelayerFee(task) => task.wallet_id,
@@ -143,6 +148,7 @@ impl TaskDescriptor {
         match self {
             TaskDescriptor::NewWallet(task) => vec![task.wallet.wallet_id],
             TaskDescriptor::LookupWallet(task) => vec![task.wallet_id],
+            TaskDescriptor::RefreshWallet(task) => vec![task.wallet_id],
             TaskDescriptor::OfflineFee(task) => vec![task.wallet_id],
             TaskDescriptor::RelayerFee(task) => vec![task.wallet_id],
             TaskDescriptor::RedeemRelayerFee(task) => vec![task.wallet_id],
@@ -159,6 +165,7 @@ impl TaskDescriptor {
         match self {
             TaskDescriptor::NewWallet(_)
             | TaskDescriptor::LookupWallet(_)
+            | TaskDescriptor::RefreshWallet(_)
             | TaskDescriptor::OfflineFee(_)
             | TaskDescriptor::RelayerFee(_)
             | TaskDescriptor::RedeemRelayerFee(_)
@@ -176,6 +183,7 @@ impl TaskDescriptor {
             TaskDescriptor::NewWallet(_) => "New Wallet".to_string(),
             TaskDescriptor::UpdateWallet(args) => args.description.display_description(),
             TaskDescriptor::LookupWallet(_) => "Lookup Wallet".to_string(),
+            TaskDescriptor::RefreshWallet(_) => "Refresh Wallet".to_string(),
             TaskDescriptor::SettleMatch(_) => "Settle Match".to_string(),
             TaskDescriptor::SettleMatchInternal(_) => "Settle Match".to_string(),
             TaskDescriptor::OfflineFee(_) => "Pay Fee Offline".to_string(),

--- a/common/src/types/tasks/descriptors/refresh_wallet.rs
+++ b/common/src/types/tasks/descriptors/refresh_wallet.rs
@@ -1,0 +1,29 @@
+//! Descriptor for the refresh wallet task
+//!
+//! This task is responsible for refreshing the wallet from on-chain state
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::wallet::WalletIdentifier;
+
+use super::TaskDescriptor;
+
+/// The descriptor for the refresh wallet task
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct RefreshWalletTaskDescriptor {
+    /// The wallet to refresh
+    pub wallet_id: WalletIdentifier,
+}
+
+impl RefreshWalletTaskDescriptor {
+    /// Create a new refresh wallet task descriptor
+    pub fn new(wallet_id: WalletIdentifier) -> Self {
+        Self { wallet_id }
+    }
+}
+
+impl From<RefreshWalletTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: RefreshWalletTaskDescriptor) -> Self {
+        Self::RefreshWallet(descriptor)
+    }
+}

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -33,6 +33,7 @@ use crate::{
         pay_offline_fee::{PayOfflineFeeTask, PayOfflineFeeTaskState},
         pay_relayer_fee::{PayRelayerFeeTask, PayRelayerFeeTaskState},
         redeem_relayer_fee::{RedeemRelayerFeeTask, RedeemRelayerFeeTaskState},
+        refresh_wallet::{RefreshWalletTask, RefreshWalletTaskState},
         settle_match::{SettleMatchTask, SettleMatchTaskState},
         settle_match_internal::{SettleMatchInternalTask, SettleMatchInternalTaskState},
         update_merkle_proof::{UpdateMerkleProofTask, UpdateMerkleProofTaskState},
@@ -319,6 +320,9 @@ impl TaskExecutor {
             TaskDescriptor::LookupWallet(desc) => {
                 self.start_task_helper::<LookupWalletTask>(immediate, id, desc).await
             },
+            TaskDescriptor::RefreshWallet(desc) => {
+                self.start_task_helper::<RefreshWalletTask>(immediate, id, desc).await
+            },
             TaskDescriptor::OfflineFee(desc) => {
                 self.start_task_helper::<PayOfflineFeeTask>(immediate, id, desc).await
             },
@@ -427,6 +431,8 @@ impl TaskExecutor {
 pub enum StateWrapper {
     /// The state object for the lookup wallet task
     LookupWallet(LookupWalletTaskState),
+    /// The state object for the refresh wallet task
+    RefreshWallet(RefreshWalletTaskState),
     /// The state object for the new wallet task
     NewWallet(NewWalletTaskState),
     /// The state object for the pay protocol fee task
@@ -452,6 +458,7 @@ impl StateWrapper {
     pub fn committed(&self) -> bool {
         match self {
             StateWrapper::LookupWallet(state) => state.committed(),
+            StateWrapper::RefreshWallet(state) => state.committed(),
             StateWrapper::NewWallet(state) => state.committed(),
             StateWrapper::PayOfflineFee(state) => state.committed(),
             StateWrapper::PayRelayerFee(state) => state.committed(),
@@ -469,6 +476,7 @@ impl StateWrapper {
     pub fn is_committing(&self) -> bool {
         match self {
             StateWrapper::LookupWallet(state) => state == &LookupWalletTaskState::commit_point(),
+            StateWrapper::RefreshWallet(state) => state == &RefreshWalletTaskState::commit_point(),
             StateWrapper::NewWallet(state) => state == &NewWalletTaskState::commit_point(),
             StateWrapper::PayOfflineFee(state) => state == &PayOfflineFeeTaskState::commit_point(),
             StateWrapper::PayRelayerFee(state) => state == &PayRelayerFeeTaskState::commit_point(),
@@ -491,6 +499,7 @@ impl StateWrapper {
     pub fn completed(&self) -> bool {
         match self {
             StateWrapper::LookupWallet(state) => state.completed(),
+            StateWrapper::RefreshWallet(state) => state.completed(),
             StateWrapper::NewWallet(state) => state.completed(),
             StateWrapper::PayOfflineFee(state) => state.completed(),
             StateWrapper::PayRelayerFee(state) => state.completed(),
@@ -508,6 +517,7 @@ impl Display for StateWrapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
             StateWrapper::LookupWallet(state) => state.to_string(),
+            StateWrapper::RefreshWallet(state) => state.to_string(),
             StateWrapper::NewWallet(state) => state.to_string(),
             StateWrapper::PayOfflineFee(state) => state.to_string(),
             StateWrapper::PayRelayerFee(state) => state.to_string(),

--- a/workers/task-driver/src/helpers.rs
+++ b/workers/task-driver/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Helpers for common functionality across tasks
 
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use arbitrum_client::{client::ArbitrumClient, errors::ArbitrumClientError};
 use circuit_types::{
@@ -12,7 +12,8 @@ use circuit_types::{
     note::Note,
     order::Order,
     r#match::{MatchResult, OrderSettlementIndices},
-    SizedWallet,
+    traits::BaseType,
+    SizedWallet, SizedWalletShare,
 };
 use circuits::zk_circuits::{
     proof_linking::link_sized_commitments_reblind,
@@ -30,15 +31,18 @@ use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::OrderIdentifier,
 };
+use constants::Scalar;
 use gossip_api::pubsub::{
     orderbook::{OrderBookManagementMessage, ORDER_BOOK_TOPIC},
     PubsubMessage,
 };
+use itertools::Itertools;
 use job_types::{
     network_manager::{NetworkManagerJob, NetworkManagerQueue},
     proof_manager::{ProofJob, ProofManagerJob, ProofManagerQueue},
 };
 use num_bigint::BigUint;
+use renegade_crypto::hash::PoseidonCSPRNG;
 use state::State;
 use tokio::sync::oneshot::{self, Receiver as TokioReceiver};
 
@@ -60,6 +64,8 @@ const ERR_PROVE_COMMITMENTS_FAILED: &str = "failed to prove valid commitments";
 const ERR_PROVE_REBLIND_FAILED: &str = "failed to prove valid reblind";
 /// The error message emitted when metadata for an order cannot be found
 const ERR_NO_ORDER_METADATA: &str = "order metadata not found";
+/// The error thrown when the wallet cannot be found in tx history
+pub const ERR_WALLET_NOT_FOUND: &str = "wallet not found in wallet_last_updated map";
 
 // ----------------
 // | Order States |
@@ -96,6 +102,71 @@ pub async fn record_order_fill(
 
     state.update_order_metadata(metadata).await?;
     Ok(())
+}
+
+// -----------------
+// | Wallet Lookup |
+// -----------------
+
+/// Get the i'th set of private shares for a wallet from the given share seed
+///
+/// The `idx` here is an index (in number of wallets) into the share CSPRNG
+/// stream
+pub(crate) fn gen_private_shares(
+    idx: usize,
+    share_seed: Scalar,
+    private_blinder: Scalar,
+) -> SizedWalletShare {
+    // Subtract one from the number of scalars to account for the wallet blinder
+    // private share, which is sampled from the blinder stream instead of the
+    // share stream
+    let shares_per_wallet = SizedWallet::NUM_SCALARS - 1;
+    let mut share_csprng = PoseidonCSPRNG::new(share_seed);
+    share_csprng.advance_by((idx - 1) * shares_per_wallet).unwrap();
+
+    // Sample private secret shares for the wallet
+    let mut new_private_shares =
+        share_csprng.take(shares_per_wallet).chain(iter::once(private_blinder));
+    SizedWalletShare::from_scalars(&mut new_private_shares)
+}
+
+/// Find the latest update of a wallet that has been submitted to the
+/// contract. The update is represented as an index into the blinder stream
+///
+/// Returns a tuple: `(blinder_index, blinder, blinder_private_share)`
+pub(crate) async fn find_latest_wallet_tx(
+    blinder_seed: Scalar,
+    arbitrum_client: &ArbitrumClient,
+) -> Result<(usize, Scalar, Scalar), String> {
+    // Find the latest transaction updating the wallet, as indexed by the public
+    // share of the blinders
+    let mut blinder_csprng = PoseidonCSPRNG::new(blinder_seed);
+
+    let mut blinder_index = 0;
+    let mut curr_blinder = Scalar::zero();
+    let mut curr_blinder_private_share = Scalar::zero();
+
+    let mut updating_tx = None;
+
+    while let (blinder, private_share) = blinder_csprng.next_tuple().unwrap()
+        && let Some(tx) = arbitrum_client
+            .get_public_blinder_tx(blinder - private_share)
+            .await
+            .map_err(|e| e.to_string())?
+    {
+        updating_tx = Some(tx);
+
+        curr_blinder = blinder;
+        curr_blinder_private_share = private_share;
+        blinder_index += 1;
+    }
+
+    // Error if not found
+    if updating_tx.is_none() {
+        return Err(ERR_WALLET_NOT_FOUND.to_string());
+    }
+
+    Ok((blinder_index, curr_blinder, curr_blinder_private_share))
 }
 
 // --------------

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -8,29 +8,25 @@ use std::{
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use circuit_types::{traits::BaseType, SizedWalletShare};
+use circuit_types::SizedWalletShare;
 use common::types::{
     tasks::LookupWalletTaskDescriptor,
     wallet::{KeyChain, Wallet, WalletIdentifier},
 };
 use constants::Scalar;
-use itertools::Itertools;
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
-use renegade_crypto::hash::PoseidonCSPRNG;
 use serde::Serialize;
 use state::{error::StateError, State};
-use tracing::{info, instrument};
-use uuid::Uuid;
+use tracing::instrument;
 
 use crate::{
     driver::StateWrapper,
+    helpers::{find_latest_wallet_tx, gen_private_shares},
     traits::{Task, TaskContext, TaskError, TaskState},
 };
 
 use crate::helpers::{find_merkle_path, update_wallet_validity_proofs};
 
-/// The error thrown when the wallet cannot be found in tx history
-pub const ERR_WALLET_NOT_FOUND: &str = "wallet not found in wallet_last_updated map";
 /// The task name for the lookup wallet task
 const LOOKUP_WALLET_TASK_NAME: &str = "lookup-wallet";
 
@@ -218,34 +214,14 @@ impl LookupWalletTask {
     /// wallet
     async fn find_wallet(&mut self) -> Result<(), LookupWalletTaskError> {
         // Lookup the public and private shares from contract calldata
+        // then recover the wallet
         let (blinded_public_shares, private_shares) = self.find_wallet_shares().await?;
-
-        let blinder = blinded_public_shares.blinder + private_shares.blinder;
-        let unblinded_public_shares = blinded_public_shares.unblind_shares(blinder);
-        let recovered_wallet = unblinded_public_shares + private_shares.clone();
-
-        // Construct a wallet from the recovered shares
-        let mut wallet = Wallet {
-            wallet_id: self.wallet_id,
-            orders: recovered_wallet.orders.iter().cloned().map(|o| (Uuid::new_v4(), o)).collect(),
-            balances: recovered_wallet
-                .balances
-                .iter()
-                .cloned()
-                .map(|b| (b.mint.clone(), b))
-                .collect(),
-            key_chain: KeyChain {
-                public_keys: recovered_wallet.keys,
-                secret_keys: self.key_chain.secret_keys.clone(),
-            },
-            match_fee: recovered_wallet.match_fee,
-            managing_cluster: recovered_wallet.managing_cluster,
-            blinder: recovered_wallet.blinder,
-            private_shares,
+        let mut wallet = Wallet::new_from_shares(
+            self.wallet_id,
+            self.key_chain.clone(),
             blinded_public_shares,
-            merkle_proof: None, // constructed below
-            merkle_staleness: Default::default(),
-        };
+            private_shares,
+        );
 
         // Find the authentication path for the wallet
         let authentication_path = find_merkle_path(&wallet, &self.arbitrum_client)
@@ -291,7 +267,9 @@ impl LookupWalletTask {
     ) -> Result<(SizedWalletShare, SizedWalletShare), LookupWalletTaskError> {
         // Find the latest index of the wallet in its share stream
         let (blinder_index, curr_blinder, curr_blinder_private_share) =
-            self.find_latest_wallet_tx().await?;
+            find_latest_wallet_tx(self.blinder_seed, &self.arbitrum_client)
+                .await
+                .map_err(|e| LookupWalletTaskError::NotFound(e.to_string()))?;
 
         // Fetch the secret shares from the tx
         let blinder_public_share = curr_blinder - curr_blinder_private_share;
@@ -301,59 +279,10 @@ impl LookupWalletTask {
             .await
             .map_err(|e| LookupWalletTaskError::Arbitrum(e.to_string()))?;
 
-        // Build an iterator over private secret shares and fast forward to the given
-        // wallet index.
-        //
-        // `shares_per_wallet` does not include the private share of the wallet blinder,
-        // this comes from a separate stream of randomness, so we take the serialized
-        // length minus one
-        let shares_per_wallet = blinded_public_shares.to_scalars().len();
-        let mut private_share_csprng = PoseidonCSPRNG::new(self.secret_share_seed);
-        private_share_csprng.advance_by((blinder_index - 1) * (shares_per_wallet - 1)).unwrap();
-
-        // Sample private secret shares for the wallet
-        let mut new_private_shares = private_share_csprng.take(shares_per_wallet);
-        let mut private_shares = SizedWalletShare::from_scalars(&mut new_private_shares);
-        private_shares.blinder = curr_blinder_private_share;
+        // Sample the private shares for the wallet
+        let private_shares =
+            gen_private_shares(blinder_index, self.secret_share_seed, curr_blinder_private_share);
 
         Ok((blinded_public_shares, private_shares))
-    }
-
-    /// Find the latest update of a wallet that has been submitted to the
-    /// contract. The update is represented as an index into the blinder stream
-    ///
-    /// Returns a tuple: `(blinder_index, blinder, blinder_private_share)`
-    async fn find_latest_wallet_tx(
-        &self,
-    ) -> Result<(usize, Scalar, Scalar), LookupWalletTaskError> {
-        // Find the latest transaction updating the wallet, as indexed by the public
-        // share of the blinders
-        let mut blinder_csprng = PoseidonCSPRNG::new(self.blinder_seed);
-
-        let mut blinder_index = 0;
-        let mut curr_blinder = Scalar::zero();
-        let mut curr_blinder_private_share = Scalar::zero();
-
-        let mut updating_tx = None;
-
-        while let (blinder, private_share) = blinder_csprng.next_tuple().unwrap()
-            && let Some(tx) = self
-                .arbitrum_client
-                .get_public_blinder_tx(blinder - private_share)
-                .await
-                .map_err(|e| LookupWalletTaskError::Arbitrum(e.to_string()))?
-        {
-            updating_tx = Some(tx);
-
-            curr_blinder = blinder;
-            curr_blinder_private_share = private_share;
-            blinder_index += 1;
-        }
-
-        let latest_tx = updating_tx
-            .ok_or_else(|| LookupWalletTaskError::NotFound(ERR_WALLET_NOT_FOUND.to_string()))?;
-        info!("latest updating tx: {:#x}", latest_tx);
-
-        Ok((blinder_index, curr_blinder, curr_blinder_private_share))
     }
 }

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -6,6 +6,7 @@ pub mod node_startup;
 pub mod pay_offline_fee;
 pub mod pay_relayer_fee;
 pub mod redeem_relayer_fee;
+pub mod refresh_wallet;
 pub mod settle_match;
 pub mod settle_match_internal;
 pub mod update_merkle_proof;

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -36,7 +36,7 @@ use util::{
 use crate::{
     await_task,
     driver::StateWrapper,
-    tasks::lookup_wallet::ERR_WALLET_NOT_FOUND,
+    helpers::ERR_WALLET_NOT_FOUND,
     traits::{Task, TaskContext, TaskError, TaskState},
 };
 

--- a/workers/task-driver/src/tasks/redeem_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_relayer_fee.rs
@@ -28,10 +28,11 @@ use crate::{
     traits::{Task, TaskContext, TaskError, TaskState},
 };
 
-use super::lookup_wallet::ERR_WALLET_NOT_FOUND;
-
 /// The name of the task
 const TASK_NAME: &str = "redeem-relayer-fee";
+
+/// The error message emitted when a wallet cannot be found
+const ERR_WALLET_NOT_FOUND: &str = "wallet not found in state";
 
 // --------------
 // | Task State |

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -1,0 +1,298 @@
+//! Refresh a wallet from on-chain state
+
+// --------------
+// | Task State |
+// --------------
+
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
+
+use arbitrum_client::{client::ArbitrumClient, errors::ArbitrumClientError};
+use async_trait::async_trait;
+use circuit_types::SizedWalletShare;
+use common::types::{
+    tasks::RefreshWalletTaskDescriptor,
+    wallet::{Wallet, WalletIdentifier},
+};
+use constants::Scalar;
+use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use serde::Serialize;
+use state::{error::StateError, State};
+use tracing::instrument;
+
+use crate::{
+    driver::StateWrapper,
+    helpers::{
+        find_latest_wallet_tx, find_merkle_path, gen_private_shares, update_wallet_validity_proofs,
+    },
+    traits::{Task, TaskContext, TaskError, TaskState},
+};
+
+/// The task name
+const REFRESH_WALLET_TASK_NAME: &str = "refresh-wallet";
+
+/// Error emitted when the wallet is not found in contract storage
+const ERR_WALLET_NOT_FOUND: &str = "wallet not found";
+
+/// Defines the state of the refresh wallet task
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RefreshWalletTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is finding the wallet in contract storage
+    FindingWallet,
+    /// The task is creating validity proofs for the orders in the wallet
+    CreatingValidityProofs,
+    /// The task is completed
+    Completed,
+}
+
+impl TaskState for RefreshWalletTaskState {
+    fn commit_point() -> Self {
+        RefreshWalletTaskState::CreatingValidityProofs
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, RefreshWalletTaskState::Completed)
+    }
+}
+
+impl Display for RefreshWalletTaskState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RefreshWalletTaskState::Pending => write!(f, "Pending"),
+            RefreshWalletTaskState::FindingWallet => write!(f, "Finding Wallet"),
+            RefreshWalletTaskState::CreatingValidityProofs => write!(f, "Creating Validity Proofs"),
+            RefreshWalletTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl From<RefreshWalletTaskState> for StateWrapper {
+    fn from(state: RefreshWalletTaskState) -> Self {
+        StateWrapper::RefreshWallet(state)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type thrown by the wallet refresh task
+#[derive(Clone, Debug)]
+pub enum RefreshWalletTaskError {
+    /// Wallet was not found in contract storage
+    NotFound(String),
+    /// Error generating a proof of `VALID COMMITMENTS`
+    ProofGeneration(String),
+    /// Error interacting with the arbitrum client
+    Arbitrum(String),
+    /// Error interacting with state
+    State(String),
+}
+
+impl TaskError for RefreshWalletTaskError {
+    fn retryable(&self) -> bool {
+        matches!(
+            self,
+            RefreshWalletTaskError::Arbitrum(_)
+                | RefreshWalletTaskError::ProofGeneration(_)
+                | RefreshWalletTaskError::State(_)
+        )
+    }
+}
+
+impl Display for RefreshWalletTaskError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl Error for RefreshWalletTaskError {}
+
+impl From<StateError> for RefreshWalletTaskError {
+    fn from(e: StateError) -> Self {
+        RefreshWalletTaskError::State(e.to_string())
+    }
+}
+
+impl From<ArbitrumClientError> for RefreshWalletTaskError {
+    fn from(e: ArbitrumClientError) -> Self {
+        RefreshWalletTaskError::Arbitrum(e.to_string())
+    }
+}
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Represents a task to refresh a wallet from on-chain state
+pub struct RefreshWalletTask {
+    /// The ID to provision for the wallet
+    pub wallet_id: WalletIdentifier,
+    /// An arbitrum client for the task to submit transactions
+    pub arbitrum_client: ArbitrumClient,
+    /// A sender to the network manager's work queue
+    pub network_sender: NetworkManagerQueue,
+    /// A copy of the relayer-global state
+    pub state: State,
+    /// The work queue to add proof management jobs to
+    pub proof_manager_work_queue: ProofManagerQueue,
+    /// The state of the task's execution
+    pub task_state: RefreshWalletTaskState,
+}
+
+#[async_trait]
+impl Task for RefreshWalletTask {
+    type State = RefreshWalletTaskState;
+    type Error = RefreshWalletTaskError;
+    type Descriptor = RefreshWalletTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        Ok(Self {
+            wallet_id: descriptor.wallet_id,
+            arbitrum_client: ctx.arbitrum_client,
+            network_sender: ctx.network_queue,
+            state: ctx.state,
+            proof_manager_work_queue: ctx.proof_queue,
+            task_state: RefreshWalletTaskState::Pending,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.state()))]
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        // Dispatch based on task state
+        match self.task_state {
+            RefreshWalletTaskState::Pending => {
+                self.task_state = RefreshWalletTaskState::FindingWallet
+            },
+
+            RefreshWalletTaskState::FindingWallet => {
+                self.find_wallet().await?;
+                self.task_state = RefreshWalletTaskState::CreatingValidityProofs;
+            },
+
+            RefreshWalletTaskState::CreatingValidityProofs => {
+                self.update_validity_proofs().await?;
+                self.task_state = RefreshWalletTaskState::Completed;
+            },
+
+            RefreshWalletTaskState::Completed => {
+                unreachable!("step called on task in Completed state")
+            },
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        REFRESH_WALLET_TASK_NAME.to_string()
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl RefreshWalletTask {
+    // --------------
+    // | Task Steps |
+    // --------------
+
+    /// Find the wallet in contract storage
+    async fn find_wallet(&mut self) -> Result<(), RefreshWalletTaskError> {
+        let curr_wallet = self.get_wallet().await?;
+        let (public_share, private_share) = self.find_wallet_shares(&curr_wallet).await?;
+        let mut wallet = Wallet::new_from_shares(
+            self.wallet_id,
+            curr_wallet.key_chain,
+            public_share,
+            private_share,
+        );
+
+        // Update the merkle proof for the wallet, then write to state
+        let merkle_proof = find_merkle_path(&wallet, &self.arbitrum_client).await?;
+        wallet.merkle_proof = Some(merkle_proof);
+
+        let waiter = self.state.update_wallet(wallet.clone()).await?;
+        waiter.await?;
+        Ok(())
+    }
+
+    /// Update validity proofs for the wallet
+    async fn update_validity_proofs(&mut self) -> Result<(), RefreshWalletTaskError> {
+        let wallet = self.get_wallet().await?;
+        update_wallet_validity_proofs(
+            &wallet,
+            self.proof_manager_work_queue.clone(),
+            self.state.clone(),
+            self.network_sender.clone(),
+        )
+        .await
+        .map_err(RefreshWalletTaskError::ProofGeneration)
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Get the wallet from the state
+    async fn get_wallet(&self) -> Result<Wallet, RefreshWalletTaskError> {
+        self.state
+            .get_wallet(&self.wallet_id)
+            .await?
+            .ok_or_else(|| RefreshWalletTaskError::NotFound(ERR_WALLET_NOT_FOUND.to_string()))
+    }
+
+    /// Find the latest wallet shares from on-chain
+    ///
+    /// Returns the public shares and private shares in order
+    async fn find_wallet_shares(
+        &self,
+        wallet: &Wallet,
+    ) -> Result<(SizedWalletShare, SizedWalletShare), RefreshWalletTaskError> {
+        let (public_blinder, private_share) = self.get_latest_shares(wallet).await?;
+
+        // Fetch public shares from on-chain
+        let blinded_public_shares =
+            self.arbitrum_client.fetch_public_shares_for_blinder(public_blinder).await?;
+        Ok((blinded_public_shares, private_share))
+    }
+
+    /// Get the latest known shares on-chain
+    ///
+    /// Returns the public blinder share and the private shares
+    async fn get_latest_shares(
+        &self,
+        wallet: &Wallet,
+    ) -> Result<(Scalar, SizedWalletShare), RefreshWalletTaskError> {
+        // If the locally stored version of the wallet has not been nullified on-chain,
+        // it is the latest
+        let nullifier = wallet.get_wallet_nullifier();
+        if !self.arbitrum_client.check_nullifier_used(nullifier).await? {
+            let public_blinder = wallet.blinded_public_shares.blinder;
+            return Ok((public_blinder, wallet.private_shares.clone()));
+        }
+
+        // Otherwise lookup the wallet
+        let blinder_seed = wallet.private_blinder_share();
+        let (idx, blinder, private_blinder_share) =
+            find_latest_wallet_tx(blinder_seed, &self.arbitrum_client)
+                .await
+                .map_err(|e| RefreshWalletTaskError::NotFound(e.to_string()))?;
+
+        // Construct private shares from the blinder index
+        let share_seed = wallet.get_last_private_share();
+        let private_shares = gen_private_shares(idx, share_seed, private_blinder_share);
+
+        let public_blinder = blinder - private_blinder_share;
+        Ok((public_blinder, private_shares))
+    }
+}


### PR DESCRIPTION
### Purpose
This PR moves the wallet refresh logic to a separate task that better handles edge cases like an already up-to-date wallet. This task will lookup the wallet on-chain much like the `LookupWalletTask` but more directly uses the wallet information already in state.

Clearing the queue via the API causes running tasks to fail. For this reason, I transitioned some errors in the task queue applicator to be warnings or log rejections so as not to panic the raft.

### Testing
- Tested refreshing a wallet in a variety of cases, and verified that errors were appropriately handled:
    - While an `UpdateWallet` is running
    - While a `SettleInternalMatch` is running
    - While no tasks are running
- Unit tests pass