### PR TITLE
workers: task-driver: update_wallet: order matching pool assignment

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -29,3 +29,6 @@ pub fn new_cancel_channel() -> (WatchSender<()>, CancelChannel) {
 /// An alias for the price of an asset pair that abstracts away its
 /// representation
 pub type Price = f64;
+
+/// A type alias for matching pool names
+pub type MatchingPoolName = String;

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -215,9 +215,6 @@ pub mod mocks {
         NewWalletTaskDescriptor, QueuedTask, QueuedTaskState, TaskDescriptor, TaskQueueKey,
     };
 
-    /// The name of a mock matching pool used for testing task history
-    pub const MOCK_MATCHING_POOL: &str = "mock-matching-pool";
-
     /// Generate the wallet update signature for a new wallet
     pub fn gen_wallet_update_sig(wallet: &Wallet, key: &SecretSigningKey) -> Vec<u8> {
         let new_wallet_comm = wallet.get_wallet_share_commitment();
@@ -271,11 +268,13 @@ pub mod mocks {
 mod test {
     use constants::Scalar;
 
-    use crate::types::wallet_mocks::{mock_empty_wallet, mock_order};
+    use crate::types::{
+        wallet::OrderIdentifier,
+        wallet_mocks::{mock_empty_wallet, mock_order},
+    };
 
     use super::{
-        mocks::{gen_wallet_update_sig, MOCK_MATCHING_POOL},
-        NewWalletTaskDescriptor, UpdateWalletTaskDescriptor,
+        mocks::gen_wallet_update_sig, NewWalletTaskDescriptor, UpdateWalletTaskDescriptor,
     };
 
     /// Tests creating a new wallet task with an invalid secret sharing
@@ -297,10 +296,10 @@ mod test {
 
         UpdateWalletTaskDescriptor::new_order(
             mock_order(),
+            OrderIdentifier::new_v4(),
             wallet.clone(),
             wallet,
             vec![],
-            MOCK_MATCHING_POOL.to_string(),
         )
         .unwrap();
     }
@@ -314,10 +313,10 @@ mod test {
 
         UpdateWalletTaskDescriptor::new_order(
             mock_order(),
+            OrderIdentifier::new_v4(),
             wallet.clone(),
             wallet,
             sig,
-            MOCK_MATCHING_POOL.to_string(),
         )
         .unwrap();
     }
@@ -332,10 +331,10 @@ mod test {
 
         UpdateWalletTaskDescriptor::new_order(
             mock_order(),
+            OrderIdentifier::new_v4(),
             wallet.clone(),
             wallet,
             sig,
-            MOCK_MATCHING_POOL.to_string(),
         )
         .unwrap();
     }

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -215,6 +215,9 @@ pub mod mocks {
         NewWalletTaskDescriptor, QueuedTask, QueuedTaskState, TaskDescriptor, TaskQueueKey,
     };
 
+    /// The name of a mock matching pool used for testing task history
+    pub const MOCK_MATCHING_POOL: &str = "mock-matching-pool";
+
     /// Generate the wallet update signature for a new wallet
     pub fn gen_wallet_update_sig(wallet: &Wallet, key: &SecretSigningKey) -> Vec<u8> {
         let new_wallet_comm = wallet.get_wallet_share_commitment();
@@ -271,7 +274,8 @@ mod test {
     use crate::types::wallet_mocks::{mock_empty_wallet, mock_order};
 
     use super::{
-        mocks::gen_wallet_update_sig, NewWalletTaskDescriptor, UpdateWalletTaskDescriptor,
+        mocks::{gen_wallet_update_sig, MOCK_MATCHING_POOL},
+        NewWalletTaskDescriptor, UpdateWalletTaskDescriptor,
     };
 
     /// Tests creating a new wallet task with an invalid secret sharing
@@ -291,8 +295,14 @@ mod test {
         let mut wallet = mock_empty_wallet();
         wallet.blinded_public_shares.orders[0].amount += Scalar::one();
 
-        UpdateWalletTaskDescriptor::new_order(mock_order(), wallet.clone(), wallet, vec![])
-            .unwrap();
+        UpdateWalletTaskDescriptor::new_order(
+            mock_order(),
+            wallet.clone(),
+            wallet,
+            vec![],
+            MOCK_MATCHING_POOL.to_string(),
+        )
+        .unwrap();
     }
 
     /// Tests creating an update wallet task with an invalid signatures
@@ -302,7 +312,14 @@ mod test {
         let wallet = mock_empty_wallet();
         let sig = vec![0; 64];
 
-        UpdateWalletTaskDescriptor::new_order(mock_order(), wallet.clone(), wallet, sig).unwrap();
+        UpdateWalletTaskDescriptor::new_order(
+            mock_order(),
+            wallet.clone(),
+            wallet,
+            sig,
+            MOCK_MATCHING_POOL.to_string(),
+        )
+        .unwrap();
     }
 
     /// Tests creating a valid update wallet task
@@ -313,6 +330,13 @@ mod test {
         let key = wallet.key_chain.secret_keys.sk_root.as_ref().unwrap();
         let sig = gen_wallet_update_sig(&wallet, key);
 
-        UpdateWalletTaskDescriptor::new_order(mock_order(), wallet.clone(), wallet, sig).unwrap();
+        UpdateWalletTaskDescriptor::new_order(
+            mock_order(),
+            wallet.clone(),
+            wallet,
+            sig,
+            MOCK_MATCHING_POOL.to_string(),
+        )
+        .unwrap();
     }
 }

--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -39,6 +39,8 @@ pub enum WalletUpdateType {
     PlaceOrder {
         /// The order to place
         order: Order,
+        /// The matching pool to assign the order to
+        matching_pool: String,
     },
     /// Cancel an order
     CancelOrder {
@@ -140,8 +142,9 @@ impl UpdateWalletTaskDescriptor {
         old_wallet: Wallet,
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
+        matching_pool: String,
     ) -> Result<Self, String> {
-        let desc = WalletUpdateType::PlaceOrder { order };
+        let desc = WalletUpdateType::PlaceOrder { order, matching_pool };
         Self::new(desc, None, old_wallet, new_wallet, wallet_update_signature)
     }
 

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -100,7 +100,7 @@ pub mod historical_mocks {
     use rand::{thread_rng, RngCore};
 
     use crate::types::{
-        tasks::{QueuedTaskState, TaskIdentifier, WalletUpdateType},
+        tasks::{QueuedTaskState, TaskIdentifier, WalletUpdateType, mocks::MOCK_MATCHING_POOL},
         wallet_mocks::mock_order,
     };
 
@@ -109,7 +109,7 @@ pub mod historical_mocks {
     /// Return a mock historical task
     pub fn mock_historical_task() -> HistoricalTask {
         let mut rng = thread_rng();
-        let ty = WalletUpdateType::PlaceOrder { order: mock_order() };
+        let ty = WalletUpdateType::PlaceOrder { order: mock_order(), matching_pool: MOCK_MATCHING_POOL.to_string() };
         HistoricalTask {
             id: TaskIdentifier::new_v4(),
             state: QueuedTaskState::Completed,

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -100,16 +100,25 @@ pub mod historical_mocks {
     use rand::{thread_rng, RngCore};
 
     use crate::types::{
-        tasks::{QueuedTaskState, TaskIdentifier, WalletUpdateType, mocks::MOCK_MATCHING_POOL},
+        tasks::{QueuedTaskState, TaskIdentifier, WalletUpdateType},
+        wallet::OrderIdentifier,
         wallet_mocks::mock_order,
     };
 
     use super::{HistoricalTask, HistoricalTaskDescription};
 
+    /// The name of a mock matching pool used for testing task history
+    const MOCK_MATCHING_POOL: &str = "mock-matching-pool";
+
     /// Return a mock historical task
     pub fn mock_historical_task() -> HistoricalTask {
         let mut rng = thread_rng();
-        let ty = WalletUpdateType::PlaceOrder { order: mock_order(), matching_pool: MOCK_MATCHING_POOL.to_string() };
+        let id = OrderIdentifier::new_v4();
+        let ty = WalletUpdateType::PlaceOrder {
+            order: mock_order(),
+            id,
+            matching_pool: MOCK_MATCHING_POOL.to_string(),
+        };
         HistoricalTask {
             id: TaskIdentifier::new_v4(),
             state: QueuedTaskState::Completed,

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -109,3 +109,10 @@ pub const HANDSHAKE_STATUS_TOPIC: &str = "handshakes";
 
 /// The topic published to when a state change occurs on an order
 pub const ORDER_STATE_CHANGE_TOPIC: &str = "order-state";
+
+// ---------------------------
+// | Matching Pool Constants |
+// ---------------------------
+
+/// The name of the global matching pool
+pub const GLOBAL_MATCHING_POOL: &str = "global";

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -202,7 +202,7 @@ impl From<WalletUpdateType> for ApiWalletUpdateType {
                 let amount = u128_to_number(amount);
                 Self::Withdraw { mint, amount }
             },
-            WalletUpdateType::PlaceOrder { order } => {
+            WalletUpdateType::PlaceOrder { order, .. } => {
                 Self::PlaceOrder { order: WalletUpdateOrder::from(order) }
             },
             WalletUpdateType::CancelOrder { order } => {

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -124,6 +124,7 @@ mod test {
         wallet::OrderIdentifier,
         wallet_mocks::{mock_empty_wallet, mock_order},
     };
+    use constants::GLOBAL_MATCHING_POOL;
 
     use crate::applicator::test_helpers::mock_applicator;
 
@@ -132,7 +133,10 @@ mod test {
     fn test_add_validity_proof() {
         let applicator = mock_applicator();
 
-        // First add an order via a wallet
+        // Create the global matching pool
+        applicator.create_matching_pool(GLOBAL_MATCHING_POOL).unwrap();
+
+        // Add an order via a wallet
         let mut wallet = mock_empty_wallet();
         let order_id = OrderIdentifier::new_v4();
         wallet.add_order(order_id, mock_order()).unwrap();

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -137,6 +137,7 @@ impl StateApplicator {
             if !old_orders.contains(&id) {
                 let new_state = OrderMetadata::new(id, o);
                 self.update_order_metadata_with_tx(new_state, tx)?;
+                // TODO: Add the order to the global matching pool
             }
         }
 
@@ -151,6 +152,7 @@ impl StateApplicator {
                 if !old_meta.state.is_terminal() {
                     old_meta.state = OrderState::Cancelled;
                     self.update_order_metadata_with_tx(old_meta, tx)?;
+                    // TODO: Remove the order from its matching pool
                 }
             }
         }

--- a/state/src/interface/matching_pools.rs
+++ b/state/src/interface/matching_pools.rs
@@ -4,12 +4,9 @@
 // | Constants |
 // -------------
 
-use common::types::wallet::OrderIdentifier;
+use common::types::{wallet::OrderIdentifier, MatchingPoolName};
 
 use crate::{error::StateError, notifications::ProposalWaiter, State, StateTransition};
-
-/// The name of the global matching pool
-pub const GLOBAL_MATCHING_POOL: &str = "global";
 
 impl State {
     // -----------
@@ -21,7 +18,7 @@ impl State {
     pub async fn get_matching_pool_for_order(
         &self,
         order_id: &OrderIdentifier,
-    ) -> Result<Option<String>, StateError> {
+    ) -> Result<Option<MatchingPoolName>, StateError> {
         let order_id = *order_id;
         self.with_read_tx(move |tx| {
             let matching_pool = tx.get_matching_pool_for_order(&order_id)?;
@@ -47,7 +44,7 @@ impl State {
     /// Create a matching pool with the given name
     pub async fn create_matching_pool(
         &self,
-        pool_name: String,
+        pool_name: MatchingPoolName,
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::CreateMatchingPool { pool_name }).await
     }
@@ -55,7 +52,7 @@ impl State {
     /// Destroy a matching pool
     pub async fn destroy_matching_pool(
         &self,
-        pool_name: String,
+        pool_name: MatchingPoolName,
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::DestroyMatchingPool { pool_name }).await
     }
@@ -64,7 +61,7 @@ impl State {
     pub async fn assign_order_to_matching_pool(
         &self,
         order_id: OrderIdentifier,
-        pool_name: String,
+        pool_name: MatchingPoolName,
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::AssignOrderToMatchingPool { order_id, pool_name }).await
     }

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -6,10 +6,11 @@ use common::types::{
     wallet::{derivation::derive_wallet_id, Wallet, WalletIdentifier},
 };
 use config::RelayerConfig;
+use constants::GLOBAL_MATCHING_POOL;
 use libp2p::{core::Multiaddr, identity::Keypair};
 use util::res_some;
 
-use crate::{error::StateError, matching_pools::GLOBAL_MATCHING_POOL, State, NODE_METADATA_TABLE};
+use crate::{error::StateError, State, NODE_METADATA_TABLE};
 
 impl State {
     // -----------

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -327,6 +327,10 @@ pub mod test_helpers {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
+        // Set up the global matching pool
+        let waiter = state.create_global_matching_pool().await.unwrap();
+        waiter.await.unwrap();
+
         state
     }
 

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -21,6 +21,7 @@ use common::types::{
     proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
     tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey},
     wallet::{order_metadata::OrderMetadata, OrderIdentifier, Wallet},
+    MatchingPoolName,
 };
 use notifications::ProposalId;
 #[cfg(not(feature = "mocks"))]
@@ -141,11 +142,11 @@ pub enum StateTransition {
 
     // --- Matching Pools --- //
     /// Create a matching pool
-    CreateMatchingPool { pool_name: String },
+    CreateMatchingPool { pool_name: MatchingPoolName },
     /// Destroy a matching pool
-    DestroyMatchingPool { pool_name: String },
+    DestroyMatchingPool { pool_name: MatchingPoolName },
     /// Assign an order to a matching pool
-    AssignOrderToMatchingPool { order_id: OrderIdentifier, pool_name: String },
+    AssignOrderToMatchingPool { order_id: OrderIdentifier, pool_name: MatchingPoolName },
 
     // --- Task Queue --- //
     /// Add a task to the task queue
@@ -326,10 +327,6 @@ pub mod test_helpers {
             state.send_proposal(prop).await.unwrap();
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-
-        // Set up the global matching pool
-        let waiter = state.create_global_matching_pool().await.unwrap();
-        waiter.await.unwrap();
 
         state
     }

--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -209,7 +209,6 @@ impl<'db> StateTxn<'db, RW> {
 
     /// Delete an order from the order book
     pub fn delete_order(&self, order_id: &OrderIdentifier) -> Result<(), StorageError> {
-        // TODO: Remove the order from its matching pool
         self.inner().delete(ORDERS_TABLE, &order_key(order_id)).map(|_| ())
     }
 
@@ -219,6 +218,11 @@ impl<'db> StateTxn<'db, RW> {
         let orders = self.get_orders_by_nullifier(nullifier)?;
         for order_id in orders {
             self.delete_order(&order_id)?;
+
+            // Remove the order from its matching pool
+            if self.get_matching_pool_for_order(&order_id)?.is_some() {
+                self.remove_order_from_matching_pool(&order_id)?;
+            }
         }
 
         // Delete the index for the nullifier

--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -209,6 +209,7 @@ impl<'db> StateTxn<'db, RW> {
 
     /// Delete an order from the order book
     pub fn delete_order(&self, order_id: &OrderIdentifier) -> Result<(), StorageError> {
+        // TODO: Remove the order from its matching pool
         self.inner().delete(ORDERS_TABLE, &order_key(order_id)).map(|_| ())
     }
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -30,7 +30,7 @@ use hyper::HeaderMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use renegade_crypto::fields::biguint_to_scalar;
-use state::{matching_pools::GLOBAL_MATCHING_POOL, State};
+use state::State;
 use task_driver::simulation::simulate_wallet_tasks;
 use util::{err_str, hex::jubjub_to_hex_string};
 
@@ -423,10 +423,10 @@ impl TypedHandler for CreateOrderHandler {
 
         let task = UpdateWalletTaskDescriptor::new_order(
             new_order,
+            id,
             old_wallet,
             new_wallet,
             req.statement_sig,
-            GLOBAL_MATCHING_POOL.to_string(),
         )
         .map_err(bad_request)?;
 
@@ -485,10 +485,10 @@ impl TypedHandler for UpdateOrderHandler {
 
         let task = UpdateWalletTaskDescriptor::new_order(
             new_order,
+            order_id,
             old_wallet,
             new_wallet,
             req.statement_sig,
-            GLOBAL_MATCHING_POOL.to_string(),
         )
         .map_err(bad_request)?;
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -30,7 +30,7 @@ use hyper::HeaderMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use renegade_crypto::fields::biguint_to_scalar;
-use state::State;
+use state::{matching_pools::GLOBAL_MATCHING_POOL, State};
 use task_driver::simulation::simulate_wallet_tasks;
 use util::{err_str, hex::jubjub_to_hex_string};
 
@@ -426,6 +426,7 @@ impl TypedHandler for CreateOrderHandler {
             old_wallet,
             new_wallet,
             req.statement_sig,
+            GLOBAL_MATCHING_POOL.to_string(),
         )
         .map_err(bad_request)?;
 
@@ -487,6 +488,7 @@ impl TypedHandler for UpdateOrderHandler {
             old_wallet,
             new_wallet,
             req.statement_sig,
+            GLOBAL_MATCHING_POOL.to_string(),
         )
         .map_err(bad_request)?;
 

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -18,6 +18,7 @@ use eyre::Result;
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use rand::thread_rng;
+use state::matching_pools::GLOBAL_MATCHING_POOL;
 use test_helpers::{
     contract_interaction::{attach_merkle_opening, new_wallet_in_darkpool},
     integration_test_async,
@@ -94,7 +95,10 @@ async fn execute_wallet_update_and_verify_shares(
     share_seed: Scalar,
     test_args: IntegrationTestArgs,
 ) -> Result<()> {
-    let desc = WalletUpdateType::PlaceOrder { order: mock_order() };
+    let desc = WalletUpdateType::PlaceOrder {
+        order: mock_order(),
+        matching_pool: GLOBAL_MATCHING_POOL.to_string(),
+    };
     execute_wallet_update(
         desc,
         old_wallet,

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -10,15 +10,14 @@ use circuit_types::{
 use common::types::{
     tasks::{mocks::gen_wallet_update_sig, UpdateWalletTaskDescriptor, WalletUpdateType},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::Wallet,
+    wallet::{OrderIdentifier, Wallet},
     wallet_mocks::{mock_empty_wallet, mock_order},
 };
-use constants::Scalar;
+use constants::{Scalar, GLOBAL_MATCHING_POOL};
 use eyre::Result;
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use rand::thread_rng;
-use state::matching_pools::GLOBAL_MATCHING_POOL;
 use test_helpers::{
     contract_interaction::{attach_merkle_opening, new_wallet_in_darkpool},
     integration_test_async,
@@ -97,6 +96,7 @@ async fn execute_wallet_update_and_verify_shares(
 ) -> Result<()> {
     let desc = WalletUpdateType::PlaceOrder {
         order: mock_order(),
+        id: OrderIdentifier::new_v4(),
         matching_pool: GLOBAL_MATCHING_POOL.to_string(),
     };
     execute_wallet_update(


### PR DESCRIPTION
This PR implements the logic for assigning orders to the appropriate matching pool. The logic is as follows: by default, indexed new orders are added to the global matching pool. However, we add the desired matching pool for an order to be added to the `UpdateWalletTaskDescriptor`, and in the `UpdateWalletTask` we subsequently assign a new order to the desired matching pool after it is indexed.

This gets us 2 things:
1. In the "happy path," orders that are created in the global matching pool do not need to invoke another state transition for being assigned to the global matching pool.
2. Orders that are intended for non-global matching pools are assigned to those pools during the `UpdateWalletTask`, i.e. there is no danger of a race in which we begin matching those orders across the (default) global matching pool before they are assigned to the correct one.

All unit tests pass, and I updated the `test_update_wallet` test to also check that a new order is assigned to the global matching pool by default. Because integration tests are blocked at the moment, testing of creating orders into non-global matching pools is deferred until the admin API endpoint for doing this is implemented.