### PR TITLE
workers: api-server: http: admin: check order existence by metadata

### DIFF
--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -366,8 +366,11 @@ impl TypedHandler for AdminAssignOrderToMatchingPoolHandler {
         let order_id = parse_order_id_from_params(&params)?;
         let matching_pool = parse_matching_pool_from_url_params(&params)?;
 
-        // Check that the order exists
-        if !self.state.contains_order(&order_id).await? {
+        // Check that the order exists. We do this by checking the order
+        // metadata, as filled orders (which a client may still want to reassign
+        // ahead of subsequent order updates) are removed from the network
+        // orderbook.
+        if self.state.get_order_metadata(&order_id).await?.is_none() {
             return Err(not_found(ERR_ORDER_NOT_FOUND));
         }
 


### PR DESCRIPTION
This PR updates the admin order assignment endpoint to check for an order's existence via it's metadata as opposed to the network order book - this is because filled orders are removed from the network order book, and there is also a critical section in the `Updating State` step of the `SettleMatchInternalTask` wherein a partially filled order is removed but not yet reindexed to the network order book.

As such it is less error-prone and more semantically correct to check for an order's existence via it's presence in the metadata table.