### PR TITLE
circuits: valid-match-settle-atomic: Matching engine constraints

### DIFF
--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -15,6 +15,10 @@ use crate::{
     Amount, Fabric,
 };
 
+// ----------------
+// | Match Result |
+// ----------------
+
 /// Represents the match result of a matching MPC in the cleartext
 /// in which two tokens are exchanged
 #[circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)]
@@ -103,4 +107,32 @@ pub struct OrderSettlementIndices {
     pub balance_receive: usize,
     /// The index of the order that is to be matched
     pub order: usize,
+}
+
+// -------------------------
+// | External Match Result |
+// -------------------------
+
+/// The result of an external match settlement
+///
+/// An external match is one between a darkpool (internal) order and an external
+/// order, facilitated directly by token transfers in the contract
+#[circuit_type(serde, singleprover_circuit)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalMatchResult {
+    /// The mint of the quote token in the matched asset pair
+    pub quote_mint: BigUint,
+    /// The mint of the base token in the matched asset pair
+    pub base_mint: BigUint,
+    /// The amount of the quote token exchanged by the match
+    pub quote_amount: Amount,
+    /// The amount of the base token exchanged by the match
+    pub base_amount: Amount,
+    /// The direction of the match
+    ///
+    /// - `true` implies that the internal party buys the quote and sells the
+    ///   base
+    /// - `false` implies that the internal party buys the base and sells the
+    ///   quote
+    pub direction: bool,
 }

--- a/circuit-types/src/transfers.rs
+++ b/circuit-types/src/transfers.rs
@@ -1,10 +1,6 @@
 //! Defines native and circuit types for internal/external transfers
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-// ----------------------
-// | External Transfers |
-// ----------------------
-
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, BoolVar, Variable};
@@ -16,6 +12,10 @@ use crate::{
     traits::{BaseType, CircuitBaseType, CircuitVarType},
     Amount,
 };
+
+// ----------------------
+// | External Transfers |
+// ----------------------
 
 /// The base external transfer type, not allocated in a constraint system
 /// or an MPC circuit


### PR DESCRIPTION
### Purpose
This PR adds the initial set of constraints for `VALID MATCH SETTLE ATOMIC`. This is focused on the constraints in the matching engine, ensuring that the internal party's order parameters are not violated by the match.

### Todo
- Settlement constraints
- Proof Linking
- Tests

### Testing
- Unit tests pass