### PR TITLE
config: cli: Add environment variable for bootstrap mode

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -76,7 +76,7 @@ pub struct Cli {
     #[clap(long, value_parser, default_value = "testnet", env = "CHAIN")]
     pub chain_id: Chain,
     /// The address of the darkpool contract, defaults to the internal testnet deployment
-    #[clap(long, value_parser, env = "DARKPOOL_ADDRESS")]
+    #[clap(long, value_parser, env = "DARKPOOL_ADDRESS", default_value = "0x2f88458fc25591f1de247dd3297f039eecfcd534")]
     pub contract_address: String,
     /// The path to the file containing deployments info for the darkpool contract
     #[clap(long, value_parser)]
@@ -119,7 +119,7 @@ pub struct Cli {
     /// Run the relayer in bootstrap mode
     /// 
     /// Bootstrap mode omits much of the relayer's functionality and ignores most messages
-    #[clap(long)]
+    #[clap(long, env = "BOOTSTRAP_MODE")]
     pub bootstrap_mode: bool,
 
     /// The bootstrap servers that the peer should dial initially

--- a/node-support/bootloader/src/main.rs
+++ b/node-support/bootloader/src/main.rs
@@ -357,8 +357,10 @@ async fn setup_gas_wallet(
 
 /// Read in the funds manager HMAC key from environment variables
 fn read_funds_manager_key() -> Result<[u8; 32], String> {
-    let key = read_env_var::<String>(ENV_FUNDS_MANAGER_KEY)?;
-    let decoded = hex::decode(key).expect("Invalid HMAC key");
+    let key_str = read_env_var::<String>(ENV_FUNDS_MANAGER_KEY)?;
+    let key_str = key_str.trim_start_matches("0x");
+
+    let decoded = hex::decode(key_str).expect("Invalid HMAC key");
     if decoded.len() != 32 {
         panic!("HMAC key must be 32 bytes long");
     }


### PR DESCRIPTION
### Purpose
This PR makes three fixes:
- Add a bootstrap mode environment variable
- Add a default value for the `--contract-address` field. This is a meaningless default but is important for testing methods that require a mock config
- Fix hmac key parsing in the bootloader script to properly handle a `0x` prefixed hex string

### Testing
- Ran in bootloader mode via env var
- All unit tests pass