### PR TITLE
common: types, workers: handshake-manager: use timestamped price in order metadata

### DIFF
--- a/common/src/types/handshake.rs
+++ b/common/src/types/handshake.rs
@@ -1,12 +1,11 @@
 //! Groups type definitions for handshake state objects used throughout the node
 
-use circuit_types::fixed_point::FixedPoint;
 use constants::Scalar;
 use crossbeam::channel::Sender;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::wallet::OrderIdentifier;
+use super::{wallet::OrderIdentifier, TimestampedPrice};
 
 /// The role in an MPC network setup; either Dialer or Listener depending on
 /// which node initiates the connection
@@ -49,7 +48,7 @@ pub struct HandshakeState {
     /// The public secret share nullifier of the local peer's order
     pub local_share_nullifier: Scalar,
     /// The agreed upon price of the asset the local party intends to match on
-    pub execution_price: FixedPoint,
+    pub execution_price: TimestampedPrice,
     /// The current state information of the
     pub state: State,
     /// The cancel channel that the coordinator may use to cancel MPC execution
@@ -88,7 +87,7 @@ impl HandshakeState {
         local_order_id: OrderIdentifier,
         peer_share_nullifier: Scalar,
         local_share_nullifier: Scalar,
-        execution_price: FixedPoint,
+        execution_price: TimestampedPrice,
     ) -> Self {
         Self {
             request_id,
@@ -134,10 +133,11 @@ impl HandshakeState {
 /// Handshake object mocks for testing
 #[cfg(feature = "mocks")]
 pub mod mocks {
-    use circuit_types::fixed_point::FixedPoint;
     use constants::Scalar;
     use rand::thread_rng;
     use uuid::Uuid;
+
+    use crate::types::TimestampedPrice;
 
     use super::{ConnectionRole, HandshakeState, State};
 
@@ -152,7 +152,7 @@ pub mod mocks {
             local_order_id: Uuid::new_v4(),
             peer_share_nullifier: Scalar::random(&mut rng),
             local_share_nullifier: Scalar::random(&mut rng),
-            execution_price: FixedPoint::from_f64_round_down(10.),
+            execution_price: TimestampedPrice::new(10.),
             state: State::Completed,
             cancel_channel: None,
         }

--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -1,12 +1,13 @@
 //! Descriptors for the match settlement tasks
 
-use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
+use circuit_types::r#match::MatchResult;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
     handshake::HandshakeState,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::{OrderIdentifier, WalletIdentifier},
+    TimestampedPrice,
 };
 
 use super::TaskDescriptor;
@@ -16,7 +17,7 @@ use super::TaskDescriptor;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettleMatchInternalTaskDescriptor {
     /// The price at which the match was executed
-    pub execution_price: FixedPoint,
+    pub execution_price: TimestampedPrice,
     /// The identifier of the first order
     pub order_id1: OrderIdentifier,
     /// The identifier of the second order
@@ -41,7 +42,7 @@ impl SettleMatchInternalTaskDescriptor {
     /// Constructor
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        execution_price: FixedPoint,
+        execution_price: TimestampedPrice,
         order_id1: OrderIdentifier,
         order_id2: OrderIdentifier,
         wallet_id1: WalletIdentifier,

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -1,8 +1,10 @@
 //! Order metadata for a wallet's orders
 
-use circuit_types::{fixed_point::FixedPoint, order::Order, Amount};
+use circuit_types::{order::Order, Amount};
 use serde::{Deserialize, Serialize};
 use util::get_current_time_millis;
+
+use crate::types::TimestampedPrice;
 
 use super::OrderIdentifier;
 
@@ -57,7 +59,7 @@ impl OrderMetadata {
     }
 
     /// Add a fill to the order metadata
-    pub fn record_partial_fill(&mut self, amount: Amount, price: FixedPoint) {
+    pub fn record_partial_fill(&mut self, amount: Amount, price: TimestampedPrice) {
         let fill = PartialOrderFill::new(amount, price);
         self.fills.push(fill);
     }
@@ -68,17 +70,13 @@ impl OrderMetadata {
 pub struct PartialOrderFill {
     /// The amount filled by the partial fill
     pub amount: Amount,
-    /// The price at which the fill executed
-    pub price: f64,
-    /// The time at which the fill executed, in milliseconds since the epoch
-    pub timestamp: u64,
+    /// The timestamped price at which the fill executed
+    pub price: TimestampedPrice,
 }
 
 impl PartialOrderFill {
     /// Constructor
-    pub fn new(amount: Amount, price: FixedPoint) -> Self {
-        let timestamp = get_current_time_millis();
-        let price = price.to_f64();
-        Self { amount, price, timestamp }
+    pub fn new(amount: Amount, price: TimestampedPrice) -> Self {
+        Self { amount, price }
     }
 }

--- a/gossip-api/src/request_response/handshake.rs
+++ b/gossip-api/src/request_response/handshake.rs
@@ -1,5 +1,7 @@
 //! Groups API definitions for handshake request response
-use common::types::{gossip::WrappedPeerId, token::Token, wallet::OrderIdentifier, Price};
+use common::types::{
+    gossip::WrappedPeerId, token::Token, wallet::OrderIdentifier, TimestampedPrice,
+};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -10,7 +12,7 @@ use serde::{Deserialize, Serialize};
 // ----------------
 
 /// A type representing the midpoint price of a given token pair
-pub type MidpointPrice = (Token, Token, Price);
+pub type MidpointPrice = (Token, Token, TimestampedPrice);
 
 /// A price vector that a peer proposes to its counterparty during a handshake
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -23,7 +25,7 @@ impl PriceVector {
     }
 }
 
-impl From<PriceVector> for HashMap<(Token, Token), Price> {
+impl From<PriceVector> for HashMap<(Token, Token), TimestampedPrice> {
     fn from(price_vector: PriceVector) -> Self {
         price_vector.0.into_iter().map(|(base, quote, price)| ((base, quote), price)).collect()
     }

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -61,8 +61,7 @@ impl StateApplicator {
 
 #[cfg(test)]
 mod tests {
-    use circuit_types::fixed_point::FixedPoint;
-    use common::types::wallet_mocks::mock_order;
+    use common::types::{wallet_mocks::mock_order, TimestampedPrice};
     use uuid::Uuid;
 
     use crate::applicator::test_helpers::mock_applicator;
@@ -94,7 +93,7 @@ mod tests {
         tx.commit().unwrap();
 
         // Modify the metadata and push
-        md.record_partial_fill(1, FixedPoint::from_f64_round_down(2.));
+        md.record_partial_fill(1, TimestampedPrice::new(2.));
         applicator.update_order_metadata(md).unwrap();
 
         // Check the state

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -63,8 +63,9 @@ impl State {
 pub mod test {
     use std::cmp::Reverse;
 
-    use circuit_types::fixed_point::FixedPoint;
-    use common::types::{wallet::order_metadata::OrderState, wallet_mocks::mock_order};
+    use common::types::{
+        wallet::order_metadata::OrderState, wallet_mocks::mock_order, TimestampedPrice,
+    };
     use itertools::Itertools;
     use rand::{seq::IteratorRandom, thread_rng, RngCore};
 
@@ -132,7 +133,7 @@ pub mod test {
         let idx = (0..orders.len()).choose(&mut thread_rng()).unwrap();
         let mut meta = orders[idx].clone();
         let amount = 1;
-        let price = FixedPoint::from_f64_round_down(10.);
+        let price = TimestampedPrice::new(10.);
         meta.record_partial_fill(amount, price);
 
         // Update and retrieve the order's metadata

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -107,13 +107,14 @@ mod test {
     // Wallet update handlers in the applicator handle order history changes to
     // hide the wallet index/order history denormalization
 
-    use circuit_types::{balance::Balance, fixed_point::FixedPoint};
+    use circuit_types::balance::Balance;
     use common::types::{
         wallet::{
             order_metadata::{OrderMetadata, OrderState, PartialOrderFill},
             OrderIdentifier, WalletIdentifier,
         },
         wallet_mocks::{mock_empty_wallet, mock_order},
+        TimestampedPrice,
     };
     use itertools::Itertools;
     use num_bigint::BigUint;
@@ -122,7 +123,7 @@ mod test {
 
     /// Create a set of mock historical orders
     fn create_mock_historical_orders(n: usize, wallet_id: WalletIdentifier, state: &State) {
-        let fill = PartialOrderFill::new(1, FixedPoint::from_integer(5));
+        let fill = PartialOrderFill::new(1, TimestampedPrice::new(5.));
         let history = (0..n)
             .map(|_| OrderMetadata {
                 id: OrderIdentifier::new_v4(),

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -116,10 +116,10 @@ impl<'db> StateTxn<'db, RW> {
 mod tests {
     use std::cmp::Reverse;
 
-    use circuit_types::fixed_point::FixedPoint;
     use common::types::{
         wallet::order_metadata::{OrderMetadata, OrderState},
         wallet_mocks::mock_order,
+        TimestampedPrice,
     };
     use itertools::Itertools;
     use rand::{thread_rng, Rng, RngCore};
@@ -200,7 +200,7 @@ mod tests {
         // Update the order
         let mut updated_order = curr_order;
         let amount = rng.gen();
-        let price = FixedPoint::from_f64_round_down(100.2);
+        let price = TimestampedPrice::new(100.2);
         updated_order.record_partial_fill(amount, price);
 
         let tx = db.new_write_tx().unwrap();

--- a/workers/handshake-manager/src/manager/handshake.rs
+++ b/workers/handshake-manager/src/manager/handshake.rs
@@ -4,7 +4,6 @@
 //!     2. Order selection
 //!     3. State management
 
-use circuit_types::fixed_point::FixedPoint;
 use common::types::{handshake::ConnectionRole, wallet::OrderIdentifier};
 use gossip_api::{
     pubsub::{
@@ -79,7 +78,7 @@ impl HandshakeExecutor {
                     ConnectionRole::Dialer,
                     peer_order_id,
                     local_order_id,
-                    FixedPoint::from_f64_round_down(price),
+                    price,
                 )
                 .await?;
         }
@@ -149,7 +148,7 @@ impl HandshakeExecutor {
                 ConnectionRole::Listener,
                 sender_order,
                 my_order,
-                FixedPoint::from_f64_round_down(execution_price),
+                execution_price,
             )
             .await?;
 

--- a/workers/handshake-manager/src/manager/match.rs
+++ b/workers/handshake-manager/src/manager/match.rs
@@ -135,12 +135,13 @@ impl HandshakeExecutor {
         let reblind_witness = proof_witnesses.copy_reblind_witness();
         let party0_commitments_statement = &party0_validity_bundle.commitment_proof.statement;
         let party1_commitments_statement = &party1_validity_bundle.commitment_proof.statement;
+        let price_fp = FixedPoint::from_f64_round_down(handshake_state.execution_price.price);
         let (witness, statement) = Self::execute_match_settle_mpc(
             &commitment_witness.order,
             &commitment_witness.balance_send,
             &commitment_witness.balance_receive,
             &commitment_witness.relayer_fee,
-            &handshake_state.execution_price,
+            &price_fp,
             &reblind_witness.reblinded_wallet_public_shares,
             party0_commitments_statement.indices,
             party1_commitments_statement.indices,

--- a/workers/handshake-manager/src/state.rs
+++ b/workers/handshake-manager/src/state.rs
@@ -3,12 +3,12 @@
 use std::collections::{HashMap, HashSet};
 
 use super::error::HandshakeManagerError;
-use circuit_types::fixed_point::FixedPoint;
 use common::{
     new_async_shared,
     types::{
         handshake::{ConnectionRole, HandshakeState},
         wallet::OrderIdentifier,
+        TimestampedPrice,
     },
     AsyncShared,
 };
@@ -57,7 +57,7 @@ impl HandshakeStateIndex {
         role: ConnectionRole,
         peer_order_id: OrderIdentifier,
         local_order_id: OrderIdentifier,
-        execution_price: FixedPoint,
+        execution_price: TimestampedPrice,
     ) -> Result<(), HandshakeManagerError> {
         // Lookup the public share nullifiers for the order
         let state = &self.state;

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -26,6 +26,7 @@ use common::types::{
     tasks::{SettleMatchInternalTaskDescriptor, SettleMatchTaskDescriptor},
     wallet::Wallet,
     wallet_mocks::mock_empty_wallet,
+    TimestampedPrice,
 };
 use constants::Scalar;
 use eyre::{eyre, Result};
@@ -365,7 +366,7 @@ async fn test_settle_internal_match(test_args: IntegrationTestArgs) -> Result<()
     let order_id1 = *buy_wallet.orders.keys().next().unwrap();
     let order_id2 = *sell_wallet.orders.keys().next().unwrap();
     let task = SettleMatchInternalTaskDescriptor::new(
-        FixedPoint::from_f64_round_down(EXECUTION_PRICE),
+        TimestampedPrice::new(EXECUTION_PRICE),
         buy_wallet.wallet_id,
         sell_wallet.wallet_id,
         order_id1,

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -21,6 +21,7 @@ use circuits::zk_circuits::valid_match_settle::{
 use common::types::proof_bundles::{MatchBundle, ProofBundle, ValidMatchSettleBundle};
 use common::types::tasks::SettleMatchInternalTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
+use common::types::TimestampedPrice;
 use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::Wallet,
@@ -148,7 +149,7 @@ impl From<StateError> for SettleMatchInternalTaskError {
 /// Describe the settle match internal task
 pub struct SettleMatchInternalTask {
     /// The price at which the match was executed
-    execution_price: FixedPoint,
+    execution_price: TimestampedPrice,
     /// The identifier of the first order
     order_id1: OrderIdentifier,
     /// The identifier of the second order
@@ -429,7 +430,7 @@ impl SettleMatchInternalTask {
         let commitment_witness0 = &self.order1_validity_witness.commitment_witness;
         let commitment_witness1 = &self.order2_validity_witness.commitment_witness;
 
-        let price = self.execution_price;
+        let price = FixedPoint::from_f64_round_down(self.execution_price.price);
         let order0 = commitment_witness0.order.clone();
         let balance0 = commitment_witness0.balance_send.clone();
         let balance_receive0 = commitment_witness0.balance_receive.clone();

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -1,7 +1,10 @@
 //! Helpers for transitioning order states and recording them in order history
 
-use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
-use common::types::wallet::{order_metadata::OrderState, OrderIdentifier};
+use circuit_types::r#match::MatchResult;
+use common::types::{
+    wallet::{order_metadata::OrderState, OrderIdentifier},
+    TimestampedPrice,
+};
 use state::State;
 
 /// The error message emitted when metadata for an order cannot be found
@@ -24,7 +27,7 @@ pub async fn transition_order_settling(
 pub async fn record_order_fill(
     order_id: OrderIdentifier,
     match_res: &MatchResult,
-    price: FixedPoint,
+    price: TimestampedPrice,
     state: &State,
 ) -> Result<(), String> {
     // Get the order metadata


### PR DESCRIPTION
This PR introduces the `TimestampedPrice` struct and uses it in the `SettleMatch` and `SettleMatchInternal` tasks with the purpose of it being used in the `PartialOrderFill` struct.

The goal here is to communicate to the frontend the time at which the price used in each of an order's partial fills was sampled. This allows us to more accurately estimate the savings relative to hypothetically executing the fill on Binance.

We use the timestamp of the price sampling, as opposed to the timestamp of the fill execution, as we deem that to be the point at which the execution process for a fill begins. In calculating the savings, we want to communicate to the user: "if you began the execution process at this time in Renegade, you'd get this price, if you began it at this time in Binance, you'd get this price".

All unit tests pass, and this is currently being tested in dev.

Note: because this changes a type that is communicated both in gossip and is stored directly in the DB, upgrading testnet to use this change will require an intermediary version to prevent serde issues