### PR TITLE
external-api: network: Add `local_cluster_id` to network topology resp

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -166,10 +166,11 @@ pub async fn multiprover_prove_and_verify<C: MultiProverCircuit>(
 // ----------------
 // | Test Helpers |
 // ----------------
+
+/// Helpers used in tests throughout the crate and integration tests outside
+/// the crate
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    //! Helpers used in tests throughout the crate and integration tests outside
-    //! the crate
 
     use std::iter;
 

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -550,9 +550,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod test {
-    #![allow(non_snake_case)]
-
     use circuit_types::{
         balance::{Balance, BalanceShare},
         fixed_point::FixedPointShare,

--- a/circuits/src/zk_circuits/valid_fee_redemption.rs
+++ b/circuits/src/zk_circuits/valid_fee_redemption.rs
@@ -796,7 +796,7 @@ mod test {
         // Start off with duplicates
         let (mut wallet, note) = get_testing_wallet_and_note();
         for balance in wallet.balances.iter_mut() {
-            balance.mint = note.mint.clone();
+            balance.mint.clone_from(&note.mint);
         }
 
         let (statement, witness) = create_witness_and_statement(&wallet, &note);

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -411,8 +411,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod tests {
-    #![allow(non_snake_case)]
     use ark_mpc::PARTY0;
     use circuit_types::{fixed_point::FixedPoint, traits::MpcBaseType, AMOUNT_BITS};
 

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -353,8 +353,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod test {
-    #![allow(non_snake_case)]
     use circuit_types::{
         native_helpers::compute_wallet_private_share_commitment,
         traits::{BaseType, SecretShareType},

--- a/circuits/src/zk_circuits/valid_relayer_fee_settlement.rs
+++ b/circuits/src/zk_circuits/valid_relayer_fee_settlement.rs
@@ -438,9 +438,8 @@ where
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
+/// Helper methods for testing the `VALID RELAYER FEE SETTLEMENT` circuit
 pub mod test_helpers {
-    //! Helper methods for testing the `VALID RELAYER FEE SETTLEMENT` circuit
-
     use circuit_types::{
         elgamal::DecryptionKey,
         native_helpers::{
@@ -479,7 +478,9 @@ pub mod test_helpers {
         // Pick balances to send and receive the fees from
         let send_idx = rng.gen_range(0..MAX_BALANCES);
         let receive_idx = rng.gen_range(0..MAX_BALANCES);
-        recipient_wallet.balances[receive_idx].mint = sender_wallet.balances[send_idx].mint.clone();
+        recipient_wallet.balances[receive_idx]
+            .mint
+            .clone_from(&sender_wallet.balances[send_idx].mint);
 
         let (dec, enc) = DecryptionKey::random_pair(&mut rng);
         sender_wallet.managing_cluster = enc;
@@ -555,9 +556,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod test {
-    #![allow(non_snake_case)]
-
     use ark_mpc::algebra::Scalar;
     use circuit_types::{
         balance::Balance,
@@ -1050,11 +1050,11 @@ mod test {
         // Make all balances the same mint in the sender wallet and receiver wallet
         let (mut sender_wallet, mut recipient_wallet) = get_initial_wallets();
         for bal in recipient_wallet.balances.iter_mut() {
-            bal.mint = mint.clone();
+            bal.mint.clone_from(&mint);
         }
 
         for bal in sender_wallet.balances.iter_mut() {
-            bal.mint = mint.clone();
+            bal.mint.clone_from(&mint);
         }
 
         let (statement, witness) = create_witness_statement(&sender_wallet, &recipient_wallet);

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -604,9 +604,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod test {
-    #![allow(non_snake_case)]
-
     use circuit_types::{
         balance::Balance,
         elgamal::DecryptionKey,
@@ -971,6 +970,7 @@ mod test {
 
     /// Tests the case in which a duplicate balance is given
     #[test]
+    #[allow(clippy::assigning_clones)]
     fn test_duplicate_balance() {
         // No update to the orders, but the timestamp is incorrect
         // To ablate any other constraints, make the duplicate balance present in both

--- a/circuits/src/zk_gadgets/elgamal.rs
+++ b/circuits/src/zk_gadgets/elgamal.rs
@@ -67,10 +67,9 @@ impl ElGamalGadget {
     }
 }
 
+/// Helpers for testing the ElGamal gadgets
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    //! Test helpers for the ElGamal gadgets
-
     use circuit_types::elgamal::{DecryptionKey, EncryptionKey};
     use jf_primitives::elgamal::KeyPair;
     use rand::thread_rng;

--- a/common/src/keyed_list.rs
+++ b/common/src/keyed_list.rs
@@ -266,7 +266,7 @@ mod test {
 
         // Change the value
         if let Some(v) = map.get_mut(&key) {
-            *v = new_value.clone();
+            v.clone_from(&new_value);
         }
 
         assert_eq!(map.get(&key), Some(&new_value));

--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -283,9 +283,9 @@ impl FromStr for ClusterId {
 // | Helpers |
 // -----------
 
+/// Mocks for peer info types
 #[cfg(feature = "mocks")]
 pub mod mocks {
-    //! Mocks for peer info types
     use std::{
         net::{IpAddr, Ipv4Addr},
         str::FromStr,

--- a/common/src/types/handshake.rs
+++ b/common/src/types/handshake.rs
@@ -131,9 +131,9 @@ impl HandshakeState {
     }
 }
 
+/// Handshake object mocks for testing
 #[cfg(feature = "mocks")]
 pub mod mocks {
-    //! Handshake object mocks for testing
     use circuit_types::fixed_point::FixedPoint;
     use constants::Scalar;
     use rand::thread_rng;

--- a/common/src/types/network_order.rs
+++ b/common/src/types/network_order.rs
@@ -170,9 +170,9 @@ impl Display for NetworkOrderState {
     }
 }
 
+/// Test helpers for creating dummy network orders
 #[cfg(feature = "mocks")]
 pub mod test_helpers {
-    //! Test helpers for creating dummy network orders
     use std::str::FromStr;
 
     use constants::Scalar;

--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -594,11 +594,11 @@ impl<'de> Deserialize<'de> for MatchBundle {
 // | Mocks |
 // ---------
 
+/// Mocks for proof bundle and proof objects
+///
+/// Note that these mocks are not expected to verify
 #[cfg(feature = "mocks")]
 pub mod mocks {
-    //! Mocks for proof bundle and proof objects
-    //!
-    //! Note that these mocks are not expected to verify
 
     use std::{iter, sync::Arc};
 

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -199,9 +199,9 @@ impl TaskDescriptor {
 // | Mocks |
 // ---------
 
+/// Mocks for the task descriptors
 #[cfg(any(test, feature = "mocks"))]
 pub mod mocks {
-    //! Mocks for the task descriptors
     use circuit_types::keychain::SecretSigningKey;
     use contracts_common::custom_serde::BytesSerializable;
     use ethers::core::utils::keccak256;

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -93,9 +93,9 @@ impl HistoricalTaskDescription {
     }
 }
 
+/// Mock helpers for testing task history
 #[cfg(feature = "mocks")]
 pub mod historical_mocks {
-    //! Mock helpers for testing task history
 
     use rand::{thread_rng, RngCore};
 

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -485,9 +485,9 @@ impl RelayerFeeKey {
 // | Tests |
 // ---------
 
+/// Tests for the cli
 #[cfg(test)]
 mod test {
-    //! Tests for the cli
     use crate::RelayerConfig;
 
     /// Test that the default config parses

--- a/external-api/src/http/network.rs
+++ b/external-api/src/http/network.rs
@@ -22,6 +22,8 @@ pub const GET_PEER_INFO_ROUTE: &str = "/v0/network/peers/:peer_id";
 /// The response type to fetch the entire known network topology
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetNetworkTopologyResponse {
+    /// The local peer's cluster ID
+    pub local_cluster_id: String,
     /// The network topology
     pub network: Network,
 }

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -123,9 +123,9 @@ impl StateApplicator {
     }
 }
 
+/// Test helpers for mock state applicator
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_helpers {
-    //! Test helpers for mock state applicator
     use std::{mem, str::FromStr, sync::Arc};
 
     use common::types::gossip::ClusterId;

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -340,7 +340,7 @@ mod test {
         // Check the info map
         let info_map = state.get_peer_info_map().await.unwrap();
         assert_eq!(info_map.len(), 2);
-        assert!(info_map.get(&peer1.peer_id).is_none());
+        assert!(!info_map.contains_key(&peer1.peer_id));
 
         let info_peer2 = info_map.get(&peer2.peer_id).unwrap();
         let info_peer3 = info_map.get(&peer3.peer_id).unwrap();

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -196,9 +196,9 @@ impl From<StateTransition> for Proposal {
 // | Tests |
 // ---------
 
+/// Test helpers for the state crate
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_helpers {
-    //! Test helpers for the state crate
     use std::{mem, time::Duration};
 
     use common::worker::new_worker_failure_channel;

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -65,9 +65,9 @@ pub fn get_raft_id(peer_id: &WrappedPeerId) -> u64 {
 // | Mock Raft |
 // -------------
 
+/// Test helpers for mocking rafts
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_helpers {
-    //! Test helpers for mocking rafts
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use common::{new_async_shared, AsyncShared};

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -57,6 +57,7 @@ impl TypedHandler for GetNetworkTopologyHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Fetch all peer info
+        let local_cluster_id = self.state.get_cluster_id().await?.to_string();
         let peers = self.state.get_peer_info_map().await?;
 
         // Gather by cluster
@@ -67,7 +68,7 @@ impl TypedHandler for GetNetworkTopologyHandler {
         }
 
         // Reformat into response
-        Ok(GetNetworkTopologyResponse { network: peers_by_cluster.into() })
+        Ok(GetNetworkTopologyResponse { local_cluster_id, network: peers_by_cluster.into() })
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds the local peer's cluster ID to the network topology response in `GET /v0/network`. This will be used by clients to filter the network response by exactly the cluster responding to the request.

I also cleaned up a bunch of clippy lints that were left over from upgrading the rust toolchain.

### Testing
- Tested the endpoint