### PR TITLE
api-server: http: admin: Add `trigger-snapshot` route

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -17,6 +17,8 @@ use super::wallet::WalletUpdateAuthorization;
 
 /// Check whether the target node is a raft leader
 pub const IS_LEADER_ROUTE: &str = "/v0/admin/is-leader";
+/// Trigger a raft snapshot
+pub const ADMIN_TRIGGER_SNAPSHOT_ROUTE: &str = "/v0/admin/trigger-snapshot";
 /// Get the open orders managed by the node
 pub const ADMIN_OPEN_ORDERS_ROUTE: &str = "/v0/admin/open-orders";
 /// Get the order metadata for a given order

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -69,6 +69,11 @@ impl State {
         self.raft.await_leader_election().await.map_err(StateError::Replication)
     }
 
+    /// Trigger a snapshot
+    pub async fn trigger_snapshot(&self) -> Result<(), StateError> {
+        self.raft.trigger_snapshot().await.map_err(StateError::Replication)
+    }
+
     // --- Networking --- //
 
     /// Handle a raft request from a peer

--- a/state/src/replication/raft.rs
+++ b/state/src/replication/raft.rs
@@ -262,6 +262,18 @@ impl RaftClient {
     }
 
     // -------------
+    // | Snapshots |
+    // -------------
+
+    /// Trigger a snapshot to be created
+    ///
+    /// Does not wait for the snapshot to build, returns immediately after
+    /// sending the command to the raft core
+    pub async fn trigger_snapshot(&self) -> Result<(), ReplicationV2Error> {
+        self.raft().trigger().snapshot().await.map_err(err_str!(ReplicationV2Error::Raft))
+    }
+
+    // -------------
     // | Proposals |
     // -------------
 

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -8,7 +8,7 @@ mod rate_limit;
 mod task;
 mod wallet;
 
-use admin::IsLeaderHandler;
+use admin::{AdminTriggerSnapshotHandler, IsLeaderHandler};
 use async_trait::async_trait;
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
@@ -20,7 +20,8 @@ use external_api::{
         admin::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
             ADMIN_MATCHING_POOL_CREATE_ROUTE, ADMIN_MATCHING_POOL_DESTROY_ROUTE,
-            ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE, ADMIN_TRIGGER_SNAPSHOT_ROUTE,
+            IS_LEADER_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
         order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
@@ -435,6 +436,13 @@ impl HttpServer {
             &Method::GET,
             IS_LEADER_ROUTE.to_string(),
             IsLeaderHandler::new(state.clone()),
+        );
+
+        // The "/admin/trigger-snapshot" route
+        router.add_admin_authenticated_route(
+            &Method::POST,
+            ADMIN_TRIGGER_SNAPSHOT_ROUTE.to_string(),
+            AdminTriggerSnapshotHandler::new(state.clone()),
         );
 
         // The "/admin/open-orders" route

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -61,13 +61,9 @@ const ERR_BALANCE_NOT_FOUND: &str = "balance not found in wallet";
 /// Error message emitted when price data cannot be found for a token pair
 const ERR_NO_PRICE_DATA: &str = "no price data found for token pair";
 
-// ------------------
-// | Route Handlers |
-// ------------------
-
-// --------------
-// | /is-leader |
-// --------------
+// -----------------------
+// | Raft Route Handlers |
+// -----------------------
 
 /// Handler for the GET /v0/admin/is-leader route
 pub struct IsLeaderHandler {
@@ -99,9 +95,39 @@ impl TypedHandler for IsLeaderHandler {
     }
 }
 
-// ----------------
-// | /open-orders |
-// ----------------
+/// Handler for the POST /v0/admin/trigger-snapshot route
+pub struct AdminTriggerSnapshotHandler {
+    /// A handle to the relayer state
+    state: State,
+}
+
+impl AdminTriggerSnapshotHandler {
+    /// Constructor
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for AdminTriggerSnapshotHandler {
+    type Request = EmptyRequestResponse;
+    type Response = EmptyRequestResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        _req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        self.state.trigger_snapshot().await?;
+        Ok(EmptyRequestResponse {})
+    }
+}
+
+// ------------------------
+// | Open Orders Handlers |
+// ------------------------
 
 /// Handler for the GET /v0/admin/open-orders route
 pub struct AdminOpenOrdersHandler {
@@ -173,10 +199,6 @@ impl TypedHandler for AdminOpenOrdersHandler {
     }
 }
 
-// ------------------------
-// | /orders/:id/metadata |
-// ------------------------
-
 /// Handle for the GET /v0/admin/orders/:id/metadata route
 pub struct AdminOrderMetadataHandler {
     /// A handle to the relayer state
@@ -213,9 +235,9 @@ impl TypedHandler for AdminOrderMetadataHandler {
     }
 }
 
-// ----------------------------------
-// | /matching_pools/:matching_pool |
-// ----------------------------------
+// --------------------------
+// | Matching Pool Handlers |
+// --------------------------
 
 /// Handler for the POST /v0/admin/matching_pools/:matching_pool route
 pub struct AdminCreateMatchingPoolHandler {
@@ -256,10 +278,6 @@ impl TypedHandler for AdminCreateMatchingPoolHandler {
     }
 }
 
-// ------------------------------------------
-// | /matching_pools/:matching_pool/destroy |
-// ------------------------------------------
-
 /// Handler for the POST /v0/admin/matching_pools/:matching_pool/destroy route
 pub struct AdminDestroyMatchingPoolHandler {
     /// A handle to the relayer state
@@ -293,10 +311,6 @@ impl TypedHandler for AdminDestroyMatchingPoolHandler {
         Ok(EmptyRequestResponse {})
     }
 }
-
-// -----------------------------
-// | /wallet/:id/order-in-pool |
-// -----------------------------
 
 /// Handler for the POST /v0/admin/wallet/:id/order-in-pool route
 pub struct AdminCreateOrderInMatchingPoolHandler {
@@ -361,10 +375,6 @@ impl TypedHandler for AdminCreateOrderInMatchingPoolHandler {
         Ok(CreateOrderResponse { id: oid, task_id })
     }
 }
-
-// ------------------------------------------
-// | /orders/:id/assign-pool/:matching_pool |
-// ------------------------------------------
 
 /// Handler for the POST /v0/admin/orders/:id/assign-pool/:matching_pool route
 pub struct AdminAssignOrderToMatchingPoolHandler {


### PR DESCRIPTION
### Purpose
This PR adds the `/v0/admin/trigger-snapshot` route that allows us to trigger an immediate snapshot of the raft state.

### Testing
- All unit tests pass
- Tested the endpoint on a locally running node