### PR TITLE
util: matching-engine: Use fixed point floor div when generating amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "mpc-plonk",
  "mpc-relation",
  "num-bigint",
+ "num-integer",
  "rand 0.8.5",
  "renegade-crypto",
  "serde",

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -21,6 +21,7 @@ mpc-relation = { workspace = true }
 # === Arithmetic === #
 bigdecimal = "0.3"
 num-bigint = { version = "0.4", features = ["rand", "serde"] }
+num-integer = "0.1"
 rand = "0.8"
 
 # === Async + Runtime === #


### PR DESCRIPTION
### Purpose
This PR changes the implementation of `compute_max_amount` in the matching engine to use `FixedPoint` floor division rather than `f64` floor division. This fixes a bug we saw in a deployment wherein the matching engine generates invalid witnesses, which then fail to prove.

### Testing
- I added a test using an order and balance I saw fail in a load test, verified that `compute_max_amount` returns a valid value now.
- All tests pass