### PR TITLE
price-reporter: manager: Do not block binance price on min connections

### DIFF
--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -164,4 +164,4 @@ cargo run \
     --deployments-path $DEPLOYMENTS_PATH \
     deploy-proxy \
     --owner $DEVNET_ACCOUNT_ADDRESS \
-    --fee 858993
+    --fee 1844674407370955

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -10,7 +10,6 @@ use circuit_types::{
 };
 use constants::Scalar;
 use renegade_crypto::fields::scalar_to_u128;
-use tracing::warn;
 
 use crate::arbitrum::get_protocol_fee;
 
@@ -62,9 +61,6 @@ pub fn match_orders_with_max_amount(
 
     // Validate that the midpoint price is acceptable for both orders
     valid_match = valid_match && o1.price_in_range(price) && o2.price_in_range(price);
-    if !valid_match {
-        warn!("Price ({}) falls outside of acceptable range for orders", price.to_f64());
-    }
 
     // Neither order is zero'd out
     // Orders are not removed when they are zero'd because a counterparty cannot

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -367,11 +367,8 @@ pub fn compute_price_reporter_state(
     // we have enough.
     let non_zero_prices: Vec<Price> = exchange_prices
         .iter()
-        .filter(|(exchange, (price, ts))| {
-            exchange != &Exchange::Binance
-                && *price != Price::default()
-                && price.is_finite()
-                && !ts_too_stale(*ts).0
+        .filter(|(_exchange, (price, ts))| {
+            *price != Price::default() && price.is_finite() && !ts_too_stale(*ts).0
         })
         .map(|(_, (price, _))| *price)
         .collect();


### PR DESCRIPTION
### Purpose
This PR makes a few miscellaneous changes including that we now add Binance to the `non_zero_prices` list so that the min connections constraint does not fail.

### Testing
- Fetched prices for all pairs from the relayer directly, all were nominal