### PR TITLE
state: replication, workers: task-driver: node-startup: remove learners separately, only setup wallet if leader

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -166,7 +166,7 @@ pub enum StateTransition {
     /// Add a raft peer to the local consensus cluster
     AddRaftVoters { peer_ids: Vec<NodeId> },
     /// Remove a raft peer from the local consensus cluster
-    RemoveRaftPeer { peer_id: NodeId },
+    RemoveRaftPeers { peer_ids: Vec<NodeId> },
 }
 
 impl From<StateTransition> for Proposal {


### PR DESCRIPTION
This PR makes a couple tweaks to how we set up & maintain a Raft cluster, namely:
1. In the node startup task, we only transition to setting up a relayer wallet if the local nodes is the elected leader. It is possible for a node to attempt to initialize a Raft if the true leader takes too long to begin sending it logs, but when it succeeds in doing so, the new node should await voter promotion
2. We correctly remove expired learners via the `sync_membership` loop, and we add batched semantics to the `RemovePeers` state transition. We previously would never correctly remove learners.

All state unit tests pass, and I am testing the effect on thrash in dev.