### PR TITLE
circuits: valid-match-settle-atomic: Add external party fees

### DIFF
--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -6,7 +6,6 @@ use std::ops::Add;
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, Variable};
-use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -18,7 +17,7 @@ use crate::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
         MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    validate_amount_bitlength, Amount, Fabric,
+    validate_amount_bitlength, Address, Amount, Fabric,
 };
 
 /// Error message when a balance amount is too large
@@ -31,7 +30,7 @@ const ERR_BALANCE_AMOUNT_TOO_LARGE: &str = "balance amount is too large";
 pub struct Balance {
     /// The mint (ERC-20 token address) of the token in the balance
     #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
-    pub mint: BigUint,
+    pub mint: Address,
     /// The amount of the given token stored in this balance
     pub amount: Amount,
     /// The amount of this balance owed to the managing relayer cluster
@@ -42,7 +41,7 @@ pub struct Balance {
 
 impl Balance {
     /// Construct a new balance with zero fees; validating its amount
-    pub fn new(mint: BigUint, amount: Amount) -> Result<Balance, String> {
+    pub fn new(mint: Address, amount: Amount) -> Result<Balance, String> {
         let bal = Self::new_from_mint_and_amount(mint, amount);
         bal.validate()?;
 
@@ -69,12 +68,12 @@ impl Balance {
     }
 
     /// Construct a zero'd balance from a mint
-    pub fn new_from_mint(mint: BigUint) -> Balance {
+    pub fn new_from_mint(mint: Address) -> Balance {
         Balance { mint, amount: 0, relayer_fee_balance: 0, protocol_fee_balance: 0 }
     }
 
     /// Construct a balance with zero fees from a mint and amount
-    pub fn new_from_mint_and_amount(mint: BigUint, amount: Amount) -> Balance {
+    pub fn new_from_mint_and_amount(mint: Address, amount: Amount) -> Balance {
         Balance { mint, amount, relayer_fee_balance: 0, protocol_fee_balance: 0 }
     }
 

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -132,6 +132,9 @@ impl From<AuthenticatedBool> for AuthenticatedScalar {
     }
 }
 
+/// A type alias for an on-chain address, we represent these as `BigUint`
+pub type Address = BigUint;
+
 // -----------
 // | Helpers |
 // -----------

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -4,7 +4,6 @@
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, Variable};
-use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -12,7 +11,7 @@ use crate::{
     traits::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType, MultiproverCircuitBaseType,
     },
-    Amount, Fabric,
+    Address, Amount, Fabric,
 };
 
 // ----------------
@@ -25,9 +24,9 @@ use crate::{
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MatchResult {
     /// The mint of the order token in the asset pair being matched
-    pub quote_mint: BigUint,
+    pub quote_mint: Address,
     /// The mint of the base token in the asset pair being matched
-    pub base_mint: BigUint,
+    pub base_mint: Address,
     /// The amount of the quote token exchanged by this match
     pub quote_amount: Amount,
     /// The amount of the base token exchanged by this match
@@ -50,7 +49,7 @@ pub struct MatchResult {
 
 impl MatchResult {
     /// Get the send mint and amount given a side of the order
-    pub fn send_mint_amount(&self, side: OrderSide) -> (BigUint, Amount) {
+    pub fn send_mint_amount(&self, side: OrderSide) -> (Address, Amount) {
         match side {
             // Buy the base, sell the quote
             OrderSide::Buy => (self.quote_mint.clone(), self.quote_amount),
@@ -60,7 +59,7 @@ impl MatchResult {
     }
 
     /// Get the receive mint and amount given a side of the order
-    pub fn receive_mint_amount(&self, side: OrderSide) -> (BigUint, Amount) {
+    pub fn receive_mint_amount(&self, side: OrderSide) -> (Address, Amount) {
         match side {
             // Buy the base, sell the quote
             OrderSide::Buy => (self.base_mint.clone(), self.base_amount),
@@ -121,9 +120,9 @@ pub struct OrderSettlementIndices {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExternalMatchResult {
     /// The mint of the quote token in the matched asset pair
-    pub quote_mint: BigUint,
+    pub quote_mint: Address,
     /// The mint of the base token in the matched asset pair
-    pub base_mint: BigUint,
+    pub base_mint: Address,
     /// The amount of the quote token exchanged by the match
     pub quote_amount: Amount,
     /// The amount of the base token exchanged by the match

--- a/circuit-types/src/note.rs
+++ b/circuit-types/src/note.rs
@@ -6,7 +6,6 @@
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, Variable};
-use num_bigint::BigUint;
 use rand::thread_rng;
 use renegade_crypto::{fields::biguint_to_scalar, hash::compute_poseidon_hash};
 use serde::{Deserialize, Serialize};
@@ -15,7 +14,7 @@ use crate::{
     balance::Balance,
     elgamal::EncryptionKey,
     traits::{BaseType, CircuitBaseType, CircuitVarType},
-    Amount,
+    Address, Amount,
 };
 
 /// The size of the note ciphertext when encrypted
@@ -29,7 +28,7 @@ pub const NOTE_CIPHERTEXT_SIZE: usize = Note::NUM_SCALARS - EncryptionKey::NUM_S
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Note {
     /// The mint of the note
-    pub mint: BigUint,
+    pub mint: Address,
     /// The amount of the note
     pub amount: Amount,
     /// The receiver's identification key
@@ -40,7 +39,7 @@ pub struct Note {
 
 impl Note {
     /// Constructor
-    pub fn new(mint: BigUint, amount: Amount, receiver: EncryptionKey) -> Self {
+    pub fn new(mint: Address, amount: Amount, receiver: EncryptionKey) -> Self {
         // Sample a blinder
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -4,7 +4,6 @@
 use circuit_macros::circuit_type;
 use constants::{AuthenticatedScalar, Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, BoolVar, Variable};
-use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, ops::Add, str::FromStr};
@@ -16,7 +15,7 @@ use crate::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
         MultiproverCircuitBaseType, SecretShareBaseType, SecretShareType, SecretShareVarType,
     },
-    Amount, AuthenticatedBool, Fabric,
+    Address, Amount, AuthenticatedBool, Fabric,
 };
 
 /// Represents the base type of an open order, including the asset pair, the
@@ -26,10 +25,10 @@ use crate::{
 pub struct Order {
     /// The mint (ERC-20 contract address) of the quote token
     #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
-    pub quote_mint: BigUint,
+    pub quote_mint: Address,
     /// The mint (ERC-20 contract address) of the base token
     #[serde(serialize_with = "biguint_to_hex_addr", deserialize_with = "biguint_from_hex_string")]
-    pub base_mint: BigUint,
+    pub base_mint: Address,
     /// The side this order is for (0 = buy, 1 = sell)
     pub side: OrderSide,
     /// The amount of base currency to buy or sell
@@ -58,7 +57,7 @@ impl Order {
 
     /// The mint of the token sent by the creator of this order in the event
     /// that the order is matched
-    pub fn send_mint(&self) -> &BigUint {
+    pub fn send_mint(&self) -> &Address {
         match self.side {
             OrderSide::Buy => &self.quote_mint,
             OrderSide::Sell => &self.base_mint,
@@ -67,7 +66,7 @@ impl Order {
 
     /// The mint of the token received by the creator of this order in the event
     /// that the order is matched
-    pub fn receive_mint(&self) -> &BigUint {
+    pub fn receive_mint(&self) -> &Address {
         match self.side {
             OrderSide::Buy => &self.base_mint,
             OrderSide::Sell => &self.quote_mint,

--- a/circuit-types/src/transfers.rs
+++ b/circuit-types/src/transfers.rs
@@ -4,13 +4,12 @@
 use circuit_macros::circuit_type;
 use constants::{Scalar, ScalarField};
 use mpc_relation::{traits::Circuit, BoolVar, Variable};
-use num_bigint::BigUint;
 use renegade_crypto::fields::scalar_to_u64;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     traits::{BaseType, CircuitBaseType, CircuitVarType},
-    Amount,
+    Address, Amount,
 };
 
 // ----------------------
@@ -23,9 +22,9 @@ use crate::{
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct ExternalTransfer {
     /// The address of the account contract to transfer to/from
-    pub account_addr: BigUint,
+    pub account_addr: Address,
     /// The mint (ERC20 address) of the token to transfer
-    pub mint: BigUint,
+    pub mint: Address,
     /// The amount of the token transferred
     pub amount: Amount,
     /// The direction of transfer

--- a/circuits/benches/valid_fee_redemption.rs
+++ b/circuits/benches/valid_fee_redemption.rs
@@ -7,7 +7,7 @@
 use circuit_types::elgamal::DecryptionKey;
 use circuit_types::note::Note;
 use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
-use circuit_types::{Amount, PlonkCircuit};
+use circuit_types::{Address, Amount, PlonkCircuit};
 use circuits::test_helpers::wallet_with_random_balances;
 use circuits::zk_circuits::valid_fee_redemption::ValidFeeRedemption;
 use circuits::zk_circuits::valid_fee_redemption::{
@@ -17,7 +17,6 @@ use circuits::zk_circuits::valid_fee_redemption::{
 use circuits::{singleprover_prove, verify_singleprover_proof};
 use constants::{Scalar, MAX_BALANCES, MAX_ORDERS, MERKLE_HEIGHT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use num_bigint::BigUint;
 use rand::thread_rng;
 
 /// The parameter set for the small sized circuit (MAX_BALANCES, MAX_ORDERS,
@@ -47,7 +46,7 @@ where
     let sender_wallet = wallet_with_random_balances();
     let (_, dummy_receiver) = DecryptionKey::random_pair(&mut rng);
     let note = Note {
-        mint: BigUint::from(1u8),
+        mint: Address::from(1u8),
         amount: Amount::from(1u8),
         receiver: dummy_receiver,
         blinder: Scalar::zero(),

--- a/circuits/src/zk_circuits/valid_commitments.rs
+++ b/circuits/src/zk_circuits/valid_commitments.rs
@@ -430,8 +430,8 @@ pub mod test_helpers {
         balance::Balance,
         native_helpers::create_wallet_shares_from_private,
         wallet::{Wallet, WalletShare},
+        Address,
     };
-    use num_bigint::BigUint;
 
     use crate::zk_circuits::test_helpers::{create_wallet_shares, MAX_BALANCES, MAX_ORDERS};
 
@@ -522,7 +522,7 @@ pub mod test_helpers {
     /// If the balance does not exist the `augment` flag lets the method augment
     /// the wallet with a zero'd balance
     pub(super) fn find_balance_or_augment<const MAX_BALANCES: usize>(
-        mint: BigUint,
+        mint: Address,
         balances: &mut [Balance; MAX_BALANCES],
         augment: bool,
     ) -> (usize, Balance) {
@@ -539,7 +539,7 @@ pub mod test_helpers {
                 let (zerod_index, _) = balances
                     .iter()
                     .enumerate()
-                    .find(|(_ind, balance)| balance.mint == BigUint::from(0u8))
+                    .find(|(_ind, balance)| balance.mint == Address::from(0u8))
                     .expect("wallet must have zero'd balance to augment");
 
                 balances[zerod_index] = Balance::new_from_mint(mint);
@@ -557,10 +557,10 @@ mod test {
         fixed_point::FixedPointShare,
         order::{OrderShare, OrderSide},
         traits::{SecretShareType, SingleProverCircuit},
+        Address,
     };
     use constants::Scalar;
     use lazy_static::lazy_static;
-    use num_bigint::BigUint;
     use rand::{thread_rng, RngCore};
 
     use crate::zk_circuits::{
@@ -866,7 +866,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the mint of the send balance
-        witness.balance_send.mint = BigUint::from(rng.next_u64());
+        witness.balance_send.mint = Address::from(rng.next_u64());
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
     }
@@ -912,7 +912,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the mint of the receive balance
-        witness.balance_receive.mint = BigUint::from(rng.next_u64());
+        witness.balance_receive.mint = Address::from(rng.next_u64());
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
     }
@@ -976,7 +976,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the amount of the order
-        witness.order.base_mint = BigUint::from(0u8);
+        witness.order.base_mint = Address::from(0u8);
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
     }
@@ -988,7 +988,7 @@ mod test {
         let (mut witness, statement) = create_witness_and_statement(&wallet);
 
         // Modify the quote mint of the order
-        witness.order.quote_mint = BigUint::from(0u8);
+        witness.order.quote_mint = Address::from(0u8);
 
         assert!(!check_constraint_satisfaction::<SizedCommitments>(&witness, &statement));
     }

--- a/circuits/src/zk_circuits/valid_relayer_fee_settlement.rs
+++ b/circuits/src/zk_circuits/valid_relayer_fee_settlement.rs
@@ -570,9 +570,8 @@ mod test {
         },
         traits::BaseType,
         wallet::{Wallet, WalletShare},
-        AMOUNT_BITS,
+        Address, AMOUNT_BITS,
     };
-    use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
     use renegade_crypto::fields::{scalar_to_biguint, scalar_to_u128};
 
@@ -781,7 +780,7 @@ mod test {
     fn test_invalid_settlement__send_balance_zero() {
         let (mut sender_wallet, recipient_wallet) = get_initial_wallets();
         for bal in sender_wallet.balances.iter_mut() {
-            bal.mint = BigUint::from(0u8);
+            bal.mint = Address::from(0u8);
         }
 
         let (statement, witness) = create_witness_statement(&sender_wallet, &recipient_wallet);

--- a/circuits/src/zk_circuits/valid_wallet_update.rs
+++ b/circuits/src/zk_circuits/valid_wallet_update.rs
@@ -615,12 +615,11 @@ mod test {
         order::Order,
         traits::CircuitBaseType,
         transfers::{ExternalTransfer, ExternalTransferDirection},
-        AMOUNT_BITS, PRICE_BITS,
+        Address, AMOUNT_BITS, PRICE_BITS,
     };
     use constants::Scalar;
     use k256::ecdsa::SigningKey;
     use mpc_relation::{traits::Circuit, PlonkCircuit};
-    use num_bigint::BigUint;
     use rand::{thread_rng, Rng, RngCore};
     use renegade_crypto::fields::scalar_to_u128;
 
@@ -809,7 +808,7 @@ mod test {
 
         // Quote mint is zero in new order
         let mut new_wallet = new_wallet.clone();
-        new_wallet.orders[0].quote_mint = BigUint::from(0u8);
+        new_wallet.orders[0].quote_mint = Address::from(0u8);
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
@@ -820,7 +819,7 @@ mod test {
 
         // Base mint is zero in new order
         let mut new_wallet = new_wallet.clone();
-        new_wallet.orders[0].base_mint = BigUint::from(0u8);
+        new_wallet.orders[0].base_mint = Address::from(0u8);
 
         assert!(!constraints_satisfied_on_wallets(
             &old_wallet,
@@ -868,8 +867,8 @@ mod test {
         let mut cs = PlonkCircuit::new_turbo_plonk();
 
         let transfer = ExternalTransfer {
-            account_addr: BigUint::from(0u8),
-            mint: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
+            mint: Address::from(0u8),
             amount: 1u128,
             direction: ExternalTransferDirection::Deposit,
         };
@@ -890,8 +889,8 @@ mod test {
     fn test_invalid_transfer__large_amount() {
         let mut cs = PlonkCircuit::new_turbo_plonk();
         let transfer = ExternalTransfer {
-            account_addr: BigUint::from(0u8),
-            mint: BigUint::from(1u8),
+            account_addr: Address::from(0u8),
+            mint: Address::from(1u8),
             amount: 0, // replaced
             direction: ExternalTransferDirection::Deposit,
         };
@@ -922,7 +921,7 @@ mod test {
     fn test_invalid_balance__non_zero_zero_mint() {
         // To ablate any other constraints, make the zero mint present in both
         let mut old_wallet = INITIAL_WALLET.clone();
-        old_wallet.balances[0].mint = BigUint::from(0u8);
+        old_wallet.balances[0].mint = Address::from(0u8);
         let new_wallet = old_wallet.clone();
 
         assert!(!constraints_satisfied_on_wallets(
@@ -953,7 +952,7 @@ mod test {
                 mint: old_wallet.balances[0].mint.clone(),
                 amount: transfer_amt,
                 direction: ExternalTransferDirection::Deposit,
-                account_addr: BigUint::from(0u8),
+                account_addr: Address::from(0u8),
             },
         );
 
@@ -1028,7 +1027,7 @@ mod test {
             mint: old_wallet.balances[idx].mint.clone(),
             amount: old_wallet.balances[idx].amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1052,7 +1051,7 @@ mod test {
             mint: withdrawn_mint,
             amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1077,7 +1076,7 @@ mod test {
             mint: withdrawn_mint,
             amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1102,7 +1101,7 @@ mod test {
             mint: withdrawn_mint,
             amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1117,7 +1116,7 @@ mod test {
 
         // Withdraw a random balance
         let mut rng = thread_rng();
-        let withdrawn_mint = BigUint::from(rng.next_u32());
+        let withdrawn_mint = Address::from(rng.next_u32());
         let withdrawn_amount = 1u128;
 
         // Build a valid transfer
@@ -1126,7 +1125,7 @@ mod test {
             mint: withdrawn_mint,
             amount: withdrawn_amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1152,7 +1151,7 @@ mod test {
             mint: withdrawal_mint,
             amount: withdrawal_amount,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1178,7 +1177,7 @@ mod test {
             mint: old_wallet.balances[idx].mint.clone(),
             amount: 1,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1204,7 +1203,7 @@ mod test {
             mint: old_wallet.balances[idx].mint.clone(),
             amount: 1,
             direction: ExternalTransferDirection::Withdrawal,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1230,7 +1229,7 @@ mod test {
             mint: deposit_mint,
             amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1253,7 +1252,7 @@ mod test {
             mint: deposit_mint,
             amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1277,7 +1276,7 @@ mod test {
             mint: deposit_mint,
             amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1304,7 +1303,7 @@ mod test {
             mint: deposit_mint,
             amount: deposit_amount,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(!constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1326,7 +1325,7 @@ mod test {
             mint: old_wallet.balances[idx].mint.clone(),
             amount: 1,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1346,7 +1345,7 @@ mod test {
         old_wallet.balances[idx] = Balance::new_from_mint(old_wallet.balances[idx].mint.clone());
 
         // Replace that balance with a new deposit
-        let new_mint = BigUint::from(rng.next_u64());
+        let new_mint = Address::from(rng.next_u64());
         let new_amt = 1;
         let mut new_wallet = old_wallet.clone();
         new_wallet.balances[idx] = Balance::new_from_mint_and_amount(new_mint.clone(), new_amt);
@@ -1355,7 +1354,7 @@ mod test {
             mint: new_mint,
             amount: new_amt,
             direction: ExternalTransferDirection::Deposit,
-            account_addr: BigUint::from(0u8),
+            account_addr: Address::from(0u8),
         };
 
         assert!(constraints_satisfied_on_wallets(&old_wallet, &new_wallet, idx, transfer));
@@ -1368,7 +1367,7 @@ mod test {
         let mut new_wallet = INITIAL_WALLET.clone();
 
         // Set the first balance to have zero amount and fees
-        old_wallet.balances[0] = Balance::new_from_mint(BigUint::from(1u8));
+        old_wallet.balances[0] = Balance::new_from_mint(Address::from(1u8));
 
         // Replace it with an entirely zero'd balance
         new_wallet.balances[0] = Balance::default();

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -21,6 +21,27 @@ use super::comparators::LessThanGadget;
 // | Single Prover Gadgets |
 // -------------------------
 
+/// The noop gadget is used to prevent certain fields from being changed in the
+/// circuit
+///
+/// We do this by constraining each variable with a zero product: `a * 0 = 0`
+pub struct NoopGadget {}
+impl NoopGadget {
+    /// Constrain the noop gadget
+    pub fn constrain_noop<V, C>(a: &V, cs: &mut C) -> Result<(), CircuitError>
+    where
+        V: CircuitVarType,
+        C: Circuit<ScalarField>,
+    {
+        let zero_var = cs.zero();
+        for a_var in a.to_vars() {
+            cs.mul_gate(a_var, zero_var, zero_var)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// The maximum bit size of the divisor in the div-rem gadget
 ///
 /// This value is safely under half the field size, which prevents wraparound


### PR DESCRIPTION
### Purpose
This PR adds constraints for the external party's settlement; which is effectively just their fees. Specifically:
- Constrain both of the protocol fee and relayer fee to be valid amounts
- Constrain the protocol fee to be computed correctly

We do not validate the relayer fee _value_; instead allowing the relayer to set its fee on a per-trade basis. The actor submitting the tx should validate this fee.

### Todo
- Proof linking
- Testing

### Testing
- Unit tests pass