### PR TITLE
workers: api-server: admin: add admin route for fetching a wallet's balances

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -25,6 +25,8 @@ pub const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE: &str =
     "/v0/admin/wallet/:wallet_id/order-in-pool";
 /// Route to assign an order to a matching pool
 pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
+/// Admin route to get a wallet's balances
+pub const ADMIN_GET_BALANCES_ROUTE: &str = "/v0/admin/wallet/:wallet_id/balances";
 
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -17,8 +17,9 @@ use external_api::{
     http::{
         admin::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
-            ADMIN_MATCHING_POOL_CREATE_ROUTE, ADMIN_MATCHING_POOL_DESTROY_ROUTE,
-            ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_GET_BALANCES_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
+            ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
+            IS_LEADER_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
         order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
@@ -61,7 +62,7 @@ use self::{
     admin::{
         AdminAssignOrderToMatchingPoolHandler, AdminCreateMatchingPoolHandler,
         AdminCreateOrderInMatchingPoolHandler, AdminDestroyMatchingPoolHandler,
-        AdminOpenOrdersHandler, AdminOrderMetadataHandler,
+        AdminGetBalancesHandler, AdminOpenOrdersHandler, AdminOrderMetadataHandler,
     },
     network::{GetClusterInfoHandler, GetNetworkTopologyHandler, GetPeerInfoHandler},
     order_book::{GetNetworkOrderByIdHandler, GetNetworkOrdersHandler},
@@ -463,9 +464,16 @@ impl HttpServer {
             &Method::POST,
             ADMIN_ASSIGN_ORDER_ROUTE.to_string(),
             AdminAssignOrderToMatchingPoolHandler::new(
-                state,
+                state.clone(),
                 config.handshake_manager_work_queue.clone(),
             ),
+        );
+
+        // The "/admin/wallet/:id/balances" route
+        router.add_admin_authenticated_route(
+            &Method::GET,
+            ADMIN_GET_BALANCES_ROUTE.to_string(),
+            AdminGetBalancesHandler::new(state),
         );
 
         router


### PR DESCRIPTION
This PR adds an admin route for fetching a wallet's balances. This will be used in the quoter dashboard to determine the maximum size of a matching order to construct.

This has been tested via the CLI & local relayer, the balances returned match those included in fetching a wallet using wallet auth