### PR TITLE
workers: api-server: websocket: Remove spammy websocket connection log

### DIFF
--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -244,7 +244,6 @@ impl WebsocketServer {
                     match message {
                         Some(msg) => {
                             if let Err(e) = msg {
-                                info!("error handling websocket connection: {e}");
                                 return Err(ApiServerError::WebsocketServerFailure(e.to_string()));
                             }
 


### PR DESCRIPTION
### Purpose
This PR removes a spammy log that occurs when a client resets a websocket connection. It doesn't inform anything useful