### PR TITLE
constants: update testnet deploy block to match Sepolia deployment

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -94,7 +94,7 @@ pub const MAINNET_CONTRACT_DEPLOYMENT_BLOCK: u64 = 0;
 pub const DEVNET_DEPLOY_BLOCK: u64 = 0;
 
 /// The block number at which the darkpool was deployed on testnet
-pub const TESTNET_DEPLOY_BLOCK: u64 = 0;
+pub const TESTNET_DEPLOY_BLOCK: u64 = 55713322;
 
 // ----------------------
 // | Pubsub Topic Names |


### PR DESCRIPTION
This PR updates the `TESTNET_DEPLOY_BLOCK` constant to match the block at which we deployed the Darkpool proxy contract to Arbitrum Sepolia