### PR TITLE
circuit-types, common: Validate amounts and prices in constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "api-server"
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "ark-mpc"
 version = "0.1.2"
-source = "git+https://github.com/renegade-fi/ark-mpc#a7c118546ad721f9e606afc68196594e7bf309f1"
+source = "git+https://github.com/renegade-fi/ark-mpc#96895f469d4276fb71c01a4887d4b55f539b9297"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.49.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e518950d4ac43508c8bfc2fe4e24b0752d99eab80134461d5e162dcda0214b55"
+checksum = "c09fd4b5c7ed75f52b913b4f3ff0501dae7f8cb9125f6d45db4553980cbc0528"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bf24cd0d389daa923e974b0e7c38daf308fc21e963c049f57980235017175e"
+checksum = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43b3220f1c46ac0e9dcc0a97d94b93305dacb36d1dd393996300c6b9b74364"
+checksum = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c46924fb1add65bba55636e12812cae2febf68c0f37361766f627ddcca91ce"
+checksum = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1627,9 +1627,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1720,9 +1720,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "base64 0.22.1",
  "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
@@ -4588,9 +4588,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5051,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5504,7 +5504,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
 ]
 
 [[package]]
@@ -6703,7 +6703,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
  "smallvec 1.13.2",
  "windows-targets 0.52.6",
 ]
@@ -7557,9 +7557,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -8016,9 +8016,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -8565,9 +8565,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -9520,9 +9520,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -9872,24 +9872,24 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#35d72dd32a4931057b6f64636cdacd7c1db62dd2"
+source = "git+https://github.com/renegade-fi/renegade.git#9ad7381ed654d23deb6437b2fd2a6f7002174af8"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",

--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -18,8 +18,11 @@ use crate::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
         MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    Amount, Fabric,
+    validate_amount_bitlength, Amount, Fabric,
 };
+
+/// Error message when a balance amount is too large
+const ERR_BALANCE_AMOUNT_TOO_LARGE: &str = "balance amount is too large";
 
 /// Represents the base type of a balance in tuple holding a reference to the
 /// ERC-20 token and its amount
@@ -38,6 +41,23 @@ pub struct Balance {
 }
 
 impl Balance {
+    /// Construct a new balance with zero fees; validating its amount
+    pub fn new(mint: BigUint, amount: Amount) -> Result<Balance, String> {
+        let bal = Self::new_from_mint_and_amount(mint, amount);
+        bal.validate()?;
+
+        Ok(bal)
+    }
+
+    /// Validate the balance
+    pub fn validate(&self) -> Result<(), String> {
+        if !validate_amount_bitlength(self.amount) {
+            return Err(ERR_BALANCE_AMOUNT_TOO_LARGE.to_string());
+        }
+
+        Ok(())
+    }
+
     /// Whether or not the instance is a default balance
     pub fn is_default(&self) -> bool {
         self.eq(&Balance::default())

--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -94,15 +94,18 @@ impl Wallet {
             return Ok(());
         }
 
+        let mint = balance.mint.clone();
         if let Some(index) = self.find_first_replaceable_balance() {
-            self.balances.replace_at_index(index, balance.mint.clone(), balance);
+            self.balances.replace_at_index(index, mint.clone(), balance);
         } else if self.balances.len() < MAX_BALANCES {
-            self.balances.append(balance.mint.clone(), balance);
+            self.balances.append(mint.clone(), balance);
         } else {
             return Err(ERR_BALANCES_FULL.to_string());
         }
 
-        Ok(())
+        // Validate the balance after update
+        let bal = self.balances.get(&mint).unwrap();
+        bal.validate()
     }
 
     /// Find the first replaceable balance

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -79,6 +79,9 @@ impl Wallet {
     /// Add an order to the wallet, replacing the first default order if the
     /// wallet is full
     pub fn add_order(&mut self, id: OrderIdentifier, order: Order) -> Result<(), String> {
+        // Validate the order
+        order.validate()?;
+
         // Append if the orders are not full
         if let Some(index) = self.find_first_replaceable_order() {
             self.orders.replace_at_index(index, id, order);

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -342,7 +342,7 @@ impl TypedHandler for AdminCreateOrderInMatchingPoolHandler {
         let mut new_wallet = old_wallet.clone();
         maybe_rotate_root_key(&req.update_auth, &mut new_wallet)?;
 
-        let new_order: Order = req.order.into();
+        let new_order: Order = req.order.try_into().map_err(bad_request)?;
         new_wallet.add_order(oid, new_order.clone()).map_err(bad_request)?;
         new_wallet.reblind_wallet();
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -526,7 +526,7 @@ impl TypedHandler for CreateOrderHandler {
         maybe_rotate_root_key(&req.update_auth, &mut new_wallet)?;
 
         // Add the order to the wallet
-        let new_order: Order = req.order.into();
+        let new_order: Order = req.order.try_into().map_err(bad_request)?;
         new_wallet.add_order(oid, new_order.clone()).map_err(bad_request)?;
         new_wallet.reblind_wallet();
 
@@ -583,7 +583,7 @@ impl TypedHandler for UpdateOrderHandler {
         maybe_rotate_root_key(&req.update_auth, &mut new_wallet)?;
 
         // Edit the order if it exists in the wallet
-        let new_order: Order = req.order.into();
+        let new_order: Order = req.order.try_into().map_err(bad_request)?;
         let order = new_wallet
             .orders
             .get_mut(&order_id)


### PR DESCRIPTION
### Purpose
This PR validates the amounts and prices in type constructors so that API requests with invalid amounts and prices fail immediately rather than in proving.

This resolves a failure we saw the other day with a task that failed to prove:
- [Proof Manager Trace](https://us5.datadoghq.com/apm/trace/7336502415864029284?env=mainnet&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=9997409649345608247&timeHint=1726577099553.513)
- [Task Trace](https://us5.datadoghq.com/apm/trace/7867002605463599268?env=mainnet&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=12153791715795463094&timeHint=1726577094800.8882)

### Testing
- Added validation tests
- All tests pass
- Tested a huge order at the API layer