### PR TITLE
state: applicator: wallet_index: update local orders set & network order state when cancelling

### DIFF
--- a/common/src/types/network_order.rs
+++ b/common/src/types/network_order.rs
@@ -119,20 +119,13 @@ impl NetworkOrder {
         self.validity_proofs = Some(validity_proofs)
     }
 
-    /// The following state transition methods are made module private because
-    /// we prefer that access flow through the parent (`OrderBook`) object.
-    /// This object has a reference to the system bus for internal events to
-    /// be published
-
     /// Transitions the state of an order back to the received state, this drops
     /// the existing proof of `VALID COMMITMENTS`
-    #[allow(unused)]
     pub fn transition_received(&mut self) {
         self.state = NetworkOrderState::Received;
     }
 
     /// Transitions the state of an order to the verified state
-    #[allow(unused)]
     pub fn transition_verified(&mut self, validity_proofs: OrderValidityProofBundle) {
         self.attach_validity_proofs(validity_proofs);
     }
@@ -144,7 +137,6 @@ impl NetworkOrder {
     }
 
     /// Transitions the state of an order to `Cancelled`
-    #[allow(unused)]
     pub fn transition_cancelled(&mut self) {
         self.state = NetworkOrderState::Cancelled;
 

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -149,10 +149,18 @@ impl StateApplicator {
 
                 // Only update the state if it has not already entered a terminal state
                 if !old_meta.state.is_terminal() {
+                    // Update the order metadata to reflect the order's cancellation
                     old_meta.state = OrderState::Cancelled;
                     self.update_order_metadata_with_tx(old_meta, tx)?;
+
                     // Remove the order from its matching pool
                     tx.remove_order_from_matching_pool(&id)?;
+
+                    // Remove the order from the local orders set
+                    tx.remove_local_order(&id)?;
+
+                    // Transition the order to a cancelled state
+                    tx.mark_order_cancelled(&id)?;
                 }
             }
         }

--- a/workers/gossip-server/src/orderbook.rs
+++ b/workers/gossip-server/src/orderbook.rs
@@ -10,9 +10,7 @@ use circuits::{
     },
 };
 use common::types::{
-    gossip::ClusterId,
-    network_order::{NetworkOrder, NetworkOrderState},
-    proof_bundles::OrderValidityProofBundle,
+    gossip::ClusterId, network_order::NetworkOrder, proof_bundles::OrderValidityProofBundle,
     wallet::OrderIdentifier,
 };
 use futures::executor::block_on;
@@ -71,7 +69,7 @@ impl GossipProtocolExecutor {
             // Move fields out of `order_info` before transferring ownership
             let proof = order.validity_proofs.take();
 
-            order.state = NetworkOrderState::Received;
+            order.transition_received();
             order.local = is_local;
             self.state.add_order(order).await?;
 


### PR DESCRIPTION
This PR smooths out some bugs / inconsistencies in order cancellation. In doing so, we slightly change the semantics of the local order set from "any orders managed by the local cluster" to "any _open_ orders managed by the local cluster," where "open" signifies that they are not cancelled and not completely filled.

Namely, the following changes are made:
1. When an order is cancelled, remove it from the local orders set, and mark the underlying `NetworkOrder` as cancelled
    - This also drops the validity proofs/witnesses from the order, which previously was not happening, resulting in the order still being considered `ready_for_match`
2. When recording an order fill, if the order is completely filled, remove it from the local orders set

All unit tests pass.