### PR TITLE
api-server: http: wallet: Enforce minimum deposit/withdrawal amounts

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -162,6 +162,11 @@ pub struct Cli {
     /// Defaults to 500
     #[clap(long, value_parser, default_value = "500")]
     pub wallet_task_rate_limit: u32,
+    /// The minimum usdc denominated value for a deposit or withdrawal
+    /// 
+    /// Defaults to 1 USDC (ignoring decimals)
+    #[clap(long, value_parser, default_value = "1.0")]
+    pub min_transfer_amount: f64,
     /// The maximum staleness (number of newer roots observed) to allow on Merkle proofs for 
     /// managed wallets. After this threshold is exceeded, the Merkle proof will be updated
     #[clap(long, value_parser, default_value = "100")]
@@ -327,6 +332,8 @@ pub struct RelayerConfig {
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour
     pub wallet_task_rate_limit: u32,
+    /// The minimum usdc denominated value for a deposit or withdrawal
+    pub min_transfer_amount: f64,
     /// The maximum staleness (number of newer roots observed) to allow on
     /// Merkle proofs for managed wallets. After this threshold is exceeded,
     /// the Merkle proof will be updated
@@ -428,6 +435,7 @@ impl Clone for RelayerConfig {
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
             wallet_task_rate_limit: self.wallet_task_rate_limit,
+            min_transfer_amount: self.min_transfer_amount,
             max_merkle_staleness: self.max_merkle_staleness,
             allow_local: self.allow_local,
             bind_addr: self.bind_addr,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -117,6 +117,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
         wallet_task_rate_limit: cli_args.wallet_task_rate_limit,
+        min_transfer_amount: cli_args.min_transfer_amount,
         bind_addr: cli_args.bind_addr,
         public_ip: cli_args.public_ip,
         gossip_warmup: cli_args.gossip_warmup,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -321,6 +321,7 @@ async fn main() -> Result<(), CoordinatorError> {
         http_port: args.http_port,
         websocket_port: args.websocket_port,
         admin_api_key: args.admin_api_key,
+        min_transfer_amount: args.min_transfer_amount,
         compliance_service_url: args.compliance_service_url,
         wallet_task_rate_limit: args.wallet_task_rate_limit,
         network_sender: network_sender.clone(),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -485,6 +485,7 @@ impl MockNodeController {
             http_port: config.http_port,
             websocket_port: config.websocket_port,
             admin_api_key: config.admin_api_key,
+            min_transfer_amount: config.min_transfer_amount,
             compliance_service_url: config.compliance_service_url.clone(),
             wallet_task_rate_limit: config.wallet_task_rate_limit,
             network_sender,

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -348,9 +348,11 @@ impl HttpServer {
             &Method::POST,
             DEPOSIT_BALANCE_ROUTE.to_string(),
             DepositBalanceHandler::new(
+                config.min_transfer_amount,
                 config.compliance_service_url.clone(),
                 state.clone(),
                 wallet_rate_limiter.clone(),
+                config.price_reporter_work_queue.clone(),
             ),
         );
 
@@ -358,7 +360,12 @@ impl HttpServer {
         router.add_wallet_authenticated_route(
             &Method::POST,
             WITHDRAW_BALANCE_ROUTE.to_string(),
-            WithdrawBalanceHandler::new(state.clone(), wallet_rate_limiter.clone()),
+            WithdrawBalanceHandler::new(
+                config.min_transfer_amount,
+                state.clone(),
+                wallet_rate_limiter.clone(),
+                config.price_reporter_work_queue.clone(),
+            ),
         );
 
         // The "/wallet/:id/redeem-note" route

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -51,6 +51,8 @@ pub struct ApiServerConfig {
     pub admin_api_key: Option<HmacKey>,
     /// The number of tasks per hour a given wallet is allowed to make
     pub wallet_task_rate_limit: u32,
+    /// The minimum usdc denominated value for a deposit or withdrawal
+    pub min_transfer_amount: f64,
     /// The URL of the compliance service to use for wallet screening
     ///
     /// Compliance screening is disabled if this is not set

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -1,7 +1,7 @@
 //! Defines all possible jobs for the PriceReporter.
 use common::types::{exchange::PriceReporterState, token::Token};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioUnboundedSender};
-use tokio::sync::oneshot::Sender as TokioSender;
+use tokio::sync::oneshot::{self, Receiver as TokioReceiver, Sender as TokioSender};
 use util::metered_channels::MeteredTokioReceiver;
 
 /// The name of the price reporter queue, used to label queue length metrics
@@ -53,4 +53,15 @@ pub enum PriceReporterJob {
         /// The return channel for the price report
         channel: TokioSender<PriceReporterState>,
     },
+}
+
+impl PriceReporterJob {
+    /// A new job to peek at a price report
+    pub fn peek_price(
+        base_token: Token,
+        quote_token: Token,
+    ) -> (Self, TokioReceiver<PriceReporterState>) {
+        let (send, recv) = oneshot::channel();
+        (Self::PeekPrice { base_token, quote_token, channel: send }, recv)
+    }
 }


### PR DESCRIPTION
### Purpose
This PR enables a configurable deposit/withdrawal limit on the relayer, denominated in $USDC and defaulting to $1.

Note that on withdrawal, a user is allowed to withdraw their full balance, even if it does not exceed the withdrawal minimum.

### Testing
- Tested depositing and withdrawing with small amounts and amounts barely above the threshold
- Unit tests pass