### PR TITLE
config: cli: Allow public-key-only configuration for fee key

### DIFF
--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -1,11 +1,11 @@
 //! Stores state information relating to the node's configuration
 
-use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
+use circuit_types::fixed_point::FixedPoint;
 use common::types::{
     gossip::{ClusterId, PeerInfo, WrappedPeerId},
     wallet::{derivation::derive_wallet_id, Wallet, WalletIdentifier},
 };
-use config::RelayerConfig;
+use config::{RelayerConfig, RelayerFeeKey};
 use libp2p::{core::Multiaddr, identity::Keypair};
 use util::res_some;
 
@@ -47,8 +47,8 @@ impl State {
     }
 
     /// Get the decryption key used to settle managed match fees
-    pub async fn get_fee_decryption_key(&self) -> Result<DecryptionKey, StateError> {
-        self.with_read_tx(|tx| tx.get_fee_decryption_key().map_err(StateError::Db)).await
+    pub async fn get_fee_key(&self) -> Result<RelayerFeeKey, StateError> {
+        self.with_read_tx(|tx| tx.get_fee_key().map_err(StateError::Db)).await
     }
 
     /// Get the local relayer's match take rate
@@ -118,7 +118,7 @@ impl State {
         let peer_id = config.peer_id();
         let cluster_id = config.cluster_id.clone();
         let p2p_key = config.p2p_key.clone();
-        let fee_decryption_key = config.fee_decryption_key;
+        let fee_key = config.fee_key;
         let match_take_rate = config.match_take_rate;
         let relayer_fee_whitelist = config.relayer_fee_whitelist.clone();
         let auto_redeem_fees = config.auto_redeem_fees;
@@ -131,7 +131,7 @@ impl State {
             tx.set_peer_id(&peer_id)?;
             tx.set_cluster_id(&cluster_id)?;
             tx.set_node_keypair(&p2p_key)?;
-            tx.set_fee_decryption_key(&fee_decryption_key)?;
+            tx.set_fee_key(&fee_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
             tx.set_local_node_wallet(relayer_wallet_id)?;
             tx.set_auto_redeem_fees(auto_redeem_fees)?;

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -1,10 +1,11 @@
 //! Storage access methods for the local node's metadata
 
-use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
+use circuit_types::fixed_point::FixedPoint;
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     wallet::WalletIdentifier,
 };
+use config::RelayerFeeKey;
 use libmdbx::{TransactionKind, RW};
 use libp2p::core::Multiaddr;
 use libp2p::identity::Keypair;
@@ -30,7 +31,7 @@ const LOCAL_ADDR_KEY: &str = "local-addr";
 const LOCAL_WALLET_ID_KEY: &str = "local-wallet-id";
 /// The key for the local relayer's fee decryption key in the node metadata
 /// table
-const LOCAL_RELAYER_DECRYPTION_KEY: &str = "local-relayer-decryption-key";
+const LOCAL_RELAYER_FEE_KEY: &str = "local-relayer-fee-key";
 /// The key for the local relayer's match take rate in the node metadata table
 const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
 /// The key for the local relayer's auto-redeem fees flag in the node metadata
@@ -94,10 +95,10 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// Get the local relayer's fee decryption key
-    pub fn get_fee_decryption_key(&self) -> Result<DecryptionKey, StorageError> {
+    pub fn get_fee_key(&self) -> Result<RelayerFeeKey, StorageError> {
         self.inner()
-            .read(NODE_METADATA_TABLE, &LOCAL_RELAYER_DECRYPTION_KEY.to_string())?
-            .ok_or_else(|| err_not_found(LOCAL_RELAYER_DECRYPTION_KEY))
+            .read(NODE_METADATA_TABLE, &LOCAL_RELAYER_FEE_KEY.to_string())?
+            .ok_or_else(|| err_not_found(LOCAL_RELAYER_FEE_KEY))
     }
 
     /// Get the local relayer's match take rate
@@ -147,8 +148,8 @@ impl<'db> StateTxn<'db, RW> {
     }
 
     /// Set the local relayer's fee decryption key
-    pub fn set_fee_decryption_key(&self, fee_key: &DecryptionKey) -> Result<(), StorageError> {
-        self.inner().write(NODE_METADATA_TABLE, &LOCAL_RELAYER_DECRYPTION_KEY.to_string(), fee_key)
+    pub fn set_fee_key(&self, fee_key: &RelayerFeeKey) -> Result<(), StorageError> {
+        self.inner().write(NODE_METADATA_TABLE, &LOCAL_RELAYER_FEE_KEY.to_string(), fee_key)
     }
 
     /// Set the local relayer's match take rate

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -239,7 +239,7 @@ impl TypedHandler for CreateWalletHandler {
         }
 
         // Overwrite the managing cluster and the match fee with the configured values
-        let relayer_key = self.state.get_fee_decryption_key().await?.public_key();
+        let relayer_key = self.state.get_fee_key().await?.public_key();
         let relayer_take_rate = self.state.get_relayer_fee_for_wallet(&wallet_id).await?;
         req.wallet.managing_cluster = jubjub_to_hex_string(&relayer_key);
         req.wallet.match_fee = relayer_take_rate;

--- a/workers/task-driver/integration/tests/pay_relayer_fee.rs
+++ b/workers/task-driver/integration/tests/pay_relayer_fee.rs
@@ -48,7 +48,7 @@ async fn setup_trader_wallet(
     let state = &test_args.state;
 
     // Read the local relayer's decryption key from the state to manage the wallet
-    let decryption_key = state.get_fee_decryption_key().await.unwrap();
+    let decryption_key = state.get_fee_key().await?.secret_key().unwrap();
 
     // Create a wallet in the darkpool with a non-zero fee
     let mut wallet = mock_empty_wallet();

--- a/workers/task-driver/integration/tests/redeem_relayer_fee.rs
+++ b/workers/task-driver/integration/tests/redeem_relayer_fee.rs
@@ -46,7 +46,7 @@ async fn setup_trader_wallet(test_args: &IntegrationTestArgs) -> Result<(Balance
     wallet.add_balance(bal.clone()).unwrap();
 
     // Set the managing cluster of the wallet to the local relayer
-    let key = test_args.state.get_fee_decryption_key().await.unwrap().public_key();
+    let key = test_args.state.get_fee_key().await?.public_key();
     wallet.managing_cluster = key;
 
     setup_initial_wallet(blinder_seed, share_seed, &mut wallet, test_args).await?;

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -96,7 +96,7 @@ async fn setup_wallet_with_order_balance(
     test_args: IntegrationTestArgs,
 ) -> Result<(Wallet, Scalar, Scalar)> {
     let mut rng = thread_rng();
-    let managing_cluster = test_args.state.get_fee_decryption_key().await?.public_key();
+    let managing_cluster = test_args.state.get_fee_key().await?.public_key();
 
     let blinder_seed = Scalar::random(&mut rng);
     let share_seed = Scalar::random(&mut rng);

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -291,7 +291,8 @@ impl PayOfflineFeeTask {
         // If this was a relayer fee payment and auto-redeem is enabled, enqueue a job
         // for the relayer to redeem the fee
         let auto_redeem = self.state.get_auto_redeem_fees().await?;
-        if !self.is_protocol_fee && auto_redeem {
+        let decryption_key = self.state.get_fee_key().await?.secret_key();
+        if !self.is_protocol_fee && auto_redeem && decryption_key.is_some() {
             enqueue_relayer_redeem_job(self.note.clone(), &self.state)
                 .await
                 .map_err(PayOfflineFeeTaskError::State)?;


### PR DESCRIPTION
### Purpose
This PR adds a `fee-encryption-key` config option and makes this option mutually exclusive with `fee-decryption-key`. For relayers that run fee decryption and settlement externally, the decryption key need not be placed in the relayer config; only the encryption key.

### Testing
- Ran a relayer with only an encryption key, went through common flows of creating a new wallet, depositing, placing an order, matching, then paying fees. Verified that all flows, including fee payment, worked as expected