### PR TITLE
constants: Add `in_bootstrap_mode` and gate functionality behind it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "async-trait",
  "circuit-types 0.1.0",
  "common 0.1.0",
+ "constants 0.1.0",
  "crossbeam",
  "ethers",
  "gossip-api",
@@ -1795,6 +1796,7 @@ dependencies = [
  "state",
  "tokio",
  "tracing",
+ "util 0.1.0",
 ]
 
 [[package]]
@@ -2292,6 +2294,7 @@ dependencies = [
  "clap 4.5.16",
  "colored",
  "common 0.1.0",
+ "constants 0.1.0",
  "ed25519-dalek 1.0.1",
  "ethers",
  "json",
@@ -4018,6 +4021,7 @@ dependencies = [
  "circuit-types 0.1.0",
  "circuits 0.1.0",
  "common 0.1.0",
+ "constants 0.1.0",
  "futures",
  "gossip-api",
  "itertools 0.10.5",
@@ -7056,6 +7060,7 @@ dependencies = [
  "atomic_float 0.1.0",
  "bimap",
  "common 0.1.0",
+ "constants 0.1.0",
  "create2",
  "external-api 0.1.0",
  "futures",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -16,6 +16,7 @@ arbitrum-client = { path = "../arbitrum-client" }
 circuit-types = { path = "../circuit-types" }
 colored = "2.0"
 common = { path = "../common" }
+constants = { path = "../constants" }
 util = { path = "../util" }
 
 # === Misc Dependencies === #

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -115,6 +115,13 @@ pub struct Cli {
     // -------------------------
     // | Cluster Configuration |
     // -------------------------
+
+    /// Run the relayer in bootstrap mode
+    /// 
+    /// Bootstrap mode omits much of the relayer's functionality and ignores most messages
+    #[clap(long)]
+    pub bootstrap_mode: bool,
+
     /// The bootstrap servers that the peer should dial initially
     #[clap(short, long, value_parser, env = "BOOTSTRAP_SERVERS", use_value_delimiter = true)]
     pub bootstrap_servers: Option<Vec<String>>,
@@ -301,6 +308,11 @@ pub struct RelayerConfig {
     // -------------------------
     // | Cluster Configuration |
     // -------------------------
+    /// Run the relayer in bootstrap mode
+    ///
+    /// Bootstrap mode omits much of the relayer's functionality and ignores
+    /// most messages
+    pub bootstrap_mode: bool,
     /// Bootstrap servers that the peer should connect to
     pub bootstrap_servers: Vec<(WrappedPeerId, Multiaddr)>,
     /// The cluster keypair
@@ -427,6 +439,7 @@ impl Clone for RelayerConfig {
             chain_id: self.chain_id,
             contract_address: self.contract_address.clone(),
             compliance_service_url: self.compliance_service_url.clone(),
+            bootstrap_mode: self.bootstrap_mode,
             bootstrap_servers: self.bootstrap_servers.clone(),
             p2p_port: self.p2p_port,
             http_port: self.http_port,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -8,6 +8,7 @@ use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     wallet::{keychain::HmacKey, WalletIdentifier},
 };
+use constants::set_bootstrap_mode;
 use ed25519_dalek::{Keypair as DalekKeypair, PublicKey, SecretKey};
 use ethers::{core::rand::thread_rng, signers::LocalWallet};
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
@@ -48,6 +49,9 @@ pub fn parse_command_line_args() -> Result<RelayerConfig, String> {
     let cli = Cli::parse_from(full_args);
     // Setup the token remap
     setup_token_remaps(cli.token_remap_file.clone(), cli.chain_id)?;
+
+    // Set the bootstrap mode
+    set_bootstrap_mode(cli.bootstrap_mode);
 
     let config = parse_config_from_args(cli)?;
     Ok(config)
@@ -107,6 +111,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         chain_id: cli_args.chain_id,
         contract_address: cli_args.contract_address,
         compliance_service_url: cli_args.compliance_service_url,
+        bootstrap_mode: cli_args.bootstrap_mode,
         bootstrap_servers: parsed_bootstrap_addrs,
         p2p_port: cli_args.p2p_port,
         http_port: cli_args.http_port,

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -4,6 +4,8 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![deny(missing_docs)]
 
+use std::sync::OnceLock;
+
 use ark_ec::Group;
 #[cfg(feature = "mpc-types")]
 use ark_mpc::algebra::{
@@ -17,6 +19,24 @@ use ark_mpc::algebra::{
 
 /// The current relayer version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Whether or not the relayer is in bootstrap mode
+pub static BOOTSTRAP_MODE: OnceLock<bool> = OnceLock::new();
+
+/// Whether or not the relayer is in bootstrap mode
+///
+/// We default to false instead of erroring here to allow use of workers
+/// _without_ setting this value. This is especially important outside of the
+/// relayer repo
+pub fn in_bootstrap_mode() -> bool {
+    BOOTSTRAP_MODE.get().copied().unwrap_or(false)
+}
+
+/// Set the bootstrap mode
+pub fn set_bootstrap_mode(mode: bool) {
+    BOOTSTRAP_MODE
+        .set(mode)
+        .expect("BOOTSTRAP_MODE should not be initialized before calling set_bootstrap_mode()")
+}
 
 // -------------------------
 // | System-Wide Constants |

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -23,7 +23,7 @@ use arbitrum_client::{
 use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::default_wrapper::default_option;
 use common::worker::{new_worker_failure_channel, watch_worker, Worker};
-use constants::VERSION;
+use constants::{in_bootstrap_mode, VERSION};
 use external_api::bus_message::SystemBusMessage;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};
@@ -102,6 +102,10 @@ async fn main() -> Result<(), CoordinatorError> {
         "Relayer running with\n\t version: {}\n\t port: {}\n\t cluster: {:?}",
         VERSION, args.p2p_port, args.cluster_id
     );
+
+    if in_bootstrap_mode() {
+        info!("Running in bootstrap mode");
+    }
 
     // Build communication primitives
     // First, the global shared mpmc bus that all workers have access to

--- a/util/src/runtime.rs
+++ b/util/src/runtime.rs
@@ -14,3 +14,13 @@ pub fn block_current<T, F: Future<Output = T>>(res: F) -> T {
 pub fn block_current_multi<T, F: Future<Output = T>>(res: Vec<F>) -> Vec<T> {
     Handle::current().block_on(join_all(res))
 }
+
+/// Sleep forever in an async context
+pub async fn sleep_forever_async() {
+    std::future::pending::<()>().await;
+}
+
+/// Sleep forever in a blocking context
+pub fn sleep_forever_blocking() {
+    std::thread::sleep(std::time::Duration::MAX);
+}

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -2,7 +2,7 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use constants::{HANDSHAKE_STATUS_TOPIC, ORDER_STATE_CHANGE_TOPIC};
+use constants::{in_bootstrap_mode, HANDSHAKE_STATUS_TOPIC, ORDER_STATE_CHANGE_TOPIC};
 use external_api::{
     bus_message::{SystemBusMessage, SystemBusMessageWithTopic, NETWORK_TOPOLOGY_TOPIC},
     websocket::{ClientWebsocketMessage, SubscriptionResponse, WebsocketMessage},
@@ -208,6 +208,11 @@ impl WebsocketServer {
     /// Manages subscriptions to internal channels and dispatches
     /// subscribe/unsubscribe requests
     async fn handle_connection(&self, stream: TcpStream) -> Result<(), ApiServerError> {
+        // Ignore connections in bootstrap mode
+        if in_bootstrap_mode() {
+            return Ok(());
+        }
+
         // Accept the websocket upgrade and split into read/write streams
         let websocket_stream = accept_async(stream)
             .await

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -15,10 +15,12 @@ ethers = { workspace = true }
 arbitrum-client = { path = "../../arbitrum-client" }
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 renegade-crypto = { path = "../../renegade-crypto" }
 gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
 state = { path = "../../state" }
+util = { path = "../../util" }
 
 # === Misc Dependencies === #
 lazy_static = { workspace = true }

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -4,6 +4,7 @@ use std::thread::JoinHandle;
 
 use arbitrum_client::{abi::NullifierSpentFilter, client::ArbitrumClient};
 use common::types::CancelChannel;
+use constants::in_bootstrap_mode;
 use ethers::prelude::StreamExt;
 use job_types::{
     handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue},
@@ -13,6 +14,7 @@ use job_types::{
 use renegade_crypto::fields::u256_to_scalar;
 use state::State;
 use tracing::{error, info};
+use util::runtime::sleep_forever_async;
 
 use super::error::OnChainEventListenerError;
 
@@ -74,6 +76,11 @@ impl OnChainEventListenerExecutor {
 
     /// The main execution loop for the executor
     pub async fn execute(self) -> Result<(), OnChainEventListenerError> {
+        // If the node is running in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_async().await;
+        }
+
         // Get the current block number to start from
         let starting_block_number = self
             .arbitrum_client()

--- a/workers/gossip-server/Cargo.toml
+++ b/workers/gossip-server/Cargo.toml
@@ -17,6 +17,7 @@ arbitrum-client = { path = "../../arbitrum-client" }
 circuits = { path = "../../circuits" }
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
 state = { path = "../../state" }

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -4,10 +4,11 @@
 use std::time::Duration;
 
 use common::types::CancelChannel;
+use constants::in_bootstrap_mode;
 use job_types::handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue};
 use state::State;
 use tracing::info;
-use util::err_str;
+use util::{err_str, runtime::sleep_forever_async};
 
 use crate::error::HandshakeManagerError;
 
@@ -36,6 +37,10 @@ impl HandshakeScheduler {
 
     /// The execution loop of the timer, periodically enqueues handshake jobs
     pub async fn execution_loop(mut self) -> HandshakeManagerError {
+        if in_bootstrap_mode() {
+            sleep_forever_async().await;
+        }
+
         let interval_seconds = HANDSHAKE_INTERVAL_MS / 1000;
         let interval_nanos = (HANDSHAKE_INTERVAL_MS % 1000 * NANOS_PER_MILLI) as u32;
 

--- a/workers/price-reporter/Cargo.toml
+++ b/workers/price-reporter/Cargo.toml
@@ -25,6 +25,7 @@ web3 = "0.18"
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 external-api = { path = "../../external-api" }
 job-types = { path = "../job-types" }
 system-bus = { path = "../../system-bus" }

--- a/workers/price-reporter/src/manager/native_executor.rs
+++ b/workers/price-reporter/src/manager/native_executor.rs
@@ -6,9 +6,11 @@ use common::default_wrapper::{DefaultOption, DefaultWrapper};
 use common::types::exchange::{Exchange, PriceReporterState};
 use common::types::token::Token;
 use common::types::CancelChannel;
+use constants::in_bootstrap_mode;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::sync::oneshot::Sender as TokioSender;
 use tracing::{error, info, info_span, warn, Instrument};
+use util::runtime::sleep_forever_async;
 
 use crate::{
     errors::{ExchangeConnectionError, PriceReporterError},
@@ -48,6 +50,11 @@ impl PriceReporterExecutor {
 
     /// The execution loop for the price reporter
     pub(crate) async fn execution_loop(mut self) -> Result<(), PriceReporterError> {
+        // If the relayer is in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_async().await;
+        }
+
         let mut job_receiver = self.job_receiver.take().unwrap();
         let mut cancel_channel = self.cancel_channel.take().unwrap();
 

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -36,10 +36,11 @@ use circuits::{
     },
 };
 use common::types::{proof_bundles::ProofBundle, CancelChannel};
+use constants::in_bootstrap_mode;
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
 use rayon::ThreadPool;
 use tracing::{error, info, info_span, instrument};
-use util::err_str;
+use util::{err_str, runtime::sleep_forever_blocking};
 
 use super::error::ProofManagerError;
 
@@ -80,6 +81,11 @@ impl ProofManager {
         thread_pool: Arc<ThreadPool>,
         cancel_channel: CancelChannel,
     ) -> Result<(), ProofManagerError> {
+        // If the relayer is in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_blocking();
+        }
+
         // Preprocess the circuits
         ProofManager::preprocess_circuits()?;
 

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -19,7 +19,7 @@ use common::types::{
         Wallet, WalletIdentifier,
     },
 };
-use constants::Scalar;
+use constants::{in_bootstrap_mode, Scalar};
 use ethers::signers::LocalWallet;
 use job_types::{
     network_manager::{NetworkManagerControlSignal, NetworkManagerJob, NetworkManagerQueue},
@@ -275,6 +275,11 @@ impl NodeStartupTask {
     ///
     /// Concretely, this is the contract protocol key and the protocol fee
     async fn fetch_contract_constants(&self) -> Result<(), NodeStartupTaskError> {
+        // Do not fetch constants in bootstrap mode
+        if in_bootstrap_mode() {
+            return Ok(());
+        }
+
         // Fetch the values from the contract
         let protocol_fee = self
             .arbitrum_client
@@ -348,6 +353,11 @@ impl NodeStartupTask {
     ///
     /// If the wallet is found on-chain, recover it. Otherwise, create a new one
     async fn setup_relayer_wallet(&self) -> Result<(), NodeStartupTaskError> {
+        // Do not setup a wallet in bootstrap mode
+        if in_bootstrap_mode() {
+            return Ok(());
+        }
+
         // If the state setup did not allocate a wallet id, we do not need a wallet
         if !self.needs_relayer_wallet {
             info!("no relayer wallet needed, skipping creation...");
@@ -384,6 +394,11 @@ impl NodeStartupTask {
 
     /// Refresh state when recovering from a snapshot
     async fn refresh_state(&self) -> Result<(), NodeStartupTaskError> {
+        // Do not refresh state in bootstrap mode
+        if in_bootstrap_mode() {
+            return Ok(());
+        }
+
         // If the node did not recover from a snapshot we need not refresh
         if !self.state.was_recovered_from_snapshot() {
             return Ok(());


### PR DESCRIPTION
### Purpose
This PR adds a bootstrap mode to the relayer. This is set via a `OnceLock` and checked in various locations throughout the relayer to avoid work that isn't relevant to a bootstrap node.

### Testing
- All unit tests pass
- Ran a relayer in bootstrap mode, bootstrapped two nodes off of it and made sure they discovered one another