### PR TITLE
workers: api-server: admin: order metadata endpoint

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -13,6 +13,8 @@ use crate::types::ApiOrder;
 pub const IS_LEADER_ROUTE: &str = "/v0/admin/is-leader";
 /// Get the open orders managed by the node
 pub const ADMIN_OPEN_ORDERS_ROUTE: &str = "/v0/admin/open-orders";
+/// Get the order metadata for a given order
+pub const ADMIN_ORDER_METADATA_ROUTE: &str = "/v0/admin/orders/:order_id/metadata";
 /// Route to create a matching pool
 pub const ADMIN_MATCHING_POOL_CREATE_ROUTE: &str = "/v0/admin/matching_pools/:matching_pool";
 /// Route to destroy a matching pool
@@ -48,4 +50,11 @@ pub struct CreateOrderInMatchingPoolRequest {
     pub statement_sig: Vec<u8>,
     /// The matching pool to create the order in
     pub matching_pool: MatchingPoolName,
+}
+
+/// The response to an "order metadata" request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdminOrderMetadataResponse {
+    /// The order metadata
+    pub order: OrderMetadata,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -17,7 +17,8 @@ use external_api::{
     http::{
         admin::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
-            ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
+            IS_LEADER_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
         order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
@@ -60,7 +61,7 @@ use self::{
     admin::{
         AdminAssignOrderToMatchingPoolHandler, AdminCreateMatchingPoolHandler,
         AdminCreateOrderInMatchingPoolHandler, AdminDestroyMatchingPoolHandler,
-        AdminOpenOrdersHandler,
+        AdminOpenOrdersHandler, AdminOrderMetadataHandler,
     },
     network::{GetClusterInfoHandler, GetNetworkTopologyHandler, GetPeerInfoHandler},
     order_book::{GetNetworkOrderByIdHandler, GetNetworkOrdersHandler},
@@ -427,6 +428,13 @@ impl HttpServer {
             &Method::GET,
             ADMIN_OPEN_ORDERS_ROUTE.to_string(),
             AdminOpenOrdersHandler::new(state.clone()),
+        );
+
+        // The "/admin/orders/:id/metadata" route
+        router.add_admin_authenticated_route(
+            &Method::GET,
+            ADMIN_ORDER_METADATA_ROUTE.to_string(),
+            AdminOrderMetadataHandler::new(state.clone()),
         );
 
         // The "/admin/matching_pools/:matching_pool" route


### PR DESCRIPTION
This PR introduces a convenience endpoint for getting an order's metadata via the admin API. This will be used by the quoters to poll for the successful fill of an order that has been targeted for matching. The information returned here is already available vis the open orders API endpoint, but this makes it simpler to search for a specific order.

This has been tested locally via the CLI.