### PR TITLE
config: Add `--auto-redeem-fees` flag set to false by default

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -60,6 +60,9 @@ pub struct Cli {
     /// The path to the file containing relayer fee whitelist info
     #[clap(long, value_parser)]
     pub relayer_fee_whitelist: Option<String>,
+    /// When set, the relayer will automatically redeem new fees into its wallet
+    #[clap(long, value_parser, default_value = "false")]
+    pub auto_redeem_fees: bool,
 
     // -----------------------
     // | Environment Configs |
@@ -230,6 +233,8 @@ pub struct RelayerConfig {
     /// The take rate of this relayer on a managed match, i.e. the amount of the
     /// received asset that the relayer takes as a fee
     pub match_take_rate: FixedPoint,
+    /// When set, the relayer will automatically redeem new fees into its wallet
+    pub auto_redeem_fees: bool,
     /// The mutual exclusion list for matches, two wallets in this list will
     /// never be matched internally by the node
     pub match_mutual_exclusion_list: HashSet<WalletIdentifier>,
@@ -371,6 +376,7 @@ impl Clone for RelayerConfig {
         Self {
             min_fill_size: self.min_fill_size,
             match_take_rate: self.match_take_rate,
+            auto_redeem_fees: self.auto_redeem_fees,
             match_mutual_exclusion_list: self.match_mutual_exclusion_list.clone(),
             relayer_fee_whitelist: self.relayer_fee_whitelist.clone(),
             price_reporter_url: self.price_reporter_url.clone(),

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -98,6 +98,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
     let mut config = RelayerConfig {
         min_fill_size: cli_args.min_fill_size,
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
+        auto_redeem_fees: cli_args.auto_redeem_fees,
         match_mutual_exclusion_list: cli_args.match_mutual_exclusion_list.into_iter().collect(),
         relayer_fee_whitelist,
         price_reporter_url,

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -65,6 +65,11 @@ impl State {
         self.with_read_tx(move |tx| tx.get_relayer_fee(&wid).map_err(StateError::Db)).await
     }
 
+    /// Get the local relayer's auto-redeem fees flag
+    pub async fn get_auto_redeem_fees(&self) -> Result<bool, StateError> {
+        self.with_read_tx(|tx| tx.get_auto_redeem_fees().map_err(StateError::Db)).await
+    }
+
     // -----------
     // | Setters |
     // -----------
@@ -116,6 +121,7 @@ impl State {
         let fee_decryption_key = config.fee_decryption_key;
         let match_take_rate = config.match_take_rate;
         let relayer_fee_whitelist = config.relayer_fee_whitelist.clone();
+        let auto_redeem_fees = config.auto_redeem_fees;
 
         let relayer_wallet_id =
             derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
@@ -128,6 +134,7 @@ impl State {
             tx.set_fee_decryption_key(&fee_decryption_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
             tx.set_local_node_wallet(relayer_wallet_id)?;
+            tx.set_auto_redeem_fees(auto_redeem_fees)?;
 
             // Setup the relayer fee whitelist
             for entry in relayer_fee_whitelist {

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -33,6 +33,8 @@ const LOCAL_WALLET_ID_KEY: &str = "local-wallet-id";
 const LOCAL_RELAYER_DECRYPTION_KEY: &str = "local-relayer-decryption-key";
 /// The key for the local relayer's match take rate in the node metadata table
 const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
+/// The key for the local relayer's auto-redeem fees flag in the node metadata
+const AUTO_REDEEM_FEES_KEY: &str = "auto-redeem-fees";
 
 // -----------
 // | Helpers |
@@ -104,6 +106,13 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
             .read(NODE_METADATA_TABLE, &RELAYER_TAKE_RATE_KEY.to_string())?
             .ok_or_else(|| err_not_found(RELAYER_TAKE_RATE_KEY))
     }
+
+    /// Get the local relayer's auto-redeem fees flag
+    pub fn get_auto_redeem_fees(&self) -> Result<bool, StorageError> {
+        self.inner()
+            .read(NODE_METADATA_TABLE, &AUTO_REDEEM_FEES_KEY.to_string())?
+            .ok_or_else(|| err_not_found(AUTO_REDEEM_FEES_KEY))
+    }
 }
 
 // -----------
@@ -145,5 +154,14 @@ impl<'db> StateTxn<'db, RW> {
     /// Set the local relayer's match take rate
     pub fn set_relayer_take_rate(&self, take_rate: &FixedPoint) -> Result<(), StorageError> {
         self.inner().write(NODE_METADATA_TABLE, &RELAYER_TAKE_RATE_KEY.to_string(), take_rate)
+    }
+
+    /// Set the local relayer's auto-redeem fees flag
+    pub fn set_auto_redeem_fees(&self, auto_redeem_fees: bool) -> Result<(), StorageError> {
+        self.inner().write(
+            NODE_METADATA_TABLE,
+            &AUTO_REDEEM_FEES_KEY.to_string(),
+            &auto_redeem_fees,
+        )
     }
 }

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -288,9 +288,10 @@ impl PayOfflineFeeTask {
         let waiter = self.state.update_wallet(self.new_wallet.clone()).await?;
         waiter.await?;
 
-        // If this was a relayer fee payment, enqueue a job for the relayer to redeem
-        // the fee
-        if !self.is_protocol_fee {
+        // If this was a relayer fee payment and auto-redeem is enabled, enqueue a job
+        // for the relayer to redeem the fee
+        let auto_redeem = self.state.get_auto_redeem_fees().await?;
+        if !self.is_protocol_fee && auto_redeem {
             enqueue_relayer_redeem_job(self.note.clone(), &self.state)
                 .await
                 .map_err(PayOfflineFeeTaskError::State)?;


### PR DESCRIPTION
### Purpose
This PR adds an `--auto-redeem-fees` flag that is set to false by default. On the Renegade internal relayer cluster, we will _not_ enable this flag, and will instead use separate fee redemption infra.

### Testing
- Submitted fee payments for a wallet, verified that the relayer did not redeem