### PR TITLE
gossip-api: request-response: Remove trace fields

### DIFF
--- a/gossip-api/src/request_response/mod.rs
+++ b/gossip-api/src/request_response/mod.rs
@@ -189,7 +189,7 @@ impl AuthenticatedGossipResponse {
     }
 
     /// Verify the signature on an authenticated request
-    #[instrument(name = "verify_cluster_auth")]
+    #[instrument(name = "verify_cluster_auth", skip_all)]
     pub fn verify_cluster_auth(&self, cluster_key: &HmacKey) -> bool {
         if !self.inner.requires_cluster_auth() {
             return true;


### PR DESCRIPTION
### Purpose
This PR removes span tags for the arguments to `AuthenticatedGossipResponse::verify_cluster_auth`. This includes the hmac key and the gossip response body.

### Testing
- Unit tests pass