### PR TITLE
state: applicator: matching_pools: state transitions & handlers

### DIFF
--- a/state/src/applicator/matching_pools.rs
+++ b/state/src/applicator/matching_pools.rs
@@ -1,0 +1,44 @@
+//! Applicator methods for matching pools
+
+use common::types::wallet::OrderIdentifier;
+
+use super::{error::StateApplicatorError, return_type::ApplicatorReturnType, StateApplicator};
+
+impl StateApplicator {
+    /// Create a matching pool with the given name
+    pub fn create_matching_pool(
+        &self,
+        pool_name: &str,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        tx.create_matching_pool(pool_name)?;
+        tx.commit()?;
+
+        Ok(ApplicatorReturnType::None)
+    }
+
+    /// Destroy a matching pool
+    pub fn destroy_matching_pool(
+        &self,
+        pool_name: &str,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        tx.destroy_matching_pool(pool_name)?;
+        tx.commit()?;
+
+        Ok(ApplicatorReturnType::None)
+    }
+
+    /// Assign an order to a matching pool
+    pub fn assign_order_to_matching_pool(
+        &self,
+        order_id: &OrderIdentifier,
+        pool_name: &str,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        tx.assign_order_to_matching_pool(order_id, pool_name)?;
+        tx.commit()?;
+
+        Ok(ApplicatorReturnType::None)
+    }
+}

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -13,6 +13,7 @@ use crate::{storage::db::DB, StateTransition};
 use self::{error::StateApplicatorError, return_type::ApplicatorReturnType};
 
 pub mod error;
+pub mod matching_pools;
 pub mod mpc_preprocessing;
 pub mod order_book;
 pub mod order_history;
@@ -79,6 +80,15 @@ impl StateApplicator {
                 self.add_order_validity_proof(order_id, proof, witness)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
+            StateTransition::CreateMatchingPool { pool_name } => {
+                self.create_matching_pool(&pool_name)
+            },
+            StateTransition::DestroyMatchingPool { pool_name } => {
+                self.destroy_matching_pool(&pool_name)
+            },
+            StateTransition::AssignOrderToMatchingPool { order_id, pool_name } => {
+                self.assign_order_to_matching_pool(&order_id, &pool_name)
+            },
             StateTransition::AppendTask { task, executor } => self.append_task(&task, &executor),
             StateTransition::PopTask { task_id, success } => self.pop_task(task_id, success),
             StateTransition::TransitionTask { task_id, state } => {

--- a/state/src/interface/matching_pools.rs
+++ b/state/src/interface/matching_pools.rs
@@ -6,7 +6,7 @@
 
 use common::types::wallet::OrderIdentifier;
 
-use crate::{error::StateError, notifications::ProposalWaiter, State};
+use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
 
 /// The name of the global matching pool
 pub const GLOBAL_MATCHING_POOL: &str = "global";
@@ -47,39 +47,39 @@ impl State {
     /// Create a matching pool with the given name
     pub async fn create_matching_pool(
         &self,
-        _pool_name: &str,
+        pool_name: String,
     ) -> Result<ProposalWaiter, StateError> {
-        todo!()
+        self.send_proposal(StateTransition::CreateMatchingPool { pool_name }).await
     }
 
     /// Destroy a matching pool
     pub async fn destroy_matching_pool(
         &self,
-        _pool_name: &str,
+        pool_name: String,
     ) -> Result<ProposalWaiter, StateError> {
-        todo!()
+        self.send_proposal(StateTransition::DestroyMatchingPool { pool_name }).await
     }
 
     /// Assign an order to a matching pool
     pub async fn assign_order_to_matching_pool(
         &self,
-        _order_id: &OrderIdentifier,
-        _pool_name: &str,
+        order_id: OrderIdentifier,
+        pool_name: String,
     ) -> Result<ProposalWaiter, StateError> {
-        todo!()
+        self.send_proposal(StateTransition::AssignOrderToMatchingPool { order_id, pool_name }).await
     }
 
     /// Create the global matching pool
     pub async fn create_global_matching_pool(&self) -> Result<ProposalWaiter, StateError> {
-        self.create_matching_pool(GLOBAL_MATCHING_POOL).await
+        self.create_matching_pool(GLOBAL_MATCHING_POOL.to_string()).await
     }
 
     /// Assign an order to the global matching pool
     pub async fn assign_order_to_global_matching_pool(
         &self,
-        order_id: &OrderIdentifier,
+        order_id: OrderIdentifier,
     ) -> Result<ProposalWaiter, StateError> {
-        self.assign_order_to_matching_pool(order_id, GLOBAL_MATCHING_POOL).await
+        self.assign_order_to_matching_pool(order_id, GLOBAL_MATCHING_POOL.to_string()).await
     }
 }
 
@@ -112,7 +112,7 @@ mod test {
 
         // Assign an order into it
         let order_id = OrderIdentifier::new_v4();
-        let waiter = state.assign_order_to_global_matching_pool(&order_id).await.unwrap();
+        let waiter = state.assign_order_to_global_matching_pool(order_id).await.unwrap();
         waiter.await.unwrap();
 
         // Assert the order is in the global matching pool

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -139,6 +139,14 @@ pub enum StateTransition {
     /// Update the metadata for a given order
     UpdateOrderMetadata { meta: OrderMetadata },
 
+    // --- Matching Pools --- //
+    /// Create a matching pool
+    CreateMatchingPool { pool_name: String },
+    /// Destroy a matching pool
+    DestroyMatchingPool { pool_name: String },
+    /// Assign an order to a matching pool
+    AssignOrderToMatchingPool { order_id: OrderIdentifier, pool_name: String },
+
     // --- Task Queue --- //
     /// Add a task to the task queue
     AppendTask { task: QueuedTask, executor: WrappedPeerId },


### PR DESCRIPTION
This PR introduces the state transitions & handlers for matching pools, & fills out the interface stubs for sending the associated proposals for these state transitions.

Because the applicator handlers for these transitions are so thin (they directly call the underlying storage methods and do nothing else), I don't believe this merits any tests in the applicator.

All matching pool unit tests now pass.