### PR TITLE
state: storage: matching_pools: create pool table & barebones access methods

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -44,7 +44,7 @@ use uuid::Uuid;
 // -------------
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 16;
+const NUM_TABLES: usize = 17;
 
 /// The name of the db table that stores node metadata
 pub(crate) const NODE_METADATA_TABLE: &str = "node-metadata";
@@ -62,6 +62,9 @@ pub(crate) const PRIORITIES_TABLE: &str = "priorities";
 pub(crate) const ORDERS_TABLE: &str = "orders";
 /// The table that stores order metadata indexed by wallet id
 pub(crate) const ORDER_HISTORY_TABLE: &str = "order-history";
+
+/// The name of the db table mapping orders to their matching pool
+pub(crate) const POOL_TABLE: &str = "matching-pools";
 
 /// The name of the db table that maps order to their encapsulating wallet
 pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";
@@ -93,6 +96,7 @@ pub const ALL_TABLES: [&str; NUM_TABLES] = [
     PRIORITIES_TABLE,
     ORDERS_TABLE,
     ORDER_HISTORY_TABLE,
+    POOL_TABLE,
     ORDER_TO_WALLET_TABLE,
     WALLETS_TABLE,
     TASK_QUEUE_TABLE,

--- a/state/src/storage/tx/matching_pools.rs
+++ b/state/src/storage/tx/matching_pools.rs
@@ -1,0 +1,209 @@
+//! Helpers for accessing information about matching pools in the database
+
+use common::types::wallet::OrderIdentifier;
+use libmdbx::{TransactionKind, RW};
+
+use crate::{storage::error::StorageError, POOL_TABLE};
+
+use super::StateTxn;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The name of the global matching pool
+pub const GLOBAL_MATCHING_POOL: &str = "global";
+
+/// The prefix of all matching pool keys
+pub const POOL_KEY_PREFIX: &str = "matching-pool/";
+
+/// The error message used when trying to create a matching pool that already
+/// exists
+const MATCHING_POOL_EXISTS_ERR: &str = "matching pool already exists";
+/// The error message used when assigning an order to a nonexistent matching
+/// pool
+const MATCHING_POOL_DOES_NOT_EXIST_ERR: &str = "matching pool does not exist";
+/// The error message used when a non-empty matching pool is attempted to be
+/// destroyed
+const MATCHING_POOL_NOT_EMPTY_ERR: &str = "matching pool not empty";
+
+// ---------------
+// | Key Helpers |
+// ---------------
+
+/// The key for the set of all matching pools
+pub fn all_matching_pools_key() -> String {
+    "all-matching-pools".to_string()
+}
+
+/// The key for the given order's matching pool
+pub fn matching_pool_key(order_id: &OrderIdentifier) -> String {
+    format!("{}{}", POOL_KEY_PREFIX, order_id)
+}
+
+// -----------
+// | Getters |
+// -----------
+
+impl<'db, T: TransactionKind> StateTxn<'db, T> {
+    /// Get the name of the matching pool the given order is in, if it's been
+    /// assigned to one
+    pub fn get_matching_pool_for_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<String>, StorageError> {
+        let pool_key = matching_pool_key(order_id);
+        self.inner().read(POOL_TABLE, &pool_key)
+    }
+
+    /// Whether or not a pool with the given name exists
+    pub fn matching_pool_exists(&self, pool_name: &str) -> Result<bool, StorageError> {
+        let all_pools_key = all_matching_pools_key();
+        let all_pools: Vec<String> = self.read_set(POOL_TABLE, &all_pools_key)?;
+        Ok(all_pools.contains(&pool_name.to_string()))
+    }
+
+    /// Whether or not the matching pool is empty
+    pub fn matching_pool_is_empty(&self, pool_name: &str) -> Result<bool, StorageError> {
+        // We iterate over the mapping from orders -> their matching pool, and check
+        // if any orders are in the given pool
+        let cursor = self
+            .inner()
+            .cursor::<String, String>(POOL_TABLE)?
+            .with_key_filter(|key| key.starts_with(POOL_KEY_PREFIX));
+
+        let mut pool_in_use = false;
+        for pool_for_order in cursor.into_iter().values() {
+            if pool_for_order? == pool_name {
+                pool_in_use = true;
+                break;
+            }
+        }
+
+        Ok(!pool_in_use)
+    }
+}
+
+// -----------
+// | Setters |
+// -----------
+
+impl<'db> StateTxn<'db, RW> {
+    /// Create a matching pool with the given name
+    pub fn create_matching_pool(&self, pool_name: &str) -> Result<(), StorageError> {
+        // Check that the pool does not already exist
+        if self.matching_pool_exists(pool_name)? {
+            return Err(StorageError::Other(MATCHING_POOL_EXISTS_ERR.to_string()));
+        }
+
+        let all_pools_key = all_matching_pools_key();
+        self.add_to_set(POOL_TABLE, &all_pools_key, &pool_name.to_string())
+    }
+
+    /// Destroy a matching pool
+    pub fn destroy_matching_pool(&self, pool_name: &str) -> Result<(), StorageError> {
+        // Check that the pool is empty
+        if !self.matching_pool_is_empty(pool_name)? {
+            return Err(StorageError::Other(MATCHING_POOL_NOT_EMPTY_ERR.to_string()));
+        }
+
+        let all_pools_key = all_matching_pools_key();
+        self.remove_from_set(POOL_TABLE, &all_pools_key, &pool_name.to_string())
+    }
+
+    /// Assign an order to a matching pool.
+    ///
+    /// Note that we allow overwriting an order's pool, this signifies moving
+    /// the order from one pool to another.
+    pub fn assign_order_to_pool(
+        &self,
+        order_id: &OrderIdentifier,
+        pool_name: &str,
+    ) -> Result<(), StorageError> {
+        // Check that the pool exists
+        if !self.matching_pool_exists(pool_name)? {
+            return Err(StorageError::Other(MATCHING_POOL_DOES_NOT_EXIST_ERR.to_string()));
+        }
+
+        let pool_key = matching_pool_key(order_id);
+        self.inner().write(POOL_TABLE, &pool_key, &pool_name.to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use common::types::wallet::OrderIdentifier;
+
+    use crate::{storage::tx::matching_pools::GLOBAL_MATCHING_POOL, test_helpers::mock_db};
+
+    /// Tests creating a matching pool
+    #[test]
+    fn test_create_matching_pool() {
+        let db = mock_db();
+
+        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+
+        // Create a matching pool
+        let tx = db.new_write_tx().unwrap();
+        tx.create_matching_pool(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        // Assert the pool exists
+        let tx = db.new_read_tx().unwrap();
+        let pool_exists = tx.matching_pool_exists(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        assert!(pool_exists);
+    }
+
+    /// Tests destroying a matching pool
+    #[test]
+    fn test_destroy_matching_pool() {
+        let db = mock_db();
+
+        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+
+        // Create a matching pool
+        let tx = db.new_write_tx().unwrap();
+        tx.create_matching_pool(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        // Destroy the matching pool
+        let tx = db.new_write_tx().unwrap();
+        tx.destroy_matching_pool(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        // Assert the matching pool does not exist
+        let tx = db.new_read_tx().unwrap();
+        let pool_exists = tx.matching_pool_exists(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        assert!(!pool_exists);
+    }
+
+    /// Tests assigning an order to a matching pool
+    #[test]
+    fn test_assign_order_to_pool() {
+        let db = mock_db();
+
+        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let order_id = OrderIdentifier::new_v4();
+
+        // Create a matching pool
+        let tx = db.new_write_tx().unwrap();
+        tx.create_matching_pool(&pool_name).unwrap();
+        tx.commit().unwrap();
+
+        // Assign the order to the pool
+        let tx = db.new_write_tx().unwrap();
+        tx.assign_order_to_pool(&order_id, &pool_name).unwrap();
+        tx.commit().unwrap();
+
+        // Assert that the order is in the pool
+        let tx = db.new_read_tx().unwrap();
+        let pool_for_order = tx.get_matching_pool_for_order(&order_id).unwrap().unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(pool_for_order, pool_name);
+    }
+}

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -6,6 +6,7 @@
 //! Each of the files in this module are named after the high level interface
 //! they expose
 
+pub mod matching_pools;
 pub mod mpc_preprocessing;
 pub mod node_metadata;
 pub mod order_book;


### PR DESCRIPTION
This PR initializes the storage layer for the matching pools feature, establishing the DB layout for the `POOL_TABLE` and the minimum necessary access methods for the expected usage.

This includes some basic unit tests, all of which pass.

Next up is the interface layer for interacting with matching pools state.