### PR TITLE
state: Fix timing bugs in unit tests

### DIFF
--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -121,7 +121,7 @@ pub mod test {
     /// Test updating an order's metadata    
     #[tokio::test]
     async fn test_update_order_metadata() {
-        const N: usize = 100;
+        const N: usize = 10;
         let state = mock_state().await;
         let orders = (0..N).map(|_| random_metadata()).collect_vec();
         let wallet_id = WalletIdentifier::new_v4();

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -198,7 +198,7 @@ mod test {
     #[tokio::test]
     #[allow(non_snake_case)]
     async fn test_order_history__cancel_replace() {
-        const N: usize = 100;
+        const N: usize = 10;
         let state = mock_state().await;
         let mut wallet = mock_empty_wallet();
 

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -446,8 +446,9 @@ mod test {
         let new_nid = 2;
         raft.add_node(new_nid).await;
 
-        // Add the node as a learner
+        // Add the node as a learner and wait for replication
         client.add_learner(new_nid, RaftNode::default()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
 
         // Check the DB of the new node
         let db = raft.get_db(new_nid).await;
@@ -625,6 +626,7 @@ mod test {
         // Only nodes {0, 1} remain
         for i in 0..N - SCALE_TO {
             let removed_nid = N - i - 1;
+            raft.remove_node(removed_nid as u64).await;
             client.remove_peer(removed_nid as u64).await.unwrap();
             tokio::time::sleep(Duration::from_millis(200)).await;
         }

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -147,7 +147,7 @@ mod tests {
     /// Test appending and retrieving order metadata
     #[test]
     fn test_append_orders() {
-        const N: usize = 1000;
+        const N: usize = 100;
         let db = mock_db();
         let wallet_id = Uuid::new_v4();
         let mut history = random_order_history(N);
@@ -175,7 +175,7 @@ mod tests {
     /// Tests updating an order in the history
     #[test]
     fn test_update_order() {
-        const N: usize = 1000;
+        const N: usize = 100;
         let db = mock_db();
         let wallet_id = Uuid::new_v4();
         let history = random_order_history(N);


### PR DESCRIPTION
### Purpose
This PR fixes a number of timing and concurrency bugs in unit tests that largely amount to shrinking the test size. As well, I fixed a bug that occurs when expiring the leader in which we campaign and then attempt to forward the expiry proposal to the leader.

### Testing
- All unit tests pass