### PR TITLE
state: benches: interface: Add consensus benchmarks

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -3,6 +3,10 @@ name = "config"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+silent = []
+
 [dependencies]
 # === Networking === #
 libp2p = { workspace = true }

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -4,7 +4,6 @@ pub use crate::token_remaps::setup_token_remaps;
 use crate::{cli::RelayerConfig, validation::validate_config, Cli, RelayerFeeKey};
 use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use clap::Parser;
-use colored::*;
 use common::types::{
     gossip::{ClusterId, SymmetricAuthKey, WrappedPeerId, CLUSTER_SYMMETRIC_KEY_LENGTH},
     wallet::WalletIdentifier,
@@ -199,8 +198,13 @@ pub fn parse_fee_key(
         let key = DecryptionKey::from_hex_str(&k)?;
         Ok(RelayerFeeKey::new_secret(key))
     } else {
-        // Must print here as logger is not yet setup
-        println!("{}\n", "WARN: No fee decryption key provided, generating one".yellow());
+        #[cfg(not(feature = "silent"))]
+        {
+            // Must print here as logger is not yet setup
+            use colored::*;
+            println!("{}\n", "WARN: No fee decryption key provided, generating one".yellow());
+        }
+
         let key = DecryptionKey::random(&mut thread_rng());
         Ok(RelayerFeeKey::new_secret(key))
     }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -19,6 +19,11 @@ name = "applicator"
 harness = false
 required-features = ["mocks"]
 
+[[bench]]
+name = "interface"
+harness = false
+required-features = ["mocks"]
+
 [dependencies]
 
 # === Replication === #
@@ -68,7 +73,7 @@ uuid = "1.1.2"
 metrics = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.5" }
+criterion = { version = "0.5", features = ["async", "async_tokio"] }
 multiaddr = "0.17"
 num-bigint = "0.4"
 tempfile = "3.8"
@@ -76,3 +81,6 @@ rand = { workspace = true }
 uuid = "1.4"
 test-helpers = { path = "../test-helpers" }
 tokio-stream = "0.1"
+
+# Silence config warnings for testing
+config = { path = "../config", features = ["silent"] }

--- a/state/benches/interface.rs
+++ b/state/benches/interface.rs
@@ -1,0 +1,105 @@
+//! Benchmarks the state interface
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+use std::mem;
+
+use common::types::{
+    tasks::mocks::mock_task_descriptor, wallet::WalletIdentifier, wallet_mocks::mock_empty_wallet,
+};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use job_types::task_driver::new_task_driver_queue;
+use state::{
+    test_helpers::{mock_relayer_config, mock_state_with_task_queue},
+    State,
+};
+use tokio::runtime::Builder as RuntimeBuilder;
+
+/// The network delays to benchmark
+const BENCHMARK_DELAYS_MS: [u64; 3] = [0, 10, 100];
+
+/// Create a mock raft with a given network delay
+async fn mock_raft(network_delay_ms: u64) -> State {
+    let config = mock_relayer_config();
+    let (task_sender, task_recv) = new_task_driver_queue();
+    mem::forget(task_recv);
+
+    mock_state_with_task_queue(network_delay_ms, task_sender, &config).await
+}
+
+/// Benchmark updating a wallet through the raft
+fn bench_update_wallet(c: &mut Criterion) {
+    let mut group = c.benchmark_group("state_interface");
+    group.throughput(Throughput::Elements(1));
+
+    for delay in BENCHMARK_DELAYS_MS {
+        group.bench_function(BenchmarkId::new("update_wallet", delay), |b| {
+            // Build a Tokio runtime and spawn benchmarks in it
+            let runtime = RuntimeBuilder::new_multi_thread().enable_all().build().unwrap();
+            let mut async_bencher = b.to_async(runtime);
+
+            async_bencher.iter_custom(|n_iters| {
+                async move {
+                    // Setup the state
+                    let state = mock_raft(delay).await;
+                    let wallet = mock_empty_wallet();
+
+                    // Propose a series of wallet updates
+                    let mut total_time = std::time::Duration::default();
+                    for _ in 0..n_iters {
+                        let start = std::time::Instant::now();
+                        let waiter = state.update_wallet(wallet.clone()).await.unwrap();
+                        black_box(waiter.await.unwrap());
+
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                }
+            });
+        });
+    }
+}
+
+/// Benchmark appending a task to a wallet's task queue
+fn bench_append_task(c: &mut Criterion) {
+    let mut group = c.benchmark_group("state_interface");
+    group.throughput(Throughput::Elements(1));
+
+    for delay in BENCHMARK_DELAYS_MS {
+        group.bench_function(BenchmarkId::new("append_task", delay), |b| {
+            // Build a Tokio runtime and spawn benchmarks in it
+            let runtime = RuntimeBuilder::new_multi_thread().enable_all().build().unwrap();
+            let mut async_bencher = b.to_async(runtime);
+
+            async_bencher.iter_custom(|n_iters| {
+                async move {
+                    // Setup the state
+                    let state = mock_raft(delay).await;
+
+                    let mut total_time = std::time::Duration::default();
+                    for _ in 0..n_iters {
+                        // Create a task on a new wallet
+                        let wallet_id = WalletIdentifier::new_v4();
+                        let desc = mock_task_descriptor(wallet_id);
+
+                        let start = std::time::Instant::now();
+                        let (_, waiter) = state.append_task(desc).await.unwrap();
+                        black_box(waiter.await.unwrap());
+
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                }
+            });
+        });
+    }
+}
+
+criterion_group!(
+    name = storage;
+    config = Criterion::default().sample_size(10);
+    targets = bench_update_wallet, bench_append_task
+);
+criterion_main!(storage);

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -122,7 +122,7 @@ pub mod test {
     /// Test updating an order's metadata    
     #[tokio::test]
     async fn test_update_order_metadata() {
-        const N: usize = 100;
+        const N: usize = 10;
         let state = mock_state().await;
         let orders = (0..N).map(|_| random_metadata()).collect_vec();
         let wallet_id = WalletIdentifier::new_v4();

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -199,7 +199,7 @@ mod test {
     #[tokio::test]
     #[allow(non_snake_case)]
     async fn test_order_history__cancel_replace() {
-        const N: usize = 100;
+        const N: usize = 10;
         let state = mock_state().await;
         let mut wallet = mock_empty_wallet();
 

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -446,8 +446,9 @@ mod test {
         let new_nid = 2;
         raft.add_node(new_nid).await;
 
-        // Add the node as a learner
+        // Add the node as a learner and wait for replication
         client.add_learner(new_nid, RaftNode::default()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
 
         // Check the DB of the new node
         let db = raft.get_db(new_nid).await;
@@ -625,6 +626,7 @@ mod test {
         // Only nodes {0, 1} remain
         for i in 0..N - SCALE_TO {
             let removed_nid = N - i - 1;
+            raft.remove_node(removed_nid as u64).await;
             client.remove_peer(removed_nid as u64).await.unwrap();
             tokio::time::sleep(Duration::from_millis(200)).await;
         }

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -147,7 +147,7 @@ mod tests {
     /// Test appending and retrieving order metadata
     #[test]
     fn test_append_orders() {
-        const N: usize = 1000;
+        const N: usize = 100;
         let db = mock_db();
         let wallet_id = Uuid::new_v4();
         let mut history = random_order_history(N);
@@ -175,7 +175,7 @@ mod tests {
     /// Tests updating an order in the history
     #[test]
     fn test_update_order() {
-        const N: usize = 1000;
+        const N: usize = 100;
         let db = mock_db();
         let wallet_id = Uuid::new_v4();
         let history = random_order_history(N);

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -173,7 +173,7 @@ impl IntegrationTestArgs {
 
 /// Create a global state mock for the `task-driver` integration tests
 async fn setup_global_state_mock(task_queue: TaskDriverQueue) -> State {
-    mock_state_with_task_queue(task_queue, &mock_relayer_config()).await
+    mock_state_with_task_queue(0 /* network_delay_ms */, task_queue, &mock_relayer_config()).await
 }
 
 /// Setup a mock `ArbitrumClient` for the integration tests


### PR DESCRIPTION
### Purpose
This PR adds consensus benchmarks to the `state` module. These benchmarks measure the full round trip latency of proposing a state update simulated under various network delays.

### Testing
- Ran the benchmarks