### PR TITLE
state: storage: order-history: Record partial fills in order history

### DIFF
--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -1,6 +1,6 @@
 //! Order metadata for a wallet's orders
 
-use circuit_types::{order::Order, Amount};
+use circuit_types::{fixed_point::FixedPoint, order::Order, Amount};
 use serde::{Deserialize, Serialize};
 use util::get_current_time_millis;
 
@@ -39,7 +39,7 @@ pub struct OrderMetadata {
     /// The order state
     pub state: OrderState,
     /// The amount that has been filled
-    pub filled: Amount,
+    pub fills: Vec<PartialOrderFill>,
     /// The unix timestamp in milliseconds since the order was created
     pub created: u64,
 }
@@ -48,6 +48,36 @@ impl OrderMetadata {
     /// Create a new order metadata instance, defaults to `Created` state
     pub fn new(id: OrderIdentifier, order: Order) -> Self {
         let created = get_current_time_millis();
-        Self { id, data: order, state: OrderState::Created, filled: 0, created }
+        Self { id, data: order, state: OrderState::Created, fills: vec![], created }
+    }
+
+    /// The total amount filled
+    pub fn total_filled(&self) -> Amount {
+        self.fills.iter().map(|f| f.amount).sum()
+    }
+
+    /// Add a fill to the order metadata
+    pub fn record_partial_fill(&mut self, amount: Amount, price: FixedPoint) {
+        let fill = PartialOrderFill::new(amount, price);
+        self.fills.push(fill);
+    }
+}
+
+/// A partial fill of an order, recording the information parameterizing a match
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartialOrderFill {
+    /// The amount filled by the partial fill
+    pub amount: Amount,
+    /// The price at which the fill executed
+    pub price: FixedPoint,
+    /// The time at which the fill executed, in milliseconds since the epoch
+    pub timestamp: u64,
+}
+
+impl PartialOrderFill {
+    /// Constructor
+    pub fn new(amount: Amount, price: FixedPoint) -> Self {
+        let timestamp = get_current_time_millis();
+        Self { amount, price, timestamp }
     }
 }

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -52,6 +52,7 @@ impl StateApplicator {
 
 #[cfg(test)]
 mod tests {
+    use circuit_types::fixed_point::FixedPoint;
     use common::types::{wallet::order_metadata::OrderState, wallet_mocks::mock_order};
     use uuid::Uuid;
 
@@ -73,7 +74,7 @@ mod tests {
             id: order_id,
             data: order,
             state: OrderState::Created,
-            filled: 0,
+            fills: vec![],
             created: 1,
         };
         let tx = db.new_write_tx().unwrap();
@@ -84,12 +85,12 @@ mod tests {
         tx.commit().unwrap();
 
         // Modify the metadata and push
-        md.filled += 1;
+        md.record_partial_fill(1, FixedPoint::from_f64_round_down(2.));
         applicator.update_order_metadata(md).unwrap();
 
         // Check the state
         let tx = db.new_read_tx().unwrap();
         let md = tx.get_order_metadata(wallet_id, order_id).unwrap().unwrap();
-        assert_eq!(md.filled, 1);
+        assert_eq!(md.total_filled(), 1);
     }
 }

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -63,6 +63,7 @@ impl State {
 pub mod test {
     use std::cmp::Reverse;
 
+    use circuit_types::fixed_point::FixedPoint;
     use common::types::{wallet::order_metadata::OrderState, wallet_mocks::mock_order};
     use itertools::Itertools;
     use rand::{seq::IteratorRandom, thread_rng, RngCore};
@@ -79,7 +80,7 @@ pub mod test {
             id: OrderIdentifier::new_v4(),
             data,
             state: OrderState::Created,
-            filled: 0,
+            fills: vec![],
             created: rng.next_u64(),
         }
     }
@@ -130,7 +131,9 @@ pub mod test {
         // Modify a single order's metadata
         let idx = (0..orders.len()).choose(&mut thread_rng()).unwrap();
         let mut meta = orders[idx].clone();
-        meta.filled += 1;
+        let amount = 1;
+        let price = FixedPoint::from_f64_round_down(10.);
+        meta.record_partial_fill(amount, price);
 
         // Update and retrieve the order's metadata
         let waiter = state.update_order_metadata(meta.clone()).await.unwrap();

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -107,10 +107,10 @@ mod test {
     // Wallet update handlers in the applicator handle order history changes to
     // hide the wallet index/order history denormalization
 
-    use circuit_types::balance::Balance;
+    use circuit_types::{balance::Balance, fixed_point::FixedPoint};
     use common::types::{
         wallet::{
-            order_metadata::{OrderMetadata, OrderState},
+            order_metadata::{OrderMetadata, OrderState, PartialOrderFill},
             OrderIdentifier, WalletIdentifier,
         },
         wallet_mocks::{mock_empty_wallet, mock_order},
@@ -122,11 +122,12 @@ mod test {
 
     /// Create a set of mock historical orders
     fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &State) {
+        let fill = PartialOrderFill::new(1, FixedPoint::from_integer(5));
         let history = (0..n)
             .map(|_| OrderMetadata {
                 id: OrderIdentifier::new_v4(),
                 state: OrderState::Filled,
-                filled: 1,
+                fills: vec![fill],
                 created: 0,
                 data: mock_order(),
             })

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -116,6 +116,7 @@ impl<'db> StateTxn<'db, RW> {
 mod tests {
     use std::cmp::Reverse;
 
+    use circuit_types::fixed_point::FixedPoint;
     use common::types::{
         wallet::order_metadata::{OrderMetadata, OrderState},
         wallet_mocks::mock_order,
@@ -132,7 +133,7 @@ mod tests {
         OrderMetadata {
             id: Uuid::new_v4(),
             state: OrderState::Created,
-            filled: 0,
+            fills: vec![],
             created: rng.next_u64(),
             data: mock_order(),
         }
@@ -198,7 +199,9 @@ mod tests {
 
         // Update the order
         let mut updated_order = curr_order;
-        updated_order.filled = rng.gen();
+        let amount = rng.gen();
+        let price = FixedPoint::from_f64_round_down(100.2);
+        updated_order.record_partial_fill(amount, price);
 
         let tx = db.new_write_tx().unwrap();
         tx.update_order_metadata(&wallet_id, updated_order.clone()).unwrap();

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -293,9 +293,14 @@ impl SettleMatchTask {
 
         // Transition the order state to filled if the new volume is zero
         let id = self.handshake_state.local_order_id;
-        record_order_fill(id, &self.match_res, &self.global_state)
-            .await
-            .map_err(SettleMatchTaskError::State)?;
+        record_order_fill(
+            id,
+            &self.match_res,
+            self.handshake_state.execution_price,
+            &self.global_state,
+        )
+        .await
+        .map_err(SettleMatchTaskError::State)?;
 
         // Update the shares of the wallet
         let (private_shares, blinded_public_shares) = self.get_new_shares().await?;

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -338,10 +338,11 @@ impl SettleMatchInternalTask {
         self.state.nullify_orders(nullifier2).await?;
 
         // Transition the orders to the `Filled` state if necessary
-        record_order_fill(self.order_id1, &self.match_result, &self.state)
+        let price = self.execution_price;
+        record_order_fill(self.order_id1, &self.match_result, price, &self.state)
             .await
             .map_err(SettleMatchInternalTaskError::State)?;
-        record_order_fill(self.order_id2, &self.match_result, &self.state)
+        record_order_fill(self.order_id2, &self.match_result, price, &self.state)
             .await
             .map_err(SettleMatchInternalTaskError::State)?;
 

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -1,6 +1,6 @@
 //! Helpers for transitioning order states and recording them in order history
 
-use circuit_types::r#match::MatchResult;
+use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
 use common::types::wallet::{order_metadata::OrderState, OrderIdentifier};
 use state::State;
 
@@ -24,6 +24,7 @@ pub async fn transition_order_settling(
 pub async fn record_order_fill(
     order_id: OrderIdentifier,
     match_res: &MatchResult,
+    price: FixedPoint,
     state: &State,
 ) -> Result<(), String> {
     // Get the order metadata
@@ -31,8 +32,8 @@ pub async fn record_order_fill(
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;
 
     // Increment filled amount and transition state if the entire order has matched
-    metadata.filled += match_res.base_amount;
-    if metadata.data.amount == metadata.filled {
+    metadata.record_partial_fill(match_res.base_amount, price);
+    if metadata.data.amount == metadata.total_filled() {
         metadata.state = OrderState::Filled;
     }
 


### PR DESCRIPTION
### Purpose
This PR adds partial fill information to historical orders. Each partial fill contains the amount, price, and timestamp of the partial fill.

### Testing
- Unit tests pass
- Tested via the CLI with unmatched, incrementally matched, and fully matched orders