### PR TITLE
state: replication: clear tables instead of dropping & remove db when applying snapshots

### DIFF
--- a/state/src/replication/state_machine/mod.rs
+++ b/state/src/replication/state_machine/mod.rs
@@ -291,7 +291,8 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
                 self.open_snap_db().await.map_err(new_snapshot_error)?
             }
         };
-        self.update_from_snapshot(meta, snap_db).await.map_err(new_snapshot_error)
+        self.update_from_snapshot(meta, snap_db).await.map_err(new_snapshot_error)?;
+        self.delete_snapshot_data().await.map_err(new_snapshot_error)
     }
 
     async fn get_current_snapshot(

--- a/state/src/replication/state_machine/recovery.rs
+++ b/state/src/replication/state_machine/recovery.rs
@@ -35,7 +35,8 @@ impl StateMachine {
         };
 
         self.update_from_snapshot(&dummy_meta, snap_db).await?;
-        self.clear_wallet_task_queues()
+        self.clear_wallet_task_queues()?;
+        self.delete_snapshot_data().await
     }
 
     /// Clear all wallet task queues

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -265,10 +265,8 @@ impl StateMachine {
                 continue;
             }
 
-            // Delete and create the table on the destination
-            #[allow(unsafe_code)]
-            unsafe { dest_tx.drop_table(table) }?;
-            dest_tx.create_table(table)?;
+            // Clear the table on the destination
+            dest_tx.clear_table(table)?;
 
             // Copy all keys and values
             let src_cursor = src_tx.inner().cursor(table)?;

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -256,6 +256,20 @@ impl StateMachine {
         jh.await.map_err(|_| ReplicationV2Error::Snapshot(ERR_AWAIT_INSTALL.to_string()))?
     }
 
+    /// Deletes the snapshot data
+    pub async fn delete_snapshot_data(&self) -> Result<(), ReplicationV2Error> {
+        let snapshot_data_path = self.snapshot_data_path();
+        if !snapshot_data_path.exists() {
+            return Ok(());
+        }
+
+        // Delete the snapshot DB
+        tokio::fs::remove_file(snapshot_data_path)
+            .await
+            .map_err(err_str!(ReplicationV2Error::Snapshot))
+            .map(|_| ())
+    }
+
     /// Copy all data from one DB to another
     pub(crate) fn copy_db_data(src: &DB, dest: &DB) -> Result<(), ReplicationV2Error> {
         let src_tx = src.new_read_tx()?;


### PR DESCRIPTION
This PR makes the following 2 changes to how snapshots are handled:
1. When applying an installed snapshot, we use MDBX's `clear_table` method instead of dropping & re-adding a table. We are seeing `BadDbi` errors occasionally after installing snapshots that are generally linked to accessing tables that are deleted ([ex](https://github.com/erthink/libmdbx/issues/146))
2. When updating from a snapshot, either when recovering from one on startup or after installing one, we delete the snapshot data afterwards to save on disk space in the relayer

Things are working smoothly in dev, though it has proven difficult to reproduce the issue that prompted these changes even before deploying them to dev.