### PR TITLE
common, workers, util: use millisecond timestamps universally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8989,6 +8989,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "util 0.1.0",
 ]
 
 [[package]]

--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -63,7 +63,8 @@ pub struct PriceReport {
     pub quote_token: Token,
     /// The reported price
     pub price: Price,
-    /// The time that this update was received by the relayer node.
+    /// The time that this update was received by the relayer node,
+    /// expected to be in milliseconds since the UNIX epoch
     pub local_timestamp: u64,
 }
 

--- a/common/src/types/network_order.rs
+++ b/common/src/types/network_order.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use circuit_types::wallet::Nullifier;
 use serde::{Deserialize, Serialize};
-use util::get_current_time_seconds;
+use util::get_current_time_millis;
 
 use super::{
     gossip::ClusterId,
@@ -67,7 +67,8 @@ pub struct NetworkOrder {
     /// have `None` in place
     #[serde(skip)]
     pub validity_proof_witnesses: Option<OrderValidityWitnessBundle>,
-    /// The timestamp this order was received at
+    /// The timestamp this order was received at, in milliseconds since the UNIX
+    /// epoch
     pub timestamp: u64,
 }
 
@@ -87,7 +88,7 @@ impl NetworkOrder {
             state: NetworkOrderState::Received,
             validity_proofs: None,
             validity_proof_witnesses: None,
-            timestamp: get_current_time_seconds(),
+            timestamp: get_current_time_millis(),
         }
     }
 
@@ -205,7 +206,7 @@ mod test {
 
     use constants::Scalar;
     use rand::thread_rng;
-    use util::get_current_time_seconds;
+    use util::get_current_time_millis;
     use uuid::Uuid;
 
     use crate::types::gossip::ClusterId;
@@ -229,7 +230,7 @@ mod test {
             state: NetworkOrderState::Cancelled,
             validity_proofs: None,
             validity_proof_witnesses: None,
-            timestamp: get_current_time_seconds(),
+            timestamp: get_current_time_millis(),
         };
         let mut order2 = order1.clone();
 

--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -14,5 +14,5 @@ pub mod wallet;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PingResponse {
     /// The timestamp when the response is sent
-    pub timestamp: u128,
+    pub timestamp: u64,
 }

--- a/state/src/tui.rs
+++ b/state/src/tui.rs
@@ -11,7 +11,6 @@ use std::{
     cell::RefCell,
     fmt::{self, Display},
     thread::JoinHandle,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use std::{io::Stdout, thread::Builder as ThreadBuilder, time::Duration};
 use tracing::log::LevelFilter;
@@ -27,7 +26,7 @@ use tui_logger::{
     init_logger, TuiLoggerLevelOutput, TuiLoggerSmartWidget, TuiLoggerWidget,
     TuiWidgetEvent as LoggerEvent, TuiWidgetState as SmartLoggerState,
 };
-use util::runtime::block_current;
+use util::{get_current_time_millis, runtime::block_current};
 
 use std::io;
 
@@ -413,14 +412,11 @@ impl StateTuiApp {
         sorted_keys.sort();
 
         // Collect into a table
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let now = get_current_time_millis();
         let mut rows = Vec::new();
         for (peer_id, info) in sorted_keys.iter().map(|key| (key, peer_info.get(key).unwrap())) {
-            let last_heartbeat_elapsed = if peer_id.ne(&local_peer_id) {
-                (now - info.get_last_heartbeat()) * 1000
-            } else {
-                0
-            };
+            let last_heartbeat_elapsed =
+                if peer_id.ne(&local_peer_id) { now - info.get_last_heartbeat() } else { 0 };
 
             let row = Row::new(vec![peer_id.to_string(), format!("{last_heartbeat_elapsed} ms")])
                 .style(*TABLE_ROW_STYLE);

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -31,6 +31,7 @@ circuit-types = { path = "../circuit-types" }
 common = { path = "../common", features = ["mocks"] }
 constants = { path = "../constants" }
 renegade-crypto = { path = "../renegade-crypto" }
+util = { path = "../util" }
 
 # === Misc Dependencies === #
 itertools = "0.10.5"

--- a/test-helpers/src/mpc_network/mock_with_delay.rs
+++ b/test-helpers/src/mpc_network/mock_with_delay.rs
@@ -130,7 +130,7 @@ impl Sink<NetworkOutbound<SystemCurveGroup>> for MockNetworkWithDelay {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::Duration;
 
     use ark_mpc::{
         network::{NetworkOutbound, NetworkPayload},
@@ -139,13 +139,9 @@ mod tests {
     use constants::Scalar;
     use futures::{SinkExt, StreamExt};
     use renegade_crypto::fields::scalar_to_u64;
+    use util::get_current_time_millis;
 
     use crate::mpc_network::{mock_with_delay::MockNetworkWithDelay, mocks::UnboundedDuplexStream};
-
-    /// Get the time in milliseconds since the unix epoch
-    pub fn unix_ts_millis() -> u64 {
-        SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis() as u64
-    }
 
     /// Test that the delay is accurate
     #[tokio::test]
@@ -164,7 +160,7 @@ mod tests {
 
             // Send the current timestamp as a `Scalar`
             for _ in 0..N_SENDS {
-                let now = unix_ts_millis();
+                let now = get_current_time_millis();
                 let msg = NetworkOutbound {
                     result_id: 0,
                     payload: NetworkPayload::Scalar(Scalar::from(now)),
@@ -186,7 +182,7 @@ mod tests {
                 for _ in 0..N_SENDS {
                     let msg = conn.next().await.unwrap().unwrap();
                     if let NetworkPayload::Scalar(send_ts) = msg.payload {
-                        let recv_ts = unix_ts_millis();
+                        let recv_ts = get_current_time_millis();
                         let delay = recv_ts - scalar_to_u64(&send_ts);
 
                         // Check that the delay is within `DELAY_TOLERANCE` of the expected delay

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -45,12 +45,8 @@ use hyper::{
 use num_bigint::BigUint;
 use num_traits::Num;
 use state::State;
-use std::{
-    convert::Infallible,
-    net::SocketAddr,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use util::get_current_time_millis;
 use uuid::Uuid;
 
 use crate::{
@@ -528,7 +524,7 @@ impl TypedHandler for PingHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+        let timestamp = get_current_time_millis();
         Ok(PingResponse { timestamp })
     }
 }

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -43,14 +43,10 @@ use libp2p::request_response::ResponseChannel;
 use rand::{seq::SliceRandom, thread_rng};
 use renegade_metrics::helpers::record_match_volume;
 use state::State;
-use std::{
-    collections::HashSet,
-    thread::JoinHandle,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashSet, thread::JoinHandle};
 use system_bus::SystemBus;
 use tracing::{error, info, info_span, Instrument};
-use util::err_str;
+use util::{err_str, get_current_time_millis};
 use uuid::Uuid;
 
 pub(super) use price_agreement::init_price_streams;
@@ -76,15 +72,6 @@ use super::{
 pub(super) const HANDSHAKE_CACHE_SIZE: usize = 500;
 /// The number of threads executing handshakes
 pub(super) const HANDSHAKE_EXECUTOR_N_THREADS: usize = 8;
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get the current unix timestamp in milliseconds since the epoch
-fn get_timestamp_millis() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis().try_into().unwrap()
-}
 
 // ------------------------
 // | Manager and Executor |
@@ -270,7 +257,7 @@ impl HandshakeExecutor {
                     SystemBusMessage::HandshakeInProgress {
                         local_order_id: order_state.local_order_id,
                         peer_order_id: order_state.peer_order_id,
-                        timestamp: get_timestamp_millis(),
+                        timestamp: get_current_time_millis(),
                     },
                 );
 
@@ -463,7 +450,7 @@ impl HandshakeExecutor {
             SystemBusMessage::HandshakeCompleted {
                 local_order_id,
                 peer_order_id,
-                timestamp: get_timestamp_millis(),
+                timestamp: get_current_time_millis(),
             },
         );
 

--- a/workers/price-reporter/src/exchange/binance.rs
+++ b/workers/price-reporter/src/exchange/binance.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use tracing::error;
 use tungstenite::{Error as WsError, Message};
 use url::Url;
-use util::{err_str, get_current_time_seconds};
+use util::{err_str, get_current_time_millis};
 
 use crate::{
     errors::ExchangeConnectionError, manager::exchange_lists_pair_tokens,
@@ -107,7 +107,7 @@ impl BinanceConnection {
             base_token,
             quote_token,
             price: midpoint_price,
-            local_timestamp: get_current_time_seconds(),
+            local_timestamp: get_current_time_millis(),
         })
     }
 

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -14,7 +14,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, Web
 use tracing::{error, info, warn};
 use tungstenite::Error as WsError;
 use url::Url;
-use util::{err_str, get_current_time_seconds};
+use util::{err_str, get_current_time_millis};
 
 use crate::{
     manager::{
@@ -240,7 +240,7 @@ impl ExchangeConnectionManager {
         }
 
         // Save the price update to the global map
-        let ts = get_current_time_seconds();
+        let ts = get_current_time_millis();
         self.price_stream_states
             .new_price(self.exchange, self.base_token.clone(), self.quote_token.clone(), price, ts)
             .await

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -20,7 +20,7 @@ use common::{
 use external_api::bus_message::{price_report_topic, SystemBusMessage};
 use itertools::Itertools;
 use statrs::statistics::{Data, Median};
-use util::get_current_time_seconds;
+use util::get_current_time_millis;
 
 use crate::{errors::PriceReporterError, worker::PriceReporterConfig};
 
@@ -396,7 +396,7 @@ pub fn compute_price_reporter_state(
 /// Returns whether or not the provided timestamp is too stale,
 /// and the time difference between the current time and the provided timestamp
 fn ts_too_stale(ts: u64) -> (bool, u64) {
-    let time_diff = get_current_time_seconds() - ts;
+    let time_diff = get_current_time_millis() - ts;
     (time_diff > MAX_REPORT_AGE, time_diff)
 }
 

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -30,7 +30,7 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tracing::{error, info, info_span, warn, Instrument};
 use tungstenite::Message;
 use url::Url;
-use util::{err_str, get_current_time_seconds};
+use util::{err_str, get_current_time_millis};
 
 use crate::{
     errors::{ExchangeConnectionError, PriceReporterError},
@@ -167,7 +167,7 @@ impl ExternalPriceReporterExecutor {
 
         let (exchange, base_token, quote_token) = parse_topic(&price_message.topic)
             .map_err(err_str!(ExchangeConnectionError::InvalidMessage))?;
-        let ts = get_current_time_seconds();
+        let ts = get_current_time_millis();
 
         // Save the price update for the pair on the given exchange
         self.price_stream_states

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -10,7 +10,7 @@ use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::oneshot::Sender as OneshotSender;
 use tracing::{debug, error};
-use util::get_current_time_seconds;
+use util::get_current_time_millis;
 
 use crate::errors::PriceReporterError;
 
@@ -86,7 +86,7 @@ impl MockPriceReporter {
         channel: OneshotSender<PriceReporterState>,
     ) -> Result<(), PriceReporterError> {
         // Construct a state and send it back on the queue
-        let timestamp = get_current_time_seconds();
+        let timestamp = get_current_time_millis();
         let state = PriceReporterState::Nominal(PriceReport {
             base_token,
             quote_token,

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -23,7 +23,7 @@ use test_helpers::{
     integration_test_async,
 };
 use tracing::info;
-use util::{get_current_time_seconds, hex::biguint_from_hex_string};
+use util::hex::biguint_from_hex_string;
 use uuid::Uuid;
 
 use crate::{
@@ -35,8 +35,6 @@ use crate::{
 };
 
 lazy_static! {
-    /// A dummy timestamp used for updates
-    static ref DUMMY_TIMESTAMP: u64 = get_current_time_seconds();
     /// A dummy order that is allocated in a wallet as an update
     static ref DUMMY_ORDER: Order = Order {
         quote_mint: 1u8.into(),


### PR DESCRIPTION
This PR normalizes all timestamps in the codebase to use millisecond format, except for when constructing the subscription message for the Coinbase websocket API as that is expected to be in seconds.

This standardizes all downstream logic, e.g. in the bot server or the UI.

All unit tests pass.

**TODO:**
- Ingest these changes in the price reporter