### PR TITLE
workers: task-driver: refresh wallets for post-commit task failures

### DIFF
--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -21,8 +21,7 @@ pub async fn node_setup(
     // Start the node setup task and await its completion
     let desc: TaskDescriptor =
         NodeStartupTaskDescriptor::new(config.gossip_warmup, config.relayer_arbitrum_key()).into();
-    let (job, rx) =
-        TaskDriverJob::new_immediate_with_notification(desc, vec![] /* wallet_ids */);
+    let (job, rx) = TaskDriverJob::new_immediate_with_notification(desc);
     task_queue
         .send(job)
         .map_err(|_| CoordinatorError::Setup(ERR_SENDING_STARTUP_TASK.to_string()))?;

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -499,8 +499,7 @@ impl HandshakeExecutor {
         .into();
 
         // Signal the task driver to preempt its queue with the task
-        let wallet_ids = vec![wallet_id];
-        let (job, rx) = TaskDriverJob::new_immediate_with_notification(task, wallet_ids);
+        let (job, rx) = TaskDriverJob::new_immediate_with_notification(task);
         self.task_queue.send(job).map_err(err_str!(HandshakeManagerError::SendMessage))?;
 
         rx.await

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -175,9 +175,7 @@ impl HandshakeExecutor {
         .unwrap()
         .into();
 
-        let wallet_ids = vec![wallet_id1, wallet_id2];
-
-        let (job, rx) = TaskDriverJob::new_immediate_with_notification(task, wallet_ids);
+        let (job, rx) = TaskDriverJob::new_immediate_with_notification(task);
         self.task_queue.send(job).map_err(err_str!(HandshakeManagerError::TaskError))?;
 
         rx.await

--- a/workers/job-types/src/task_driver.rs
+++ b/workers/job-types/src/task_driver.rs
@@ -1,9 +1,6 @@
 //! Job types for the task driver
 
-use common::types::{
-    tasks::{QueuedTask, TaskDescriptor, TaskIdentifier},
-    wallet::WalletIdentifier,
-};
+use common::types::tasks::{QueuedTask, TaskDescriptor, TaskIdentifier};
 use crossbeam::channel::Sender as CrossbeamSender;
 use tokio::sync::oneshot::{
     channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender,
@@ -47,8 +44,6 @@ pub enum TaskDriverJob {
     RunImmediate {
         /// The ID to assign the task
         task_id: TaskIdentifier,
-        /// The wallet(s) that this task modifies
-        wallet_ids: Vec<WalletIdentifier>,
         /// The task to run
         task: TaskDescriptor,
         /// The response channel on which to send the task result
@@ -65,18 +60,17 @@ pub enum TaskDriverJob {
 
 impl TaskDriverJob {
     /// Create a new immediate task without a notification channel
-    pub fn new_immediate(task: TaskDescriptor, wallet_ids: Vec<WalletIdentifier>) -> Self {
+    pub fn new_immediate(task: TaskDescriptor) -> Self {
         let id = TaskIdentifier::new_v4();
-        Self::RunImmediate { task_id: id, wallet_ids, task, resp: None }
+        Self::RunImmediate { task_id: id, task, resp: None }
     }
 
     /// Create a new immediate task with a notification channel
     pub fn new_immediate_with_notification(
         task: TaskDescriptor,
-        wallet_ids: Vec<WalletIdentifier>,
     ) -> (Self, TaskNotificationReceiver) {
         let id = TaskIdentifier::new_v4();
         let (sender, receiver) = oneshot_channel();
-        (Self::RunImmediate { task_id: id, wallet_ids, task, resp: Some(sender) }, receiver)
+        (Self::RunImmediate { task_id: id, task, resp: Some(sender) }, receiver)
     }
 }

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -94,11 +94,10 @@ pub(crate) async fn await_task(
 
 /// Await the execution and completion of a task run immediately
 pub(crate) async fn await_immediate_task(
-    modified_wallets: Vec<WalletIdentifier>,
     task: TaskDescriptor,
     test_args: &IntegrationTestArgs,
 ) -> Result<()> {
-    let (job, rx) = TaskDriverJob::new_immediate_with_notification(task, modified_wallets);
+    let (job, rx) = TaskDriverJob::new_immediate_with_notification(task);
     test_args.task_queue.send(job).unwrap();
 
     rx.await.unwrap().map_err(|e| eyre::eyre!(e))

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -378,8 +378,7 @@ async fn test_settle_internal_match(test_args: IntegrationTestArgs) -> Result<()
     )
     .unwrap();
 
-    let modified_wallets = vec![buy_wallet.wallet_id, sell_wallet.wallet_id];
-    await_immediate_task(modified_wallets, task.into(), &test_args).await?;
+    await_immediate_task(task.into(), &test_args).await?;
 
     // Verify the match on both wallets
     verify_settlement(
@@ -432,8 +431,7 @@ async fn test_settle_mpc_match(test_args: IntegrationTestArgs) -> Result<()> {
     )
     .unwrap();
 
-    let modified_wallets = vec![buy_wallet.wallet_id];
-    let res = await_immediate_task(modified_wallets, task.into(), &test_args).await;
+    let res = await_immediate_task(task.into(), &test_args).await;
     assert_true_result!(res.is_ok())?;
 
     // Only the first wallet would have been updated in the global state, as the


### PR DESCRIPTION
This PR has the task driver enqueue a refresh task for wallets affected by tasks which failed after the task's commit point. This ensures that there is no discrepancy between onchain and relayer wallet state, in the case that the relayer failed to update wallet state after new state has been committed onchain.

All unit tests pass, and this is currently being tested in dev, as integration tests currently do not work (and assume that verification is disabled, so they can't be run against the devnet sequencer).

Confirmed that refresh tasks are enqueued when failing in e.g. the `SubmittingTx` step of tasks, and that orderbot load is handled as expected (e.g. matches being processed, queues pausing/resuming expectedly)