### PR TITLE
handshake-manager: price-agreement: Initialize streams from token map

### DIFF
--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -50,7 +50,6 @@ use util::{err_str, get_current_time_millis, runtime::sleep_forever_async};
 use uuid::Uuid;
 
 pub(super) use price_agreement::init_price_streams;
-pub use price_agreement::DEFAULT_PAIRS;
 
 use self::{
     handshake::{ERR_NO_PROOF, ERR_NO_WALLET},


### PR DESCRIPTION
### Purpose
This PR removes the `DEFAULT_PAIRS` static and instead replaces it with the token mapped tickers for all named tokens we support. This more directly represents the prices we want in an environment and works better across environments with different token lists.

### Testing
- Ran a relayer after this change without panicking on the mainnet token list
- All tests pass