### PR TITLE
external-api, common: tasks: Record fee payment mint + amount in history

### DIFF
--- a/common/src/types/tasks/descriptors/pay_fees.rs
+++ b/common/src/types/tasks/descriptors/pay_fees.rs
@@ -1,5 +1,6 @@
 //! Task descriptors for paying fees
 
+use circuit_types::{balance::Balance, Amount};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -15,24 +16,33 @@ pub struct PayOfflineFeeTaskDescriptor {
     /// The wallet to pay fees for
     pub wallet_id: WalletIdentifier,
     /// The balance to pay fees for
-    pub balance_mint: BigUint,
+    pub mint: BigUint,
+    /// The amount of the mint paid as a fee
+    ///
+    /// For now, this is always set to the full balance and is only used for
+    /// informational purposes in API queries
+    pub amount: Amount,
 }
 
 impl PayOfflineFeeTaskDescriptor {
     /// Constructor for the relayer fee payment task
-    pub fn new_relayer_fee(
-        wallet_id: WalletIdentifier,
-        balance_mint: BigUint,
-    ) -> Result<Self, String> {
-        Ok(PayOfflineFeeTaskDescriptor { is_protocol_fee: false, wallet_id, balance_mint })
+    pub fn new_relayer_fee(wallet_id: WalletIdentifier, balance: Balance) -> Result<Self, String> {
+        Ok(PayOfflineFeeTaskDescriptor {
+            is_protocol_fee: false,
+            wallet_id,
+            mint: balance.mint,
+            amount: balance.relayer_fee_balance,
+        })
     }
 
     /// Constructor for the protocol fee payment task
-    pub fn new_protocol_fee(
-        wallet_id: WalletIdentifier,
-        balance_mint: BigUint,
-    ) -> Result<Self, String> {
-        Ok(PayOfflineFeeTaskDescriptor { is_protocol_fee: true, wallet_id, balance_mint })
+    pub fn new_protocol_fee(wallet_id: WalletIdentifier, balance: Balance) -> Result<Self, String> {
+        Ok(PayOfflineFeeTaskDescriptor {
+            is_protocol_fee: true,
+            wallet_id,
+            mint: balance.mint,
+            amount: balance.protocol_fee_balance,
+        })
     }
 }
 

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -1,7 +1,8 @@
 //! Types for task history storage
 
 use ark_mpc::PARTY1;
-use circuit_types::r#match::MatchResult;
+use circuit_types::{r#match::MatchResult, Amount};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -46,7 +47,14 @@ pub enum HistoricalTaskDescription {
     /// A match was settled
     SettleMatch(MatchResult),
     /// A fee was paid
-    PayOfflineFee,
+    PayOfflineFee {
+        /// The mind the fee was paid from
+        mint: BigUint,
+        /// The amount of the fee
+        amount: Amount,
+        /// Whether the fee was paid for a protocol fee
+        is_protocol: bool,
+    },
 }
 
 impl HistoricalTaskDescription {
@@ -75,7 +83,11 @@ impl HistoricalTaskDescription {
                 match_res.direction = my_direction;
                 Some(Self::SettleMatch(match_res))
             },
-            TaskDescriptor::OfflineFee(_) => Some(Self::PayOfflineFee),
+            TaskDescriptor::OfflineFee(desc) => Some(Self::PayOfflineFee {
+                mint: desc.mint.clone(),
+                amount: desc.amount,
+                is_protocol: desc.is_protocol_fee,
+            }),
             _ => None,
         }
     }

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -79,7 +79,14 @@ pub enum ApiHistoricalTaskDescription {
     /// A match was settled
     SettleMatch(ApiHistoricalMatch),
     /// A fee was paid
-    PayOfflineFee,
+    PayOfflineFee {
+        /// The mint of the fee
+        mint: String,
+        /// The amount of the fee
+        amount: Number,
+        /// Whether the fee was paid for a protocol fee
+        is_protocol: bool,
+    },
 }
 
 impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
@@ -92,7 +99,13 @@ impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
             HistoricalTaskDescription::SettleMatch(match_result) => {
                 Self::SettleMatch(match_result.into())
             },
-            HistoricalTaskDescription::PayOfflineFee => Self::PayOfflineFee,
+            HistoricalTaskDescription::PayOfflineFee { mint, amount, is_protocol } => {
+                Self::PayOfflineFee {
+                    mint: biguint_to_hex_string(&mint),
+                    amount: u128_to_number(amount),
+                    is_protocol,
+                }
+            },
         }
     }
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -792,17 +792,18 @@ impl TypedHandler for PayFeesHandler {
 
         // Pay all fees in the wallet
         let mut tasks = Vec::new();
-        for (mint, balance) in wallet.balances.iter() {
+        for (_mint, balance) in wallet.balances.iter() {
             if balance.relayer_fee_balance > 0 {
-                let task = PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet_id, mint.clone())
+                let task = PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet_id, balance.clone())
                     .expect("infallible");
                 let task_id = append_task_and_await(task.into(), &self.state).await?;
                 tasks.push(task_id);
             }
 
             if balance.protocol_fee_balance > 0 {
-                let task = PayOfflineFeeTaskDescriptor::new_protocol_fee(wallet_id, mint.clone())
-                    .expect("infallible");
+                let task =
+                    PayOfflineFeeTaskDescriptor::new_protocol_fee(wallet_id, balance.clone())
+                        .expect("infallible");
                 let task_id = append_task_and_await(task.into(), &self.state).await?;
                 tasks.push(task_id);
             }

--- a/workers/task-driver/integration/tests/pay_offline_fee.rs
+++ b/workers/task-driver/integration/tests/pay_offline_fee.rs
@@ -51,9 +51,8 @@ async fn test_pay_offline_fees(test_args: IntegrationTestArgs) -> Result<()> {
     setup_initial_wallet(blinder_seed, share_seed, &mut wallet, &test_args).await?;
 
     // Pay the protocol fee
-    let descriptor =
-        PayOfflineFeeTaskDescriptor::new_protocol_fee(wallet.wallet_id, bal.mint.clone())
-            .expect("infallible");
+    let descriptor = PayOfflineFeeTaskDescriptor::new_protocol_fee(wallet.wallet_id, bal.clone())
+        .expect("infallible");
     await_task(descriptor.into(), &test_args).await?;
 
     // Check the wallet, first from global state
@@ -75,9 +74,8 @@ async fn test_pay_offline_fees(test_args: IntegrationTestArgs) -> Result<()> {
     lookup_wallet_and_check_result(&expected_wallet, blinder_seed, share_seed, &test_args).await?;
 
     // Now pay the relayer fee
-    let descriptor =
-        PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet.wallet_id, bal.mint.clone())
-            .expect("infallible");
+    let descriptor = PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet.wallet_id, bal.clone())
+        .expect("infallible");
     await_task(descriptor.into(), &test_args).await?;
 
     // Check the wallet, first from global state

--- a/workers/task-driver/integration/tests/redeem_relayer_fee.rs
+++ b/workers/task-driver/integration/tests/redeem_relayer_fee.rs
@@ -68,7 +68,7 @@ async fn test_auto_redeem_relayer_fee(test_args: IntegrationTestArgs) -> Result<
 
     // Pay the relayer fee for the balance
     let descriptor =
-        PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet.wallet_id, bal.mint.clone()).unwrap();
+        PayOfflineFeeTaskDescriptor::new_relayer_fee(wallet.wallet_id, bal.clone()).unwrap();
     await_task(descriptor.into(), &test_args).await?;
 
     // Await for the relayer's queue to flush

--- a/workers/task-driver/src/simulation/wallet_tasks.rs
+++ b/workers/task-driver/src/simulation/wallet_tasks.rs
@@ -172,7 +172,7 @@ fn simulate_offline_fee_payment(
 
     // Set the relevant fee to zero
     let balance = wallet
-        .get_balance_mut(&desc.balance_mint)
+        .get_balance_mut(&desc.mint)
         .ok_or(TaskSimulationError::InvalidTask(ERR_BALANCE_MISSING))?;
 
     if desc.is_protocol_fee {


### PR DESCRIPTION
### Purpose
This PR adds the `amount`, `mint`, and `is_protocol` fields to the historical fee payment task description. This will allow for these fields to be consumed via the API and displayed on the FE.

### Testing
- Tested via the API locally