### PR TITLE
external-api: Make API changes for key rotation

### DIFF
--- a/common/src/types/tasks/descriptors/lookup_wallet.rs
+++ b/common/src/types/tasks/descriptors/lookup_wallet.rs
@@ -3,7 +3,7 @@
 use constants::Scalar;
 use serde::{Deserialize, Serialize};
 
-use crate::types::wallet::{KeyChain, WalletIdentifier};
+use crate::types::wallet::{PrivateKeyChain, WalletIdentifier};
 
 use super::TaskDescriptor;
 
@@ -17,8 +17,8 @@ pub struct LookupWalletTaskDescriptor {
     pub blinder_seed: Scalar,
     /// The CSPRNG seed for the secret share stream
     pub secret_share_seed: Scalar,
-    /// The keychain to manage the wallet with
-    pub key_chain: KeyChain,
+    /// The secret keys used to manage the wallet when it is found
+    pub secret_keys: PrivateKeyChain,
 }
 
 impl LookupWalletTaskDescriptor {
@@ -27,9 +27,9 @@ impl LookupWalletTaskDescriptor {
         wallet_id: WalletIdentifier,
         blinder_seed: Scalar,
         secret_share_seed: Scalar,
-        key_chain: KeyChain,
+        secret_keys: PrivateKeyChain,
     ) -> Result<Self, String> {
-        Ok(LookupWalletTaskDescriptor { wallet_id, blinder_seed, secret_share_seed, key_chain })
+        Ok(LookupWalletTaskDescriptor { wallet_id, blinder_seed, secret_share_seed, secret_keys })
     }
 }
 

--- a/common/src/types/tasks/descriptors/lookup_wallet.rs
+++ b/common/src/types/tasks/descriptors/lookup_wallet.rs
@@ -3,7 +3,7 @@
 use constants::Scalar;
 use serde::{Deserialize, Serialize};
 
-use crate::types::wallet::{PrivateKeyChain, WalletIdentifier};
+use crate::types::wallet::{keychain::PrivateKeyChain, WalletIdentifier};
 
 use super::TaskDescriptor;
 

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -294,13 +294,12 @@ mod test {
         let mut wallet = mock_empty_wallet();
         wallet.blinded_public_shares.orders[0].amount += Scalar::one();
 
-        UpdateWalletTaskDescriptor::new_order_with_maybe_pool(
-            mock_order(),
+        UpdateWalletTaskDescriptor::new_order_placement(
             OrderIdentifier::new_v4(),
+            mock_order(),
             wallet.clone(),
             wallet,
             vec![],
-            None, // matching_pool
         )
         .unwrap();
     }
@@ -312,13 +311,12 @@ mod test {
         let wallet = mock_empty_wallet();
         let sig = vec![0; 64];
 
-        UpdateWalletTaskDescriptor::new_order_with_maybe_pool(
-            mock_order(),
+        UpdateWalletTaskDescriptor::new_order_placement(
             OrderIdentifier::new_v4(),
+            mock_order(),
             wallet.clone(),
             wallet,
             sig,
-            None, // matching_pool
         )
         .unwrap();
     }
@@ -331,13 +329,12 @@ mod test {
         let key = wallet.key_chain.secret_keys.sk_root.as_ref().unwrap();
         let sig = gen_wallet_update_sig(&wallet, key);
 
-        UpdateWalletTaskDescriptor::new_order_with_maybe_pool(
-            mock_order(),
+        UpdateWalletTaskDescriptor::new_order_placement(
             OrderIdentifier::new_v4(),
+            mock_order(),
             wallet.clone(),
             wallet,
             sig,
-            None, // matching_pool
         )
         .unwrap();
     }

--- a/common/src/types/wallet/derivation.rs
+++ b/common/src/types/wallet/derivation.rs
@@ -11,7 +11,10 @@ use num_bigint::BigUint;
 use num_traits::Num;
 use util::raw_err_str;
 
-use super::{KeyChain, PrivateKeyChain, WalletIdentifier};
+use super::{
+    keychain::{KeyChain, PrivateKeyChain},
+    WalletIdentifier,
+};
 
 /// The message used to derive the blinder stream seed
 const BLINDER_STREAM_SEED_MESSAGE: &[u8] = b"blinder seed";

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -21,7 +21,10 @@ use uuid::Uuid;
 
 use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
-use super::{KeyChain, PrivateKeyChain, Wallet};
+use super::{
+    keychain::{KeyChain, PrivateKeyChain},
+    Wallet,
+};
 
 /// Create a mock empty wallet
 pub fn mock_empty_wallet() -> Wallet {

--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -4,7 +4,7 @@
 
 mod balances;
 pub mod derivation;
-mod keychain;
+pub mod keychain;
 mod r#match;
 #[cfg(feature = "mocks")]
 pub mod mocks;

--- a/common/src/types/wallet/types.rs
+++ b/common/src/types/wallet/types.rs
@@ -47,6 +47,18 @@ pub struct PrivateKeyChain {
     pub sk_match: SecretIdentificationKey,
 }
 
+impl PrivateKeyChain {
+    /// Create a new private key chain from a match key and a root key
+    pub fn new(sk_match: SecretIdentificationKey, sk_root: Option<SecretSigningKey>) -> Self {
+        Self { sk_match, sk_root }
+    }
+
+    /// Create a new private key chain without the root key
+    pub fn new_without_root(sk_match: SecretIdentificationKey) -> Self {
+        Self { sk_match, sk_root: None }
+    }
+}
+
 /// Represents the public and private keys given to the relayer managing a
 /// wallet
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,13 +174,14 @@ impl Wallet {
     /// Construct a new wallet from private shares and blinded public shares
     pub fn new_from_shares(
         wallet_id: WalletIdentifier,
-        key_chain: KeyChain,
+        secret_keys: PrivateKeyChain,
         blinded_public_shares: SizedWalletShare,
         private_shares: SizedWalletShare,
     ) -> Self {
         let blinder = blinded_public_shares.blinder + private_shares.blinder;
         let unblinded_public_shares = blinded_public_shares.unblind_shares(blinder);
         let recovered_wallet = unblinded_public_shares + private_shares.clone();
+        let key_chain = KeyChain { public_keys: recovered_wallet.keys, secret_keys };
 
         // Construct a wallet from the recovered shares
         Wallet {

--- a/common/src/types/wallet/types.rs
+++ b/common/src/types/wallet/types.rs
@@ -9,13 +9,8 @@ use std::{
 };
 
 use circuit_types::{
-    balance::Balance,
-    elgamal::EncryptionKey,
-    fixed_point::FixedPoint,
-    keychain::{PublicKeyChain, SecretIdentificationKey, SecretSigningKey},
-    native_helpers::create_wallet_shares_with_randomness,
-    order::Order,
-    traits::BaseType,
+    balance::Balance, elgamal::EncryptionKey, fixed_point::FixedPoint,
+    native_helpers::create_wallet_shares_with_randomness, order::Order, traits::BaseType,
     SizedWallet as SizedCircuitWallet, SizedWalletShare,
 };
 use constants::Scalar;
@@ -28,46 +23,12 @@ use uuid::Uuid;
 
 use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
+use super::keychain::{KeyChain, PrivateKeyChain};
+
 /// A type alias for the wallet identifier type, currently a UUID
 pub type WalletIdentifier = Uuid;
 /// An identifier of an order used for caching
 pub type OrderIdentifier = Uuid;
-
-/// Represents the private keys a relayer has access to for a given wallet
-#[derive(Clone, Debug, Derivative, Serialize, Deserialize)]
-#[derivative(PartialEq, Eq)]
-pub struct PrivateKeyChain {
-    /// Optionally the relayer holds sk_root, in which case the relayer has
-    /// heightened permissions than the standard case
-    ///
-    /// We call such a relayer a "super relayer"
-    pub sk_root: Option<SecretSigningKey>,
-    /// The match private key, authorizes the relayer to match orders for the
-    /// wallet
-    pub sk_match: SecretIdentificationKey,
-}
-
-impl PrivateKeyChain {
-    /// Create a new private key chain from a match key and a root key
-    pub fn new(sk_match: SecretIdentificationKey, sk_root: Option<SecretSigningKey>) -> Self {
-        Self { sk_match, sk_root }
-    }
-
-    /// Create a new private key chain without the root key
-    pub fn new_without_root(sk_match: SecretIdentificationKey) -> Self {
-        Self { sk_match, sk_root: None }
-    }
-}
-
-/// Represents the public and private keys given to the relayer managing a
-/// wallet
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct KeyChain {
-    /// The public keys in the wallet
-    pub public_keys: PublicKeyChain,
-    /// The secret keys in the wallet
-    pub secret_keys: PrivateKeyChain,
-}
 
 /// The Merkle opening from the wallet shares' commitment to the global root
 pub type WalletAuthenticationPath = MerkleAuthenticationPath;

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ApiOrder;
 
+use super::wallet::WalletUpdateAuthorization;
+
 /// Check whether the target node is a raft leader
 pub const IS_LEADER_ROUTE: &str = "/v0/admin/is-leader";
 /// Get the open orders managed by the node
@@ -66,10 +68,9 @@ pub struct OpenOrder {
 pub struct CreateOrderInMatchingPoolRequest {
     /// The order to be created
     pub order: ApiOrder,
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    pub statement_sig: Vec<u8>,
+    /// The update authorization
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
     /// The matching pool to create the order in
     pub matching_pool: MatchingPoolName,
 }

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -53,6 +53,19 @@ pub const PAY_FEES_ROUTE: &str = "/v0/wallet/:wallet_id/pay-fees";
 /// Returns the order history of a wallet
 pub const ORDER_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/order-history";
 
+/// The type encapsulating a wallet update's authorization parameters
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WalletUpdateAuthorization {
+    /// A signature of the circuit statement used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    pub statement_sig: Vec<u8>,
+    /// The new public root key to rotate to if desired by the client
+    ///
+    /// Hex encoded
+    pub new_root_key: Option<String>,
+}
+
 // --------------------
 // | Wallet API Types |
 // --------------------
@@ -132,10 +145,9 @@ pub struct GetOrderByIdResponse {
 pub struct CreateOrderRequest {
     /// The order to be created
     pub order: ApiOrder,
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    pub statement_sig: Vec<u8>,
+    /// The authorization parameters for the update
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
 }
 
 /// The response type to a request that adds a new order to a wallet
@@ -152,10 +164,9 @@ pub struct CreateOrderResponse {
 pub struct UpdateOrderRequest {
     /// The order to be updated
     pub order: ApiOrder,
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    pub statement_sig: Vec<u8>,
+    /// The authorization parameters for the update
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
 }
 
 /// The response type to update an order
@@ -168,10 +179,9 @@ pub struct UpdateOrderResponse {
 /// The request type to cancel a given order
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CancelOrderRequest {
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    pub statement_sig: Vec<u8>,
+    /// The authorization parameters for the update
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
 }
 
 /// The response type to a request to cancel a given order
@@ -218,13 +228,9 @@ pub struct DepositBalanceRequest {
     pub mint: BigUint,
     /// The amount of the token to deposit
     pub amount: BigUint,
-    /// A signature of the wallet commitment used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    ///
-    /// TODO: For now this is just a blob, we will add this feature in
-    /// a follow up
-    pub wallet_commitment_sig: Vec<u8>,
+    /// The update authorization parameters
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
     /// The nonce used in the associated Permit2 permit
     pub permit_nonce: BigUint,
     /// The deadline used in the associated Permit2 permit
@@ -254,13 +260,9 @@ pub struct WithdrawBalanceRequest {
     pub destination_addr: BigUint,
     /// The amount of the token to withdraw
     pub amount: BigUint,
-    /// A signature of the wallet commitment used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    ///
-    /// TODO: For now this is just a blob, we will add this feature in
-    /// a follow up
-    pub wallet_commitment_sig: Vec<u8>,
+    /// The authorization parameters for the update
+    #[serde(flatten)]
+    pub update_auth: WalletUpdateAuthorization,
     /// A signature over the external transfer, allowing the contract
     /// to guarantee that the withdrawal is directed at the correct
     /// recipient

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr,
-    types::{ApiKeychain, ApiOrder, ApiWallet},
+    types::{ApiOrder, ApiWallet},
 };
 
 // ---------------
@@ -90,8 +90,8 @@ pub struct FindWalletRequest {
     pub blinder_seed: BigUint,
     /// The seed for the wallet's secret share CSPRNG
     pub secret_share_seed: BigUint,
-    /// The keychain to use for management after the wallet is found
-    pub key_chain: ApiKeychain,
+    /// The secret match key to use for management after the wallet is found
+    pub sk_match: String,
 }
 
 /// The response type to a request to find a wallet in contract storage

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -11,7 +11,7 @@ use circuit_types::{
 use common::types::wallet::{KeyChain, OrderIdentifier, PrivateKeyChain, Wallet, WalletIdentifier};
 use itertools::Itertools;
 use num_bigint::BigUint;
-use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
+use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint, scalar_to_u64};
 use serde::{Deserialize, Serialize};
 use util::hex::{
     jubjub_from_hex_string, jubjub_to_hex_string, nonnative_scalar_from_hex_string,
@@ -190,6 +190,8 @@ pub struct ApiKeychain {
     pub public_keys: ApiPublicKeychain,
     /// The private keychain
     pub private_keys: ApiPrivateKeychain,
+    /// The nonce of the keychain
+    pub nonce: u64,
 }
 
 /// A public keychain for the API wallet
@@ -221,6 +223,7 @@ impl From<KeyChain> for ApiKeychain {
                 sk_root: keys.secret_keys.sk_root.map(|k| nonnative_scalar_to_hex_string(&k)),
                 sk_match: scalar_to_hex_string(&keys.secret_keys.sk_match.key),
             },
+            nonce: scalar_to_u64(&keys.public_keys.nonce),
         }
     }
 }

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -8,7 +8,10 @@ use circuit_types::{
     traits::BaseType,
     Amount, SizedWalletShare,
 };
-use common::types::wallet::{KeyChain, OrderIdentifier, PrivateKeyChain, Wallet, WalletIdentifier};
+use common::types::wallet::{
+    keychain::{KeyChain, PrivateKeyChain},
+    OrderIdentifier, Wallet, WalletIdentifier,
+};
 use itertools::Itertools;
 use num_bigint::BigUint;
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint, scalar_to_u64};
@@ -191,6 +194,7 @@ pub struct ApiKeychain {
     /// The private keychain
     pub private_keys: ApiPrivateKeychain,
     /// The nonce of the keychain
+    #[serde(default)]
     pub nonce: u64,
 }
 

--- a/workers/handshake-manager-tests/src/helpers.rs
+++ b/workers/handshake-manager-tests/src/helpers.rs
@@ -43,7 +43,7 @@ pub(crate) async fn lookup_wallet(
         wallet_id: wallet.wallet_id,
         secret_share_seed: share_seed,
         blinder_seed,
-        key_chain: wallet.key_chain.clone(),
+        secret_keys: wallet.key_chain.secret_keys.clone(),
     };
     let (id, waiter) = state.append_task(task.into()).await?;
     waiter.await?;

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -63,9 +63,13 @@ pub(crate) async fn lookup_wallet_and_check_result(
     let state = &test_args.state;
 
     let key_chain = expected_wallet.key_chain.clone();
-    let task =
-        LookupWalletTaskDescriptor::new(wallet_id, blinder_seed, secret_share_seed, key_chain)
-            .unwrap();
+    let task = LookupWalletTaskDescriptor::new(
+        wallet_id,
+        blinder_seed,
+        secret_share_seed,
+        key_chain.secret_keys,
+    )
+    .unwrap();
     await_task(task.into(), test_args).await?;
 
     // Check the global state for the wallet and verify that it was correctly

--- a/workers/task-driver/integration/tests/lookup_wallet.rs
+++ b/workers/task-driver/integration/tests/lookup_wallet.rs
@@ -23,7 +23,7 @@ async fn test_lookup_wallet__invalid_wallet(test_args: IntegrationTestArgs) -> R
         Uuid::new_v4(),
         Scalar::zero(),
         Scalar::zero(),
-        wallet.key_chain,
+        wallet.key_chain.secret_keys,
     )
     .unwrap();
 

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use circuit_types::SizedWalletShare;
 use common::types::{
     tasks::LookupWalletTaskDescriptor,
-    wallet::{PrivateKeyChain, Wallet, WalletIdentifier},
+    wallet::{keychain::PrivateKeyChain, Wallet, WalletIdentifier},
 };
 use constants::Scalar;
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use circuit_types::SizedWalletShare;
 use common::types::{
     tasks::LookupWalletTaskDescriptor,
-    wallet::{KeyChain, Wallet, WalletIdentifier},
+    wallet::{PrivateKeyChain, Wallet, WalletIdentifier},
 };
 use constants::Scalar;
 use job_types::{network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue};
@@ -129,8 +129,8 @@ pub struct LookupWalletTask {
     pub blinder_seed: Scalar,
     /// The CSPRNG seed for the secret share stream
     pub secret_share_seed: Scalar,
-    /// The keychain to manage the wallet with
-    pub key_chain: KeyChain,
+    /// The private key chain to use for management after the wallet is found
+    pub keychain: PrivateKeyChain,
     /// The wallet recovered from contract state
     pub wallet: Option<Wallet>,
     /// An arbitrum client for the task to submit transactions
@@ -156,7 +156,7 @@ impl Task for LookupWalletTask {
             wallet_id: descriptor.wallet_id,
             blinder_seed: descriptor.blinder_seed,
             secret_share_seed: descriptor.secret_share_seed,
-            key_chain: descriptor.key_chain,
+            keychain: descriptor.secret_keys,
             arbitrum_client: ctx.arbitrum_client,
             network_sender: ctx.network_queue,
             global_state: ctx.state,
@@ -219,7 +219,7 @@ impl LookupWalletTask {
         let (blinded_public_shares, private_shares) = self.find_wallet_shares().await?;
         let mut wallet = Wallet::new_from_shares(
             self.wallet_id,
-            self.key_chain.clone(),
+            self.keychain.clone(),
             blinded_public_shares,
             private_shares,
         );

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -15,7 +15,8 @@ use common::types::{
         derivation::{
             derive_blinder_seed, derive_share_seed, derive_wallet_id, derive_wallet_keychain,
         },
-        KeyChain, Wallet, WalletIdentifier,
+        keychain::KeyChain,
+        Wallet, WalletIdentifier,
     },
 };
 use constants::Scalar;

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -425,9 +425,13 @@ impl NodeStartupTask {
         keychain: KeyChain,
     ) -> Result<bool, NodeStartupTaskError> {
         info!("Finding relayer wallet on-chain");
-        let descriptor =
-            LookupWalletTaskDescriptor::new(wallet_id, blinder_seed, share_seed, keychain)
-                .expect("infallible");
+        let descriptor = LookupWalletTaskDescriptor::new(
+            wallet_id,
+            blinder_seed,
+            share_seed,
+            keychain.secret_keys,
+        )
+        .expect("infallible");
         let res = await_task(descriptor.into(), &self.state, self.task_queue.clone()).await;
 
         match res {
@@ -475,7 +479,7 @@ impl NodeStartupTask {
             wallet.wallet_id,
             blinder_seed,
             share_seed,
-            wallet.key_chain.clone(),
+            wallet.key_chain.secret_keys.clone(),
         )
         .expect("infallible");
 

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -214,7 +214,7 @@ impl RefreshWalletTask {
         let (public_share, private_share) = self.find_wallet_shares(&curr_wallet).await?;
         let mut wallet = Wallet::new_from_shares(
             self.wallet_id,
-            curr_wallet.key_chain.clone(),
+            curr_wallet.key_chain.secret_keys.clone(),
             public_share,
             private_share,
         );


### PR DESCRIPTION
### Purpose
This PR adds API support for key rotation by making two key changes:
1. Only accept `sk_match` when looking up or creating a wallet. This is necessary as a client may not know their `sk_root` value if it has rotated an unknown number of times. They will find out their `sk_root` value via the `nonce` field in the looked up wallet.
2. Accept a new public root key in each wallet update request. We validate that if the root key is rotated, the nonce must be incremented.

### Testing
- Deferred until a follow up with further API changes