### PR TITLE
constants: Add temporary mainnet deploy block to remove panic

### DIFF
--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -4,7 +4,7 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use alloy_primitives::ChainId;
-use constants::{DEVNET_DEPLOY_BLOCK, TESTNET_DEPLOY_BLOCK};
+use constants::{DEVNET_DEPLOY_BLOCK, MAINNET_DEPLOY_BLOCK, TESTNET_DEPLOY_BLOCK};
 use ethers::{
     core::k256::ecdsa::SigningKey,
     middleware::{MiddlewareBuilder, NonceManagerMiddleware, SignerMiddleware},
@@ -54,7 +54,7 @@ impl ArbitrumClientConfig {
     /// Gets the block number at which the darkpool was deployed
     fn get_deploy_block(&self) -> BlockNumber {
         match self.chain {
-            Chain::Mainnet => unimplemented!(),
+            Chain::Mainnet => BlockNumber::Number(MAINNET_DEPLOY_BLOCK.into()),
             Chain::Testnet => BlockNumber::Number(TESTNET_DEPLOY_BLOCK.into()),
             Chain::Devnet => BlockNumber::Number(DEVNET_DEPLOY_BLOCK.into()),
         }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -96,6 +96,11 @@ pub const DEVNET_DEPLOY_BLOCK: u64 = 0;
 /// The block number at which the darkpool was deployed on testnet
 pub const TESTNET_DEPLOY_BLOCK: u64 = 55713322;
 
+/// The block number at which the darkpool was deployed on mainnet
+///
+/// TODO: Update this once the contract is deployed
+pub const MAINNET_DEPLOY_BLOCK: u64 = 0;
+
 /// The number of bytes in an Arbitrum address
 pub const ADDRESS_BYTE_LENGTH: usize = 20;
 


### PR DESCRIPTION
### Purpose
This PR adds a temporary `MAINNET_DEPLOY_BLOCK` to `constants` set to zero to avoid panics in the `arbitrum-client`.