### PR TITLE
metrics-sampler: add aggregate onboarding metrics samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,6 +5705,7 @@ dependencies = [
 name = "metrics-sampler"
 version = "0.1.0"
 dependencies = [
+ "common 0.1.0",
  "metrics",
  "state",
  "system-clock",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -42,7 +42,7 @@ use state::State;
 use system_bus::SystemBus;
 
 use error::CoordinatorError;
-use metrics_sampler::{raft_metrics_sampler::RaftMetricsSampler, sampler::MetricSampler};
+use metrics_sampler::setup_metrics_samplers;
 use system_clock::SystemClock;
 use task_driver::worker::{TaskDriver, TaskDriverConfig};
 use tokio::{select, sync::watch};
@@ -134,7 +134,7 @@ async fn main() -> Result<(), CoordinatorError> {
     .await?;
 
     // Register metrics samplers
-    RaftMetricsSampler::new(global_state.clone()).register(&system_clock).await?;
+    setup_metrics_samplers(global_state.clone(), &system_clock).await?;
 
     if args.debug {
         // Build the TUI

--- a/metrics-sampler/Cargo.toml
+++ b/metrics-sampler/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # === Workspace Dependencies === #
 state = { path = "../state" }
 system-clock = { path = "../system-clock" }
+common = { path = "../common" }
 
 # === Misc === #
 metrics = { workspace = true }

--- a/metrics-sampler/src/lib.rs
+++ b/metrics-sampler/src/lib.rs
@@ -8,5 +8,23 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![allow(async_fn_in_trait)]
 
+use onboarding_metrics_sampler::OnboardingMetricsSampler;
+use raft_metrics_sampler::RaftMetricsSampler;
+use sampler::{AsyncMetricSampler, MetricSampler};
+use state::State;
+use system_clock::{SystemClock, SystemClockError};
+
+pub mod onboarding_metrics_sampler;
 pub mod raft_metrics_sampler;
 pub mod sampler;
+
+/// Registers all the metrics samplers with the system clock.
+pub async fn setup_metrics_samplers(
+    state: State,
+    system_clock: &SystemClock,
+) -> Result<(), SystemClockError> {
+    RaftMetricsSampler::new(state.clone()).register(system_clock).await?;
+    OnboardingMetricsSampler::new(state).register(system_clock).await?;
+
+    Ok(())
+}

--- a/metrics-sampler/src/onboarding_metrics_sampler.rs
+++ b/metrics-sampler/src/onboarding_metrics_sampler.rs
@@ -1,0 +1,157 @@
+//! Samples onboarding-related metrics at a fixed interval
+
+use std::time::Duration;
+
+use common::types::{
+    tasks::{HistoricalTaskDescription, WalletUpdateType},
+    wallet::{Wallet, WalletIdentifier},
+};
+use state::State;
+
+use crate::sampler::AsyncMetricSampler;
+
+/// The name of the sampler for onboarding metrics
+const ONBOARDING_METRICS_SAMPLER_NAME: &str = "onboarding-metrics-sampler";
+/// The interval at which to sample onboarding metrics
+const ONBOARDING_METRICS_SAMPLE_INTERVAL_MS: u64 = 3_600_000; // 1 hour
+
+/// Metric describing the number of wallets
+const NUM_WALLETS_METRIC: &str = "num_wallets";
+/// Metric describing the number of wallets with at least one deposit
+const NUM_WALLETS_WITH_DEPOSITS_METRIC: &str = "num_wallets_with_deposits";
+/// Metric describing the number of wallets with at least one order placement
+const NUM_WALLETS_WITH_ORDERS_METRIC: &str = "num_wallets_with_orders";
+/// Metric describing the number of wallets with at least one match
+const NUM_WALLETS_WITH_MATCHES_METRIC: &str = "num_wallets_with_matches";
+
+/// Samples onboarding metrics at a fixed interval
+#[derive(Clone)]
+pub struct OnboardingMetricsSampler {
+    /// A handle to the global state
+    state: State,
+}
+
+impl OnboardingMetricsSampler {
+    /// Create a new `OnboardingMetricsSampler`
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+
+    // -------------------
+    // | Private Helpers |
+    // -------------------
+
+    /// Processes the onboarding progress of a given wallet
+    async fn process_wallet_onboarding_progress(
+        &self,
+        wallet: Wallet,
+    ) -> Result<(bool, bool, bool), String> {
+        // Short-circuit state queries for task history by checking if the wallet has
+        // outstanding fees. This implies that the wallet has experienced at
+        // least one match, which itself implies that that the wallet has
+        // had deposits and orders.
+        if wallet.has_outstanding_fees() {
+            Ok((
+                true, // has_deposited
+                true, // has_placed_order
+                true, // has_matched
+            ))
+        } else {
+            // If the wallet does not have outstanding fees, we must query
+            // its task history to see if it has deposited /
+            // placed an order / matched.
+            self.scan_tasks_for_onboarding_progress(&wallet.wallet_id).await
+        }
+    }
+
+    /// Scans the task history of a given wallet to determine its onboarding
+    /// progress
+    async fn scan_tasks_for_onboarding_progress(
+        &self,
+        wallet_id: &WalletIdentifier,
+    ) -> Result<(bool, bool, bool), String> {
+        let mut has_deposited = false;
+        let mut has_placed_order = false;
+        let mut has_matched = false;
+
+        // We fetch only the last 50 tasks for the wallet. This should be
+        // a sufficient sample to determine the wallet's onboarding state.
+        let tasks = self.state.get_task_history(50, wallet_id).await?;
+
+        for task in tasks {
+            match task.task_info {
+                HistoricalTaskDescription::UpdateWallet(WalletUpdateType::Deposit { .. }) => {
+                    has_deposited = true;
+                },
+                HistoricalTaskDescription::UpdateWallet(WalletUpdateType::PlaceOrder {
+                    ..
+                })
+                | HistoricalTaskDescription::UpdateWallet(WalletUpdateType::CancelOrder {
+                    ..
+                }) => {
+                    has_placed_order = true;
+                },
+                HistoricalTaskDescription::SettleMatch(_) => {
+                    has_matched = true;
+                },
+                _ => {},
+            }
+
+            // If the wallet has deposited, placed an order, and matched, we can
+            // break early
+            if has_deposited && has_placed_order && has_matched {
+                break;
+            }
+        }
+
+        Ok((has_deposited, has_placed_order, has_matched))
+    }
+}
+
+impl AsyncMetricSampler for OnboardingMetricsSampler {
+    fn name(&self) -> &str {
+        ONBOARDING_METRICS_SAMPLER_NAME
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_millis(ONBOARDING_METRICS_SAMPLE_INTERVAL_MS)
+    }
+
+    async fn sample(&self) -> Result<(), String> {
+        // First metric: number of wallets
+        // Second metric: number of wallets w/ at least one deposit
+        // Third metric: number of wallets w/ at least one order placement
+        // Fourth metric: number of wallets w/ at least one match
+        // Latter 3 metrics need task history. So we fetch all wallet IDs, task history
+        // for all wallets, and bucket into sets from there
+
+        let wallets = self.state.get_all_wallets().await?;
+        let num_wallets = wallets.len();
+
+        let mut num_wallets_with_deposits = 0;
+        let mut num_wallets_with_orders = 0;
+        let mut num_wallets_with_matches = 0;
+
+        for wallet in wallets {
+            let (has_deposited, has_placed_order, has_matched) =
+                self.process_wallet_onboarding_progress(wallet).await?;
+
+            if has_deposited {
+                num_wallets_with_deposits += 1;
+            }
+            if has_placed_order {
+                num_wallets_with_orders += 1;
+            }
+            if has_matched {
+                num_wallets_with_matches += 1;
+            }
+        }
+
+        metrics::gauge!(NUM_WALLETS_METRIC).set(num_wallets as f64);
+        metrics::gauge!(NUM_WALLETS_WITH_DEPOSITS_METRIC).set(num_wallets_with_deposits as f64);
+        metrics::gauge!(NUM_WALLETS_WITH_ORDERS_METRIC).set(num_wallets_with_orders as f64);
+        metrics::gauge!(NUM_WALLETS_WITH_MATCHES_METRIC).set(num_wallets_with_matches as f64);
+
+        Ok(())
+    }
+}

--- a/metrics-sampler/src/raft_metrics_sampler.rs
+++ b/metrics-sampler/src/raft_metrics_sampler.rs
@@ -1,4 +1,4 @@
-//! Records raft metrics snapshots at a fixed interval
+//! Samples raft metrics at a fixed interval
 
 use std::time::Duration;
 
@@ -7,14 +7,14 @@ use state::State;
 use crate::sampler::MetricSampler;
 
 /// The name of the sampler for raft metrics
-pub const RAFT_METRICS_SAMPLER_NAME: &str = "raft-metrics-sampler";
+const RAFT_METRICS_SAMPLER_NAME: &str = "raft-metrics-sampler";
 /// The interval at which to sample raft metrics
-pub const RAFT_METRICS_SAMPLE_INTERVAL_MS: u64 = 10_000;
+const RAFT_METRICS_SAMPLE_INTERVAL_MS: u64 = 10_000;
 
 /// Metric describing the size of the raft cluster
-pub const RAFT_CLUSTER_SIZE_METRIC: &str = "raft_cluster_size";
+const RAFT_CLUSTER_SIZE_METRIC: &str = "raft_cluster_size";
 /// Metric describing if the local node is the leader of the raft cluster
-pub const RAFT_LEADER_METRIC: &str = "raft_leader";
+const RAFT_LEADER_METRIC: &str = "raft_leader";
 
 /// Samples raft metrics at a fixed interval
 pub struct RaftMetricsSampler {

--- a/metrics-sampler/src/sampler.rs
+++ b/metrics-sampler/src/sampler.rs
@@ -34,7 +34,7 @@ pub trait AsyncMetricSampler: Sized + Send + Sync + 'static + Clone {
     fn interval(&self) -> Duration;
 
     /// Samples the metrics
-    fn sample(&self) -> impl Future<Output = Result<(), String>> + Send + 'static;
+    fn sample(&self) -> impl Future<Output = Result<(), String>> + Send;
 
     /// Registers the sampler with the system clock
     async fn register(self, clock: &SystemClock) -> Result<(), SystemClockError> {


### PR DESCRIPTION
This PR utilizes the new `AsyncMetricsSampler` primitive to sample metrics regarding aggregate user onboarding progress states.

This has been tested in testnet by creating a new user, executing the full suite of onboarding tasks, and confirming that the sampled metrics reflected this progress.