### PR TITLE
workers: api-server: admin: open-orders: matching pool filter + fillable amt

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -5,7 +5,7 @@
 // ---------------
 
 use circuit_types::Amount;
-use common::types::{wallet::order_metadata::OrderMetadata, MatchingPoolName};
+use common::types::{wallet::order_metadata::OrderMetadata, MatchingPoolName, Price};
 use serde::{Deserialize, Serialize};
 
 use crate::types::ApiOrder;
@@ -51,6 +51,8 @@ pub struct OpenOrder {
     pub order: OrderMetadata,
     /// The fillable amount of the order
     pub fillable: Amount,
+    /// The price used to calculate the fillable amount
+    pub price: Price,
 }
 
 /// The request type to add a new order to a given wallet, within a non-global

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -4,6 +4,7 @@
 // | HTTP Routes |
 // ---------------
 
+use circuit_types::Amount;
 use common::types::{wallet::order_metadata::OrderMetadata, MatchingPoolName};
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +38,19 @@ pub struct IsLeaderResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenOrdersResponse {
     /// The open orders
-    pub orders: Vec<OrderMetadata>,
+    pub orders: Vec<OpenOrder>,
+}
+
+/// An open order, containing the order's metadata
+/// as well as the fillable amount of the order
+/// given the underlying wallet's balances and potentially
+/// the current price of the base asset
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OpenOrder {
+    /// The order metadata
+    pub order: OrderMetadata,
+    /// The fillable amount of the order
+    pub fillable: Amount,
 }
 
 /// The request type to add a new order to a given wallet, within a non-global

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -42,17 +42,17 @@ pub struct OpenOrdersResponse {
 }
 
 /// An open order, containing the order's metadata
-/// as well as the fillable amount of the order
-/// given the underlying wallet's balances and potentially
+/// and potentially the fillable amount of the order
+/// given the underlying wallet's balances and
 /// the current price of the base asset
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenOrder {
     /// The order metadata
     pub order: OrderMetadata,
-    /// The fillable amount of the order
-    pub fillable: Amount,
-    /// The price used to calculate the fillable amount
-    pub price: Price,
+    /// The fillable amount of the order, if calculated
+    pub fillable: Option<Amount>,
+    /// The price used to calculate the fillable amount, if calculated
+    pub price: Option<Price>,
 }
 
 /// The request type to add a new order to a given wallet, within a non-global

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     tasks::TaskIdentifier,
+    MatchingPoolName,
 };
 use external_api::{
     http::{
@@ -122,6 +123,8 @@ const PEER_ID_URL_PARAM: &str = "peer_id";
 const TASK_ID_URL_PARAM: &str = "task_id";
 /// The :matching_pool param in a URL
 const MATCHING_POOL_URL_PARAM: &str = "matching_pool";
+/// The ?matching_pool param in a query string
+const MATCHING_POOL_QUERY_PARAM: &str = "matching_pool";
 
 /// A helper to parse out a mint from a URL param
 pub(super) fn parse_mint_from_params(params: &UrlParams) -> Result<BigUint, ApiServerError> {
@@ -187,14 +190,17 @@ pub(super) fn parse_task_id_from_params(
 }
 
 /// A helper to parse out a matching pool name from a URL param
-pub(super) fn parse_matching_pool_from_params(
+pub(super) fn parse_matching_pool_from_url_params(
     params: &UrlParams,
-) -> Result<String, ApiServerError> {
-    params
-        .get(MATCHING_POOL_URL_PARAM)
-        .ok_or_else(|| bad_request(ERR_MATCHING_POOL_PARSE))?
-        .parse()
-        .map_err(|_| bad_request(ERR_MATCHING_POOL_PARSE))
+) -> Result<MatchingPoolName, ApiServerError> {
+    params.get(MATCHING_POOL_URL_PARAM).ok_or_else(|| bad_request(ERR_MATCHING_POOL_PARSE)).cloned()
+}
+
+/// A helper to parse out a matching pool name from a query string
+pub(super) fn parse_matching_pool_from_query_params(
+    params: &QueryParams,
+) -> Option<MatchingPoolName> {
+    params.get(MATCHING_POOL_QUERY_PARAM).cloned()
 }
 
 /// A wrapper around the router and task management operations that

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -121,10 +121,8 @@ const CLUSTER_ID_URL_PARAM: &str = "cluster_id";
 const PEER_ID_URL_PARAM: &str = "peer_id";
 /// The :task_id param in a URL
 const TASK_ID_URL_PARAM: &str = "task_id";
-/// The :matching_pool param in a URL
-const MATCHING_POOL_URL_PARAM: &str = "matching_pool";
-/// The ?matching_pool param in a query string
-const MATCHING_POOL_QUERY_PARAM: &str = "matching_pool";
+/// The :matching_pool param in a URL / query string
+const MATCHING_POOL_PARAM: &str = "matching_pool";
 
 /// A helper to parse out a mint from a URL param
 pub(super) fn parse_mint_from_params(params: &UrlParams) -> Result<BigUint, ApiServerError> {
@@ -193,14 +191,14 @@ pub(super) fn parse_task_id_from_params(
 pub(super) fn parse_matching_pool_from_url_params(
     params: &UrlParams,
 ) -> Result<MatchingPoolName, ApiServerError> {
-    params.get(MATCHING_POOL_URL_PARAM).ok_or_else(|| bad_request(ERR_MATCHING_POOL_PARSE)).cloned()
+    params.get(MATCHING_POOL_PARAM).ok_or_else(|| bad_request(ERR_MATCHING_POOL_PARSE)).cloned()
 }
 
 /// A helper to parse out a matching pool name from a query string
 pub(super) fn parse_matching_pool_from_query_params(
     params: &QueryParams,
 ) -> Option<MatchingPoolName> {
-    params.get(MATCHING_POOL_QUERY_PARAM).cloned()
+    params.get(MATCHING_POOL_PARAM).cloned()
 }
 
 /// A wrapper around the router and task management operations that

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -433,7 +433,7 @@ impl HttpServer {
         router.add_admin_authenticated_route(
             &Method::GET,
             ADMIN_OPEN_ORDERS_ROUTE.to_string(),
-            AdminOpenOrdersHandler::new(state.clone()),
+            AdminOpenOrdersHandler::new(state.clone(), config.price_reporter_work_queue.clone()),
         );
 
         // The "/admin/orders/:id/metadata" route

--- a/workers/handshake-manager/src/manager/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/internal_engine.rs
@@ -216,13 +216,16 @@ impl HandshakeExecutor {
         order: &OrderIdentifier,
     ) -> Result<FixedPoint, HandshakeManagerError> {
         let (base, quote) = self.token_pair_for_order(order).await?;
-        let price_recv = self.request_price(base, quote)?;
+        let base_addr = base.get_addr().to_string();
+        let quote_addr = quote.get_addr().to_string();
+        let price_recv = self.request_price(base.clone(), quote.clone())?;
         let price =
             match price_recv.await.map_err(err_str!(HandshakeManagerError::PriceReporter))? {
                 PriceReporterState::Nominal(report) => report.price,
                 err_state => {
                     return Err(HandshakeManagerError::NoPriceData(format!(
-                        "{ERR_NO_PRICE_DATA}: {err_state:?}"
+                        "{ERR_NO_PRICE_DATA}: {} / {} {err_state:?}",
+                        base_addr, quote_addr,
                     )));
                 },
             };


### PR DESCRIPTION
This PR tweaks the admin `/open-orders` endpoint to support a `matching_pool` query param to filter open orders by, and also to calculate the fillable amount of each order & include that in the response. This may require using the current price of the order's base asset, which is naturally liable to drift by the time the client receives this API response. This is assumed to be understood by the client.

I tested this by running a local relayer & probing the `/open-orders` API while I moved an order between matching pools, including the global pool. I asserted that the responses were properly filtered and included the expected fillable amount