### PR TITLE
state: Switch serialization to cbor to allow type evolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8840,6 +8840,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "ciborium",
  "circuit-types 0.1.0",
  "common 0.1.0",
  "config",

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -31,6 +31,7 @@ openraft = { version = "=0.9.13", features = ["serde", "storage-v2"] }
 
 # === Storage === #
 bincode = "1.3"
+ciborium = "0.2"
 flate2 = "1.0"
 libmdbx = "0.3"
 serde = { workspace = true, features = ["derive"] }

--- a/state/benches/storage.rs
+++ b/state/benches/storage.rs
@@ -42,7 +42,7 @@ pub fn bench_read_throughput(c: &mut Criterion) {
         // Fill the table with `N_VALUES` values of size `n_bytes`
         for j in 0..N_VALUES {
             let key = format!("key_{j}");
-            let mut val = vec![0; *n_bytes];
+            let mut val: Vec<u8> = vec![0; *n_bytes];
             rng.fill(&mut val[..]);
 
             db.write(BENCHMARK_TABLE, &key, &val).unwrap();

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -135,6 +135,9 @@ impl State {
     }
 
     /// Get all known orders in the book
+    ///
+    /// Warning: this can be very slow when the state has a medium to large
+    /// number of orders
     pub async fn get_all_orders(&self) -> Result<Vec<NetworkOrder>, StateError> {
         self.with_read_tx(move |tx| {
             let orders = tx.get_all_orders()?;
@@ -228,7 +231,7 @@ impl State {
 
     /// Choose an order to handshake with according to their priorities
     ///
-    /// TODO: Optimize this method if necessary
+    /// TODO(@joeykraut): Optimize this method when implementing multi-cluster
     pub async fn choose_handshake_order(&self) -> Result<Option<OrderIdentifier>, StateError> {
         self.with_read_tx(|tx| {
             // Get all orders and filter by those that are not managed internally and ready

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -117,13 +117,13 @@ impl State {
     ) -> Result<HeartbeatMessage, StateError> {
         self.with_read_tx(move |tx| {
             let peers = tx.get_info_map()?;
-            let orders = tx.get_all_orders()?;
+            // We don't currently send orders in heartbeats
+            // TODO: Append local orders to heartbeats when multi-cluster support is added
+            let known_orders = vec![];
 
             // Filter out cancelled orders & excluded peers
             let known_peers =
                 peers.into_keys().filter(|peer| !excluded_peers.contains(peer)).collect_vec();
-            let known_orders =
-                orders.into_iter().filter(|order| !order.is_cancelled()).map(|o| o.id).collect();
 
             Ok(HeartbeatMessage { known_peers, known_orders })
         })

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -109,6 +109,10 @@ pub const ALL_TABLES: [&str; NUM_TABLES] = [
     RAFT_LOGS_TABLE,
 ];
 
+// ---------------------
+// | State Transitions |
+// ---------------------
+
 /// The proposal submitted to the state machine
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Proposal {
@@ -190,6 +194,19 @@ impl From<StateTransition> for Proposal {
         let transition = Box::new(transition);
         Self { id: Uuid::new_v4(), transition }
     }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Serialize a value using ciborium
+pub fn ciborium_serialize<T: Serialize>(
+    value: &T,
+) -> Result<Vec<u8>, ciborium::ser::Error<std::io::Error>> {
+    let mut buf = vec![];
+    ciborium::ser::into_writer(value, &mut buf)?;
+    Ok(buf)
 }
 
 // ---------

--- a/state/src/replication/network/mod.rs
+++ b/state/src/replication/network/mod.rs
@@ -19,7 +19,7 @@ use openraft::{
 use serde::{Deserialize, Serialize};
 use util::err_str;
 
-use crate::{error::StateError, Proposal};
+use crate::{ciborium_serialize, error::StateError, Proposal};
 
 use super::{Node, NodeId, TypeConfig};
 
@@ -70,7 +70,7 @@ pub enum RaftResponse {
 impl RaftResponse {
     /// Serialize a raft response to bytes
     pub fn to_bytes(&self) -> Result<Vec<u8>, StateError> {
-        bincode::serialize(self).map_err(err_str!(StateError::Serde))
+        ciborium_serialize(self).map_err(err_str!(StateError::Serde))
     }
 
     /// Convert the response to an append entries request

--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -273,21 +273,21 @@ impl StateMachine {
     /// Copy all data from one DB to another
     pub(crate) fn copy_db_data(src: &DB, dest: &DB) -> Result<(), ReplicationV2Error> {
         let src_tx = src.new_read_tx()?;
-        let dest_tx = dest.new_write_tx()?;
         for table in ALL_TABLES.iter() {
             if EXCLUDED_TABLES.contains(table) {
                 continue;
             }
 
             // Clear the table on the destination
+            let dest_tx = dest.new_write_tx()?;
             dest_tx.clear_table(table)?;
 
             // Copy all keys and values
             let src_cursor = src_tx.inner().cursor(table)?;
             dest_tx.inner().copy_cursor_to_table(table, src_cursor)?;
+            dest_tx.commit()?;
         }
 
-        dest_tx.commit()?;
         src_tx.commit()?;
         Ok(())
     }

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -7,8 +7,9 @@ use std::{ops::Bound, path::Path};
 
 use libmdbx::{Database, Geometry, WriteMap, RO, RW};
 use serde::{Deserialize, Serialize};
+use util::err_str;
 
-use crate::NUM_TABLES;
+use crate::{ciborium_serialize, NUM_TABLES};
 
 use super::{
     error::StorageError,
@@ -25,14 +26,14 @@ const MAX_DB_SIZE_BYTES: usize = 1 << 36; // 64 GB
 
 /// Serialize a value to a `flexbuffers` byte vector
 pub(crate) fn serialize_value<V: Serialize>(value: &V) -> Result<Vec<u8>, StorageError> {
-    bincode::serialize(value).map_err(StorageError::Serialization)
+    ciborium_serialize(value).map_err(err_str!(StorageError::Serialization))
 }
 
 /// Deserialize a value from a `flexbuffers` byte vector
 pub(crate) fn deserialize_value<V: for<'de> Deserialize<'de>>(
     value_bytes: &[u8],
 ) -> Result<V, StorageError> {
-    bincode::deserialize(value_bytes).map_err(StorageError::Deserialization)
+    ciborium::de::from_reader(value_bytes).map_err(err_str!(StorageError::Deserialization))
 }
 
 // ------------

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -2,7 +2,6 @@
 
 use std::{error::Error, fmt::Display};
 
-use bincode::Error as BincodeError;
 use libmdbx::Error as MdbxError;
 
 /// The error type emitted by the storage layer
@@ -13,7 +12,7 @@ pub enum StorageError {
     /// Error committing a transaction
     Commit(MdbxError),
     /// Error deserializing a value from storage
-    Deserialization(BincodeError),
+    Deserialization(String),
     /// An invalid key was used to access the database
     InvalidKey(String),
     /// An entry was not found in the database
@@ -25,7 +24,7 @@ pub enum StorageError {
     /// An uncategorized error
     Other(String),
     /// Error serializing a value for storage
-    Serialization(BincodeError),
+    Serialization(String),
     /// Error syncing the database
     Sync(MdbxError),
     /// Error while performing a transaction operation

--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -105,6 +105,9 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
     }
 
     /// Get all orders in the book
+    ///
+    /// Warning: this can be very slow when the state has a medium to large
+    /// number of orders
     pub fn get_all_orders(&self) -> Result<Vec<NetworkOrder>, StorageError> {
         // Build a cursor over the table
         let cursor = self

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -86,12 +86,15 @@ impl GossipProtocolExecutor {
             }
         }
 
-        // Merge the peer and order info from the heartbeat into the local state
-        self.request_missing_orders(peer, message).await?;
+        // Merge the peer info from the heartbeat into the local state
         self.request_missing_peers(peer, message).await
     }
 
     /// Request any missing orders in the heartbeat message from the given peer
+    ///
+    /// TODO: Add local matchable orders back to the heartbeat when
+    /// multi-cluster is implemented
+    #[allow(dead_code)]
     async fn request_missing_orders(
         &self,
         peer: &WrappedPeerId,

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -101,7 +101,10 @@ impl GossipProtocolExecutor {
         let maybe_info = self.state.get_peer_info(&peer_id).await?;
         let mut info = match maybe_info {
             Some(info) => info,
-            None => return Ok(()),
+            None => {
+                warn!("received reject expiry request for {peer_id} from {sender}, but {peer_id} is not in the peer index");
+                return Ok(());
+            },
         };
 
         if info.last_heartbeat < last_heartbeat {

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -16,6 +16,8 @@ use crate::error::HandshakeManagerError;
 pub(super) const HANDSHAKE_INTERVAL_MS: u64 = 2_000; // 2 seconds
 /// Number of nanoseconds in a millisecond, for convenience
 const NANOS_PER_MILLI: u64 = 1_000_000;
+/// Whether MPC matches are disabled
+const DISABLE_MPC_MATCHES: bool = true;
 
 /// Implements a timer that periodically enqueues jobs to the threadpool that
 /// tell the manager to send outbound handshake requests
@@ -37,7 +39,8 @@ impl HandshakeScheduler {
 
     /// The execution loop of the timer, periodically enqueues handshake jobs
     pub async fn execution_loop(mut self) -> HandshakeManagerError {
-        if in_bootstrap_mode() {
+        // TODO(@joeykraut): Enable multi-cluster support
+        if in_bootstrap_mode() || DISABLE_MPC_MATCHES {
             sleep_forever_async().await;
         }
 

--- a/workers/network-manager/src/executor/request_response.rs
+++ b/workers/network-manager/src/executor/request_response.rs
@@ -1,5 +1,7 @@
 //! Defines handlers for the request-response protocol
 
+use std::time::{Duration, Instant};
+
 use common::types::gossip::WrappedPeerId;
 use gossip_api::{
     request_response::{
@@ -11,13 +13,16 @@ use gossip_api::{
 use job_types::{gossip_server::GossipServerJob, network_manager::NetworkResponseChannel};
 use libp2p::request_response::{Message as RequestResponseMessage, ResponseChannel};
 use libp2p::PeerId;
-use tracing::{error, instrument};
+use tracing::{error, instrument, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use util::{err_str, telemetry::propagation::set_parent_span_from_headers};
 
 use crate::error::NetworkManagerError;
 
 use super::{behavior::BehaviorJob, NetworkManagerExecutor};
+
+/// The raft job execution latency at which we log a warning
+pub(super) const RAFT_JOB_LATENCY_WARNING_MS: Duration = Duration::from_millis(100);
 
 impl NetworkManagerExecutor {
     // -----------
@@ -142,11 +147,17 @@ impl NetworkManagerExecutor {
         msg_buf: Vec<u8>,
         chan: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Result<(), NetworkManagerError> {
+        let start = Instant::now();
         let resp = self
             .global_state
             .handle_raft_req(msg_buf)
             .await
             .map_err(err_str!(NetworkManagerError::State))?;
+
+        let elapsed = start.elapsed();
+        if elapsed > RAFT_JOB_LATENCY_WARNING_MS {
+            warn!("raft request took: {elapsed:.2?}");
+        }
 
         let resp = GossipResponseType::Raft(resp.to_bytes()?);
         self.handle_outbound_resp(resp.into(), chan).await


### PR DESCRIPTION
### Purpose
This PR migrates the underlying `state` serialization from `bincode` to `cbor` to support schema evolution in our `state` modules. This was deployed to mainnet in three phases:
- Deploy receiver code that allows all nodes to receive snapshots & raft messages in either `cbor` or `bincode` serialization. All snapshots were converted on-the-fly to `cbor` serialization and all new raft messages were serialized with `cbor`
- Deploy code that migrates raft messages from `bincode` -> `cbor`
- Deploy the code in this PR, which removes all shim logic.

Additionally, while deploying, I found and optimized a number of bottlenecks. Namely:
- Do not fetch all orders from state using `get_all_orders`, as our state has grown this has become a serious deserialization burden
- Do not send order IDs in hearbeats. When we support multi-cluster, we will add _local_ orders to the heartbeat. For now, we remove this logic

### Testing
- All unit tests pass
- Deployed to mainnet