### PR TITLE
handshake-manager: matching: external-engine: Add external engine logic

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -37,6 +37,11 @@ impl Wallet {
         self.balances.get_mut(mint)
     }
 
+    /// Get a balance or default to an empty balance
+    pub fn get_balance_or_default(&self, mint: &BigUint) -> Balance {
+        self.get_balance(mint).cloned().unwrap_or_else(|| Balance::new_from_mint(mint.clone()))
+    }
+
     /// Get a mutable reference to the balance for the given mint or add a
     /// zero'd balance if one does not exist
     pub fn get_balance_mut_or_default(&mut self, mint: &BigUint) -> &mut Balance {

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use std::{collections::HashSet, mem};
+use std::mem;
 
 use api_server::worker::{ApiServer, ApiServerConfig};
 use arbitrum_client::{
@@ -32,7 +32,7 @@ use job_types::{
         new_gossip_server_queue, GossipServerJob, GossipServerQueue, GossipServerReceiver,
     },
     handshake_manager::{
-        new_handshake_manager_queue, HandshakeExecutionJob, HandshakeManagerQueue,
+        new_handshake_manager_queue, HandshakeManagerJob, HandshakeManagerQueue,
         HandshakeManagerReceiver,
     },
     network_manager::{
@@ -225,7 +225,7 @@ impl MockNodeController {
     }
 
     /// Send a job to the handshake manager
-    pub fn send_handshake_job(&self, job: HandshakeExecutionJob) -> Result<(), String> {
+    pub fn send_handshake_job(&self, job: HandshakeManagerJob) -> Result<(), String> {
         self.handshake_queue.0.send(job).map_err(|e| e.to_string())
     }
 
@@ -387,7 +387,6 @@ impl MockNodeController {
 
         let conf = HandshakeManagerConfig {
             min_fill_size: self.config.min_fill_size,
-            mutual_exclusion_list: HashSet::new(),
             state,
             network_channel,
             price_reporter_job_queue,

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -75,11 +75,7 @@ impl State {
 
             // Get the balance that capitalizes the order
             let sell_mint = order.send_mint().clone();
-            let balance = wallet
-                .balances
-                .get(&sell_mint)
-                .cloned()
-                .unwrap_or_else(|| Balance::new_from_mint(sell_mint));
+            let balance = wallet.get_balance_or_default(&sell_mint);
             Ok(Some((order, balance)))
         })
         .await

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -400,7 +400,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::POST,
             REQUEST_EXTERNAL_MATCH_ROUTE.to_string(),
-            RequestExternalMatchHandler::new(state.clone(), handshake_queue),
+            RequestExternalMatchHandler::new(handshake_queue),
         );
 
         // --- Orderbook Routes --- //

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -25,7 +25,7 @@ use external_api::{
 };
 use hyper::HeaderMap;
 use job_types::{
-    handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue},
+    handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue},
     price_reporter::{PriceReporterJob, PriceReporterQueue},
 };
 use state::State;
@@ -427,7 +427,7 @@ impl TypedHandler for AdminAssignOrderToMatchingPoolHandler {
         waiter.await?;
 
         // Run the matching engine on the order
-        let job = HandshakeExecutionJob::InternalMatchingEngine { order: order_id };
+        let job = HandshakeManagerJob::InternalMatchingEngine { order: order_id };
         self.handshake_manager_queue.send(job).map_err(internal_error)?;
 
         Ok(EmptyRequestResponse {})

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -8,37 +8,39 @@
 //! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
 //! for consenting liquidity on a given token pair.
 
+use async_trait::async_trait;
+use common::types::wallet::Order;
+use external_api::http::external_match::{ExternalMatchRequest, ExternalMatchResponse};
+use hyper::HeaderMap;
+use job_types::handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue};
+
+use crate::{
+    error::{internal_error, ApiServerError},
+    router::{QueryParams, TypedHandler, UrlParams},
+};
+
 // ------------------
 // | Error Messages |
 // ------------------
+
+/// The error message returned when the relayer fails to process an external
+/// match request
+const ERR_FAILED_TO_PROCESS_EXTERNAL_MATCH: &str = "failed to process external match request";
 
 // ------------------
 // | Route Handlers |
 // ------------------
 
-use async_trait::async_trait;
-use external_api::http::external_match::{ExternalMatchRequest, ExternalMatchResponse};
-use hyper::HeaderMap;
-use job_types::handshake_manager::HandshakeManagerQueue;
-use state::State;
-
-use crate::{
-    error::ApiServerError,
-    router::{QueryParams, TypedHandler, UrlParams},
-};
-
 /// The handler for the `POST /external-match/request` route
 pub struct RequestExternalMatchHandler {
-    /// The relayer-global state
-    state: State,
     /// The handshake manager's queue
     handshake_queue: HandshakeManagerQueue,
 }
 
 impl RequestExternalMatchHandler {
     /// Create a new handler
-    pub fn new(state: State, handshake_queue: HandshakeManagerQueue) -> Self {
-        Self { state, handshake_queue }
+    pub fn new(handshake_queue: HandshakeManagerQueue) -> Self {
+        Self { handshake_queue }
     }
 }
 
@@ -54,6 +56,12 @@ impl TypedHandler for RequestExternalMatchHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        let order: Order = req.external_order.into();
+        let (job, rx) = HandshakeManagerJob::new_external_matching_job(order);
+        self.handshake_queue
+            .send(job)
+            .map_err(|_| internal_error(ERR_FAILED_TO_PROCESS_EXTERNAL_MATCH))?;
+        let _ = rx.await.map_err(|_| internal_error(ERR_FAILED_TO_PROCESS_EXTERNAL_MATCH))?;
         Ok(ExternalMatchResponse {})
     }
 }

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -7,7 +7,7 @@ use common::types::CancelChannel;
 use constants::in_bootstrap_mode;
 use ethers::prelude::StreamExt;
 use job_types::{
-    handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue},
+    handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue},
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
 };
@@ -115,7 +115,7 @@ impl OnChainEventListenerExecutor {
         let nullifier = u256_to_scalar(&event.nullifier);
         self.config
             .handshake_manager_job_queue
-            .send(HandshakeExecutionJob::MpcShootdown { nullifier })
+            .send(HandshakeManagerJob::MpcShootdown { nullifier })
             .map_err(|err| OnChainEventListenerError::SendMessage(err.to_string()))?;
 
         // Nullify any orders that used this nullifier in their validity proof

--- a/workers/handshake-manager-tests/src/mpc_match.rs
+++ b/workers/handshake-manager-tests/src/mpc_match.rs
@@ -7,7 +7,7 @@ use common::types::{
     wallet_mocks::mock_empty_wallet,
 };
 use eyre::Result;
-use job_types::handshake_manager::HandshakeExecutionJob;
+use job_types::handshake_manager::HandshakeManagerJob;
 use test_helpers::integration_test_async;
 use util::hex::biguint_from_hex_string;
 use uuid::Uuid;
@@ -111,7 +111,7 @@ async fn test_mpc_match(args: IntegrationTestArgs) -> Result<()> {
     // Peer 1 starts a handshake for peer 2's order
     let order = get_order_id(PARTY1);
     if args.party_id == PARTY0 {
-        let job = HandshakeExecutionJob::PerformHandshake { order };
+        let job = HandshakeManagerJob::PerformHandshake { order };
         node.send_handshake_job(job).unwrap();
     }
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -201,7 +201,7 @@ impl HandshakeExecutor {
 
             // A request to run the external matching engine
             HandshakeManagerJob::ExternalMatchingEngine { order, response_channel } => {
-                todo!()
+                self.run_external_matching_engine(order, response_channel).await
             },
 
             // Indicates that a peer has sent a message during the course of a handshake

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -7,16 +7,120 @@
 //! The external matching engine is responsible for matching an external order
 //! against all known internal order
 
-use common::types::wallet::Order;
+use std::collections::HashSet;
+
+use circuit_types::{balance::Balance, fixed_point::FixedPoint, r#match::MatchResult};
+use common::types::{
+    token::Token,
+    wallet::{Order, OrderIdentifier},
+};
+use constants::Scalar;
+use job_types::{handshake_manager::ExternalMatchingResponse, ResponseSender};
+use renegade_crypto::fields::scalar_to_u128;
+use tracing::{error, info};
 
 use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
+
+/// The response channel type for the external matching engine
+type ExternalMatchResponseSender = ResponseSender<ExternalMatchingResponse>;
 
 impl HandshakeExecutor {
     /// Execute an external match
     pub async fn run_external_matching_engine(
         &self,
         order: Order,
+        response_channel: ExternalMatchResponseSender,
     ) -> Result<(), HandshakeManagerError> {
+        let base = Token::from_addr_biguint(&order.base_mint);
+        let quote = Token::from_addr_biguint(&order.quote_mint);
+        info!(
+            "Running external matching engine for {}/{}",
+            base.get_ticker().unwrap_or_default(),
+            quote.get_ticker().unwrap_or_default()
+        );
+
+        // Get all orders that consent to external matching
+        let mut matchable_orders = self.get_external_match_candidates(&order).await?;
+        let ts_price = self.get_execution_price(&base, &quote).await?;
+        let price = FixedPoint::from_f64_round_down(ts_price.price);
+
+        // Mock a balance for the external order, assuming it's fully capitalized
+        let balance = self.mock_balance_for_external_order(&order, price);
+
+        // Try to find a match iteratively, we wrap this in a retry loop in case
+        // settlement fails on a match
+        while !matchable_orders.is_empty() {
+            let (other_order_id, match_res) =
+                match self.find_match(&order, &balance, price, matchable_orders.clone()).await? {
+                    Some(match_res) => match_res,
+                    None => {
+                        info!("No external matches found");
+                        return Ok(());
+                    },
+                };
+
+            // Try to settle the match
+            match self.try_settle_external_match(other_order_id, match_res).await {
+                Ok(()) => {
+                    // Stop matching if a match was found
+                    return Ok(());
+                },
+                Err(e) => {
+                    error!(
+                        "external match settlement failed on internal order {}: {e}",
+                        other_order_id,
+                    );
+                },
+            }
+
+            // If matching failed, remove the other order from the candidate set
+            matchable_orders.remove(&other_order_id);
+        }
+
+        // TODO: Send this when a match is found
+        response_channel.send(()).expect("failed to send response");
+        info!("no external matches found");
+        Ok(())
+    }
+
+    /// Get the match candidates for an external order
+    ///
+    /// TODO: Replace this with a correct implementation that filters out orders
+    /// which do not consent to external matching
+    async fn get_external_match_candidates(
+        &self,
+        order: &Order,
+    ) -> Result<HashSet<OrderIdentifier>, HandshakeManagerError> {
+        let matchable_orders = self.state.get_locally_matchable_orders().await?;
+        Ok(HashSet::from_iter(matchable_orders))
+    }
+
+    /// Settle an external match
+    async fn try_settle_external_match(
+        &self,
+        internal_order_id: OrderIdentifier,
+        match_res: MatchResult,
+    ) -> Result<(), HandshakeManagerError> {
+        // TODO: Implement this method
         todo!()
+    }
+
+    /// Mock a balance for an external order
+    ///
+    /// We cannot know the external party's balance here so we mock it for the
+    /// matching engine. We assume the external order is fully capitalized and
+    /// so we mock a full balance
+    fn mock_balance_for_external_order(&self, order: &Order, price: FixedPoint) -> Balance {
+        let base_amount = Scalar::from(order.amount);
+        let quote_amount_fp = price * base_amount + Scalar::one();
+        let quote_amount = quote_amount_fp.floor();
+
+        let (mint, amount) = if order.side.is_buy() {
+            (order.quote_mint.clone(), quote_amount)
+        } else {
+            (order.base_mint.clone(), base_amount)
+        };
+
+        Balance::new_from_mint_and_amount(mint, scalar_to_u128(&amount))
     }
 }

--- a/workers/network-manager/src/executor/control_directives.rs
+++ b/workers/network-manager/src/executor/control_directives.rs
@@ -7,7 +7,7 @@ use ark_mpc::network::QuicTwoPartyNet;
 use common::types::handshake::ConnectionRole;
 use itertools::Itertools;
 use job_types::{
-    handshake_manager::{HandshakeExecutionJob, HandshakeManagerQueue},
+    handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue},
     network_manager::NetworkManagerControlSignal,
 };
 use libp2p::PeerId;
@@ -205,7 +205,7 @@ impl NetworkManagerExecutor {
         // After the dependencies are injected into the network; forward it to the
         // handshake manager to dial the peer and begin the MPC
         handshake_work_queue
-            .send(HandshakeExecutionJob::MpcNetSetup { request_id, party_id, net: mpc_net })
+            .send(HandshakeManagerJob::MpcNetSetup { request_id, party_id, net: mpc_net })
             .map_err(|err| NetworkManagerError::EnqueueJob(err.to_string()))?;
         Ok(())
     }

--- a/workers/network-manager/src/executor/pubsub.rs
+++ b/workers/network-manager/src/executor/pubsub.rs
@@ -10,7 +10,7 @@ use gossip_api::{
     },
     GossipDestination,
 };
-use job_types::{gossip_server::GossipServerJob, handshake_manager::HandshakeExecutionJob};
+use job_types::{gossip_server::GossipServerJob, handshake_manager::HandshakeManagerJob};
 use libp2p::gossipsub::{Message as GossipsubMessage, Sha256Topic};
 use util::err_str;
 
@@ -84,11 +84,11 @@ impl NetworkManagerExecutor {
                     match message_type {
                         ClusterManagementMessageType::CacheSync(order1, order2) => self
                             .handshake_work_queue
-                            .send(HandshakeExecutionJob::CacheEntry { order1, order2 })
+                            .send(HandshakeManagerJob::CacheEntry { order1, order2 })
                             .map_err(err_str!(NetworkManagerError::EnqueueJob)),
                         ClusterManagementMessageType::MatchInProgress(order1, order2) => self
                             .handshake_work_queue
-                            .send(HandshakeExecutionJob::PeerMatchInProgress { order1, order2 })
+                            .send(HandshakeManagerJob::PeerMatchInProgress { order1, order2 })
                             .map_err(err_str!(NetworkManagerError::EnqueueJob)),
                         _ => unreachable!("handshake manager should not receive other messages"),
                     }


### PR DESCRIPTION
### Purpose
This PR sets up the initial logic for the external matching engine and connects it via the `HandshakeManager`'s job queue to the api server's endpoint.

### Todo
- External match settlement; i.e. return the bundle to the caller and await on-chain settlement

### Testing
- Unit tests pass
- Tested the endpoint, verified that it correctly called the external engine