### PR TITLE
handshake-manager: matching: Generalize local matching engine logic

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -10,14 +10,13 @@ use clap::Parser;
 use common::types::{
     exchange::Exchange,
     gossip::{ClusterId, WrappedPeerId},
-    wallet::{keychain::HmacKey, WalletIdentifier},
+    wallet::keychain::HmacKey,
 };
 use ed25519_dalek::Keypair as DalekKeypair;
 use ethers::signers::LocalWallet;
 use libp2p::{identity::Keypair, Multiaddr};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
     net::{IpAddr, SocketAddr},
     path::Path,
 };
@@ -59,9 +58,6 @@ pub struct Cli {
     /// Defaults to 8 basis points
     #[clap(long, value_parser, default_value = "0.0002")]
     pub match_take_rate: f64,
-    /// The mutual exclusion list for matches, two wallets in this list will never be matched internally by the node
-    #[clap(long, value_parser, value_delimiter=' ', num_args=0..)]
-    pub match_mutual_exclusion_list: Vec<WalletIdentifier>,
     /// The path to the file containing relayer fee whitelist info
     #[clap(long, value_parser)]
     pub relayer_fee_whitelist: Option<String>,
@@ -269,9 +265,6 @@ pub struct RelayerConfig {
     pub match_take_rate: FixedPoint,
     /// When set, the relayer will automatically redeem new fees into its wallet
     pub auto_redeem_fees: bool,
-    /// The mutual exclusion list for matches, two wallets in this list will
-    /// never be matched internally by the node
-    pub match_mutual_exclusion_list: HashSet<WalletIdentifier>,
     /// The price reporter from which to stream prices.
     /// If unset, the relayer will connect to exchanges directly.
     pub price_reporter_url: Option<Url>,
@@ -446,7 +439,6 @@ impl Clone for RelayerConfig {
             min_fill_size: self.min_fill_size,
             match_take_rate: self.match_take_rate,
             auto_redeem_fees: self.auto_redeem_fees,
-            match_mutual_exclusion_list: self.match_mutual_exclusion_list.clone(),
             relayer_fee_whitelist: self.relayer_fee_whitelist.clone(),
             price_reporter_url: self.price_reporter_url.clone(),
             chain_id: self.chain_id,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -105,7 +105,6 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         min_fill_size: cli_args.min_fill_size,
         match_take_rate: FixedPoint::from_f64_round_down(cli_args.match_take_rate),
         auto_redeem_fees: cli_args.auto_redeem_fees,
-        match_mutual_exclusion_list: cli_args.match_mutual_exclusion_list.into_iter().collect(),
         relayer_fee_whitelist,
         price_reporter_url,
         chain_id: cli_args.chain_id,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -259,7 +259,6 @@ async fn main() -> Result<(), CoordinatorError> {
     let (handshake_cancel_sender, handshake_cancel_receiver) = watch::channel(());
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
         min_fill_size: args.min_fill_size,
-        mutual_exclusion_list: args.match_mutual_exclusion_list,
         state: global_state.clone(),
         network_channel: network_sender.clone(),
         price_reporter_job_queue: price_reporter_worker_sender.clone(),

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -10,7 +10,7 @@ use external_api::{
     http::task::ApiTaskStatus,
     types::ApiHistoricalTask,
 };
-use job_types::{handshake_manager::HandshakeExecutionJob, task_driver::TaskDriverJob};
+use job_types::{handshake_manager::HandshakeManagerJob, task_driver::TaskDriverJob};
 use libmdbx::{TransactionKind, RW};
 use tracing::{error, info, instrument, warn};
 use util::err_str;
@@ -506,7 +506,7 @@ impl StateApplicator {
             };
 
             if order.ready_for_match() {
-                let job = HandshakeExecutionJob::InternalMatchingEngine { order: order.id };
+                let job = HandshakeManagerJob::InternalMatchingEngine { order: order.id };
                 if self.config.handshake_manager_queue.send(job).is_err() {
                     error!("error enqueueing internal matching engine job for order {order_id}");
                 }

--- a/workers/handshake-manager/src/error.rs
+++ b/workers/handshake-manager/src/error.rs
@@ -34,6 +34,14 @@ pub enum HandshakeManagerError {
     VerificationError(String),
 }
 
+impl HandshakeManagerError {
+    /// Create a new error from a state error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn state<T: ToString>(e: T) -> Self {
+        HandshakeManagerError::State(e.to_string())
+    }
+}
+
 impl Display for HandshakeManagerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -1,0 +1,22 @@
+//! The matching engine for external matches
+//!
+//! An external match is one that occurs between an internal party (with state
+//! allocated in the darkpool) and an external party (with no state in the
+//! darkpool).
+//!
+//! The external matching engine is responsible for matching an external order
+//! against all known internal order
+
+use common::types::wallet::Order;
+
+use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
+
+impl HandshakeExecutor {
+    /// Execute an external match
+    pub async fn run_external_matching_engine(
+        &self,
+        order: Order,
+    ) -> Result<(), HandshakeManagerError> {
+        todo!()
+    }
+}

--- a/workers/handshake-manager/src/manager/matching/match_helpers.rs
+++ b/workers/handshake-manager/src/manager/matching/match_helpers.rs
@@ -1,0 +1,66 @@
+//! Helpers for matching orders
+
+use circuit_types::{balance::Balance, fixed_point::FixedPoint, r#match::MatchResult, Amount};
+use common::types::wallet::{Order, OrderIdentifier};
+use util::matching_engine::match_orders_with_min_base_amount;
+
+use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
+
+/// A successful match between two orders
+pub type SuccessfulMatch = (OrderIdentifier, MatchResult);
+
+impl HandshakeExecutor {
+    /// Run a match between two orders
+    pub async fn find_match<I>(
+        &self,
+        order: &Order,
+        balance: &Balance,
+        price: FixedPoint,
+        target_orders: I,
+    ) -> Result<Option<SuccessfulMatch>, HandshakeManagerError>
+    where
+        I: IntoIterator<Item = OrderIdentifier>,
+    {
+        // Match against each other order in the local book
+        for order_id in target_orders.into_iter() {
+            // Lookup the other order and attempt to match with it
+            let (order2, balance2) =
+                match self.state.get_managed_order_and_balance(&order_id).await? {
+                    Some((order, balance)) => (order, balance),
+                    None => continue,
+                };
+
+            // If a match is successful, return the result
+            let res = self.try_match(order, &order2, balance, &balance2, price);
+            if let Some(match_result) = res {
+                return Ok(Some((order_id, match_result)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Try to match two orders, return the `MatchResult` if a match is found
+    fn try_match(
+        &self,
+        o1: &Order,
+        o2: &Order,
+        b1: &Balance,
+        b2: &Balance,
+        price: FixedPoint,
+    ) -> Option<MatchResult> {
+        // Match the orders
+        let min_base_amount = Amount::max(o1.min_fill_size, o2.min_fill_size);
+        let min_quote_amount = self.min_fill_size;
+
+        match_orders_with_min_base_amount(
+            &o1.clone().into(),
+            &o2.clone().into(),
+            b1,
+            b2,
+            min_quote_amount,
+            min_base_amount,
+            price,
+        )
+    }
+}

--- a/workers/handshake-manager/src/manager/matching/mod.rs
+++ b/workers/handshake-manager/src/manager/matching/mod.rs
@@ -1,0 +1,6 @@
+//! Matching engine implementations for the handshake manager
+
+pub mod external_engine;
+pub mod internal_engine;
+mod match_helpers;
+pub mod mpc_engine;

--- a/workers/handshake-manager/src/manager/matching/mpc_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/mpc_engine.rs
@@ -38,9 +38,7 @@ use tracing::info;
 use util::{arbitrum::get_protocol_fee, matching_engine::compute_max_amount};
 use uuid::Uuid;
 
-use crate::error::HandshakeManagerError;
-
-use super::HandshakeExecutor;
+use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
 
 /// Error message emitted when opening a statement fails
 const ERR_OPENING_STATEMENT: &str = "error opening statement";
@@ -60,7 +58,7 @@ impl HandshakeExecutor {
     /// Spawns the match computation in a separate thread wrapped by a custom
     /// Tokio runtime. The QUIC implementation in quinn is async and expects
     /// to be run inside of a Tokio runtime
-    pub(super) async fn execute_match(
+    pub(crate) async fn execute_match(
         &self,
         request_id: Uuid,
         party_id: u64,

--- a/workers/handshake-manager/src/manager/scheduler.rs
+++ b/workers/handshake-manager/src/manager/scheduler.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use common::types::CancelChannel;
 use constants::in_bootstrap_mode;
-use job_types::handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue};
+use job_types::handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue};
 use state::State;
 use tracing::info;
 use util::{err_str, runtime::sleep_forever_async};
@@ -57,7 +57,7 @@ impl HandshakeScheduler {
                     if let Some(order) = self.state.choose_handshake_order().await.ok().flatten() {
                         if let Err(e) = self
                             .job_sender
-                            .send(HandshakeExecutionJob::PerformHandshake { order })
+                            .send(HandshakeManagerJob::PerformHandshake { order })
                             .map_err(err_str!(HandshakeManagerError::SendMessage))
                         {
                             return e;

--- a/workers/handshake-manager/src/worker.rs
+++ b/workers/handshake-manager/src/worker.rs
@@ -1,13 +1,10 @@
 //! Implements the `Worker` trait for the handshake manager
 
-use std::{
-    collections::HashSet,
-    thread::{Builder, JoinHandle},
-};
+use std::thread::{Builder, JoinHandle};
 
 use async_trait::async_trait;
 use circuit_types::Amount;
-use common::types::{wallet::WalletIdentifier, CancelChannel};
+use common::types::CancelChannel;
 use common::worker::Worker;
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
@@ -33,11 +30,6 @@ pub struct HandshakeManagerConfig {
     /// The minimum amount of the quote asset that the relayer should settle
     /// matches on
     pub min_fill_size: Amount,
-    /// The set of wallets to mutually exclude from matches
-    ///
-    /// I.e. any two wallets in this list will never be matched internally by
-    /// the node
-    pub mutual_exclusion_list: HashSet<WalletIdentifier>,
     /// The relayer-global state
     pub state: State,
     /// The channel on which to send outbound network requests
@@ -73,7 +65,6 @@ impl Worker for HandshakeManager {
         );
         let executor = HandshakeExecutor::new(
             config.min_fill_size,
-            config.mutual_exclusion_list.clone(),
             config.job_receiver.take().unwrap(),
             config.network_channel.clone(),
             config.price_reporter_job_queue.clone(),

--- a/workers/job-types/src/lib.rs
+++ b/workers/job-types/src/lib.rs
@@ -6,3 +6,17 @@ pub mod network_manager;
 pub mod price_reporter;
 pub mod proof_manager;
 pub mod task_driver;
+
+use tokio::sync::oneshot::{
+    channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender,
+};
+
+/// A response channel sender
+pub type ResponseSender<T> = OneshotSender<T>;
+/// A response channel receiver
+pub type ResponseReceiver<T> = OneshotReceiver<T>;
+
+/// Create a new response channel for a request
+pub fn new_response_channel<T>() -> (ResponseSender<T>, ResponseReceiver<T>) {
+    oneshot_channel()
+}

--- a/workers/job-types/src/network_manager.rs
+++ b/workers/job-types/src/network_manager.rs
@@ -12,10 +12,12 @@ use libp2p::request_response::ResponseChannel;
 use libp2p_core::Multiaddr;
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender as TokioSender},
-    oneshot::{channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender},
+    oneshot::{Receiver as OneshotReceiver, Sender as OneshotSender},
 };
 use util::metered_channels::MeteredTokioReceiver;
 use uuid::Uuid;
+
+use crate::new_response_channel;
 
 /// The name of the network manager queue, used to label queue length metrics
 const NETWORK_MANAGER_QUEUE_NAME: &str = "network_manager";
@@ -35,10 +37,6 @@ pub type NetworkResponseReceiver = OneshotReceiver<GossipResponse>;
 pub fn new_network_manager_queue() -> (NetworkManagerQueue, NetworkManagerReceiver) {
     let (send, recv) = unbounded_channel();
     (send, MeteredTokioReceiver::new(recv, NETWORK_MANAGER_QUEUE_NAME))
-}
-/// Create a new response channel for a request
-pub fn new_response_channel() -> (NetworkResponseChannel, NetworkResponseReceiver) {
-    oneshot_channel()
 }
 
 /// The job type for the network manager


### PR DESCRIPTION
### Purpose
This PR generalizes the matching engine logic for locally inferred matches. Specifically, we break out much of the core matching logic into a set of helpers in the `HandshakeExecutor` that will allow for easy re-use between the internal engine and external (atomic) engine.

This has the benefit of also simplifying and optimizing the match critical path.

I also removed the match mutual exclusion list as this argument is no longer needed.

### Testing
- All tests pass
- Live testing deferred until the feature branch is ready for merge