### PR TITLE
metrics-sampler: create metrics-sampler module & port raft metrics 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5702,6 +5702,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-sampler"
+version = "0.1.0"
+dependencies = [
+ "metrics",
+ "state",
+ "system-clock",
+]
+
+[[package]]
 name = "metrics-tracing-context"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7706,6 +7715,7 @@ dependencies = [
  "handshake-manager",
  "job-types",
  "lazy_static",
+ "metrics-sampler",
  "network-manager",
  "opentelemetry",
  "price-reporter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 	"workers/task-driver",
 	"renegade-metrics",
 	"system-clock",
+	"metrics-sampler",
 ]
 
 [profile.bench]

--- a/bin/build_and_push.sh
+++ b/bin/build_and_push.sh
@@ -17,8 +17,8 @@ ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$ENVIRONMENT
 
 GIT_HASH=$(git rev-parse HEAD)
 
-TAG_1=$ECR_URL:$GIT_HASH
-TAG_2=$ECR_URL:latest
+TAG_1=$ECR_URL\:$GIT_HASH
+TAG_2=$ECR_URL\:latest
 
 echo "Building and pushing relayer image to: $ENVIRONMENT"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ system-bus = { path = "../system-bus" }
 system-clock = { path = "../system-clock" }
 task-driver = { path = "../workers/task-driver" }
 util = { path = "../util" }
+metrics-sampler = { path = "../metrics-sampler" }
 
 # === Misc Dependencies === #
 clap = { version = "3.2.8", features = ["derive"] }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::fmt::Display;
 
 use state::error::StateError;
+use system_clock::SystemClockError;
 
 /// An error type at the coordinator level
 #[derive(Clone, Debug)]
@@ -20,6 +21,8 @@ pub enum CoordinatorError {
     State(String),
     /// An error setting up telemetry
     Telemetry(String),
+    /// An error setting up the system clock timers
+    Clock(String),
 }
 
 impl Error for CoordinatorError {}
@@ -32,5 +35,11 @@ impl Display for CoordinatorError {
 impl From<StateError> for CoordinatorError {
     fn from(value: StateError) -> Self {
         CoordinatorError::State(value.to_string())
+    }
+}
+
+impl From<SystemClockError> for CoordinatorError {
+    fn from(value: SystemClockError) -> Self {
+        CoordinatorError::Clock(value.0)
     }
 }

--- a/metrics-sampler/Cargo.toml
+++ b/metrics-sampler/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "metrics-sampler"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# === Workspace Dependencies === #
+state = { path = "../state" }
+system-clock = { path = "../system-clock" }
+
+# === Misc === #
+metrics = { workspace = true }

--- a/metrics-sampler/src/lib.rs
+++ b/metrics-sampler/src/lib.rs
@@ -1,0 +1,12 @@
+//! Metrics registered with timers on the system clock that record various
+//! "snapshots" of the system on an interval.
+
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![allow(async_fn_in_trait)]
+
+pub mod raft_metrics_sampler;
+pub mod sampler;

--- a/metrics-sampler/src/raft_metrics_sampler.rs
+++ b/metrics-sampler/src/raft_metrics_sampler.rs
@@ -1,0 +1,50 @@
+//! Records raft metrics snapshots at a fixed interval
+
+use std::time::Duration;
+
+use state::State;
+
+use crate::sampler::MetricSampler;
+
+/// The name of the sampler for raft metrics
+pub const RAFT_METRICS_SAMPLER_NAME: &str = "raft-metrics-sampler";
+/// The interval at which to sample raft metrics
+pub const RAFT_METRICS_SAMPLE_INTERVAL_MS: u64 = 10_000;
+
+/// Metric describing the size of the raft cluster
+pub const RAFT_CLUSTER_SIZE_METRIC: &str = "raft_cluster_size";
+/// Metric describing if the local node is the leader of the raft cluster
+pub const RAFT_LEADER_METRIC: &str = "raft_leader";
+
+/// Samples raft metrics at a fixed interval
+pub struct RaftMetricsSampler {
+    /// A handle to the global state
+    state: State,
+}
+
+impl RaftMetricsSampler {
+    /// Create a new `RaftMetricsSampler`
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+}
+
+impl MetricSampler for RaftMetricsSampler {
+    fn name(&self) -> &str {
+        RAFT_METRICS_SAMPLER_NAME
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_millis(RAFT_METRICS_SAMPLE_INTERVAL_MS)
+    }
+
+    fn sample(&self) -> Result<(), String> {
+        let raft_cluster_size = self.state.cluster_size();
+        let is_leader = if self.state.is_leader() { 1 } else { 0 };
+
+        metrics::gauge!(RAFT_CLUSTER_SIZE_METRIC).set(raft_cluster_size as f64);
+        metrics::gauge!(RAFT_LEADER_METRIC).set(is_leader as f64);
+
+        Ok(())
+    }
+}

--- a/metrics-sampler/src/sampler.rs
+++ b/metrics-sampler/src/sampler.rs
@@ -1,0 +1,51 @@
+//! Defines a "sampler" trait that encapsulates the logic for registering
+//! a job that samples metrics at a fixed interval
+
+use std::{future::Future, time::Duration};
+use system_clock::{SystemClock, SystemClockError};
+
+/// Samples metrics at a fixed interval, using a synchronous sampling method
+pub trait MetricSampler: Sized + Send + Sync + 'static {
+    /// Returns the name of the sampler
+    fn name(&self) -> &str;
+
+    /// Returns the duration between recording samples
+    fn interval(&self) -> Duration;
+
+    /// Samples the metrics
+    fn sample(&self) -> Result<(), String>;
+
+    /// Registers the sampler with the system clock
+    async fn register(self, clock: &SystemClock) -> Result<(), SystemClockError> {
+        let name = self.name().to_string();
+        let interval = self.interval();
+        let sample = move || self.sample();
+
+        clock.add_timer(name, interval, sample).await
+    }
+}
+
+/// Samples metrics at a fixed interval, using an asynchronous sampling method
+pub trait AsyncMetricSampler: Sized + Send + Sync + 'static + Clone {
+    /// Returns the name of the sampler
+    fn name(&self) -> &str;
+
+    /// Returns the duration between recording samples
+    fn interval(&self) -> Duration;
+
+    /// Samples the metrics
+    fn sample(&self) -> impl Future<Output = Result<(), String>> + Send + 'static;
+
+    /// Registers the sampler with the system clock
+    async fn register(self, clock: &SystemClock) -> Result<(), SystemClockError> {
+        let name = self.name().to_string();
+        let interval = self.interval();
+        let sample = move || {
+            let sampler = self.clone();
+
+            async move { sampler.sample().await }
+        };
+
+        clock.add_async_timer(name, interval, sample).await
+    }
+}

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -276,7 +276,7 @@ impl MockNodeController {
             task_sender,
             handshake_queue,
             bus,
-            clock,
+            &clock,
             failure_send,
         ))
         .expect("Failed to create state instance");

--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -31,10 +31,6 @@ pub const NUM_LOCAL_PEERS_METRIC: &str = "num_local_peers";
 /// Metric describing the number of remote peers the relayer
 /// is connected to
 pub const NUM_REMOTE_PEERS_METRIC: &str = "num_remote_peers";
-/// Metric describing the size of the raft cluster
-pub const RAFT_CLUSTER_SIZE_METRIC: &str = "raft_cluster_size";
-/// Metric describing if the local node is the leader of the raft cluster
-pub const RAFT_LEADER_METRIC: &str = "raft_leader";
 
 // Task metrics
 

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -34,6 +34,11 @@ impl State {
         self.raft.is_leader()
     }
 
+    /// Get the size of the raft cluster
+    pub fn cluster_size(&self) -> usize {
+        self.raft.cluster_size()
+    }
+
     /// Get the leader of the raft
     pub fn get_leader(&self) -> Option<WrappedPeerId> {
         let (_raft_id, info) = self.raft.leader_info()?;

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -311,7 +311,7 @@ pub mod test_helpers {
             task_queue,
             handshake_manager_queue,
             SystemBus::new(),
-            SystemClock::new().await,
+            &SystemClock::new().await,
             failure_send,
         )
         .await


### PR DESCRIPTION
This PR introduces the `metrics-sampler` module, which defines a framework for sampling various system metrics on fixed intervals using the `system-clock`.

As an example, we port over the raft metrics to `metrics-sampler` in the form of the `RaftMetricsSampler`.

This pattern will subsequently be used to sample product insight metrics.

I tested this with a local relayer & on testnet, where the raft metrics are being recorded as expected.