### PR TITLE
state: applicator: wallet-index: Check order info exists when cancelling

### DIFF
--- a/renegade-crypto/src/hash.rs
+++ b/renegade-crypto/src/hash.rs
@@ -8,6 +8,7 @@ pub use poseidon2::*;
 #[cfg(feature = "non-wasm")]
 pub use mpc_type_interface::*;
 
+#[allow(clippy::mixed_attributes_style)]
 #[cfg(feature = "non-wasm")]
 mod mpc_type_interface {
     //! Defines the interface for the Poseidon 2 sponge

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -156,11 +156,11 @@ impl StateApplicator {
                     // Remove the order from its matching pool
                     tx.remove_order_from_matching_pool(&id)?;
 
-                    // Remove the order from the local orders set
+                    // Remove the order from the local orders set and mark as cancelled
                     tx.remove_local_order(&id)?;
-
-                    // Transition the order to a cancelled state
-                    tx.mark_order_cancelled(&id)?;
+                    if tx.get_order_info(&id)?.is_some() {
+                        tx.mark_order_cancelled(&id)?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Purpose
This PR fixes a bug wherein we may attempt to transition an order to the cancelled state when it does not exist. This may happen if the chain events listener removes the order before it can be cancelled.

This happened in testnet and caused the cluster to degrade.

### Testing
- Unit tests pass
- Tested the cancellation flows, this fix will be tested live