### PR TITLE
workers: api-server: http: admin: check for order existence on wallet when assigning

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -25,7 +25,8 @@ pub const ADMIN_MATCHING_POOL_DESTROY_ROUTE: &str =
 pub const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE: &str =
     "/v0/admin/wallet/:wallet_id/order-in-pool";
 /// Route to assign an order to a matching pool
-pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
+pub const ADMIN_ASSIGN_ORDER_ROUTE: &str =
+    "/v0/admin/wallet/:wallet_id/orders/:order_id/assign-pool/:matching_pool";
 
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -462,7 +462,7 @@ impl HttpServer {
             AdminCreateOrderInMatchingPoolHandler::new(state.clone()),
         );
 
-        // The "/admin/orders/:id/assign-pool/:matching_pool" route
+        // The "/admin/wallet/:id/orders/:id/assign-pool/:matching_pool" route
         router.add_admin_authenticated_route(
             &Method::POST,
             ADMIN_ASSIGN_ORDER_ROUTE.to_string(),


### PR DESCRIPTION
This PR tweaks the order existence check in the "assign order to matching pool" endpoint to check for the order's presence in a wallet as opposed to the network order book.

This is because orders that get completely filled are removed from the network order book, even if a client intends to assign them into a separate matching pool for subsequent updates / usage.

TODO:
- Update the JS SDK to invoke this endpoint correctly