### PR TITLE
external-api: http: admin: add wallet_id to OpenOrder

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -5,7 +5,10 @@
 // ---------------
 
 use circuit_types::Amount;
-use common::types::{wallet::order_metadata::OrderMetadata, MatchingPoolName, Price};
+use common::types::{
+    wallet::{order_metadata::OrderMetadata, WalletIdentifier},
+    MatchingPoolName, Price,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::types::ApiOrder;
@@ -49,6 +52,8 @@ pub struct OpenOrdersResponse {
 pub struct OpenOrder {
     /// The order metadata
     pub order: OrderMetadata,
+    /// The ID of the wallet containing the order
+    pub wallet_id: WalletIdentifier,
     /// The fillable amount of the order, if calculated
     pub fillable: Option<Amount>,
     /// The price used to calculate the fillable amount, if calculated

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -144,6 +144,12 @@ impl TypedHandler for AdminOpenOrdersHandler {
         for id in order_ids.into_iter() {
             let order = self.state.get_order_metadata(&id).await?;
             if let Some(meta) = order {
+                let wallet_id = self
+                    .state
+                    .get_wallet_for_order(&id)
+                    .await?
+                    .ok_or(not_found(ERR_WALLET_NOT_FOUND))?;
+
                 let (fillable, price) = if include_fillable {
                     get_fillable_amount_and_price(
                         &meta,
@@ -155,7 +161,8 @@ impl TypedHandler for AdminOpenOrdersHandler {
                 } else {
                     (None, None)
                 };
-                orders.push(OpenOrder { order: meta, fillable, price })
+
+                orders.push(OpenOrder { order: meta, wallet_id, fillable, price })
             }
         }
 


### PR DESCRIPTION
This PR adds the containing wallet's ID to the `OpenOrder` struct - this is to enable per-wallet rate limiting by the quoters.

**TODO:**
- Update the `OpenOrder` type in the JS SDK
- Testing (pretty straightforward change so prefer to do this once quoter changes are made)