### PR TITLE
state: applicator: reject concurrent matching pool create / delete

### DIFF
--- a/state/src/storage/tx/matching_pools.rs
+++ b/state/src/storage/tx/matching_pools.rs
@@ -15,10 +15,10 @@ pub const POOL_KEY_PREFIX: &str = "matching-pool/";
 
 /// The error message used when trying to create a matching pool that already
 /// exists
-const MATCHING_POOL_EXISTS_ERR: &str = "matching pool already exists";
+pub const MATCHING_POOL_EXISTS_ERR: &str = "matching pool already exists";
 /// The error message used when assigning an order to a nonexistent matching
 /// pool
-const MATCHING_POOL_DOES_NOT_EXIST_ERR: &str = "matching pool does not exist";
+pub const MATCHING_POOL_DOES_NOT_EXIST_ERR: &str = "matching pool does not exist";
 
 // ---------------
 // | Key Helpers |


### PR DESCRIPTION
This PR ensures that we do not try to double-create or double-delete a matching pool in the state applicator, as the only other place where this check is enforced is at the API layer, in a manner that is ignorant of concurrent requests.