### PR TITLE
workers: api-server: http: admin: add get matching pool for order route

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -33,6 +33,8 @@ pub const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE: &str =
     "/v0/admin/wallet/:wallet_id/order-in-pool";
 /// Route to assign an order to a matching pool
 pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
+/// Route to get the matching pool for an order
+pub const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE: &str = "/v0/admin/orders/:order_id/matching-pool";
 
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -82,4 +84,11 @@ pub struct CreateOrderInMatchingPoolRequest {
 pub struct AdminOrderMetadataResponse {
     /// The order metadata
     pub order: OrderMetadata,
+}
+
+/// The response to a "get order matching pool" request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdminGetOrderMatchingPoolResponse {
+    /// The matching pool name for the order
+    pub matching_pool: MatchingPoolName,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -8,7 +8,7 @@ mod rate_limit;
 mod task;
 mod wallet;
 
-use admin::{AdminTriggerSnapshotHandler, IsLeaderHandler};
+use admin::{AdminGetOrderMatchingPoolHandler, AdminTriggerSnapshotHandler, IsLeaderHandler};
 use async_trait::async_trait;
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
@@ -19,9 +19,9 @@ use external_api::{
     http::{
         admin::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
-            ADMIN_MATCHING_POOL_CREATE_ROUTE, ADMIN_MATCHING_POOL_DESTROY_ROUTE,
-            ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE, ADMIN_TRIGGER_SNAPSHOT_ROUTE,
-            IS_LEADER_ROUTE,
+            ADMIN_GET_ORDER_MATCHING_POOL_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
+            ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
+            ADMIN_TRIGGER_SNAPSHOT_ROUTE, IS_LEADER_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
         order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
@@ -485,9 +485,16 @@ impl HttpServer {
             &Method::POST,
             ADMIN_ASSIGN_ORDER_ROUTE.to_string(),
             AdminAssignOrderToMatchingPoolHandler::new(
-                state,
+                state.clone(),
                 config.handshake_manager_work_queue.clone(),
             ),
+        );
+
+        // The "/admin/orders/:id/matching-pool" route
+        router.add_admin_authenticated_route(
+            &Method::GET,
+            ADMIN_GET_ORDER_MATCHING_POOL_ROUTE.to_string(),
+            AdminGetOrderMatchingPoolHandler::new(state),
         );
 
         router


### PR DESCRIPTION
This PR introduces a new admin API endpoint for fetching the matching pool to which a given order pertains.

This was tested against a local relayer.