### PR TITLE
common: wallet: orders: Add `min_fill_size` field to `Order`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8861,6 +8861,7 @@ dependencies = [
  "metrics",
  "multiaddr",
  "num-bigint",
+ "num-traits",
  "openraft",
  "rand 0.8.5",
  "renegade-metrics",

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -16,13 +16,8 @@ use crate::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
         MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    validate_amount_bitlength, validate_price_bitlength, Amount, AuthenticatedBool, Fabric,
+    Amount, AuthenticatedBool, Fabric,
 };
-
-/// Error message when an order amount is too large
-const ERR_ORDER_AMOUNT_TOO_LARGE: &str = "amount is too large";
-/// Error message when an order worst case price is too large
-const ERR_ORDER_WORST_CASE_PRICE_TOO_LARGE: &str = "worst case price is too large";
 
 /// Represents the base type of an open order, including the asset pair, the
 /// amount, price, and direction
@@ -48,45 +43,6 @@ pub struct Order {
 }
 
 impl Order {
-    /// Create a new order
-    pub fn new(
-        quote_mint: BigUint,
-        base_mint: BigUint,
-        side: OrderSide,
-        amount: Amount,
-        worst_case_price: FixedPoint,
-    ) -> Result<Self, String> {
-        // Validate the range of the amount and worst case price
-        let order = Self::new_unchecked(quote_mint, base_mint, side, amount, worst_case_price);
-        order.validate()?;
-
-        Ok(order)
-    }
-
-    /// Create a new order without validating it
-    pub fn new_unchecked(
-        quote_mint: BigUint,
-        base_mint: BigUint,
-        side: OrderSide,
-        amount: Amount,
-        worst_case_price: FixedPoint,
-    ) -> Self {
-        Self { quote_mint, base_mint, side, amount, worst_case_price }
-    }
-
-    /// Validate the order
-    pub fn validate(&self) -> Result<(), String> {
-        if !validate_amount_bitlength(self.amount) {
-            return Err(ERR_ORDER_AMOUNT_TOO_LARGE.to_string());
-        }
-
-        if !validate_price_bitlength(self.worst_case_price) {
-            return Err(ERR_ORDER_WORST_CASE_PRICE_TOO_LARGE.to_string());
-        }
-
-        Ok(())
-    }
-
     /// Whether or not this is the zero'd order
     pub fn is_default(&self) -> bool {
         self.eq(&Self::default())

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -195,7 +195,7 @@ pub mod test_helpers {
         layer::SubscriberExt,
         util::SubscriberInitExt,
     };
-    use util::matching_engine::match_orders_with_max_amount;
+    use util::matching_engine::match_orders_with_max_min_amounts;
 
     use crate::zk_circuits::test_helpers::{MAX_BALANCES, MAX_ORDERS};
 
@@ -334,12 +334,13 @@ pub mod test_helpers {
         let (o1, o2) = if rng.gen_bool(0.5) { (o1, o2) } else { (o2, o1) };
 
         // Match orders assuming they are fully capitalized
-        let match_res = match_orders_with_max_amount(
+        let match_res = match_orders_with_max_min_amounts(
             &o1,
             &o2,
             o1.amount,
             o2.amount,
-            Amount::MIN, // min_fill_size
+            Amount::MIN, // min_quote_amount
+            Amount::MIN, // min_base_amount
             price,
         )
         .unwrap();

--- a/common/src/keyed_list.rs
+++ b/common/src/keyed_list.rs
@@ -97,6 +97,12 @@ impl<K: Eq, V: Clone> KeyedList<K, V> {
         self.elems.iter_mut()
     }
 
+    /// Returns an iterator over the map that allows modifying only the value of
+    /// each kv pair
+    pub fn iter_mut_values(&mut self) -> impl Iterator<Item = &mut V> {
+        self.elems.iter_mut().map(|(_, v)| v)
+    }
+
     /// Returns an iterator over borrowed keys
     pub fn keys(&self) -> impl Iterator<Item = &K> {
         self.elems.iter().map(|(k, _)| k)
@@ -319,6 +325,23 @@ mod test {
         assert_eq!(map.get(&non_existent_key), None);
         assert_eq!(map.len(), 0);
         assert!(!map.contains_key(&non_existent_key));
+    }
+
+    /// Tests iterating mutably over the values
+    #[test]
+    fn test_iter_mut_values() {
+        let mut map = KeyedList::default();
+        map.insert(0, 0);
+        map.insert(1, 1);
+        map.insert(2, 2);
+
+        for v in map.iter_mut_values() {
+            *v += 1;
+        }
+
+        for (i, v) in map.iter() {
+            assert_eq!(i + 1, *v);
+        }
     }
 
     /// Test that serialization and deserialization preserves the order of the

--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -1,6 +1,6 @@
 //! Descriptor for the wallet update task
 
-use circuit_types::{keychain::PublicSigningKey, order::Order, Amount};
+use circuit_types::{keychain::PublicSigningKey, Amount};
 use constants::Scalar;
 use contracts_common::custom_serde::BytesSerializable;
 use ethers::core::types::Signature;
@@ -9,7 +9,7 @@ use k256::ecdsa::VerifyingKey as K256VerifyingKey;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
-use crate::types::wallet::OrderIdentifier;
+use crate::types::wallet::{Order, OrderIdentifier};
 use crate::types::MatchingPoolName;
 use crate::types::{
     transfer_auth::ExternalTransferWithAuth,

--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -2,12 +2,12 @@
 
 use std::iter;
 
-use circuit_types::{balance::Balance, order::Order, Amount};
+use circuit_types::{balance::Balance, Amount};
 use constants::MAX_BALANCES;
 use itertools::Itertools;
 use num_bigint::BigUint;
 
-use super::Wallet;
+use super::{Order, Wallet};
 
 /// Error message emitted when a balance overflows
 const ERR_BALANCE_OVERFLOW: &str = "balance overflowed";

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -9,20 +9,21 @@ use circuit_types::{
     elgamal::DecryptionKey,
     fixed_point::FixedPoint,
     keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey, SecretSigningKey},
-    order::{Order, OrderSide},
+    order::OrderSide,
     traits::BaseType,
-    Amount, SizedWalletShare,
+    SizedWalletShare,
 };
 use constants::{Scalar, ADDRESS_BYTE_LENGTH, MERKLE_HEIGHT};
 use k256::ecdsa::SigningKey as K256SigningKey;
 use num_bigint::BigUint;
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, Rng, RngCore};
 use uuid::Uuid;
 
 use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
 use super::{
     keychain::{HmacKey, KeyChain, PrivateKeyChain},
+    orders::Order,
     Wallet,
 };
 
@@ -70,12 +71,14 @@ pub fn mock_empty_wallet() -> Wallet {
 
 /// Create a mock order
 pub fn mock_order() -> Order {
+    let mut rng = thread_rng();
     let quote_mint = rand_addr_biguint();
     let base_mint = rand_addr_biguint();
-    let amount = Amount::from(10u8);
-    let worst_case_price = FixedPoint::from_integer(100);
+    let amount = rng.next_u64().into();
+    let worst_case_price = FixedPoint::from_integer(rng.gen());
+    let min_fill_size = rng.gen();
 
-    Order { quote_mint, base_mint, amount, worst_case_price, side: OrderSide::Buy }
+    Order { quote_mint, base_mint, amount, worst_case_price, side: OrderSide::Buy, min_fill_size }
 }
 
 /// Create a mock Merkle path for a wallet

--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -13,6 +13,7 @@ mod orders;
 mod shares;
 mod types;
 
+pub use orders::Order;
 pub use types::*;
 
 // ----------------
@@ -21,18 +22,15 @@ pub use types::*;
 
 #[cfg(test)]
 mod test {
-    use circuit_types::{
-        balance::Balance,
-        fixed_point::FixedPoint,
-        order::{Order, OrderSide},
-        Amount,
-    };
+    use circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide, Amount};
     use constants::{MAX_BALANCES, MAX_ORDERS};
     use num_bigint::BigUint;
     use rand::{distributions::uniform::SampleRange, thread_rng};
     use uuid::Uuid;
 
     use crate::types::wallet::mocks::{mock_empty_wallet, mock_order};
+
+    use super::orders::Order;
 
     /// Tests adding a balance to an empty wallet
     #[test]
@@ -150,8 +148,14 @@ mod test {
         let quote_mint = BigUint::from(2u8);
         let amount = u128::MAX;
         let worst_case_price = FixedPoint::from_f64_round_down(0.1);
-        let o =
-            Order::new_unchecked(base_mint, quote_mint, OrderSide::Buy, amount, worst_case_price);
+        let o = Order::new_unchecked(
+            base_mint,
+            quote_mint,
+            OrderSide::Buy,
+            amount,
+            worst_case_price,
+            0,
+        );
 
         // Try to add the order
         wallet.add_order(id, o).unwrap();

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -1,12 +1,12 @@
 //! Order metadata for a wallet's orders
 
-use circuit_types::{order::Order, Amount};
+use circuit_types::Amount;
 use serde::{Deserialize, Serialize};
 use util::get_current_time_millis;
 
 use crate::types::TimestampedPrice;
 
-use super::OrderIdentifier;
+use super::{Order, OrderIdentifier};
 
 /// The state of an order in the wallet
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/common/src/types/wallet/shares.rs
+++ b/common/src/types/wallet/shares.rs
@@ -102,10 +102,10 @@ impl Wallet {
         self.blinder = wallet.blinder;
         self.balances = wallet.balances.into_iter().map(|b| (b.mint.clone(), b)).collect();
 
-        // Preserve the order_ids, the indexmap should give a consistent ordering
-        // between orders
-        let order_ids = self.orders.keys().cloned();
-        self.orders = order_ids.zip(wallet.orders).collect();
+        // Update the orders
+        for (order, circuit_order) in self.orders.iter_mut_values().zip(wallet.orders) {
+            order.update_from_circuit_order(&circuit_order);
+        }
 
         // Update the wallet shares
         self.private_shares = private_shares.clone();

--- a/external-api/src/types/api_task_history.rs
+++ b/external-api/src/types/api_task_history.rs
@@ -6,13 +6,13 @@
 
 use std::str::FromStr;
 
-use circuit_types::{
-    order::{Order, OrderSide},
-    r#match::MatchResult,
-};
-use common::types::tasks::{
-    HistoricalTask, HistoricalTaskDescription, QueuedTask, TaskIdentifier, TaskQueueKey,
-    WalletUpdateType,
+use circuit_types::{order::OrderSide, r#match::MatchResult};
+use common::types::{
+    tasks::{
+        HistoricalTask, HistoricalTaskDescription, QueuedTask, TaskIdentifier, TaskQueueKey,
+        WalletUpdateType,
+    },
+    wallet::Order,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Number;

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -4,7 +4,7 @@ use circuit_types::{
     balance::Balance,
     fixed_point::FixedPoint,
     keychain::{PublicIdentificationKey, PublicKeyChain, SecretIdentificationKey},
-    order::{Order, OrderSide},
+    order::OrderSide,
     traits::BaseType,
     Amount, SizedWalletShare,
 };
@@ -12,7 +12,7 @@ use common::{
     keyed_list::KeyedList,
     types::wallet::{
         keychain::{HmacKey, KeyChain, PrivateKeyChain},
-        OrderIdentifier, Wallet, WalletIdentifier,
+        Order, OrderIdentifier, Wallet, WalletIdentifier,
     },
 };
 use itertools::Itertools;
@@ -159,6 +159,9 @@ pub struct ApiOrder {
     pub worst_case_price: FixedPoint,
     /// The order size
     pub amount: Amount,
+    /// The minimum fill size for the order
+    #[serde(default)]
+    pub min_fill_size: Amount,
 }
 
 impl From<(OrderIdentifier, Order)> for ApiOrder {
@@ -171,6 +174,7 @@ impl From<(OrderIdentifier, Order)> for ApiOrder {
             type_: ApiOrderType::Midpoint,
             worst_case_price: order.worst_case_price,
             amount: order.amount,
+            min_fill_size: order.min_fill_size,
         }
     }
 }
@@ -185,6 +189,7 @@ impl TryFrom<ApiOrder> for Order {
             order.side,
             order.amount,
             order.worst_case_price,
+            order.min_fill_size,
         )
     }
 }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -77,6 +77,7 @@ metrics = { workspace = true }
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 multiaddr = "0.17"
 num-bigint = "0.4"
+num-traits = "0.2"
 tempfile = "3.8"
 rand = { workspace = true }
 uuid = "1.4"

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -3,10 +3,9 @@
 //! Wallet index updates must go through raft consensus so that the leader may
 //! order them
 
-use circuit_types::order::Order;
 use common::types::{
     tasks::QueuedTask,
-    wallet::{OrderIdentifier, Wallet, WalletIdentifier},
+    wallet::{Order, OrderIdentifier, Wallet, WalletIdentifier},
 };
 use util::res_some;
 

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -5,10 +5,13 @@
 // ------------------------
 
 use async_trait::async_trait;
-use circuit_types::{fixed_point::FixedPoint, order::Order, Amount};
+use circuit_types::{fixed_point::FixedPoint, Amount};
 use common::types::{
-    exchange::PriceReporterState, tasks::UpdateWalletTaskDescriptor, token::Token,
-    wallet::order_metadata::OrderMetadata, Price,
+    exchange::PriceReporterState,
+    tasks::UpdateWalletTaskDescriptor,
+    token::Token,
+    wallet::{order_metadata::OrderMetadata, Order},
+    Price,
 };
 use external_api::{
     http::{
@@ -481,5 +484,5 @@ async fn get_fillable_amount_and_price(
 
     let price_fp = FixedPoint::from_f64_round_down(price);
 
-    Ok((compute_max_amount(&price_fp, order, &balance), price))
+    Ok((compute_max_amount(&price_fp, &order.clone().into(), &balance), price))
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use circuit_types::{
-    balance::Balance, native_helpers::create_wallet_shares_from_private, order::Order, Amount,
+    balance::Balance, native_helpers::create_wallet_shares_from_private, Amount,
     SizedWallet as SizedCircuitWallet,
 };
 use common::types::{
@@ -14,7 +14,7 @@ use common::types::{
     },
     token::Token,
     transfer_auth::{DepositAuth, ExternalTransferWithAuth, WithdrawalAuth},
-    wallet::{keychain::PrivateKeyChain, Wallet, WalletIdentifier},
+    wallet::{keychain::PrivateKeyChain, Order, Wallet, WalletIdentifier},
 };
 use external_api::{
     http::wallet::{

--- a/workers/handshake-manager-tests/src/mpc_match.rs
+++ b/workers/handshake-manager-tests/src/mpc_match.rs
@@ -1,12 +1,11 @@
 //! Tests for matching orders via an MPC
 
 use ark_mpc::{PARTY0, PARTY1};
-use circuit_types::{
-    balance::Balance,
-    fixed_point::FixedPoint,
-    order::{Order, OrderSide},
+use circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide};
+use common::types::{
+    wallet::{Order, Wallet},
+    wallet_mocks::mock_empty_wallet,
 };
-use common::types::{wallet::Wallet, wallet_mocks::mock_empty_wallet};
 use eyre::Result;
 use job_types::handshake_manager::HandshakeExecutionJob;
 use test_helpers::integration_test_async;
@@ -68,6 +67,7 @@ fn get_order(side: OrderSide) -> Order {
         side,
         amount: DEFAULT_ORDER_AMOUNT,
         worst_case_price: FixedPoint::from_f64_round_down(worst_case_price),
+        min_fill_size: 0,
     }
 }
 

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -3,14 +3,14 @@
 use circuit_types::{
     balance::Balance,
     fixed_point::FixedPoint,
-    order::{Order, OrderSide},
+    order::OrderSide,
     transfers::{ExternalTransfer, ExternalTransferDirection},
     Amount,
 };
 use common::types::{
     tasks::{mocks::gen_wallet_update_sig, UpdateWalletTaskDescriptor, WalletUpdateType},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::{OrderIdentifier, Wallet},
+    wallet::{Order, OrderIdentifier, Wallet},
     wallet_mocks::{mock_empty_wallet, mock_order},
 };
 use constants::Scalar;
@@ -42,6 +42,7 @@ lazy_static! {
         side: OrderSide::Buy,
         amount: 10,
         worst_case_price: FixedPoint::from_integer(10),
+        min_fill_size: 0,
     };
 }
 

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -316,8 +316,9 @@ fn matchup_order_ids(
             existing_order == refreshed_order && !used_existing_ids.contains(id)
         });
 
-        if let Some((existing_id, _)) = maybe_order {
+        if let Some((existing_id, existing_order)) = maybe_order {
             *refreshed_id = *existing_id;
+            refreshed_order.min_fill_size = existing_order.min_fill_size;
             used_existing_ids.insert(*existing_id);
         }
     }

--- a/workers/task-driver/src/utils/validity_proofs.rs
+++ b/workers/task-driver/src/utils/validity_proofs.rs
@@ -257,7 +257,7 @@ pub(crate) async fn update_wallet_validity_proofs(
     for (id, order) in matchable_orders.iter() {
         // Start a proof of `VALID COMMITMENTS`
         let (commitments_witness, response_channel) = construct_order_commitment_proof(
-            order.clone(),
+            order.clone().into(),
             &reblind_witness,
             &proof_manager_work_queue,
         )?;


### PR DESCRIPTION
### Purpose
This PR adds the `min_fill_size` field to the `Order` type. This involves breaking out the `common::wallet::Order` into a new type -- distinct from `circuit_types::Order` -- to include fields that don't go into the circuits.

### Testing
- Deployed to testnet
- Tested min fills