### PR TITLE
workers: price-reporter: external-executor: Downgrade error logs to warn

### DIFF
--- a/bin/build_and_push.sh
+++ b/bin/build_and_push.sh
@@ -1,12 +1,26 @@
 #!/bin/sh
 REGION=us-east-2
-ENVIRONMENT=${1:-dev}
+DEFAULT_ENVIRONMENT=dev
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --env) ENVIRONMENT="$2"; shift ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Use default if not provided
+ENVIRONMENT=${ENVIRONMENT:-$DEFAULT_ENVIRONMENT}
 ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$ENVIRONMENT
 
 GIT_HASH=$(git rev-parse HEAD)
 
-TAG_1=$ECR_URL\:$GIT_HASH
-TAG_2=$ECR_URL\:latest
+TAG_1=$ECR_URL:$GIT_HASH
+TAG_2=$ECR_URL:latest
+
+echo "Building and pushing relayer image to: $ENVIRONMENT"
 
 docker build -t relayer:latest  -f ./docker/release/Dockerfile .
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_URL

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -42,6 +42,9 @@ use crate::{
 
 use super::SharedPriceStreamStates;
 
+/// The delay between connection retries
+const CONNECTION_RETRY_DELAY_MS: u64 = 3_000; // 3 seconds
+
 /// A type alias for the write end of the websocket connection
 type WsWriteStream = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 
@@ -278,7 +281,16 @@ async fn ws_handler_loop(
                 // to the executor
                 Some(res) = ws_read.next() => {
                     if let Err(e) = handle_incoming_ws_message(res, &msg_in_tx) {
-                        error!("Error handling incoming message from external price reporter: {e}, retrying...");
+                        match e {
+                            ExchangeConnectionError::ConnectionHangup(_) => {
+                                warn!("Error handling incoming message from external price reporter: {e}, retrying...");
+                            },
+                            _ => {
+                                error!("Error handling incoming message from external price reporter: {e}, retrying...");
+                            }
+                        }
+
+                        // Fail over into connection retry loop
                         break;
                     }
                 }
@@ -297,6 +309,7 @@ async fn ws_handler_loop(
         // As such, we will have to re-subscribe to all the price streams that
         // were previously subscribed to on the re-established connection, so we
         // enqueue the re-subscription jobs here
+        tokio::time::sleep(Duration::from_millis(CONNECTION_RETRY_DELAY_MS)).await;
         (ws_write, ws_read) = connect_and_resubscribe(
             price_reporter_url.clone(),
             msg_out_tx.clone(),


### PR DESCRIPTION
### Purpose
This PR makes two changes:
- Downgrades an error log for `ConnectionHangup` in the price reporter to a warn
- Fixes the `bin/deploy.sh` and `bin/build_and_push.sh` scripts to use explicit flags rather than indexed arguments. Among other things this fixes an issue we've seen before in parsing the tag `latest` for an ECS revision rather than the SHA itself

### Testing
- Deployed to testnet
- Unit tests pass