### PR TITLE
external-api: Allow base64 serialization of wallet update signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,12 +3572,14 @@ dependencies = [
 name = "external-api"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "circuit-types 0.1.0",
  "common 0.1.0",
  "constants 0.1.0",
  "hex 0.4.3",
  "itertools 0.10.5",
  "num-bigint",
+ "rand 0.8.5",
  "renegade-crypto 0.1.0",
  "serde",
  "serde_json",

--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -15,8 +15,12 @@ renegade-crypto = { path = "../renegade-crypto" }
 util = { path = "../util" }
 
 # === Misc Dependencies === #
+base64 = "0.22.1"
 itertools = { workspace = true }
 hex = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -9,10 +9,24 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::types::{ApiOrder, ApiPrivateKeychain, ApiWallet};
 use crate::{
-    deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr,
-    types::{ApiOrder, ApiPrivateKeychain, ApiWallet},
+    deserialize_biguint_from_hex_string, deserialize_bytes_or_base64, serialize_biguint_to_hex_addr,
 };
+
+/// The type encapsulating a wallet update's authorization parameters
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WalletUpdateAuthorization {
+    /// A signature of the circuit statement used in the proof of
+    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
+    /// to guarantee that the wallet updates are properly authorized
+    #[serde(deserialize_with = "deserialize_bytes_or_base64")]
+    pub statement_sig: Vec<u8>,
+    /// The new public root key to rotate to if desired by the client
+    ///
+    /// Hex encoded
+    pub new_root_key: Option<String>,
+}
 
 // ---------------
 // | HTTP Routes |
@@ -52,19 +66,6 @@ pub const PAY_FEES_ROUTE: &str = "/v0/wallet/:wallet_id/pay-fees";
 
 /// Returns the order history of a wallet
 pub const ORDER_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/order-history";
-
-/// The type encapsulating a wallet update's authorization parameters
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WalletUpdateAuthorization {
-    /// A signature of the circuit statement used in the proof of
-    /// VALID WALLET UPDATE by `sk_root`. This allows the contract
-    /// to guarantee that the wallet updates are properly authorized
-    pub statement_sig: Vec<u8>,
-    /// The new public root key to rotate to if desired by the client
-    ///
-    /// Hex encoded
-    pub new_root_key: Option<String>,
-}
 
 // --------------------
 // | Wallet API Types |


### PR DESCRIPTION
### Purpose
This PR allows wallet update signatures to be base64 serialized by introducing a custom visitor that deserializes bytes from _either_ a json array or a base64 string encoding of the bytes.

### Testing
- Unit tests pass
- Tested wallet updates through the CLI to ensure current clients will still work