### PR TITLE
circuits, circuit-types: Add keychain nonce and constrain increments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "inventory",
  "itertools 0.10.5",
  "jf-primitives",
+ "k256",
  "lazy_static",
  "mpc-plonk",
  "mpc-relation",

--- a/circuit-types/src/keychain.rs
+++ b/circuit-types/src/keychain.rs
@@ -337,6 +337,19 @@ pub struct PublicKeyChain {
     pub pk_root: PublicSigningKey,
     /// The public match key
     pub pk_match: PublicIdentificationKey,
+    /// A nonce set by the wallet owner
+    ///
+    /// The owner may use this nonce to track the number of rotations of the
+    /// keychain. We only allow this nonce to change when authorized by the
+    /// end-user
+    pub nonce: Scalar,
+}
+
+impl PublicKeyChain {
+    /// Create a new public keychain with nonce zero
+    pub fn new(pk_root: PublicSigningKey, pk_match: PublicIdentificationKey) -> Self {
+        Self { pk_root, pk_match, nonce: Scalar::zero() }
+    }
 }
 
 #[cfg(test)]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -44,7 +44,7 @@ required-features = ["test_helpers"]
 name = "full_match"
 harness = false
 required-features = ["test_helpers"]
-    
+
 [[bench]]
 name = "internal_match_settlement"
 harness = false
@@ -113,6 +113,7 @@ ctor = "0.1"
 dns-lookup = "1.0"
 eyre = { workspace = true }
 inventory = "0.3"
+k256 = "0.13"
 mpc-plonk = { workspace = true, features = ["test_apis", "std"] }
 rand = "0.8"
 serde_json = "1.0"

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -116,6 +116,7 @@ pub mod test_helpers {
                 y: NonNativeScalar::from(&BigUint::from(2u8).pow(256)),
             },
             pk_match: compute_poseidon_hash(&[PRIVATE_KEYS[1]]).into(),
+            nonce: 0u8.into(),
         };
         pub static ref INITIAL_BALANCES: [Balance; MAX_BALANCES] = [
             Balance { mint: 1u8.into(), amount: 5, relayer_fee_balance: 0, protocol_fee_balance: 0 },

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -730,10 +730,16 @@ mod test {
     #[test]
     fn test_invalid_commitment__augmentation_modifies_keys() {
         let wallet = UNAUGMENTED_WALLET.clone();
-        let (mut witness, statement) = create_witness_and_statement(&wallet);
+        let (original_witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify a key in the wallet
+        let mut witness = original_witness.clone();
         witness.augmented_public_shares.keys.pk_match.key = Scalar::one();
+        assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
+
+        // Modify the nonce in the keychain, constraints should fail
+        let mut witness = original_witness.clone();
+        witness.augmented_public_shares.keys.nonce += Scalar::one();
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
     }
 

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -891,6 +891,15 @@ mod tests {
             &statement
         ));
 
+        // Modify the keychain nonce
+        let mut statement = original_statement.clone();
+        statement.party0_modified_shares.keys.nonce += Scalar::one();
+
+        assert!(!check_constraint_satisfaction::<SizedValidMatchSettle>(
+            &witness.clone(),
+            &statement
+        ));
+
         // Modify the blinder
         let mut statement = original_statement;
         statement.party0_modified_shares.blinder += Scalar::one();

--- a/circuits/src/zk_circuits/valid_offline_fee_settlement.rs
+++ b/circuits/src/zk_circuits/valid_offline_fee_settlement.rs
@@ -723,6 +723,12 @@ mod test {
 
         assert!(!check_constraints_satisfied(&statement, &witness));
 
+        // Modify the keychain nonce
+        let mut statement = original_statement.clone();
+        statement.updated_wallet_public_shares.keys.nonce += Scalar::one();
+
+        assert!(!check_constraints_satisfied(&statement, &witness));
+
         // Modify the match fee
         let mut statement = original_statement.clone();
         statement.updated_wallet_public_shares.match_fee.repr += Scalar::one();

--- a/circuits/src/zk_circuits/valid_reblind.rs
+++ b/circuits/src/zk_circuits/valid_reblind.rs
@@ -412,6 +412,18 @@ mod test {
         assert!(check_constraint_satisfaction::<SizedReblind>(&witness, &statement))
     }
 
+    /// Tests an invalid reblind that modifies the keychain nonce
+    #[test]
+    fn test_invalid_reblind__keychain_nonce_modified() {
+        // Construct the witness and statement
+        let wallet = INITIAL_WALLET.clone();
+        let (mut witness, statement) = construct_witness_statement(&wallet);
+
+        // Modify the keychain nonce
+        witness.reblinded_wallet_public_shares.keys.nonce += Scalar::one();
+        assert!(!check_constraint_satisfaction::<SizedReblind>(&witness, &statement));
+    }
+
     /// Tests an invalid reblinding, i.e. a secret share that was sampled
     /// incorrectly
     #[test]

--- a/circuits/src/zk_circuits/valid_wallet_create.rs
+++ b/circuits/src/zk_circuits/valid_wallet_create.rs
@@ -80,6 +80,8 @@ where
             cs.enforce_equal(order_var, zero)?;
         }
 
+        // Constrain the keychain nonce to be zero
+        cs.enforce_equal(wallet.keys.nonce, zero)?;
         Ok(())
     }
 }
@@ -264,11 +266,21 @@ pub mod tests {
         assert!(!check_constraint_satisfaction::<SizedWalletCreate>(&witness, &statement));
     }
 
-    /// Tests the cas in which a non-zero balance is given
+    /// Tests the case in which a non-zero balance is given
     #[test]
     fn test_nonzero_balance() {
         let mut wallet = create_empty_wallet();
         wallet.balances[0] = INITIAL_BALANCES[0].clone();
+
+        let (witness, statement) = create_witness_statement_from_wallet(&wallet);
+        assert!(!check_constraint_satisfaction::<SizedWalletCreate>(&witness, &statement));
+    }
+
+    /// Tests the case in which the keychain nonce is non-zero
+    #[test]
+    fn test_nonzero_nonce() {
+        let mut wallet = create_empty_wallet();
+        wallet.keys.nonce += Scalar::one();
 
         let (witness, statement) = create_witness_statement_from_wallet(&wallet);
         assert!(!check_constraint_satisfaction::<SizedWalletCreate>(&witness, &statement));

--- a/common/src/types/wallet/derivation.rs
+++ b/common/src/types/wallet/derivation.rs
@@ -57,7 +57,7 @@ pub fn derive_wallet_keychain(eth_key: &EthWallet, chain_id: u64) -> Result<KeyC
     let pk_match = sk_match.get_public_key();
 
     Ok(KeyChain {
-        public_keys: PublicKeyChain { pk_root, pk_match },
+        public_keys: PublicKeyChain::new(pk_root, pk_match),
         secret_keys: PrivateKeyChain { sk_root: Some(sk_root), sk_match },
     })
 }

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -43,7 +43,7 @@ pub fn mock_empty_wallet() -> Wallet {
         orders: KeyedList::default(),
         balances: KeyedList::default(),
         key_chain: KeyChain {
-            public_keys: PublicKeyChain { pk_root, pk_match },
+            public_keys: PublicKeyChain::new(pk_root, pk_match),
             secret_keys: PrivateKeyChain { sk_root, sk_match },
         },
         blinder: Scalar::random(&mut rng),

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -230,12 +230,12 @@ impl TryFrom<ApiKeychain> for KeyChain {
 
     fn try_from(keys: ApiKeychain) -> Result<Self, Self::Error> {
         Ok(KeyChain {
-            public_keys: PublicKeyChain {
-                pk_root: public_sign_key_from_hex_string(&keys.public_keys.pk_root)?,
-                pk_match: PublicIdentificationKey {
+            public_keys: PublicKeyChain::new(
+                public_sign_key_from_hex_string(&keys.public_keys.pk_root)?,
+                PublicIdentificationKey {
                     key: scalar_from_hex_string(&keys.public_keys.pk_match)?,
                 },
-            },
+            ),
             secret_keys: PrivateKeyChain {
                 sk_root: keys
                     .private_keys


### PR DESCRIPTION
### Purpose
This PR adds a `nonce` field to the `PublicKeychain` type and constrains its use in the circuits. The nonce is allowed to change exactly when the keychain rotates, and in no other location. 

I added constraints where necessary, but most circuits already captured this constraint in a more general keychain equality check. For those circuits, I made sure to test the fallibility of our nonce tests when these constraints were not present.

### Testing
- For each circuit, I added a unit test for the nonce behavior. Then I commented out constraints to make the test fail, and then added them back to ensure the test passes.
- All other tests pass