### PR TITLE
task-driver: redeem-note: Define redeem note task skeleton

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -4,6 +4,7 @@ mod new_wallet;
 mod node_startup;
 mod pay_fees;
 mod redeem_fees;
+mod redeem_note;
 mod refresh_wallet;
 mod settle_match;
 mod update_merkle_proof;
@@ -14,6 +15,7 @@ pub use new_wallet::*;
 pub use node_startup::*;
 pub use pay_fees::*;
 pub use redeem_fees::*;
+pub use redeem_note::*;
 pub use refresh_wallet::*;
 pub use settle_match::*;
 pub use update_merkle_proof::*;
@@ -109,6 +111,8 @@ pub enum TaskDescriptor {
     RelayerFee(PayRelayerFeeTaskDescriptor),
     /// The task descriptor for the `RedeemRelayerFee` task
     RedeemRelayerFee(RedeemRelayerFeeTaskDescriptor),
+    /// The task descriptor for the `RedeemNote` task
+    RedeemNote(RedeemNoteTaskDescriptor),
     /// The task descriptor for the `SettleMatchInternal` task
     SettleMatchInternal(SettleMatchInternalTaskDescriptor),
     /// The task descriptor for the `SettleMatch` task
@@ -131,6 +135,7 @@ impl TaskDescriptor {
             TaskDescriptor::OfflineFee(task) => task.wallet_id,
             TaskDescriptor::RelayerFee(task) => task.wallet_id,
             TaskDescriptor::RedeemRelayerFee(task) => task.wallet_id,
+            TaskDescriptor::RedeemNote(task) => task.wallet_id,
             TaskDescriptor::SettleMatch(_) => {
                 unimplemented!("SettleMatch should preempt queue, no key needed")
             },
@@ -152,6 +157,7 @@ impl TaskDescriptor {
             TaskDescriptor::OfflineFee(task) => vec![task.wallet_id],
             TaskDescriptor::RelayerFee(task) => vec![task.wallet_id],
             TaskDescriptor::RedeemRelayerFee(task) => vec![task.wallet_id],
+            TaskDescriptor::RedeemNote(task) => vec![task.wallet_id],
             TaskDescriptor::SettleMatch(task) => vec![task.wallet_id],
             TaskDescriptor::SettleMatchInternal(task) => vec![task.wallet_id1, task.wallet_id2],
             TaskDescriptor::UpdateMerkleProof(task) => vec![task.wallet.wallet_id],
@@ -169,6 +175,7 @@ impl TaskDescriptor {
             | TaskDescriptor::OfflineFee(_)
             | TaskDescriptor::RelayerFee(_)
             | TaskDescriptor::RedeemRelayerFee(_)
+            | TaskDescriptor::RedeemNote(_)
             | TaskDescriptor::UpdateWallet(_)
             | TaskDescriptor::SettleMatch(_)
             | TaskDescriptor::SettleMatchInternal(_)
@@ -188,6 +195,7 @@ impl TaskDescriptor {
             TaskDescriptor::SettleMatchInternal(_) => "Settle Match".to_string(),
             TaskDescriptor::OfflineFee(_) => "Pay Fee Offline".to_string(),
             TaskDescriptor::RelayerFee(_) => "Pay Relayer Fee".to_string(),
+            TaskDescriptor::RedeemNote(_) => "Redeem Note".to_string(),
             TaskDescriptor::RedeemRelayerFee(_) => "Redeem Relayer Fee".to_string(),
             TaskDescriptor::UpdateMerkleProof(_) => "Update Merkle Proof".to_string(),
             TaskDescriptor::NodeStartup(_) => "Node Startup".to_string(),

--- a/common/src/types/tasks/descriptors/redeem_note.rs
+++ b/common/src/types/tasks/descriptors/redeem_note.rs
@@ -1,0 +1,41 @@
+//! Descriptor for the redeem note task
+//!
+//! n.b. Notes are encrypted and running this task requires access to the
+//! decryption key. Many actors will choose not to trust a relayer with this key
+//! and will instead opt to manually redeem. This task exists mostly to allow
+//! actors to redeem fees through their _own_ relayer
+
+use circuit_types::elgamal::DecryptionKey;
+use serde::{Deserialize, Serialize};
+
+use crate::types::wallet::WalletIdentifier;
+
+use super::TaskDescriptor;
+
+/// The task descriptor parameterizing the `RedeemNote` task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RedeemNoteTaskDescriptor {
+    /// The id of the wallet to redeem the note into
+    pub wallet_id: WalletIdentifier,
+    /// The tx hash of the note to redeem
+    pub tx_hash: String,
+    /// The decryption key to decrypt the note
+    pub decryption_key: DecryptionKey,
+}
+
+impl RedeemNoteTaskDescriptor {
+    /// Construct a new task descriptor
+    pub fn new(
+        wallet_id: WalletIdentifier,
+        tx_hash: String,
+        decryption_key: DecryptionKey,
+    ) -> Self {
+        Self { wallet_id, tx_hash, decryption_key }
+    }
+}
+
+impl From<RedeemNoteTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: RedeemNoteTaskDescriptor) -> Self {
+        TaskDescriptor::RedeemNote(descriptor)
+    }
+}

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -31,6 +31,7 @@ use crate::{
         node_startup::{NodeStartupTask, NodeStartupTaskState},
         pay_offline_fee::{PayOfflineFeeTask, PayOfflineFeeTaskState},
         pay_relayer_fee::{PayRelayerFeeTask, PayRelayerFeeTaskState},
+        redeem_note::{RedeemNoteTask, RedeemNoteTaskState},
         redeem_relayer_fee::{RedeemRelayerFeeTask, RedeemRelayerFeeTaskState},
         refresh_wallet::{RefreshWalletTask, RefreshWalletTaskState},
         settle_match::{SettleMatchTask, SettleMatchTaskState},
@@ -327,6 +328,9 @@ impl TaskExecutor {
             TaskDescriptor::RedeemRelayerFee(desc) => {
                 self.start_task_helper::<RedeemRelayerFeeTask>(immediate, id, desc).await
             },
+            TaskDescriptor::RedeemNote(desc) => {
+                self.start_task_helper::<RedeemNoteTask>(immediate, id, desc).await
+            },
             TaskDescriptor::UpdateWallet(desc) => {
                 self.start_task_helper::<UpdateWalletTask>(immediate, id, desc).await
             },
@@ -458,6 +462,8 @@ pub enum StateWrapper {
     PayRelayerFee(PayRelayerFeeTaskState),
     /// The state object for the redeem relayer fees task
     RedeemRelayerFee(RedeemRelayerFeeTaskState),
+    /// The state object for the redeem note task
+    RedeemNote(RedeemNoteTaskState),
     /// The state object for the settle match task
     SettleMatch(SettleMatchTaskState),
     /// The state object for the settle match internal task
@@ -480,6 +486,7 @@ impl StateWrapper {
             StateWrapper::PayOfflineFee(state) => state.committed(),
             StateWrapper::PayRelayerFee(state) => state.committed(),
             StateWrapper::RedeemRelayerFee(state) => state.committed(),
+            StateWrapper::RedeemNote(state) => state.committed(),
             StateWrapper::SettleMatch(state) => state.committed(),
             StateWrapper::SettleMatchInternal(state) => state.committed(),
             StateWrapper::UpdateWallet(state) => state.committed(),
@@ -500,6 +507,7 @@ impl StateWrapper {
             StateWrapper::RedeemRelayerFee(state) => {
                 state == &RedeemRelayerFeeTaskState::commit_point()
             },
+            StateWrapper::RedeemNote(state) => state == &RedeemNoteTaskState::commit_point(),
             StateWrapper::SettleMatch(state) => state == &SettleMatchTaskState::commit_point(),
             StateWrapper::SettleMatchInternal(state) => {
                 state == &SettleMatchInternalTaskState::commit_point()
@@ -521,6 +529,7 @@ impl StateWrapper {
             StateWrapper::PayOfflineFee(state) => state.completed(),
             StateWrapper::PayRelayerFee(state) => state.completed(),
             StateWrapper::RedeemRelayerFee(state) => state.completed(),
+            StateWrapper::RedeemNote(state) => state.completed(),
             StateWrapper::SettleMatch(state) => state.completed(),
             StateWrapper::SettleMatchInternal(state) => state.completed(),
             StateWrapper::UpdateWallet(state) => state.completed(),
@@ -539,6 +548,7 @@ impl Display for StateWrapper {
             StateWrapper::PayOfflineFee(state) => state.to_string(),
             StateWrapper::PayRelayerFee(state) => state.to_string(),
             StateWrapper::RedeemRelayerFee(state) => state.to_string(),
+            StateWrapper::RedeemNote(state) => state.to_string(),
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
             StateWrapper::UpdateWallet(state) => state.to_string(),

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -5,6 +5,7 @@ pub mod lookup_wallet;
 pub mod node_startup;
 pub mod pay_offline_fee;
 pub mod pay_relayer_fee;
+pub mod redeem_note;
 pub mod redeem_relayer_fee;
 pub mod refresh_wallet;
 pub mod settle_match;

--- a/workers/task-driver/src/tasks/redeem_note.rs
+++ b/workers/task-driver/src/tasks/redeem_note.rs
@@ -1,0 +1,236 @@
+//! Redeem a note into a wallet
+
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
+
+use arbitrum_client::{client::ArbitrumClient, errors::ArbitrumClientError};
+use async_trait::async_trait;
+use circuit_types::elgamal::DecryptionKey;
+use common::types::{tasks::RedeemNoteTaskDescriptor, wallet::WalletIdentifier};
+use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
+use serde::Serialize;
+use state::{error::StateError, State};
+use tracing::instrument;
+
+use crate::{
+    driver::StateWrapper,
+    traits::{Task, TaskContext, TaskError, TaskState},
+};
+
+/// The name of the task
+const REDEEM_NOTE_TASK_NAME: &str = "redeem-note";
+
+// --------------
+// | Task State |
+// --------------
+
+/// Defines the state of the redeem note task
+#[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RedeemNoteTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is finding the note on-chain
+    FindingNote,
+    /// The task is proving redemption
+    ProvingRedemption,
+    /// The task is submitting the redemption transaction
+    SubmittingRedemption,
+    /// The task is finding the wallet in contract storage
+    FindingWallet,
+    /// The task is creating validity proofs for the orders in the wallet
+    CreatingValidityProofs,
+    /// The task is completed
+    Completed,
+}
+
+impl TaskState for RedeemNoteTaskState {
+    fn commit_point() -> Self {
+        RedeemNoteTaskState::SubmittingRedemption
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, RedeemNoteTaskState::Completed)
+    }
+}
+
+impl Display for RedeemNoteTaskState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RedeemNoteTaskState::Pending => write!(f, "Pending"),
+            RedeemNoteTaskState::FindingNote => write!(f, "Finding Note"),
+            RedeemNoteTaskState::ProvingRedemption => write!(f, "Proving Redemption"),
+            RedeemNoteTaskState::SubmittingRedemption => write!(f, "Submitting Redemption"),
+            RedeemNoteTaskState::FindingWallet => write!(f, "Finding Wallet"),
+            RedeemNoteTaskState::CreatingValidityProofs => write!(f, "Creating Validity Proofs"),
+            RedeemNoteTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl From<RedeemNoteTaskState> for StateWrapper {
+    fn from(state: RedeemNoteTaskState) -> Self {
+        StateWrapper::RedeemNote(state)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type for the redeem note task
+#[derive(Clone, Debug, Serialize)]
+pub enum RedeemNoteTaskError {
+    /// An error occurred while finding the note on-chain
+    Arbitrum(String),
+    /// An error interacting with relayer state
+    State(String),
+}
+
+impl TaskError for RedeemNoteTaskError {
+    fn retryable(&self) -> bool {
+        match self {
+            RedeemNoteTaskError::Arbitrum(_) => true,
+            RedeemNoteTaskError::State(_) => true,
+        }
+    }
+}
+
+impl Display for RedeemNoteTaskError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl Error for RedeemNoteTaskError {}
+
+impl From<StateError> for RedeemNoteTaskError {
+    fn from(error: StateError) -> Self {
+        RedeemNoteTaskError::Arbitrum(error.to_string())
+    }
+}
+
+impl From<ArbitrumClientError> for RedeemNoteTaskError {
+    fn from(error: ArbitrumClientError) -> Self {
+        RedeemNoteTaskError::Arbitrum(error.to_string())
+    }
+}
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Represents a task to redeem a note into a wallet
+pub struct RedeemNoteTask {
+    /// The id of the wallet to redeem the note into
+    pub wallet_id: WalletIdentifier,
+    /// The tx hash of the note to redeem
+    pub tx_hash: String,
+    /// The decryption key to decrypt the note
+    pub decryption_key: DecryptionKey,
+    /// An arbitrum client for the task to submit transactions
+    pub arbitrum_client: ArbitrumClient,
+    /// A sender to the network manager's work queue
+    pub network_sender: NetworkManagerQueue,
+    /// A copy of the relayer-global state
+    pub state: State,
+    /// The work queue to add proof management jobs to
+    pub proof_queue: ProofManagerQueue,
+    /// The state of the task's execution
+    pub task_state: RedeemNoteTaskState,
+}
+
+#[async_trait]
+impl Task for RedeemNoteTask {
+    type Error = RedeemNoteTaskError;
+    type State = RedeemNoteTaskState;
+    type Descriptor = RedeemNoteTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
+        Ok(Self {
+            wallet_id: descriptor.wallet_id,
+            tx_hash: descriptor.tx_hash,
+            decryption_key: descriptor.decryption_key,
+            arbitrum_client: ctx.arbitrum_client,
+            network_sender: ctx.network_queue,
+            state: ctx.state,
+            proof_queue: ctx.proof_queue,
+            task_state: RedeemNoteTaskState::Pending,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.state()))]
+    async fn step(&mut self) -> Result<(), Self::Error> {
+        // Dispatch based on task state
+        match self.task_state {
+            RedeemNoteTaskState::Pending => {
+                self.task_state = RedeemNoteTaskState::FindingNote;
+            },
+            RedeemNoteTaskState::FindingNote => {
+                self.find_note().await?;
+                self.task_state = RedeemNoteTaskState::ProvingRedemption;
+            },
+            RedeemNoteTaskState::ProvingRedemption => {
+                self.prove_redemption().await?;
+                self.task_state = RedeemNoteTaskState::SubmittingRedemption;
+            },
+            RedeemNoteTaskState::SubmittingRedemption => {
+                self.submit_redemption().await?;
+                self.task_state = RedeemNoteTaskState::Completed;
+            },
+            RedeemNoteTaskState::FindingWallet => {
+                self.find_wallet().await?;
+                self.task_state = RedeemNoteTaskState::CreatingValidityProofs;
+            },
+            RedeemNoteTaskState::CreatingValidityProofs => {
+                self.create_validity_proofs().await?;
+                self.task_state = RedeemNoteTaskState::Completed;
+            },
+            RedeemNoteTaskState::Completed => {
+                unreachable!("step called on task in Completed state");
+            },
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        REDEEM_NOTE_TASK_NAME.to_string()
+    }
+
+    fn state(&self) -> Self::State {
+        self.task_state
+    }
+}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl RedeemNoteTask {
+    /// Find the note in contract state and decrypt it
+    async fn find_note(&mut self) -> Result<(), RedeemNoteTaskError> {
+        todo!()
+    }
+
+    /// Prove the redemption of the note
+    async fn prove_redemption(&mut self) -> Result<(), RedeemNoteTaskError> {
+        todo!()
+    }
+
+    /// Submit the redemption transaction
+    async fn submit_redemption(&mut self) -> Result<(), RedeemNoteTaskError> {
+        todo!()
+    }
+
+    /// Find the wallet in contract storage
+    async fn find_wallet(&mut self) -> Result<(), RedeemNoteTaskError> {
+        todo!()
+    }
+
+    /// Create validity proofs for the orders in the wallet
+    async fn create_validity_proofs(&mut self) -> Result<(), RedeemNoteTaskError> {
+        todo!()
+    }
+}

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -1,9 +1,5 @@
 //! Refresh a wallet from on-chain state
 
-// --------------
-// | Task State |
-// --------------
-
 use std::{
     error::Error,
     fmt::{self, Display},
@@ -36,6 +32,10 @@ const REFRESH_WALLET_TASK_NAME: &str = "refresh-wallet";
 
 /// Error emitted when the wallet is not found in contract storage
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found";
+
+// --------------
+// | Task State |
+// --------------
 
 /// Defines the state of the refresh wallet task
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
### Purpose
This PR defines the skeleton for the `RedeemNote` task. This task allows a relayer to redeem a note on behalf of the caller. Internally, we will use this to redeem protocol and relayer notes into their respective wallets.

### Testing
- Unit tests pass