### PR TITLE
util: hex, circuit-types: ensure biguint -> address conversion has proper padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,6 +1819,7 @@ dependencies = [
  "circuit-macros",
  "constants",
  "futures",
+ "hex 0.4.3",
  "itertools 0.10.5",
  "jf-primitives",
  "k256",

--- a/circuit-types/Cargo.toml
+++ b/circuit-types/Cargo.toml
@@ -34,6 +34,7 @@ constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
 
 # === Misc === #
+hex = "0.4"
 byteorder = "1.5"
 itertools = "0.10"
 lazy_static = { workspace = true }

--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -10,7 +10,7 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    biguint_from_hex_string, biguint_to_hex_string,
+    biguint_from_hex_string, biguint_to_hex_addr,
     elgamal::EncryptionKey,
     note::Note,
     r#match::FeeTake,
@@ -27,10 +27,7 @@ use crate::{
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Balance {
     /// The mint (ERC-20 token address) of the token in the balance
-    #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
-    )]
+    #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
     pub mint: BigUint,
     /// The amount of the given token stored in this balance
     pub amount: Amount,

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -27,8 +27,8 @@ use ark_ff::BigInt;
 use ark_mpc::MpcFabric;
 use bigdecimal::Num;
 use constants::{
-    AuthenticatedScalar, Scalar, ScalarField, SystemCurve, SystemCurveGroup, MAX_BALANCES,
-    MAX_ORDERS, MERKLE_HEIGHT,
+    AuthenticatedScalar, Scalar, ScalarField, SystemCurve, SystemCurveGroup, ADDRESS_BYTE_LENGTH,
+    MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT,
 };
 use fixed_point::DEFAULT_FP_PRECISION;
 use jf_primitives::pcs::prelude::Commitment;
@@ -167,6 +167,23 @@ where
     S: Serializer,
 {
     s.serialize_str(&format!("0x{}", val.to_str_radix(16 /* radix */)))
+}
+
+/// A helper to serialize a BigUint to a hex address
+pub fn biguint_to_hex_addr<S>(val: &BigUint, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut bytes = [0_u8; ADDRESS_BYTE_LENGTH];
+    let val_bytes = val.to_bytes_be();
+
+    let len = val_bytes.len();
+    debug_assert!(len <= ADDRESS_BYTE_LENGTH, "BigUint too large for an address");
+
+    bytes[ADDRESS_BYTE_LENGTH - val_bytes.len()..].copy_from_slice(&val_bytes);
+    let hex_str = hex::encode(bytes);
+
+    s.serialize_str(&format!("0x{hex_str}"))
 }
 
 /// A helper to deserialize a BigUint from a hex string

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, ops::Add, str::FromStr};
 
 use crate::{
-    biguint_from_hex_string, biguint_to_hex_string,
+    biguint_from_hex_string, biguint_to_hex_addr,
     fixed_point::FixedPoint,
     traits::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
@@ -25,16 +25,10 @@ use crate::{
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Order {
     /// The mint (ERC-20 contract address) of the quote token
-    #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
-    )]
+    #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
     pub quote_mint: BigUint,
     /// The mint (ERC-20 contract address) of the base token
-    #[serde(
-        serialize_with = "biguint_to_hex_string",
-        deserialize_with = "biguint_from_hex_string"
-    )]
+    #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
     pub base_mint: BigUint,
     /// The side this order is for (0 = buy, 1 = sell)
     pub side: OrderSide,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,8 +9,6 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![feature(generic_const_exprs)]
 
-use ethers::types::Address;
-use num_bigint::BigUint;
 use std::sync::{Arc, RwLock};
 use tokio::sync::RwLock as TokioRwLock;
 
@@ -33,26 +31,4 @@ pub fn new_shared<T>(wrapped: T) -> Shared<T> {
 /// Wrap an abstract value in an async shared lock
 pub fn new_async_shared<T>(wrapped: T) -> AsyncShared<T> {
     Arc::new(TokioRwLock::new(wrapped))
-}
-
-/// From a biguint, get a lowercase hex string with a 0x prefix, padded to the
-/// Ethereum address length
-pub fn biguint_to_str_addr(x: &BigUint) -> String {
-    let mut bytes = [0_u8; Address::len_bytes()];
-    let x_bytes = x.to_bytes_be();
-    bytes[..x_bytes.len()].copy_from_slice(&x_bytes);
-    let addr = Address::from_slice(&bytes);
-    format!("{addr:#x}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_biguint_to_str_addr() {
-        let x = BigUint::from(1u8);
-        let addr = biguint_to_str_addr(&x);
-        println!("addr: {}", addr);
-    }
 }

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -23,8 +23,7 @@ use std::{
     iter,
     sync::OnceLock,
 };
-
-use crate::biguint_to_str_addr;
+use util::hex::biguint_to_hex_addr;
 
 use super::exchange::{Exchange, ALL_EXCHANGES};
 
@@ -357,7 +356,7 @@ impl Token {
     /// Given an ERC-20 contract address represented as a `BigUint`, returns a
     /// Token
     pub fn from_addr_biguint(addr: &BigUint) -> Self {
-        Self { addr: biguint_to_str_addr(addr) }
+        Self { addr: biguint_to_hex_addr(addr) }
     }
 
     /// Given an ERC-20 ticker, returns a new Token.

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -81,8 +81,8 @@ pub const COMP_TICKER: &str = "COMP";
 pub const MKR_TICKER: &str = "MKR";
 /// TORN ticker
 pub const TORN_TICKER: &str = "TORN";
-/// ARB ticker
-pub const ARB_TICKER: &str = "ARB";
+/// REN ticker
+pub const REN_TICKER: &str = "REN";
 /// SHIB ticker
 pub const SHIB_TICKER: &str = "SHIB";
 /// ENS ticker
@@ -250,7 +250,7 @@ pub static TICKER_NAMES: &[(
     ),
     // Bridges
     (
-        ARB_TICKER,
+        REN_TICKER,
         ExchangeTicker::Same,
         ExchangeTicker::Same,
         ExchangeTicker::Same,

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -13,11 +13,10 @@ use circuit_types::{
     traits::BaseType,
     Amount, SizedWalletShare,
 };
-use constants::{Scalar, MERKLE_HEIGHT};
+use constants::{Scalar, ADDRESS_BYTE_LENGTH, MERKLE_HEIGHT};
 use k256::ecdsa::SigningKey as K256SigningKey;
 use num_bigint::BigUint;
-use rand::thread_rng;
-use renegade_crypto::fields::scalar_to_biguint;
+use rand::{thread_rng, RngCore};
 use uuid::Uuid;
 
 use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
@@ -67,9 +66,8 @@ pub fn mock_empty_wallet() -> Wallet {
 
 /// Create a mock order
 pub fn mock_order() -> Order {
-    let mut rng = thread_rng();
-    let quote_mint = scalar_to_biguint(&Scalar::random(&mut rng));
-    let base_mint = scalar_to_biguint(&Scalar::random(&mut rng));
+    let quote_mint = rand_addr_biguint();
+    let base_mint = rand_addr_biguint();
     let amount = Amount::from(10u8);
     let worst_case_price = FixedPoint::from_integer(100);
 
@@ -84,4 +82,16 @@ pub fn mock_merkle_path() -> MerkleAuthenticationPath {
         BigUint::from(0u8),
         Scalar::random(&mut rng),
     )
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Generate a random address as a BigUint
+pub fn rand_addr_biguint() -> BigUint {
+    let mut rng = thread_rng();
+    let mut addr_bytes = [0_u8; ADDRESS_BYTE_LENGTH];
+    rng.fill_bytes(&mut addr_bytes);
+    BigUint::from_bytes_be(&addr_bytes)
 }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -96,6 +96,9 @@ pub const DEVNET_DEPLOY_BLOCK: u64 = 0;
 /// The block number at which the darkpool was deployed on testnet
 pub const TESTNET_DEPLOY_BLOCK: u64 = 55713322;
 
+/// The number of bytes in an Arbitrum address
+pub const ADDRESS_BYTE_LENGTH: usize = 20;
+
 // ----------------------
 // | Pubsub Topic Names |
 // ----------------------

--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -64,7 +64,7 @@ cargo run \
         AAVE \
         COMP \
         MKR \
-        ARB \
+        REN \
         MANA \
         ENS \
         DYDX \

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    deserialize_biguint_from_hex_string, serialize_biguint_to_hex_string,
+    deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr,
     types::{ApiKeychain, ApiOrder, ApiWallet},
 };
 
@@ -204,13 +204,13 @@ pub struct GetBalanceByMintResponse {
 pub struct DepositBalanceRequest {
     /// The arbitrum account contract address to send the balance from
     #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
+        serialize_with = "serialize_biguint_to_hex_addr",
         deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub from_addr: BigUint,
     /// The mint (ERC-20 contract address) of the token to deposit
     #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
+        serialize_with = "serialize_biguint_to_hex_addr",
         deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub mint: BigUint,
@@ -246,7 +246,7 @@ pub struct DepositBalanceResponse {
 pub struct WithdrawBalanceRequest {
     /// The destination address to withdraw the balance to
     #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
+        serialize_with = "serialize_biguint_to_hex_addr",
         deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub destination_addr: BigUint,

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -5,7 +5,7 @@
 
 use num_bigint::BigUint;
 use serde::{de::Error as DeserializeError, Deserialize, Deserializer, Serialize, Serializer};
-use util::hex::{biguint_from_hex_string, biguint_to_hex_string};
+use util::hex::{biguint_from_hex_string, biguint_to_hex_addr};
 
 pub mod bus_message;
 pub mod http;
@@ -61,12 +61,12 @@ impl<'de> serde::de::Visitor<'de> for EmptyRequestResponseVisitor {
     }
 }
 
-/// A helper to serialize a BigUint to a hex string
-pub fn serialize_biguint_to_hex_string<S>(val: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
+/// A helper to serialize a BigUint to a hex address
+pub fn serialize_biguint_to_hex_addr<S>(val: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let hex = biguint_to_hex_string(val);
+    let hex = biguint_to_hex_addr(val);
     serializer.serialize_str(&hex)
 }
 

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -16,7 +16,7 @@ use common::types::tasks::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
-use util::hex::biguint_to_hex_string;
+use util::hex::biguint_to_hex_addr;
 
 // -----------
 // | Helpers |
@@ -101,7 +101,7 @@ impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
             },
             HistoricalTaskDescription::PayOfflineFee { mint, amount, is_protocol } => {
                 Self::PayOfflineFee {
-                    mint: biguint_to_hex_string(&mint),
+                    mint: biguint_to_hex_addr(&mint),
                     amount: u128_to_number(amount),
                     is_protocol,
                 }
@@ -125,8 +125,8 @@ pub struct ApiHistoricalMatch {
 
 impl From<MatchResult> for ApiHistoricalMatch {
     fn from(value: MatchResult) -> Self {
-        let base = biguint_to_hex_string(&value.base_mint);
-        let quote = biguint_to_hex_string(&value.quote_mint);
+        let base = biguint_to_hex_addr(&value.base_mint);
+        let quote = biguint_to_hex_addr(&value.quote_mint);
         let volume = u128_to_number(value.base_amount);
         Self { base, quote, volume, is_sell: value.direction }
     }
@@ -182,8 +182,8 @@ pub struct WalletUpdateOrder {
 
 impl From<Order> for WalletUpdateOrder {
     fn from(value: Order) -> Self {
-        let base = biguint_to_hex_string(&value.base_mint);
-        let quote = biguint_to_hex_string(&value.quote_mint);
+        let base = biguint_to_hex_addr(&value.base_mint);
+        let quote = biguint_to_hex_addr(&value.quote_mint);
         let amount = u128_to_number(value.amount);
         Self { base, quote, side: value.side, amount }
     }
@@ -193,12 +193,12 @@ impl From<WalletUpdateType> for ApiWalletUpdateType {
     fn from(value: WalletUpdateType) -> Self {
         match value {
             WalletUpdateType::Deposit { mint, amount } => {
-                let mint = biguint_to_hex_string(&mint);
+                let mint = biguint_to_hex_addr(&mint);
                 let amount = u128_to_number(amount);
                 Self::Deposit { mint, amount }
             },
             WalletUpdateType::Withdraw { mint, amount } => {
-                let mint = biguint_to_hex_string(&mint);
+                let mint = biguint_to_hex_addr(&mint);
                 let amount = u128_to_number(amount);
                 Self::Withdraw { mint, amount }
             },

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -20,7 +20,7 @@ use util::hex::{
 };
 use uuid::Uuid;
 
-use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_string};
+use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
 
 /// The wallet type, holds all balances, orders, metadata, and randomness
 /// for a trader
@@ -121,13 +121,13 @@ pub struct ApiOrder {
     pub id: Uuid,
     /// The quote token mint
     #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
+        serialize_with = "serialize_biguint_to_hex_addr",
         deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub quote_mint: BigUint,
     /// The base token mint
     #[serde(
-        serialize_with = "serialize_biguint_to_hex_string",
+        serialize_with = "serialize_biguint_to_hex_addr",
         deserialize_with = "deserialize_biguint_from_hex_string"
     )]
     pub base_mint: BigUint,

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -3,7 +3,7 @@
 use circuit_types::{r#match::MatchResult, transfers::ExternalTransferDirection};
 use common::types::{token::Token, transfer_auth::ExternalTransferWithAuth};
 use num_bigint::BigUint;
-use util::hex::biguint_to_hex_string;
+use util::hex::biguint_to_hex_addr;
 
 use crate::labels::{
     ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
@@ -26,7 +26,7 @@ use crate::{global_metrics::IN_FLIGHT_TASKS, labels::NUM_COMPLETED_TASKS_METRIC}
 /// lossy f64 conversion via the associated number of decimals
 fn get_asset_and_volume(mint: &BigUint, amount: u128) -> (String, f64) {
     let token = Token::from_addr_biguint(mint);
-    let asset = token.get_ticker().unwrap_or(&biguint_to_hex_string(mint)).to_string();
+    let asset = token.get_ticker().unwrap_or(&biguint_to_hex_addr(mint)).to_string();
     let volume = token.convert_to_decimal(amount);
 
     (asset, volume)


### PR DESCRIPTION
This PR replaces the `biguint_to_hex_str` conversion method w/ a specialized `biguint_to_hex_addr` one that preserves padding to 20 bytes for addresses where appropriate. The native `BigUint::to_str_radix` would trim leading zeroes, leading to issues across the stack when token addresses had leading zeroes, e.g. inability to find tokens by address in the token mapping, and returning trimmed addresses via the API which the frontend would fail to match to its own token mapping.

All unit tests pass, and this is being tested in the mini-env.