### PR TITLE
constants: Set `MAX_BALANCES=10`, `MAX_ORDERS=4`

### DIFF
--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -33,7 +33,7 @@ use crate::{
 
 /// A type alias for the `ValidWalletUpdate` circuit with default size
 /// parameters attached
-pub type SizedValidWalletUpdate = ValidWalletUpdate<MAX_ORDERS, MAX_BALANCES, MERKLE_HEIGHT>;
+pub type SizedValidWalletUpdate = ValidWalletUpdate<MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT>;
 
 /// The `VALID WALLET UPDATE` circuit
 pub struct ValidWalletUpdate<

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -24,11 +24,11 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The system-wide value of MAX_BALANCES; the number of allowable balances a
 /// wallet holds
-pub const MAX_BALANCES: usize = 5;
+pub const MAX_BALANCES: usize = 10;
 
 /// The system-wide value of MAX_ORDERS; the number of allowable orders a wallet
 /// holds
-pub const MAX_ORDERS: usize = 5;
+pub const MAX_ORDERS: usize = 4;
 
 /// The height of the Merkle state tree used by the contract
 pub const MERKLE_HEIGHT: usize = 32;


### PR DESCRIPTION
### Purpose
This PR increases `MAX_BALANCES` from 5 to 10 and decreases `MAX_ORDERS` from 5 to 4.

### Testing
- Unit tests pass
- Tested against deployed test contracts (using new vkeys) with a local relayer