### PR TITLE
handshake-manager: internal-engine: Check matches above `min_fill_size`

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -333,8 +333,15 @@ pub mod test_helpers {
         let (o1, o2) = if rng.gen_bool(0.5) { (o1, o2) } else { (o2, o1) };
 
         // Match orders assuming they are fully capitalized
-        let match_res =
-            match_orders_with_max_amount(&o1, &o2, o1.amount, o2.amount, price).unwrap();
+        let match_res = match_orders_with_max_amount(
+            &o1,
+            &o2,
+            o1.amount,
+            o2.amount,
+            Amount::MIN, // min_fill_size
+            price,
+        )
+        .unwrap();
 
         (o1, o2, price, match_res)
     }

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -1,7 +1,7 @@
 //! The relayer CLI and config definitions
 
 use arbitrum_client::constants::Chain;
-use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
+use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint, Amount};
 use clap::Parser;
 use common::types::{
     exchange::Exchange,
@@ -45,6 +45,9 @@ pub struct Cli {
     // | Application Level Configs |
     // -----------------------------
 
+    /// The minimum amount of the quote asset that the relayer should settle matches on
+    #[clap(long, value_parser, default_value = "0")]
+    pub min_fill_size: Amount,
     /// The take rate of this relayer on a managed match, i.e. the amount of the received asset 
     /// that the relayer takes as a fee
     /// 
@@ -221,6 +224,9 @@ pub struct RelayerConfig {
     // -----------------------------
     // | Application Level Configs |
     // -----------------------------
+    /// The minimum amount of the quote asset that the relayer should settle
+    /// matches on
+    pub min_fill_size: Amount,
     /// The take rate of this relayer on a managed match, i.e. the amount of the
     /// received asset that the relayer takes as a fee
     pub match_take_rate: FixedPoint,
@@ -363,6 +369,7 @@ impl Default for RelayerConfig {
 impl Clone for RelayerConfig {
     fn clone(&self) -> Self {
         Self {
+            min_fill_size: self.min_fill_size,
             match_take_rate: self.match_take_rate,
             match_mutual_exclusion_list: self.match_mutual_exclusion_list.clone(),
             relayer_fee_whitelist: self.relayer_fee_whitelist.clone(),

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -96,6 +96,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
     let relayer_fee_whitelist = parse_relayer_whitelist_file(cli_args.relayer_fee_whitelist)?;
 
     let mut config = RelayerConfig {
+        min_fill_size: cli_args.min_fill_size,
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
         match_mutual_exclusion_list: cli_args.match_mutual_exclusion_list.into_iter().collect(),
         relayer_fee_whitelist,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -258,6 +258,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the handshake manager
     let (handshake_cancel_sender, handshake_cancel_receiver) = watch::channel(());
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
+        min_fill_size: args.min_fill_size,
         mutual_exclusion_list: args.match_mutual_exclusion_list,
         state: global_state.clone(),
         network_channel: network_sender.clone(),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -386,6 +386,7 @@ impl MockNodeController {
         let task_queue = self.task_queue.0.clone();
 
         let conf = HandshakeManagerConfig {
+            min_fill_size: self.config.min_fill_size,
             mutual_exclusion_list: HashSet::new(),
             state,
             network_channel,

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -6,7 +6,7 @@ pub mod r#match;
 mod price_agreement;
 pub(crate) mod scheduler;
 
-use circuit_types::r#match::MatchResult;
+use circuit_types::{r#match::MatchResult, Amount};
 use common::{
     default_wrapper::{DefaultOption, DefaultWrapper},
     new_async_shared,
@@ -108,6 +108,9 @@ pub struct HandshakeManager {
 /// Manages the threaded execution of the handshake protocol
 #[derive(Clone)]
 pub struct HandshakeExecutor {
+    /// The minimum amount of the quote asset that the relayer should settle
+    /// matches on
+    pub(crate) min_fill_size: Amount,
     /// The set of wallets to mutually exclude from matches
     pub(crate) mutual_exclusion_list: HashSet<WalletIdentifier>,
     /// The cache used to mark order pairs as already matched
@@ -137,6 +140,7 @@ impl HandshakeExecutor {
     /// Create a new protocol executor
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        min_fill_size: Amount,
         mutual_exclusion_list: HashSet<WalletIdentifier>,
         job_channel: HandshakeManagerReceiver,
         network_channel: NetworkManagerQueue,
@@ -151,6 +155,7 @@ impl HandshakeExecutor {
         let handshake_state_index = HandshakeStateIndex::new(state.clone());
 
         Ok(Self {
+            min_fill_size,
             mutual_exclusion_list,
             handshake_cache,
             handshake_state_index,

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -152,7 +152,9 @@ impl HandshakeExecutor {
         // Match the orders
         let b1 = &validity_witness1.commitment_witness.balance_send;
         let b2 = &validity_witness2.commitment_witness.balance_send;
-        let match_result = match match_orders(&o1, &o2, b1, b2, price) {
+        // TODO: Use a more sophisticated version of `min_fill_size` that takes into
+        // account the cost of the match
+        let match_result = match match_orders(&o1, &o2, b1, b2, self.min_fill_size, price) {
             Some(match_) => match_,
             None => return Ok(false),
         };

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use circuit_types::Amount;
 use common::types::{wallet::WalletIdentifier, CancelChannel};
 use common::worker::Worker;
 use external_api::bus_message::SystemBusMessage;
@@ -29,6 +30,9 @@ use super::{error::HandshakeManagerError, manager::HandshakeManager};
 
 /// The config type for the handshake manager
 pub struct HandshakeManagerConfig {
+    /// The minimum amount of the quote asset that the relayer should settle
+    /// matches on
+    pub min_fill_size: Amount,
     /// The set of wallets to mutually exclude from matches
     ///
     /// I.e. any two wallets in this list will never be matched internally by
@@ -68,6 +72,7 @@ impl Worker for HandshakeManager {
             config.cancel_channel.clone(),
         );
         let executor = HandshakeExecutor::new(
+            config.min_fill_size,
             config.mutual_exclusion_list.clone(),
             config.job_receiver.take().unwrap(),
             config.network_channel.clone(),

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -147,7 +147,7 @@ async fn setup_match_result(
     let o2 = wallet2.orders.first().unwrap().1.clone();
     let b1 = wallet1.balances.first().unwrap().1.clone();
     let b2 = wallet2.balances.first().unwrap().1.clone();
-    let match_ = match_orders(&o1, &o2, &b1, &b2, price).unwrap();
+    let match_ = match_orders(&o1, &o2, &b1, &b2, Amount::MIN, price).unwrap();
 
     // Pull the validity proof witnesses for the wallets so that we may update the
     // public and private shares to the reblinded and augmented shares; as would


### PR DESCRIPTION
### Purpose
This PR adds a `min_fill_size` config option to the relayer and uses this value as a threshold which matches must exceed to be settled. Specifically, we threshold the quote asset swap implied by a match. Using the quote instead of the base is preferred as Renegade currently quotes all swaps in USDC -- so the logic is simpler.

### Testing
- Unit tests pass; added a matching engine test for a `min_fill_size` violation
- Tested on a locally run relayer with a WETH trade