### PR TITLE
common: token: Remap BTC to wBTC

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -137,10 +137,10 @@ pub static TICKER_NAMES: &[(
     // L1
     (
         WBTC_TICKER,
-        ExchangeTicker::Renamed("BTC"),
-        ExchangeTicker::Renamed("BTC"),
-        ExchangeTicker::Renamed("BTC"),
-        ExchangeTicker::Renamed("BTC"),
+        ExchangeTicker::Renamed("WBTC"),
+        ExchangeTicker::Unsupported,
+        ExchangeTicker::Unsupported,
+        ExchangeTicker::Renamed("WBTC"),
     ),
     (
         WETH_TICKER,


### PR DESCRIPTION
### Purpose
This PR remaps the BTC token to wBTC for prices. Renegade trades wBTC, so we use the wrapped price directly.

### Testing
- Tested a local price reporter with these changes