### PR TITLE
state: storage: matching_pools: default global pool at storage layer

### DIFF
--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -1,7 +1,6 @@
 //! Descriptor for the wallet update task
 
 use circuit_types::{keychain::PublicSigningKey, order::Order, Amount};
-use constants::GLOBAL_MATCHING_POOL;
 use contracts_common::custom_serde::BytesSerializable;
 use ethers::core::types::Signature;
 use ethers::utils::{keccak256, public_key_to_address};
@@ -44,8 +43,9 @@ pub enum WalletUpdateType {
         order: Order,
         /// The ID of the order
         id: OrderIdentifier,
-        /// The matching pool to assign the order to
-        matching_pool: MatchingPoolName,
+        /// The matching pool to assign the order to.
+        /// If `None`, the order is placed in the global pool.
+        matching_pool: Option<MatchingPoolName>,
     },
     /// Cancel an order
     CancelOrder {
@@ -149,11 +149,7 @@ impl UpdateWalletTaskDescriptor {
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
     ) -> Result<Self, String> {
-        let desc = WalletUpdateType::PlaceOrder {
-            order,
-            id,
-            matching_pool: GLOBAL_MATCHING_POOL.to_string(),
-        };
+        let desc = WalletUpdateType::PlaceOrder { order, id, matching_pool: None };
         Self::new(desc, None, old_wallet, new_wallet, wallet_update_signature)
     }
 
@@ -166,7 +162,7 @@ impl UpdateWalletTaskDescriptor {
         wallet_update_signature: Vec<u8>,
         matching_pool: MatchingPoolName,
     ) -> Result<Self, String> {
-        let desc = WalletUpdateType::PlaceOrder { order, id, matching_pool };
+        let desc = WalletUpdateType::PlaceOrder { order, id, matching_pool: Some(matching_pool) };
         Self::new(desc, None, old_wallet, new_wallet, wallet_update_signature)
     }
 

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -107,18 +107,11 @@ pub mod historical_mocks {
 
     use super::{HistoricalTask, HistoricalTaskDescription};
 
-    /// The name of a mock matching pool used for testing task history
-    const MOCK_MATCHING_POOL: &str = "mock-matching-pool";
-
     /// Return a mock historical task
     pub fn mock_historical_task() -> HistoricalTask {
         let mut rng = thread_rng();
         let id = OrderIdentifier::new_v4();
-        let ty = WalletUpdateType::PlaceOrder {
-            order: mock_order(),
-            id,
-            matching_pool: MOCK_MATCHING_POOL.to_string(),
-        };
+        let ty = WalletUpdateType::PlaceOrder { order: mock_order(), id, matching_pool: None };
         HistoricalTask {
             id: TaskIdentifier::new_v4(),
             state: QueuedTaskState::Completed,

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -109,10 +109,3 @@ pub const HANDSHAKE_STATUS_TOPIC: &str = "handshakes";
 
 /// The topic published to when a state change occurs on an order
 pub const ORDER_STATE_CHANGE_TOPIC: &str = "order-state";
-
-// ---------------------------
-// | Matching Pool Constants |
-// ---------------------------
-
-/// The name of the global matching pool
-pub const GLOBAL_MATCHING_POOL: &str = "global";

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -124,7 +124,6 @@ mod test {
         wallet::OrderIdentifier,
         wallet_mocks::{mock_empty_wallet, mock_order},
     };
-    use constants::GLOBAL_MATCHING_POOL;
 
     use crate::applicator::test_helpers::mock_applicator;
 
@@ -132,9 +131,6 @@ mod test {
     #[test]
     fn test_add_validity_proof() {
         let applicator = mock_applicator();
-
-        // Create the global matching pool
-        applicator.create_matching_pool(GLOBAL_MATCHING_POOL).unwrap();
 
         // Add an order via a wallet
         let mut wallet = mock_empty_wallet();

--- a/state/src/interface/matching_pools.rs
+++ b/state/src/interface/matching_pools.rs
@@ -18,21 +18,11 @@ impl State {
     pub async fn get_matching_pool_for_order(
         &self,
         order_id: &OrderIdentifier,
-    ) -> Result<Option<MatchingPoolName>, StateError> {
+    ) -> Result<MatchingPoolName, StateError> {
         let order_id = *order_id;
         self.with_read_tx(move |tx| {
             let matching_pool = tx.get_matching_pool_for_order(&order_id)?;
             Ok(matching_pool)
-        })
-        .await
-    }
-
-    /// Whether or not a pool with the given name exists
-    pub async fn matching_pool_exists(&self, pool_name: &str) -> Result<bool, StateError> {
-        let pool_name = pool_name.to_string();
-        self.with_read_tx(move |tx| {
-            let exists = tx.matching_pool_exists(&pool_name)?;
-            Ok(exists)
         })
         .await
     }

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -168,7 +168,7 @@ impl State {
             raft,
             recovered_from_snapshot,
         };
-        this.setup_node_state(config).await?;
+        this.setup_node_metadata(config).await?;
         this.setup_core_panic_timer(&system_clock, failure_send).await?;
         this.setup_membership_sync_timer(&system_clock).await?;
         this.setup_raft_metrics_timer(&system_clock).await?;

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -212,13 +212,8 @@ impl State {
             let mut res = Vec::new();
             for id in local_order_ids.into_iter() {
                 let order_matching_pool = tx.get_matching_pool_for_order(&id)?;
-                match order_matching_pool {
-                    None => continue,
-                    Some(pool) => {
-                        if pool != matching_pool {
-                            continue;
-                        }
-                    },
+                if order_matching_pool != matching_pool {
+                    continue;
                 }
 
                 if Self::is_order_matchable(&id, tx)? {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -349,6 +349,6 @@ pub mod test_helpers {
 
         // Configure the node
         let config = RelayerConfig { p2p_key: Keypair::generate_ed25519(), ..Default::default() };
-        state.setup_node_state(&config).await.unwrap();
+        state.setup_node_metadata(&config).await.unwrap();
     }
 }

--- a/state/src/storage/tx/matching_pools.rs
+++ b/state/src/storage/tx/matching_pools.rs
@@ -7,6 +7,9 @@ use crate::{storage::error::StorageError, POOL_TABLE};
 
 use super::StateTxn;
 
+/// The name of the global matching pool
+pub const GLOBAL_MATCHING_POOL: &str = "global";
+
 /// The prefix of all matching pool keys
 pub const POOL_KEY_PREFIX: &str = "matching-pool/";
 
@@ -16,9 +19,6 @@ const MATCHING_POOL_EXISTS_ERR: &str = "matching pool already exists";
 /// The error message used when assigning an order to a nonexistent matching
 /// pool
 const MATCHING_POOL_DOES_NOT_EXIST_ERR: &str = "matching pool does not exist";
-/// The error message used when a non-empty matching pool is attempted to be
-/// destroyed
-const MATCHING_POOL_NOT_EMPTY_ERR: &str = "matching pool not empty";
 
 // ---------------
 // | Key Helpers |
@@ -40,40 +40,27 @@ pub fn matching_pool_key(order_id: &OrderIdentifier) -> String {
 
 impl<'db, T: TransactionKind> StateTxn<'db, T> {
     /// Get the name of the matching pool the given order is in, if it's been
-    /// assigned to one
+    /// assigned to one. If not explicitly assigned, the order is considered to
+    /// be in the global matching pool.
     pub fn get_matching_pool_for_order(
         &self,
         order_id: &OrderIdentifier,
-    ) -> Result<Option<MatchingPoolName>, StorageError> {
+    ) -> Result<MatchingPoolName, StorageError> {
         let pool_key = matching_pool_key(order_id);
-        self.inner().read(POOL_TABLE, &pool_key)
+        self.inner()
+            .read(POOL_TABLE, &pool_key)
+            .map(|pool| pool.unwrap_or(GLOBAL_MATCHING_POOL.to_string()))
     }
 
     /// Whether or not a pool with the given name exists
     pub fn matching_pool_exists(&self, pool_name: &str) -> Result<bool, StorageError> {
+        if pool_name == GLOBAL_MATCHING_POOL {
+            return Ok(true);
+        }
+
         let all_pools_key = all_matching_pools_key();
         let all_pools: Vec<MatchingPoolName> = self.read_set(POOL_TABLE, &all_pools_key)?;
         Ok(all_pools.contains(&pool_name.to_string()))
-    }
-
-    /// Whether or not the given matching pool is empty
-    pub fn matching_pool_is_empty(&self, pool_name: &str) -> Result<bool, StorageError> {
-        // We iterate over the mapping from orders -> their matching pool, and check
-        // if any orders are in the given pool
-        let cursor = self
-            .inner()
-            .cursor::<String, MatchingPoolName>(POOL_TABLE)?
-            .with_key_filter(|key| key.starts_with(POOL_KEY_PREFIX));
-
-        let mut pool_in_use = false;
-        for pool_for_order in cursor.into_iter().values() {
-            if pool_for_order? == pool_name {
-                pool_in_use = true;
-                break;
-            }
-        }
-
-        Ok(!pool_in_use)
     }
 }
 
@@ -95,11 +82,20 @@ impl<'db> StateTxn<'db, RW> {
 
     /// Destroy a matching pool
     pub fn destroy_matching_pool(&self, pool_name: &str) -> Result<(), StorageError> {
-        // Check that the pool is empty
-        if !self.matching_pool_is_empty(pool_name)? {
-            return Err(StorageError::Other(MATCHING_POOL_NOT_EMPTY_ERR.to_string()));
+        // Remove all the order assignments in the pool
+        let cursor = self
+            .inner()
+            .cursor::<String, MatchingPoolName>(POOL_TABLE)?
+            .with_key_filter(|key| key.starts_with(POOL_KEY_PREFIX));
+
+        for entry in cursor.into_iter() {
+            let (key, value) = entry?;
+            if value == pool_name {
+                self.inner().delete(POOL_TABLE, &key)?;
+            }
         }
 
+        // Remove the pool from the set of all pools
         let all_pools_key = all_matching_pools_key();
         self.remove_from_set(POOL_TABLE, &all_pools_key, &pool_name.to_string())
     }
@@ -122,7 +118,8 @@ impl<'db> StateTxn<'db, RW> {
         self.inner().write(POOL_TABLE, &pool_key, &pool_name.to_string())
     }
 
-    /// Remove an order's matching pool assignment
+    /// Remove an order's matching pool assignment, this implicitly moves the
+    /// order back to the global pool
     pub fn remove_order_from_matching_pool(
         &self,
         order_id: &OrderIdentifier,
@@ -135,16 +132,18 @@ impl<'db> StateTxn<'db, RW> {
 #[cfg(test)]
 mod test {
     use common::types::wallet::OrderIdentifier;
-    use constants::GLOBAL_MATCHING_POOL;
 
     use crate::test_helpers::mock_db;
+
+    /// A test matching pool name
+    const TEST_POOL_NAME: &str = "test-pool";
 
     /// Tests creating a matching pool
     #[test]
     fn test_create_matching_pool() {
         let db = mock_db();
 
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let pool_name = TEST_POOL_NAME.to_string();
 
         // Create a matching pool
         let tx = db.new_write_tx().unwrap();
@@ -164,7 +163,7 @@ mod test {
     fn test_double_create_matching_pool() {
         let db = mock_db();
 
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let pool_name = TEST_POOL_NAME.to_string();
 
         // Create a matching pool
         let tx = db.new_write_tx().unwrap();
@@ -184,7 +183,7 @@ mod test {
     fn test_destroy_matching_pool() {
         let db = mock_db();
 
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let pool_name = TEST_POOL_NAME.to_string();
 
         // Create a matching pool
         let tx = db.new_write_tx().unwrap();
@@ -204,38 +203,12 @@ mod test {
         assert!(!pool_exists);
     }
 
-    /// Tests destroying a non-empty matching pool
-    #[test]
-    fn test_destroy_non_empty_matching_pool() {
-        let db = mock_db();
-
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
-        let order_id = OrderIdentifier::new_v4();
-
-        // Create a matching pool
-        let tx = db.new_write_tx().unwrap();
-        tx.create_matching_pool(&pool_name).unwrap();
-        tx.commit().unwrap();
-
-        // Assign the order to the matching pool
-        let tx = db.new_write_tx().unwrap();
-        tx.assign_order_to_matching_pool(&order_id, &pool_name).unwrap();
-        tx.commit().unwrap();
-
-        // Try destroying the matching pool
-        let tx = db.new_write_tx().unwrap();
-        let res = tx.destroy_matching_pool(&pool_name);
-        tx.commit().unwrap();
-
-        assert!(res.is_err());
-    }
-
     /// Tests assigning an order to a matching pool
     #[test]
     fn test_assign_order_to_matching_pool() {
         let db = mock_db();
 
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let pool_name = TEST_POOL_NAME.to_string();
         let order_id = OrderIdentifier::new_v4();
 
         // Create a matching pool
@@ -250,7 +223,7 @@ mod test {
 
         // Assert that the order is in the matching pool
         let tx = db.new_read_tx().unwrap();
-        let pool_for_order = tx.get_matching_pool_for_order(&order_id).unwrap().unwrap();
+        let pool_for_order = tx.get_matching_pool_for_order(&order_id).unwrap();
         tx.commit().unwrap();
 
         assert_eq!(pool_for_order, pool_name);
@@ -284,7 +257,7 @@ mod test {
 
         // Assert that the order is in the second matching pool
         let tx = db.new_read_tx().unwrap();
-        let pool_for_order = tx.get_matching_pool_for_order(&order_id).unwrap().unwrap();
+        let pool_for_order = tx.get_matching_pool_for_order(&order_id).unwrap();
         tx.commit().unwrap();
 
         assert_eq!(pool_for_order, pool_2_name);
@@ -294,7 +267,7 @@ mod test {
     fn test_assign_order_to_nonexistent_matching_pool() {
         let db = mock_db();
 
-        let pool_name = GLOBAL_MATCHING_POOL.to_string();
+        let pool_name = TEST_POOL_NAME.to_string();
         let order_id = OrderIdentifier::new_v4();
 
         // Try assigning the order to the matching pool (before creating it)

--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -218,11 +218,6 @@ impl<'db> StateTxn<'db, RW> {
         let orders = self.get_orders_by_nullifier(nullifier)?;
         for order_id in orders {
             self.delete_order(&order_id)?;
-
-            // Remove the order from its matching pool
-            if self.get_matching_pool_for_order(&order_id)?.is_some() {
-                self.remove_order_from_matching_pool(&order_id)?;
-            }
         }
 
         // Delete the index for the nullifier

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -22,9 +22,6 @@ use super::HandshakeExecutor;
 
 /// Error emitted when proofs of validity cannot be found for an order
 const ERR_MISSING_PROOFS: &str = "validity proofs not found in global state";
-/// Error emitted when an order being matched on is not assigned to any matching
-/// pool
-const ERR_NO_MATCHING_POOL: &str = "order not assigned to matching pool";
 
 // ------------------------
 // | Matching Engine Impl |
@@ -59,11 +56,7 @@ impl HandshakeExecutor {
         let price = self.get_execution_price(&network_order.id).await?;
 
         // Get the candidate order's matching pool
-        let my_pool_name = self
-            .state
-            .get_matching_pool_for_order(&network_order.id)
-            .await?
-            .ok_or(HandshakeManagerError::State(ERR_NO_MATCHING_POOL.to_string()))?;
+        let my_pool_name = self.state.get_matching_pool_for_order(&network_order.id).await?;
 
         // Fetch all other orders that are ready for matches
         // Shuffle the ordering of the other orders for fairness

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -13,7 +13,7 @@ use common::types::{
     wallet::{OrderIdentifier, Wallet},
     wallet_mocks::{mock_empty_wallet, mock_order},
 };
-use constants::{Scalar, GLOBAL_MATCHING_POOL};
+use constants::Scalar;
 use eyre::Result;
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
@@ -97,7 +97,7 @@ async fn execute_wallet_update_and_verify_shares(
     let desc = WalletUpdateType::PlaceOrder {
         order: mock_order(),
         id: OrderIdentifier::new_v4(),
-        matching_pool: GLOBAL_MATCHING_POOL.to_string(),
+        matching_pool: None,
     };
     execute_wallet_update(
         desc,


### PR DESCRIPTION
This PR lowers the assumption of the default global matching pool into the storage layer. We now no longer need to explicitly create the global pool or assign orders into it. The global pool is not tracked as a separate matching pool in the `POOL_TABLE`, and as such any orders w/o an explicit pool assignment are considered to be in the global pool.

Additionally, we now only remove orders from their matching pool when they are cancelled (this implicitly moves them back to the global pool, but they are not matchable regardless). This is the only situation in which we want to remove orders from their matching pools.

All unit tests pass.