### PR TITLE
node-support: bootloader: Download whitelist from s3 on startup

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && \
     apt-get install -y pkg-config && \
     apt-get install -y protobuf-compiler && \
     apt-get install -y libssl-dev && \
-    apt-get install -y libclang-dev
+    apt-get install -y libclang-dev && \
+    apt-get install -y ca-certificates
 
 # Disable compiler warnings and enable backtraces for panic debugging
 ENV RUSTFLAGS=-Awarnings


### PR DESCRIPTION
### Purpose
This PR adds an additional path to the bootloader wherein we download the fee whitelist file from s3 on startup if it exists and configure the relayer to use this whitelist file.

### Testing
- Unit tests pass
- Tested with a whitelist file present in the s3 bucket, created a wallet using a whitelisted wallet ID, and verified that it received the whitelisted fee