### PR TITLE
workers: api-server: admin: order assignment endpoint

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -303,7 +303,7 @@ async fn main() -> Result<(), CoordinatorError> {
         max_root_staleness: args.max_merkle_staleness,
         arbitrum_client: chain_listener_arbitrum_client,
         global_state: global_state.clone(),
-        handshake_manager_job_queue: handshake_worker_sender,
+        handshake_manager_job_queue: handshake_worker_sender.clone(),
         proof_generation_work_queue: proof_generation_worker_sender.clone(),
         network_sender: network_sender.clone(),
         cancel_channel: chain_listener_cancel_receiver,
@@ -326,6 +326,7 @@ async fn main() -> Result<(), CoordinatorError> {
         system_bus,
         price_reporter_work_queue: price_reporter_worker_sender,
         proof_generation_work_queue: proof_generation_worker_sender,
+        handshake_manager_work_queue: handshake_worker_sender,
         cancel_channel: api_cancel_receiver,
     })
     .await

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -20,7 +20,8 @@ pub const ADMIN_MATCHING_POOL_DESTROY_ROUTE: &str =
     "/v0/admin/matching_pools/:matching_pool/destroy";
 /// Route to create an order in a matching pool
 pub const ADMIN_CREATE_ORDER_ROUTE: &str = "/v0/admin/wallet/:wallet_id/order-in-pool";
-
+/// Route to assign an order to a matching pool
+pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IsLeaderResponse {

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -478,6 +478,7 @@ impl MockNodeController {
         let system_bus = self.bus.clone();
         let price_reporter_work_queue = self.price_queue.0.clone();
         let proof_generation_work_queue = self.proof_queue.0.clone();
+        let handshake_manager_work_queue = self.handshake_queue.0.clone();
         let cancel_channel = mock_cancel();
 
         let conf = ApiServerConfig {
@@ -489,6 +490,7 @@ impl MockNodeController {
             system_bus,
             price_reporter_work_queue,
             proof_generation_work_queue,
+            handshake_manager_work_queue,
             cancel_channel,
         };
 

--- a/state/src/storage/tx/matching_pools.rs
+++ b/state/src/storage/tx/matching_pools.rs
@@ -114,8 +114,14 @@ impl<'db> StateTxn<'db, RW> {
             return Err(StorageError::Other(MATCHING_POOL_DOES_NOT_EXIST_ERR.to_string()));
         }
 
-        let pool_key = matching_pool_key(order_id);
-        self.inner().write(POOL_TABLE, &pool_key, &pool_name.to_string())
+        // If assigning to the global pool, simply remove the existing assignment
+        // (this is safe to do if an existing assignment does not exist)
+        if pool_name == GLOBAL_MATCHING_POOL {
+            self.remove_order_from_matching_pool(order_id)
+        } else {
+            let pool_key = matching_pool_key(order_id);
+            self.inner().write(POOL_TABLE, &pool_key, &pool_name.to_string())
+        }
     }
 
     /// Remove an order's matching pool assignment, this implicitly moves the

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -16,7 +16,7 @@ use common::types::{
 use external_api::{
     http::{
         admin::{
-            ADMIN_CREATE_ORDER_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
+            ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
             ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, IS_LEADER_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
@@ -58,8 +58,9 @@ use crate::{
 
 use self::{
     admin::{
-        AdminCreateMatchingPoolHandler, AdminCreateOrderInMatchingPoolHandler,
-        AdminDestroyMatchingPoolHandler, AdminOpenOrdersHandler,
+        AdminAssignOrderToMatchingPoolHandler, AdminCreateMatchingPoolHandler,
+        AdminCreateOrderInMatchingPoolHandler, AdminDestroyMatchingPoolHandler,
+        AdminOpenOrdersHandler,
     },
     network::{GetClusterInfoHandler, GetNetworkTopologyHandler, GetPeerInfoHandler},
     order_book::{GetNetworkOrderByIdHandler, GetNetworkOrdersHandler},
@@ -446,7 +447,17 @@ impl HttpServer {
         router.add_admin_authenticated_route(
             &Method::POST,
             ADMIN_CREATE_ORDER_ROUTE.to_string(),
-            AdminCreateOrderInMatchingPoolHandler::new(state),
+            AdminCreateOrderInMatchingPoolHandler::new(state.clone()),
+        );
+
+        // The "/admin/orders/:id/assign-pool/:matching_pool" route
+        router.add_admin_authenticated_route(
+            &Method::POST,
+            ADMIN_ASSIGN_ORDER_ROUTE.to_string(),
+            AdminAssignOrderToMatchingPoolHandler::new(
+                state,
+                config.handshake_manager_work_queue.clone(),
+            ),
         );
 
         router

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -120,7 +120,7 @@ pub async fn create_order(
 // ------------------
 
 /// Error message displayed when a given order cannot be found
-const ERR_ORDER_NOT_FOUND: &str = "order not found";
+pub const ERR_ORDER_NOT_FOUND: &str = "order not found";
 /// Error message emitted when a withdrawal is attempted with non-zero fees
 const ERR_WITHDRAW_NONZERO_FEES: &str = "cannot withdraw with non-zero fees";
 

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -8,8 +8,8 @@ use common::{
 use external_api::bus_message::SystemBusMessage;
 use futures::executor::block_on;
 use job_types::{
-    network_manager::NetworkManagerQueue, price_reporter::PriceReporterQueue,
-    proof_manager::ProofManagerQueue,
+    handshake_manager::HandshakeManagerQueue, network_manager::NetworkManagerQueue,
+    price_reporter::PriceReporterQueue, proof_manager::ProofManagerQueue,
 };
 use state::State;
 use std::thread::{self, JoinHandle};
@@ -55,6 +55,8 @@ pub struct ApiServerConfig {
     pub price_reporter_work_queue: PriceReporterQueue,
     /// The worker job queue for the ProofGenerationManager
     pub proof_generation_work_queue: ProofManagerQueue,
+    /// The worker job queue for the HandshakeManager
+    pub handshake_manager_work_queue: HandshakeManagerQueue,
     /// The relayer-global state
     pub state: State,
     /// The system pubsub bus that all workers have access to


### PR DESCRIPTION
This PR adds an admin API endpoint for assigning an existing order to an existing matching pool. This will also trigger a matching engine run on the assigned order

This was tested on a local relayer via the CLI, where I confirmed that an order moved into a matching pool containing a crossing order proceeded to match successfully.