### PR TITLE
common: token: s/ren/arb

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -81,8 +81,8 @@ pub const COMP_TICKER: &str = "COMP";
 pub const MKR_TICKER: &str = "MKR";
 /// TORN ticker
 pub const TORN_TICKER: &str = "TORN";
-/// REN ticker
-pub const REN_TICKER: &str = "REN";
+/// ARB ticker
+pub const ARB_TICKER: &str = "ARB";
 /// SHIB ticker
 pub const SHIB_TICKER: &str = "SHIB";
 /// ENS ticker
@@ -250,7 +250,7 @@ pub static TICKER_NAMES: &[(
     ),
     // Bridges
     (
-        REN_TICKER,
+        ARB_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -64,7 +64,7 @@ cargo run \
         AAVE \
         COMP \
         MKR \
-        REN \
+        ARB \
         MANA \
         ENS \
         DYDX \


### PR DESCRIPTION
This PR replaces the `REN` token with the `ARB` token in the global ticker names list