### PR TITLE
external-api, common: Add symmetric key to wallet keychain types

### DIFF
--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
 use super::{
-    keychain::{KeyChain, PrivateKeyChain},
+    keychain::{HmacKey, KeyChain, PrivateKeyChain},
     Wallet,
 };
 
@@ -38,6 +38,7 @@ pub fn mock_empty_wallet() -> Wallet {
 
     let sk_match = SecretIdentificationKey::from(Scalar::random(&mut rng));
     let pk_match = sk_match.get_public_key();
+    let symmetric_key = HmacKey::random();
 
     let (_, managing_cluster_key) = DecryptionKey::random_pair(&mut rng);
 
@@ -47,7 +48,7 @@ pub fn mock_empty_wallet() -> Wallet {
         balances: KeyedList::default(),
         key_chain: KeyChain {
             public_keys: PublicKeyChain::new(pk_root, pk_match),
-            secret_keys: PrivateKeyChain { sk_root, sk_match },
+            secret_keys: PrivateKeyChain { sk_root, sk_match, symmetric_key },
         },
         blinder: Scalar::random(&mut rng),
         match_fee: FixedPoint::from_integer(0),

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr,
-    types::{ApiOrder, ApiWallet},
+    types::{ApiOrder, ApiPrivateKeychain, ApiWallet},
 };
 
 // ---------------
@@ -103,8 +103,8 @@ pub struct FindWalletRequest {
     pub blinder_seed: BigUint,
     /// The seed for the wallet's secret share CSPRNG
     pub secret_share_seed: BigUint,
-    /// The secret match key to use for management after the wallet is found
-    pub sk_match: String,
+    /// The private keychain to use for management after the wallet is found
+    pub private_keychain: ApiPrivateKeychain,
 }
 
 /// The response type to a request to find a wallet in contract storage

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -35,10 +35,7 @@ use state::State;
 use task_driver::simulation::simulate_wallet_tasks;
 use util::{
     err_str,
-    hex::{
-        biguint_to_hex_addr, jubjub_to_hex_string, public_sign_key_from_hex_string,
-        scalar_from_hex_string,
-    },
+    hex::{biguint_to_hex_addr, jubjub_to_hex_string, public_sign_key_from_hex_string},
 };
 
 use crate::{
@@ -287,8 +284,7 @@ impl TypedHandler for FindWalletHandler {
 
         // Create a task in thew driver to find and prove validity for
         // the wallet
-        let sk_match_scalar = scalar_from_hex_string(&req.sk_match).map_err(bad_request)?;
-        let keychain = PrivateKeyChain::new_without_root(sk_match_scalar.into());
+        let keychain = PrivateKeyChain::try_from(req.private_keychain).map_err(bad_request)?;
         let blinder_seed = biguint_to_scalar(&req.blinder_seed);
         let share_seed = biguint_to_scalar(&req.secret_share_seed);
         let task =


### PR DESCRIPTION
### Purpose
This PR adds a symmetric hmac key to the wallet keychain types in `common` and `external-api`. This key is not used on-chain, so it is not added to the circuit types.

This key will replace the `sk_root` signature for relayer API auth. Allowing for a stable auth key while `sk_root` rotates.

### Testing
- All unit tests pass
- API testing deferred until authentication steps are complete