### PR TITLE
task-driver: node-startup: Do not create wallet if not needed

### DIFF
--- a/common/src/types/tasks/descriptors/node_startup.rs
+++ b/common/src/types/tasks/descriptors/node_startup.rs
@@ -10,6 +10,8 @@ use super::{TaskDescriptor, TaskIdentifier};
 pub struct NodeStartupTaskDescriptor {
     /// The task id
     pub id: TaskIdentifier,
+    /// Whether the relayer needs a wallet created for it or not
+    pub needs_relayer_wallet: bool,
     /// The amount of time to wait for the gossip layer to warmup before setting
     /// up the rest of the node
     pub gossip_warmup_ms: u64,
@@ -22,11 +24,11 @@ pub struct NodeStartupTaskDescriptor {
 
 impl NodeStartupTaskDescriptor {
     /// Construct a new node startup task descriptor
-    pub fn new(gossip_warmup_ms: u64, keypair: &LocalWallet) -> Self {
+    pub fn new(gossip_warmup_ms: u64, keypair: &LocalWallet, needs_relayer_wallet: bool) -> Self {
         let id = TaskIdentifier::new_v4();
         let key_bytes = keypair.signer().to_bytes().to_vec();
 
-        Self { id, gossip_warmup_ms, key_bytes }
+        Self { id, gossip_warmup_ms, key_bytes, needs_relayer_wallet }
     }
 }
 

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -381,6 +381,13 @@ impl RelayerConfig {
     pub fn raft_snapshot_path(&self) -> &Path {
         Path::new(&self.raft_snapshot_path)
     }
+
+    /// Whether the relayer needs a wallet to support its configuration or not
+    ///
+    /// If it does not, the relayer may skip the wallet creation/lookup step
+    pub fn needs_relayer_wallet(&self) -> bool {
+        self.auto_redeem_fees
+    }
 }
 
 impl Default for RelayerConfig {

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -19,8 +19,14 @@ pub async fn node_setup(
     task_queue: TaskDriverQueue,
 ) -> Result<(), CoordinatorError> {
     // Start the node setup task and await its completion
-    let desc: TaskDescriptor =
-        NodeStartupTaskDescriptor::new(config.gossip_warmup, config.relayer_arbitrum_key()).into();
+    let needs_relayer_wallet = config.needs_relayer_wallet();
+    let desc: TaskDescriptor = NodeStartupTaskDescriptor::new(
+        config.gossip_warmup,
+        config.relayer_arbitrum_key(),
+        needs_relayer_wallet,
+    )
+    .into();
+
     let (job, rx) = TaskDriverJob::new_immediate_with_notification(desc);
     task_queue
         .send(job)

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -88,10 +88,8 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// Get the wallet ID of the local relayer's wallet
-    pub fn get_local_node_wallet(&self) -> Result<WalletIdentifier, StorageError> {
-        self.inner()
-            .read(NODE_METADATA_TABLE, &LOCAL_WALLET_ID_KEY.to_string())?
-            .ok_or_else(|| err_not_found(LOCAL_WALLET_ID_KEY))
+    pub fn get_local_node_wallet(&self) -> Result<Option<WalletIdentifier>, StorageError> {
+        self.inner().read(NODE_METADATA_TABLE, &LOCAL_WALLET_ID_KEY.to_string())
     }
 
     /// Get the local relayer's fee decryption key

--- a/workers/task-driver/integration/tests/redeem_relayer_fee.rs
+++ b/workers/task-driver/integration/tests/redeem_relayer_fee.rs
@@ -72,7 +72,7 @@ async fn test_auto_redeem_relayer_fee(test_args: IntegrationTestArgs) -> Result<
     await_task(descriptor.into(), &test_args).await?;
 
     // Await for the relayer's queue to flush
-    let relayer_wallet_id = state.get_relayer_wallet_id().await?;
+    let relayer_wallet_id = state.get_relayer_wallet_id().await?.unwrap();
     await_wallet_task_queue_flush(relayer_wallet_id, &test_args).await?;
 
     // Check that the relayer has redeemed the fee

--- a/workers/task-driver/src/utils/validity_proofs.rs
+++ b/workers/task-driver/src/utils/validity_proofs.rs
@@ -41,6 +41,8 @@ use super::{
 
 /// The error message emitted by the task when the fee decryption key is missing
 const ERR_FEE_KEY_MISSING: &str = "fee decryption key is missing";
+/// The error message emitted by the task when the relayer wallet is missing
+const ERR_RELAYER_WALLET_MISSING: &str = "relayer wallet is missing";
 
 /// Enqueue a job with the proof manager
 ///
@@ -335,7 +337,10 @@ async fn link_and_store_proofs(
 
 /// Enqueue a job to redeem a relayer fee into the relayer's wallet
 pub(crate) async fn enqueue_relayer_redeem_job(note: Note, state: &State) -> Result<(), String> {
-    let relayer_wallet_id = state.get_relayer_wallet_id().await?;
+    let relayer_wallet_id = state
+        .get_relayer_wallet_id()
+        .await?
+        .ok_or_else(|| ERR_RELAYER_WALLET_MISSING.to_string())?;
     let decryption_key =
         state.get_fee_key().await?.secret_key().ok_or_else(|| ERR_FEE_KEY_MISSING.to_string())?;
     let descriptor = RedeemFeeTaskDescriptor::new(relayer_wallet_id, note, decryption_key);


### PR DESCRIPTION
### Purpose
This PR skips the relayer wallet creation step if the relayer is not configured to redeem fees into its own wallet. In this case, the relayer does not need a wallet for any other purpose.

### Testing
- Started up a node that does not need a relayer wallet, verified that it did not create one