### PR TITLE
circuit-types: elgamal: Add `point_on_curve` method to jubjub point

### DIFF
--- a/circuit-types/src/elgamal.rs
+++ b/circuit-types/src/elgamal.rs
@@ -119,6 +119,14 @@ pub struct BabyJubJubPoint {
     pub y: Scalar,
 }
 
+impl BabyJubJubPoint {
+    /// Check that the point is on the curve
+    pub fn is_on_curve(&self) -> bool {
+        let affine = EmbeddedCurveGroupAffine::new_unchecked(self.x.inner(), self.y.inner());
+        affine.is_on_curve()
+    }
+}
+
 impl Default for BabyJubJubPoint {
     fn default() -> Self {
         // The group generator
@@ -199,6 +207,15 @@ pub struct ElGamalCiphertext<const N: usize> {
     /// The ciphertext
     #[serde(serialize_with = "serialize_array", deserialize_with = "deserialize_array")]
     pub ciphertext: [Scalar; N],
+}
+
+impl<const N: usize> ElGamalCiphertext<N> {
+    /// Check that the ciphertext is valid
+    ///
+    /// Currently this only checks that the ephemeral key is on the curve
+    pub fn is_valid_ciphertext(&self) -> bool {
+        self.ephemeral_key.is_on_curve()
+    }
 }
 
 /// Conversion from `jf-primitives` types


### PR DESCRIPTION
### Purpose
This PR adds a `point_on_curve` method to the `BabyJubJubPoint` type that we use for in circuit curve operations. This allows, among other things, consumers of this interface to check the validity of a point before attempting a cast to an arkworks `Projective` point, which will panic for invalid points.

I use this in the funds manager to check that a ciphertext is valid.

### Testing
- Tested in the `funds-manager`