### PR TITLE
arbitrum-client: contract_interaction: set gas price to 2x basefee

### DIFF
--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -1,6 +1,6 @@
 //! Helper functions for Arbitrum client integration tests
 
-use arbitrum_client::{client::ArbitrumClient, helpers::send_tx};
+use arbitrum_client::client::ArbitrumClient;
 use circuit_types::{
     native_helpers::compute_wallet_commitment_from_private, traits::BaseType,
     wallet::WalletShareStateCommitment, SizedWalletShare,
@@ -68,7 +68,8 @@ pub async fn setup_pre_allocated_state(client: &mut ArbitrumClient) -> Result<Pr
 /// w/ the default values for the leaves
 pub async fn clear_merkle(client: &ArbitrumClient) -> Result<()> {
     warn!("Clearing Merkle contract state");
-    send_tx(client.get_darkpool_client().clear_merkle())
+    client
+        .send_tx(client.get_darkpool_client().clear_merkle())
         .await
         .map(|_| ())
         .map_err(|e| eyre!(e.to_string()))


### PR DESCRIPTION
This PR tweaks the `send_tx` helper method on the `ArbitrumClient` to set the gas price to 2x the most recent base fee, sidestepping around the `ethers-rs` default functionality which assumes base fee constant thresholds that don't make sense in Arbitrum's fee regime (it would basically always set the max fee to 3.2gwei).