### PR TITLE
common: types: tasks: history: add wallet lookups & refreshes to task history

### DIFF
--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -55,6 +55,10 @@ pub enum HistoricalTaskDescription {
         /// Whether the fee was paid for a protocol fee
         is_protocol: bool,
     },
+    /// A wallet was looked up
+    LookupWallet,
+    /// A wallet was refreshed
+    RefreshWallet,
 }
 
 impl HistoricalTaskDescription {
@@ -88,6 +92,8 @@ impl HistoricalTaskDescription {
                 amount: desc.amount,
                 is_protocol: desc.is_protocol_fee,
             }),
+            TaskDescriptor::LookupWallet(_) => Some(Self::LookupWallet),
+            TaskDescriptor::RefreshWallet(_) => Some(Self::RefreshWallet),
             _ => None,
         }
     }

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -87,6 +87,10 @@ pub enum ApiHistoricalTaskDescription {
         /// Whether the fee was paid for a protocol fee
         is_protocol: bool,
     },
+    /// A wallet was looked up
+    LookupWallet,
+    /// A wallet was refreshed
+    RefreshWallet,
 }
 
 impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
@@ -106,6 +110,8 @@ impl From<HistoricalTaskDescription> for ApiHistoricalTaskDescription {
                     is_protocol,
                 }
             },
+            HistoricalTaskDescription::LookupWallet => Self::LookupWallet,
+            HistoricalTaskDescription::RefreshWallet => Self::RefreshWallet,
         }
     }
 }

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -32,9 +32,9 @@ pub mod native_executor;
 // -------------
 
 /// If a pair has not reported an update within
-/// MAX_REPORT_AGE_MS (in milliseconds), we pause matches until we receive a more
-/// recent price. Note that this threshold cannot be too aggressive, as certain
-/// long-tail asset pairs legitimately do not update that often.
+/// MAX_REPORT_AGE_MS (in milliseconds), we pause matches until we receive a
+/// more recent price. Note that this threshold cannot be too aggressive, as
+/// certain long-tail asset pairs legitimately do not update that often.
 const MAX_REPORT_AGE_MS: u64 = 20_000; // 20 seconds
 /// If we do not have at least MIN_CONNECTIONS reports, we pause matches until
 /// we have enough reports. This only applies to Named tokens, as Unnamed tokens


### PR DESCRIPTION
This PR adds the `LookupWallet` & `RefreshWallet` tasks to to task history, i.e. creates `HistoricalTaskDescription` and `ApiHistoricalTaskDescription` variants for them. They are written to task history via existing code paths.

I tested this by running a local relayer, triggering a wallet lookup & refresh, and ensuring that the lookup & refresh tasks were returned in the task history API endpoint by using the CLI