### PR TITLE
state: storage: tx: relayer-fees: Add storage methods for relayer fees

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -44,10 +44,12 @@ use uuid::Uuid;
 // -------------
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 15;
+const NUM_TABLES: usize = 16;
 
 /// The name of the db table that stores node metadata
 pub(crate) const NODE_METADATA_TABLE: &str = "node-metadata";
+/// The name of the db table that stores relayer fees amounts by wallet ID
+pub(crate) const RELAYER_FEES_TABLE: &str = "relayer-fees";
 
 /// The name of the db table that stores peer information
 pub(crate) const PEER_INFO_TABLE: &str = "peer-info";
@@ -85,6 +87,7 @@ pub const RAFT_LOGS_TABLE: &str = "raft-logs";
 /// All tables in the database
 pub const ALL_TABLES: [&str; NUM_TABLES] = [
     NODE_METADATA_TABLE,
+    RELAYER_FEES_TABLE,
     PEER_INFO_TABLE,
     CLUSTER_MEMBERSHIP_TABLE,
     PRIORITIES_TABLE,

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -12,6 +12,7 @@ pub mod order_book;
 pub mod order_history;
 pub mod peer_index;
 pub mod raft_log;
+pub mod relayer_fees;
 pub mod task_assignments;
 pub mod task_history;
 pub mod task_queue;

--- a/state/src/storage/tx/relayer_fees.rs
+++ b/state/src/storage/tx/relayer_fees.rs
@@ -1,0 +1,98 @@
+//! Storage helpers for relayer fees
+
+use circuit_types::fixed_point::FixedPoint;
+use common::types::wallet::WalletIdentifier;
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, RELAYER_FEES_TABLE};
+
+use super::StateTxn;
+
+/// Construct a key for a wallet's relayer fee
+fn relayer_fee_key(wallet_id: &WalletIdentifier) -> String {
+    format!("relayer-fee-{}", wallet_id)
+}
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the relayer fee for a wallet
+    ///
+    /// Defaults to the default relayer fee if no fee is set
+    pub fn get_relayer_fee(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<FixedPoint, StorageError> {
+        let key = relayer_fee_key(wallet_id);
+        let value = match self.inner().read(RELAYER_FEES_TABLE, &key)? {
+            Some(fee) => fee,
+            None => self.get_relayer_take_rate()?,
+        };
+
+        Ok(value)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Set the relayer fee for a wallet
+    pub fn set_relayer_fee(
+        &self,
+        wallet_id: &WalletIdentifier,
+        fee: FixedPoint,
+    ) -> Result<(), StorageError> {
+        let key = relayer_fee_key(wallet_id);
+        self.inner().write(RELAYER_FEES_TABLE, &key, &fee)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use circuit_types::fixed_point::FixedPoint;
+    use common::types::wallet::WalletIdentifier;
+
+    use crate::test_helpers::mock_db;
+
+    /// Tests the case in which a fee is not set for a wallet
+    #[test]
+    fn test_no_fee_set() {
+        let db = mock_db();
+        let wallet_id = WalletIdentifier::new_v4();
+
+        // Setup the default fee
+        let fee = FixedPoint::from_f64_round_down(0.01);
+        let tx = db.new_write_tx().unwrap();
+        tx.set_relayer_take_rate(&fee).unwrap();
+        tx.commit().unwrap();
+
+        // Ensure the fee is set correctly
+        let tx = db.new_read_tx().unwrap();
+        let found_fee = tx.get_relayer_fee(&wallet_id).unwrap();
+        assert_eq!(found_fee, fee);
+    }
+
+    /// Tests the case in which a fee is set for a wallet
+    #[test]
+    fn test_fee_set() {
+        let db = mock_db();
+        let wallet_id = WalletIdentifier::new_v4();
+        let fee = FixedPoint::from_f64_round_down(0.01);
+        let wallet_fee = FixedPoint::from_f64_round_down(0.02);
+
+        let tx = db.new_write_tx().unwrap();
+        tx.set_relayer_take_rate(&fee).unwrap();
+        tx.set_relayer_fee(&wallet_id, wallet_fee).unwrap();
+        tx.commit().unwrap();
+
+        // Ensure the fee is set correctly
+        let tx = db.new_read_tx().unwrap();
+        let fee = tx.get_relayer_fee(&wallet_id).unwrap();
+        assert_eq!(fee, wallet_fee);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds storage helpers for relayer fees. This allows us to set the `match-fee` field (representing the relayer's take rate) on a per-wallet basis. We will use this to implement a `fee-whitelist.json` file in the config, which allows us to set per-wallet fees.

### Testing
- Unit tests pass