### PR TITLE
api-server: http: rate-limit: Add wallet task rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
 ]
@@ -59,7 +59,7 @@ name = "ahash"
 version = "0.8.11"
 source = "git+https://github.com/tkaitchuck/aHash.git?tag=v0.8.11#db36e4c4f0606b786bc617eefaffbe4ae9100762"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -88,7 +88,7 @@ checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
 dependencies = [
  "alloy-rlp",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "const-hex",
  "derive_more",
  "hex-literal",
@@ -282,6 +282,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
+ "ratelimit_meter",
  "renegade-crypto 0.1.0",
  "reqwest 0.12.7",
  "serde",
@@ -751,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -1291,7 +1292,7 @@ checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.7.4",
  "object",
@@ -1743,6 +1744,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1753,7 +1760,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
 ]
@@ -2088,6 +2095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,7 +2313,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "hex 0.4.3",
  "proptest",
@@ -2419,7 +2435,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2675,7 +2691,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2870,7 +2886,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -2914,7 +2930,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "socket2 0.4.10",
  "winapi",
@@ -3098,7 +3114,7 @@ version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3492,7 +3508,7 @@ version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "const-hex",
  "dirs",
  "dunce",
@@ -3537,6 +3553,16 @@ checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "evmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdb60074c9b82c91f8702fa5351b85d22b668dae7f73bf06b44a09bc372380f"
+dependencies = [
+ "hashbrown 0.5.0",
+ "smallvec 0.6.14",
 ]
 
 [[package]]
@@ -3635,7 +3661,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "libredox",
  "windows-sys 0.59.0",
@@ -3925,7 +3951,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -3936,7 +3962,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -4073,7 +4099,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crunchy",
 ]
 
@@ -4179,6 +4205,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 
 [[package]]
 name = "hashbrown"
@@ -4451,7 +4483,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.13.2",
  "tokio",
  "want",
 ]
@@ -4748,7 +4780,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -4986,7 +5018,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
@@ -5001,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
 dependencies = [
  "futures-core",
- "lock_api",
+ "lock_api 0.4.12",
 ]
 
 [[package]]
@@ -5100,7 +5132,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5201,7 +5233,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -5217,7 +5249,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "parking_lot 0.12.3",
- "smallvec",
+ "smallvec 1.13.2",
  "trust-dns-resolver",
 ]
 
@@ -5246,7 +5278,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "sha2 0.10.8",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -5270,7 +5302,7 @@ dependencies = [
  "lru 0.10.1",
  "quick-protobuf",
  "quick-protobuf-codec",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror",
  "void",
 ]
@@ -5314,7 +5346,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror",
  "uint",
  "unsigned-varint",
@@ -5335,7 +5367,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.13.2",
  "socket2 0.4.10",
  "tokio",
  "trust-dns-proto",
@@ -5391,7 +5423,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.13.2",
 ]
 
 [[package]]
@@ -5409,7 +5441,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.13.2",
  "tokio",
  "void",
 ]
@@ -5482,6 +5514,15 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "lock_api"
@@ -5585,12 +5626,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
 ]
 
@@ -5899,7 +5946,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project",
- "smallvec",
+ "smallvec 1.13.2",
  "unsigned-varint",
 ]
 
@@ -6054,7 +6101,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec",
+ "smallvec 1.13.2",
 ]
 
 [[package]]
@@ -6064,7 +6111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -6077,6 +6124,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1b4163932b207be6e3a06412aed4d84cca40dc087419f231b3a38cba2ca8e9"
 
 [[package]]
 name = "notify"
@@ -6314,7 +6367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -6574,12 +6627,23 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.6.3",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api",
+ "lock_api 0.4.12",
  "parking_lot_core 0.8.6",
 ]
 
@@ -6589,8 +6653,23 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.12",
  "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "rustc_version 0.2.3",
+ "smallvec 0.6.14",
+ "winapi",
 ]
 
 [[package]]
@@ -6599,11 +6678,11 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.13.2",
  "winapi",
 ]
 
@@ -6613,10 +6692,10 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.5.3",
- "smallvec",
+ "smallvec 1.13.2",
  "windows-targets 0.52.6",
 ]
 
@@ -6890,7 +6969,7 @@ version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
@@ -7382,6 +7461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratelimit_meter"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4f95369ef809d01448bdf8d82ef974e3b21f3698d87015a575bb26f27724"
+dependencies = [
+ "evmap",
+ "nonzero_ext",
+ "parking_lot 0.9.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7439,6 +7529,12 @@ dependencies = [
  "time",
  "yasna",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -7758,7 +7854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
@@ -7870,6 +7966,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -8074,7 +8179,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec 3.6.12",
  "scale-info-derive",
@@ -8200,11 +8305,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -8215,6 +8329,12 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -8346,7 +8466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
@@ -8358,7 +8478,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -8370,7 +8490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
@@ -8382,7 +8502,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
  "sha2-asm",
@@ -8439,7 +8559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -8561,6 +8681,15 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
@@ -8665,7 +8794,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.12",
 ]
 
 [[package]]
@@ -9037,7 +9166,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "once_cell",
  "rustix",
@@ -9126,7 +9255,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -9515,7 +9644,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
- "smallvec",
+ "smallvec 1.13.2",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -9566,7 +9695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.13.2",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -9581,7 +9710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -9591,7 +9720,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.13.2",
  "socket2 0.4.10",
  "thiserror",
  "tinyvec",
@@ -9606,14 +9735,14 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-util",
  "ipconfig",
  "lazy_static",
  "lru-cache",
  "parking_lot 0.12.3",
  "resolv-conf",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -10011,7 +10140,7 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -10039,7 +10168,7 @@ version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -10498,7 +10627,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 
@@ -10647,7 +10776,7 @@ dependencies = [
  "blake2",
  "bls12_381",
  "byteorder",
- "cfg-if",
+ "cfg-if 1.0.0",
  "group 0.12.1",
  "group 0.13.0",
  "halo2",

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -157,6 +157,11 @@ pub struct Cli {
     /// The path at which to save raft snapshots
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
+    /// The maximum number of wallet operations a user is allowed to perform per hour
+    /// 
+    /// Defaults to 500
+    #[clap(long, value_parser, default_value = "500")]
+    pub wallet_task_rate_limit: u32,
     /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
     /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
     #[clap(long, value_parser, default_value = "100")]
@@ -319,6 +324,9 @@ pub struct RelayerConfig {
     pub db_path: String,
     /// The path at which to save raft snapshots
     pub raft_snapshot_path: String,
+    /// The maximum number of wallet operations a user is allowed to perform per
+    /// hour
+    pub wallet_task_rate_limit: u32,
     /// The maximum staleness (number of newer roots observed) to allow on
     /// Merkle proofs for managed wallets. After this threshold is exceeded,
     /// the Merkle proof will be updated
@@ -419,6 +427,7 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
+            wallet_task_rate_limit: self.wallet_task_rate_limit,
             max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -116,6 +116,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         p2p_key,
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
+        wallet_task_rate_limit: cli_args.wallet_task_rate_limit,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         gossip_warmup: cli_args.gossip_warmup,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -322,6 +322,7 @@ async fn main() -> Result<(), CoordinatorError> {
         websocket_port: args.websocket_port,
         admin_api_key: args.admin_api_key,
         compliance_service_url: args.compliance_service_url,
+        wallet_task_rate_limit: args.wallet_task_rate_limit,
         network_sender: network_sender.clone(),
         state: global_state.clone(),
         system_bus,

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -486,6 +486,7 @@ impl MockNodeController {
             websocket_port: config.websocket_port,
             admin_api_key: config.admin_api_key,
             compliance_service_url: config.compliance_service_url.clone(),
+            wallet_task_rate_limit: config.wallet_task_rate_limit,
             network_sender,
             state,
             system_bus,

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -14,7 +14,8 @@ sha2 = { version = "0.10", features = ["asm"] }
 # === HTTP + Websocket === #
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
 matchit = "0.7"
-reqwest = "0.12"
+ratelimit_meter = "5.0.0"
+reqwest = { version = "0.12", features = ["json"] }
 tokio-stream = "0.1"
 tokio-tungstenite = { version = "0.18", features = ["native-tls"] }
 tungstenite = "0.18"

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -7,6 +7,9 @@ use state::error::StateError;
 
 use super::router::{build_500_response, build_response_from_status_code};
 
+/// The error message for rate limit exceeded errors
+const ERR_RATE_LIMIT_EXCEEDED: &str = "Rate limit exceeded";
+
 /// The error type for errors that occur during ApiServer execution
 #[derive(Debug)]
 pub enum ApiServerError {
@@ -14,6 +17,8 @@ pub enum ApiServerError {
     ComplianceService(String),
     /// An http error code, should be forwarded as a response
     HttpStatusCode(StatusCode, String),
+    /// An error interacting with the rate limiter
+    RateLimitExceeded,
     /// HTTP server has failed
     HttpServerFailure(String),
     /// Error setting up the API server
@@ -42,6 +47,10 @@ impl From<ApiServerError> for Response<Body> {
             ApiServerError::HttpStatusCode(status, message) => {
                 build_response_from_status_code(status, message)
             },
+            ApiServerError::RateLimitExceeded => build_response_from_status_code(
+                StatusCode::TOO_MANY_REQUESTS,
+                ERR_RATE_LIMIT_EXCEEDED.to_string(),
+            ),
             _ => build_500_response(err.to_string()),
         }
     }

--- a/workers/api-server/src/http/rate_limit.rs
+++ b/workers/api-server/src/http/rate_limit.rs
@@ -1,0 +1,112 @@
+//! Per wallet task rate limiting implementation
+
+use common::{new_async_shared, types::wallet::WalletIdentifier, AsyncShared};
+use ratelimit_meter::{DirectRateLimiter, LeakyBucket};
+use std::{collections::HashMap, num::NonZeroU32, time::Duration};
+
+use crate::error::ApiServerError;
+
+/// The rate limiter type for a single wallet
+type WalletLimiter = DirectRateLimiter<LeakyBucket>;
+/// A thread-safe rate limiter for a single wallet
+type SharedWalletLimiter = AsyncShared<WalletLimiter>;
+/// The number of seconds in an hour
+const SECONDS_PER_HOUR: u64 = 3600;
+
+/// A leaky bucket rate limiter on a per-wallet basis
+#[derive(Clone)]
+pub struct WalletTaskRateLimiter {
+    /// The map of wallet identifiers to their rate limiters
+    limiters: AsyncShared<HashMap<WalletIdentifier, SharedWalletLimiter>>,
+    /// The maximum number of requests per duration
+    max_rate: NonZeroU32,
+    /// The duration over which the maximum number of requests is allowed
+    per_duration: Duration,
+}
+
+impl WalletTaskRateLimiter {
+    /// Create a new wallet task rate limiter
+    pub fn new(max_rate: u32, per_duration: Duration) -> Self {
+        let max_rate = NonZeroU32::new(max_rate).expect("max_rate must be non-zero");
+        let limiters = new_async_shared(HashMap::new());
+        Self { limiters, max_rate, per_duration }
+    }
+
+    /// Create a new wallet task rate limiter with an hour long duration
+    pub fn new_hourly(max_rate: u32) -> Self {
+        Self::new(max_rate, Duration::from_secs(SECONDS_PER_HOUR))
+    }
+
+    /// Check the rate limit for a given wallet
+    pub async fn check_rate_limit(&self, wallet: WalletIdentifier) -> Result<(), ApiServerError> {
+        let limiter = self.get_or_create_limiter(wallet).await;
+        let mut locked_limiter = limiter.write().await;
+        locked_limiter.check().map_err(|_| ApiServerError::RateLimitExceeded)
+    }
+
+    /// Get or create a rate limiter for a given wallet
+    async fn get_or_create_limiter(&self, wallet: WalletIdentifier) -> SharedWalletLimiter {
+        // Check if the limiter already exists
+        let limiters_read = self.limiters.read().await;
+        if let Some(limiter) = limiters_read.get(&wallet) {
+            return limiter.clone();
+        }
+        drop(limiters_read); // Drop the read lock to escalate to a write lock
+
+        // Create a new limiter if it doesn't exist
+        let mut limiters_write = self.limiters.write().await;
+        limiters_write
+            .entry(wallet)
+            .or_insert_with(|| {
+                let limiter = self.new_rate_limiter();
+                new_async_shared(limiter)
+            })
+            .clone()
+    }
+
+    /// Create a new rate limiter
+    fn new_rate_limiter(&self) -> WalletLimiter {
+        DirectRateLimiter::new(self.max_rate, self.per_duration)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::sleep;
+
+    /// Test that the rate limiter correctly handles rate limiting
+    #[tokio::test]
+    async fn test_rate_limit_success_and_failure() {
+        let limiter = WalletTaskRateLimiter::new(2, Duration::from_secs(1));
+        let wallet = WalletIdentifier::new_v4();
+
+        assert!(limiter.check_rate_limit(wallet).await.is_ok());
+        assert!(limiter.check_rate_limit(wallet).await.is_ok());
+        assert!(limiter.check_rate_limit(wallet).await.is_err());
+    }
+
+    /// Test the rate limiter after its duration has passed
+    #[tokio::test]
+    async fn test_rate_limit_reset() {
+        let limiter = WalletTaskRateLimiter::new(1, Duration::from_millis(100));
+        let wallet = WalletIdentifier::new_v4();
+
+        assert!(limiter.check_rate_limit(wallet).await.is_ok());
+        assert!(limiter.check_rate_limit(wallet).await.is_err());
+        sleep(Duration::from_millis(100)).await;
+        assert!(limiter.check_rate_limit(wallet).await.is_ok());
+    }
+
+    /// Test the rate limiter with multiple wallets
+    #[tokio::test]
+    async fn test_multiple_wallets() {
+        let limiter = WalletTaskRateLimiter::new(1, Duration::from_secs(1));
+        let wallet1 = WalletIdentifier::new_v4();
+        let wallet2 = WalletIdentifier::new_v4();
+
+        assert!(limiter.check_rate_limit(wallet1).await.is_ok());
+        assert!(limiter.check_rate_limit(wallet1).await.is_err());
+        assert!(limiter.check_rate_limit(wallet2).await.is_ok());
+    }
+}

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -167,12 +167,7 @@ impl<
                 // information can leak from cross-origin requests.
                 builder.body(Body::from(serde_json::to_vec(&resp).unwrap())).unwrap()
             },
-            Err(ApiServerError::HttpStatusCode(status, msg)) => {
-                builder.status(status).body(Body::from(msg)).unwrap()
-            },
-            Err(_) => {
-                builder.status(StatusCode::INTERNAL_SERVER_ERROR).body(Body::empty()).unwrap()
-            },
+            Err(e) => e.into(),
         }
     }
 }

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -49,6 +49,8 @@ pub struct ApiServerConfig {
     pub websocket_port: u16,
     /// The admin key, if one is set
     pub admin_api_key: Option<HmacKey>,
+    /// The number of tasks per hour a given wallet is allowed to make
+    pub wallet_task_rate_limit: u32,
     /// The URL of the compliance service to use for wallet screening
     ///
     /// Compliance screening is disabled if this is not set


### PR DESCRIPTION
### Purpose
This PR adds per-wallet task rate limiting in the API server. Note that we intentionally do not form consensus over rate limits. In a multi-node cluster, one can simply set the rate limit to `desired_rate_limit / num_nodes` and approximate an exact rate limit. 

Admin tasks are exempt from rate limiting, and paying fees is also not rate limiting.

### Testing
- Set the rate limit to 3 then tested repeatedly refreshing a wallet through the CLI
- All unit tests pass