### PR TITLE
task-driver: refresh-wallet: Check for public blinder on-chain

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -11,6 +11,7 @@ abigen!(
     DarkpoolContract,
     r#"[
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
+        function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool)
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
         function getPubkey() external view returns (uint256[2])
@@ -39,6 +40,7 @@ abigen!(
     DarkpoolContract,
     r#"[
         function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
+        function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool)
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
         function getPubkey() external view returns (uint256[2])

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -113,6 +113,22 @@ impl ArbitrumClient {
             .map_err(|e| ArbitrumClientError::ContractInteraction(e.to_string()))
     }
 
+    /// Check whether the given public blinder is used
+    ///
+    /// Returns `true` if the blinder is used, `false` otherwise
+    #[instrument(skip_all, err, fields(blinder = %blinder))]
+    pub async fn is_public_blinder_used(
+        &self,
+        blinder: Scalar,
+    ) -> Result<bool, ArbitrumClientError> {
+        let blinder_u256 = scalar_to_u256(&blinder);
+        self.get_darkpool_client()
+            .is_public_blinder_used(blinder_u256)
+            .call()
+            .await
+            .map_err(err_str!(ArbitrumClientError::ContractInteraction))
+    }
+
     // -----------
     // | SETTERS |
     // -----------

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -13,7 +13,7 @@ use gossip_api::{
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use tracing::info;
+use tracing::{info, instrument};
 use util::{err_str, get_current_time_millis};
 
 use crate::{
@@ -48,6 +48,7 @@ impl GossipProtocolExecutor {
 
     /// Sends heartbeat message to peers to exchange network information and
     /// ensure liveness
+    #[instrument(name = "send_heartbeat", skip(self))]
     pub async fn send_heartbeat(
         &self,
         recipient_peer_id: WrappedPeerId,
@@ -69,6 +70,7 @@ impl GossipProtocolExecutor {
     // ---------------------
 
     /// Handle a heartbeat message from a peer
+    #[instrument(name = "handle_heartbeat", skip(self, message))]
     pub async fn handle_heartbeat(
         &self,
         peer: &WrappedPeerId,

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -12,7 +12,7 @@ use gossip_api::{
     },
 };
 use job_types::network_manager::{NetworkManagerControlSignal, NetworkManagerJob};
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
 use util::{err_str, get_current_time_millis};
 
 use crate::{errors::GossipError, server::GossipProtocolExecutor};
@@ -25,6 +25,7 @@ impl GossipProtocolExecutor {
     // --------------------
 
     /// Handles a request for peer info
+    #[instrument(name = "handle_peer_info_req", skip_all, fields(n_peers = %peers.len()))]
     pub async fn handle_peer_info_req(
         &self,
         peers: Vec<WrappedPeerId>,
@@ -43,6 +44,7 @@ impl GossipProtocolExecutor {
     }
 
     /// Handles a bootstrap request from a peer    
+    #[instrument(name = "handle_bootstrap_req", skip_all, fields(peer_id = %req.peer_info.peer_id))]
     pub async fn handle_bootstrap_req(
         &self,
         req: BootstrapRequest,
@@ -58,6 +60,7 @@ impl GossipProtocolExecutor {
     ///
     /// TODO: Update this logic, for now we simply check if the local peer
     /// thinks the expiry candidate should expire
+    #[instrument(name = "handle_propose_expiry", skip(self))]
     pub async fn handle_propose_expiry(
         &self,
         sender: WrappedPeerId,
@@ -87,6 +90,7 @@ impl GossipProtocolExecutor {
     }
 
     /// Handle a request to reject expiry
+    #[instrument(name = "handle_reject_expiry", skip(self))]
     pub async fn handle_reject_expiry(
         &self,
         sender: WrappedPeerId,
@@ -120,6 +124,7 @@ impl GossipProtocolExecutor {
     // ---------------------
 
     /// Handles a response to a request for peer info
+    #[instrument(name = "handle_peer_info_resp", skip_all, fields(n_peers = %peer_info.len()))]
     pub async fn handle_peer_info_resp(&self, peer_info: Vec<PeerInfo>) -> Result<(), GossipError> {
         self.add_new_peers(peer_info).await
     }

--- a/workers/gossip-server/src/server.rs
+++ b/workers/gossip-server/src/server.rs
@@ -29,7 +29,7 @@ use std::{
     thread::JoinHandle,
     time::{Duration, Instant},
 };
-use tracing::{error, info, warn};
+use tracing::{error, info, instrument, warn};
 use util::err_str;
 
 use crate::peer_discovery::{
@@ -206,6 +206,7 @@ impl GossipProtocolExecutor {
     }
 
     /// The main dispatch method for handling jobs
+    #[instrument(name = "gossip_server_job", skip(self))]
     async fn handle_job(&self, job: GossipServerJob) -> Result<(), GossipError> {
         match job {
             GossipServerJob::ExecuteHeartbeat(peer_id) => self.send_heartbeat(peer_id).await?,
@@ -225,6 +226,7 @@ impl GossipProtocolExecutor {
     }
 
     /// Handles a gossip request type from a peer
+    #[instrument(name = "handle_request", skip(self, req))]
     async fn handle_request(
         &self,
         peer: WrappedPeerId,
@@ -249,6 +251,7 @@ impl GossipProtocolExecutor {
     }
 
     /// Handles a gossip response type from a peer
+    #[instrument(name = "handle_response", skip(self, resp))]
     async fn handle_response(
         &self,
         peer: WrappedPeerId,
@@ -269,6 +272,7 @@ impl GossipProtocolExecutor {
     }
 
     /// Handles an inbound pubsub message from the network
+    #[instrument(name = "handle_pubsub", skip(self, msg))]
     async fn handle_pubsub(
         &self,
         sender: WrappedPeerId,


### PR DESCRIPTION
### Purpose
This PR adds logic to the `refresh-wallet` task which checks whether the wallet's public blinder has been seen on-chain. If it has _not_, the refresh task can assume that the shares held locally by the relayer are up-to-date.

### Testing
- Unit tests pass
- Tested with a locally running relayer for both cases:
    - Tested the case in which a wallet was up to date
    - Tested the case in which a wallet was out of date (updated it on a different relayer)