### PR TITLE
api-server: external-match: Define initial endpoint

### DIFF
--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -110,6 +110,12 @@ impl FixedPoint {
         }
     }
 
+    /// Get the maximum value of a fixed point
+    pub fn max_value() -> Self {
+        let repr = Scalar::one().neg(); // -1 is the largest scalar value
+        Self { repr }
+    }
+
     /// Construct a fixed point value from its `Scalar` representation
     pub fn from_repr(repr: Scalar) -> Self {
         Self { repr }

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -1,0 +1,87 @@
+//! API types for external matches
+//!
+//! External matches are those brokered by the darkpool between an "internal"
+//! party (one with state committed into the protocol), and an external party,
+//! one whose trade obligations are fulfilled directly through erc20 transfers;
+//! and importantly do not commit state into the protocol
+//!
+//! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
+//! for consenting liquidity on a given token pair.
+
+use circuit_types::{fixed_point::FixedPoint, order::OrderSide, Amount};
+use common::types::wallet::Order;
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// The route for requesting an atomic match
+pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-external-match";
+
+// -------------------------------
+// | HTTP Requests and Responses |
+// -------------------------------
+
+/// The request type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchRequest {
+    /// The external order
+    pub external_order: ExternalOrder,
+}
+
+/// The response type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchResponse {
+    // TODO: Define this type
+}
+
+// ------------------
+// | Api Data Types |
+// ------------------
+
+/// An external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalOrder {
+    /// The mint (erc20 address) of the quote token
+    #[serde(
+        serialize_with = "serialize_biguint_to_hex_addr",
+        deserialize_with = "deserialize_biguint_from_hex_string"
+    )]
+    pub quote_mint: BigUint,
+    /// The mint (erc20 address) of the base token
+    #[serde(
+        serialize_with = "serialize_biguint_to_hex_addr",
+        deserialize_with = "deserialize_biguint_from_hex_string"
+    )]
+    pub base_mint: BigUint,
+    /// The side of the market this order is on
+    pub side: OrderSide,
+    /// The amount of the order
+    pub amount: Amount,
+    /// The minimum fill size for the order
+    #[serde(default)]
+    pub min_fill_size: Amount,
+}
+
+impl From<ExternalOrder> for Order {
+    fn from(order: ExternalOrder) -> Self {
+        let worst_case_price = if order.side == OrderSide::Buy {
+            FixedPoint::max_value()
+        } else {
+            FixedPoint::from_integer(0)
+        };
+
+        Order {
+            quote_mint: order.quote_mint,
+            base_mint: order.base_mint,
+            side: order.side,
+            amount: order.amount,
+            min_fill_size: order.min_fill_size,
+            worst_case_price,
+        }
+    }
+}

--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod admin;
+pub mod external_match;
 pub mod network;
 pub mod order_book;
 pub mod price_report;

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -1,0 +1,59 @@
+//! API handlers for external matches
+//!
+//! External matches are those brokered by the darkpool between an "internal"
+//! party (one with state committed into the protocol), and an external party,
+//! one whose trade obligations are fulfilled directly through erc20 transfers;
+//! and importantly do not commit state into the protocol
+//!
+//! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
+//! for consenting liquidity on a given token pair.
+
+// ------------------
+// | Error Messages |
+// ------------------
+
+// ------------------
+// | Route Handlers |
+// ------------------
+
+use async_trait::async_trait;
+use external_api::http::external_match::{ExternalMatchRequest, ExternalMatchResponse};
+use hyper::HeaderMap;
+use job_types::handshake_manager::HandshakeManagerQueue;
+use state::State;
+
+use crate::{
+    error::ApiServerError,
+    router::{QueryParams, TypedHandler, UrlParams},
+};
+
+/// The handler for the `POST /external-match/request` route
+pub struct RequestExternalMatchHandler {
+    /// The relayer-global state
+    state: State,
+    /// The handshake manager's queue
+    handshake_queue: HandshakeManagerQueue,
+}
+
+impl RequestExternalMatchHandler {
+    /// Create a new handler
+    pub fn new(state: State, handshake_queue: HandshakeManagerQueue) -> Self {
+        Self { state, handshake_queue }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for RequestExternalMatchHandler {
+    type Request = ExternalMatchRequest;
+    type Response = ExternalMatchResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        Ok(ExternalMatchResponse {})
+    }
+}

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -57,7 +57,7 @@ const TASK_DRIVER_THREAD_NAME: &str = "renegade-task-driver";
 /// The number of times to retry a step in a task before propagating the error
 const TASK_DRIVER_N_RETRIES: usize = 5;
 /// The stack size to allocate for task driver threads
-const DRIVER_THREAD_STACK_SIZE: usize = 5_000_000; // 5MB
+const DRIVER_THREAD_STACK_SIZE: usize = 50_000_000; // 50MB
 
 /// Error message sent on a notification when a task is not found
 const TASK_NOT_FOUND_ERROR: &str = "task not found";


### PR DESCRIPTION
### Purpose
This PR defines initial request/response types for the external (atomic) matching engine. The request type specifies an external order which will match against our consenting internal orders. The response type is to be defined.

The endpoint will send a job to the handshake manager for matching. If a match is found, the task driver will drive the proof and bundling of a response before sending the full payload back to the api layer.

### Testing
- Hit the endpoint
- Unit tests pass