### PR TITLE
state: interface: peer_index: mark fresh heartbeats for added peers

### DIFF
--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -160,11 +160,9 @@ impl State {
                         continue;
                     }
 
-                    // If the peer is already indexed, persist the existing `last_heartbeat`
-                    // to maintain an accurate local view of liveness
-                    if let Some(existing_peer) = tx.get_peer_info(&peer.peer_id)? {
-                        peer.last_heartbeat = existing_peer.last_heartbeat;
-                    }
+                    // We only gossip around live peers, so it's safe to optimistically give the
+                    // peer a fresh heartbeat
+                    peer.successful_heartbeat();
 
                     // Add the peer to the store
                     tx.write_peer(&peer)?;


### PR DESCRIPTION
This PR reinstates the marking of fresh heartbeats for added peers. Primarily this aids in initial communication with the bootstrap nodes, wherein they will self-report very stale heartbeats, leading to new nodes expiring one bootstrap very quickly. The previous issue with fresh heartbeats extending the lifetime of an expired peer in nodes' peer indices is alleviated by filtering out expiry candidates from heartbeats.

This was tested in dev by triggering an upgrade - bootstraps were not expired, and there was no thrash (i.e., nodes getting expired and re-added repeatedly)