### PR TITLE
config: Add `relayer-fee-whitelist` option and use whitelisted fees in `new-wallet` creation

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use url::Url;
 
-use crate::parsing::parse_config_from_args;
+use crate::parsing::{parse_config_from_args, RelayerFeeWhitelistEntry};
 
 // -------
 // | CLI |
@@ -54,6 +54,9 @@ pub struct Cli {
     /// The mutual exclusion list for matches, two wallets in this list will never be matched internally by the node
     #[clap(long, value_parser, value_delimiter=' ', num_args=0..)]
     pub match_mutual_exclusion_list: Vec<WalletIdentifier>,
+    /// The path to the file containing relayer fee whitelist info
+    #[clap(long, value_parser)]
+    pub relayer_fee_whitelist: Option<String>,
 
     // -----------------------
     // | Environment Configs |
@@ -220,6 +223,10 @@ pub struct RelayerConfig {
     /// The price reporter from which to stream prices.
     /// If unset, the relayer will connect to exchanges directly.
     pub price_reporter_url: Option<Url>,
+    /// The relayer fee whitelist
+    ///
+    /// Specifies a mapping of wallet IDs to fees for the relayer
+    pub relayer_fee_whitelist: Vec<RelayerFeeWhitelistEntry>,
 
     // -----------------------
     // | Environment Configs |
@@ -345,6 +352,7 @@ impl Clone for RelayerConfig {
         Self {
             match_take_rate: self.match_take_rate,
             match_mutual_exclusion_list: self.match_mutual_exclusion_list.clone(),
+            relayer_fee_whitelist: self.relayer_fee_whitelist.clone(),
             price_reporter_url: self.price_reporter_url.clone(),
             chain_id: self.chain_id,
             contract_address: self.contract_address.clone(),

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -105,6 +105,7 @@ impl State {
         let p2p_key = config.p2p_key.clone();
         let fee_decryption_key = config.fee_decryption_key;
         let match_take_rate = config.match_take_rate;
+        let relayer_fee_whitelist = config.relayer_fee_whitelist.clone();
 
         let relayer_wallet_id =
             derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
@@ -117,6 +118,12 @@ impl State {
             tx.set_fee_decryption_key(&fee_decryption_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
             tx.set_local_node_wallet(relayer_wallet_id)?;
+
+            // Setup the relayer fee whitelist
+            for entry in relayer_fee_whitelist {
+                let fee = FixedPoint::from_f64_round_down(entry.fee);
+                tx.set_relayer_fee(&entry.wallet_id, fee)?;
+            }
 
             Ok(())
         })

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -55,6 +55,16 @@ impl State {
     pub async fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
         self.with_read_tx(|tx| tx.get_relayer_take_rate().map_err(StateError::Db)).await
     }
+
+    /// Get the relayer fee for a given wallet
+    pub async fn get_relayer_fee_for_wallet(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<FixedPoint, StateError> {
+        let wid = *wallet_id;
+        self.with_read_tx(move |tx| tx.get_relayer_fee(&wid).map_err(StateError::Db)).await
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -17,7 +17,7 @@ use crate::replication::error::{new_snapshot_error, ReplicationV2Error};
 use crate::storage::db::{DbConfig, DB};
 use crate::{
     ALL_TABLES, CLUSTER_MEMBERSHIP_TABLE, NODE_METADATA_TABLE, PEER_INFO_TABLE, RAFT_LOGS_TABLE,
-    RAFT_METADATA_TABLE,
+    RAFT_METADATA_TABLE, RELAYER_FEES_TABLE,
 };
 
 use super::{Node, NodeId, StateMachine, TypeConfig};
@@ -34,6 +34,7 @@ const EXCLUDED_TABLES: &[&str] = &[
     PEER_INFO_TABLE,
     CLUSTER_MEMBERSHIP_TABLE,
     NODE_METADATA_TABLE,
+    RELAYER_FEES_TABLE,
 ];
 
 /// An error awaiting a blocking zip task

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -185,14 +185,14 @@ impl TypedHandler for CreateWalletHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Overwrite the managing cluster and the match fee with the configured values
+        let wallet_id = req.wallet.id;
         let relayer_key = self.state.get_fee_decryption_key().await?.public_key();
-        let relayer_take_rate = self.state.get_relayer_take_rate().await?;
+        let relayer_take_rate = self.state.get_relayer_fee_for_wallet(&wallet_id).await?;
         req.wallet.managing_cluster = jubjub_to_hex_string(&relayer_key);
         req.wallet.match_fee = relayer_take_rate;
 
         // Create an async task to drive this new wallet into the on-chain state
         // and create proofs of validity
-        let wallet_id = req.wallet.id;
         let mut wallet: Wallet = req.wallet.try_into().map_err(|e: String| bad_request(e))?;
 
         // Modify the public shares of the new wallet to reflect the overwritten fields


### PR DESCRIPTION
### Purpose
This PR adds a `--relayer-fee-whitelist` config option which allows the parent process to specify a `.json` file containing whitelist entries like the following:
```json
{
    "wallet_id": "id",
    "fee": 0.0005,
    ...
}
```

These values are parsed and stored in state. Upon wallet creation, a fee is looked up (defaulting to the relayer's base fee) and the wallet's `match_fee` field is set using this value.

### Testing
- Added a wallet to the whitelist and created a new wallet under that ID, verified that it was given the whitelisted fee
- Added a new wallet not in the whitelist, verified that it was given the base fee