### PR TITLE
task-driver: tasks: settle-match-external: Create atomic settlement bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4956,6 +4956,7 @@ dependencies = [
  "common 0.1.0",
  "constants 0.1.0",
  "crossbeam",
+ "external-api 0.1.0",
  "gossip-api",
  "lazy_static",
  "libp2p",

--- a/circuit-types/src/fixed_point.rs
+++ b/circuit-types/src/fixed_point.rs
@@ -110,12 +110,6 @@ impl FixedPoint {
         }
     }
 
-    /// Get the maximum value of a fixed point
-    pub fn max_value() -> Self {
-        let repr = Scalar::one().neg(); // -1 is the largest scalar value
-        Self { repr }
-    }
-
     /// Construct a fixed point value from its `Scalar` representation
     pub fn from_repr(repr: Scalar) -> Self {
         Self { repr }

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -139,6 +139,13 @@ pub type Address = BigUint;
 // | Helpers |
 // -----------
 
+/// Get the maximum representable price
+pub fn max_price() -> FixedPoint {
+    let repr_bigint = (BigUint::from(1u8) << PRICE_BITS) - 1u8;
+    let repr = biguint_to_scalar(&repr_bigint);
+    FixedPoint::from_repr(repr)
+}
+
 /// Verify that an amount is within the correct bitlength
 pub fn validate_amount_bitlength(amount: Amount) -> bool {
     let max_amount = (1u128 << AMOUNT_BITS) - 1;

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -31,8 +31,8 @@ pub struct MatchResult {
     pub quote_amount: Amount,
     /// The amount of the base token exchanged by this match
     pub base_amount: Amount,
-    /// The direction of the match, `true` implies that party 1 buys the quote
-    /// and sells the base, `false` implies that party 1 buys the base and
+    /// The direction of the match, `true` implies that party 0 buys the quote
+    /// and sells the base, `false` implies that party 0 buys the base and
     /// sells the quote
     pub direction: bool,
 
@@ -134,4 +134,16 @@ pub struct ExternalMatchResult {
     /// - `false` implies that the internal party buys the base and sells the
     ///   quote
     pub direction: bool,
+}
+
+impl From<MatchResult> for ExternalMatchResult {
+    fn from(value: MatchResult) -> Self {
+        Self {
+            quote_mint: value.quote_mint,
+            base_mint: value.base_mint,
+            quote_amount: value.quote_amount,
+            base_amount: value.base_amount,
+            direction: value.direction,
+        }
+    }
 }

--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -137,6 +137,20 @@ impl OrderSide {
             OrderSide::Sell => OrderSide::Buy,
         }
     }
+
+    /// Return the match direction for this order assuming that the order is
+    /// matched for party 0
+    ///
+    /// If party0 buys the base, the match direction is `false` and if party0
+    /// sells the base, the match direction is `true`
+    ///
+    /// See [`MatchResult`] for more information
+    pub fn match_direction(&self) -> bool {
+        match self {
+            OrderSide::Buy => false,
+            OrderSide::Sell => true,
+        }
+    }
 }
 
 impl BaseType for OrderSide {

--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -1,6 +1,6 @@
 //! Descriptors for the match settlement tasks
 
-use circuit_types::r#match::MatchResult;
+use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
@@ -78,30 +78,34 @@ impl From<SettleMatchInternalTaskDescriptor> for TaskDescriptor {
 /// `SettleExternalMatch` task
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettleExternalMatchTaskDescriptor {
+    /// The ID of the order that the local node matched
+    pub internal_order_id: OrderIdentifier,
     /// The ID of the wallet that the local node matched an order from
     pub internal_wallet_id: WalletIdentifier,
     /// The price at which the match was executed
-    pub execution_price: TimestampedPrice,
+    pub execution_price: FixedPoint,
     /// The match result from the external matching engine
     pub match_res: MatchResult,
-    /// The validity proofs submitted by the local party
-    pub internal_order_validity_bundle: OrderValidityProofBundle,
+    /// The system bus topic on which to send the atomic match settle bundle
+    pub atomic_match_bundle_topic: String,
 }
 
 impl SettleExternalMatchTaskDescriptor {
     /// Constructor
     pub fn new(
+        internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
-        execution_price: TimestampedPrice,
+        execution_price: FixedPoint,
         match_res: MatchResult,
-        internal_order_validity_bundle: OrderValidityProofBundle,
-    ) -> Result<Self, String> {
-        Ok(SettleExternalMatchTaskDescriptor {
+        atomic_match_bundle_topic: String,
+    ) -> Self {
+        SettleExternalMatchTaskDescriptor {
+            internal_order_id,
             internal_wallet_id,
+            atomic_match_bundle_topic,
             execution_price,
             match_res,
-            internal_order_validity_bundle,
-        })
+        }
     }
 }
 

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -8,8 +8,8 @@
 //! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
 //! for consenting liquidity on a given token pair.
 
-use circuit_types::{fixed_point::FixedPoint, order::OrderSide, Amount};
-use common::types::wallet::Order;
+use circuit_types::{fixed_point::FixedPoint, max_price, order::OrderSide, Amount};
+use common::types::{proof_bundles::AtomicMatchSettleBundle, wallet::Order};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,8 @@ pub struct ExternalMatchRequest {
 /// The response type for requesting an external match
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExternalMatchResponse {
-    // TODO: Define this type
+    /// The match bundle
+    pub match_bundle: AtomicMatchSettleBundle,
 }
 
 // ------------------
@@ -69,11 +70,8 @@ pub struct ExternalOrder {
 
 impl From<ExternalOrder> for Order {
     fn from(order: ExternalOrder) -> Self {
-        let worst_case_price = if order.side == OrderSide::Buy {
-            FixedPoint::max_value()
-        } else {
-            FixedPoint::from_integer(0)
-        };
+        let worst_case_price =
+            if order.side == OrderSide::Buy { max_price() } else { FixedPoint::from_integer(0) };
 
         Order {
             quote_mint: order.quote_mint,

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -56,6 +56,12 @@ impl From<ApiServerError> for Response<Body> {
     }
 }
 
+/// Create an `ApiServerError` with a 204 no content code
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn no_content<E: ToString>(e: E) -> ApiServerError {
+    ApiServerError::HttpStatusCode(StatusCode::NO_CONTENT, e.to_string())
+}
+
 /// Create an `ApiServerError` with a 400 bad request code
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn bad_request<E: ToString>(e: E) -> ApiServerError {

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -400,7 +400,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::POST,
             REQUEST_EXTERNAL_MATCH_ROUTE.to_string(),
-            RequestExternalMatchHandler::new(handshake_queue),
+            RequestExternalMatchHandler::new(handshake_queue, config.system_bus.clone()),
         );
 
         // --- Orderbook Routes --- //

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -200,8 +200,8 @@ impl HandshakeExecutor {
             },
 
             // A request to run the external matching engine
-            HandshakeManagerJob::ExternalMatchingEngine { order, response_channel } => {
-                self.run_external_matching_engine(order, response_channel).await
+            HandshakeManagerJob::ExternalMatchingEngine { order, response_topic } => {
+                self.run_external_matching_engine(order, response_topic).await
             },
 
             // Indicates that a peer has sent a message during the course of a handshake

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -185,7 +185,7 @@ impl HandshakeExecutor {
     }
 
     /// Get the wallet for an order
-    async fn get_wallet_id_for_order(
+    pub(crate) async fn get_wallet_id_for_order(
         &self,
         order_id: &OrderIdentifier,
     ) -> Result<WalletIdentifier, HandshakeManagerError> {

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -16,6 +16,7 @@ circuits = { path = "../../circuits" }
 circuit-types = { path = "../../circuit-types" }
 common = { path = "../../common" }
 constants = { path = "../../constants" }
+external-api = { path = "../../external-api" }
 gossip-api = { path = "../../gossip-api" }
 util = { path = "../../util" }
 

--- a/workers/job-types/src/proof_manager.rs
+++ b/workers/job-types/src/proof_manager.rs
@@ -8,6 +8,9 @@ use circuits::zk_circuits::{
     valid_commitments::{SizedValidCommitmentsWitness, ValidCommitmentsStatement},
     valid_fee_redemption::{SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness},
     valid_match_settle::{SizedValidMatchSettleStatement, SizedValidMatchSettleWitness},
+    valid_match_settle_atomic::{
+        SizedValidMatchSettleAtomicStatement, SizedValidMatchSettleAtomicWitness,
+    },
     valid_offline_fee_settlement::{
         SizedValidOfflineFeeSettlementStatement, SizedValidOfflineFeeSettlementWitness,
     },
@@ -100,6 +103,15 @@ pub enum ProofJob {
         /// The statement (public variables) to use in the proof of `VALID
         /// MATCH SETTLE`
         statement: SizedValidMatchSettleStatement,
+    },
+    /// A request to create a proof of `VALID MATCH SETTLE ATOMIC` describing an
+    /// atomic match settlement between an internal and an external order
+    ValidMatchSettleAtomic {
+        /// The witness to the proof of `VALID MATCH SETTLE ATOMIC`
+        witness: SizedValidMatchSettleAtomicWitness,
+        /// The statement (public variables) to use in the proof of `VALID
+        /// MATCH SETTLE ATOMIC`
+        statement: SizedValidMatchSettleAtomicStatement,
     },
     /// A request to create a proof of `VALID RELAYER FEE SETTLEMENT` in a
     /// single prover context

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -13,6 +13,10 @@ use circuits::zk_circuits::{
     valid_match_settle::{
         SizedValidMatchSettle, SizedValidMatchSettleStatement, SizedValidMatchSettleWitness,
     },
+    valid_match_settle_atomic::{
+        SizedValidMatchSettleAtomic, SizedValidMatchSettleAtomicStatement,
+        SizedValidMatchSettleAtomicWitness,
+    },
     valid_offline_fee_settlement::{
         SizedValidOfflineFeeSettlement, SizedValidOfflineFeeSettlementStatement,
         SizedValidOfflineFeeSettlementWitness,
@@ -92,6 +96,9 @@ impl MockProofManager {
             ProofJob::ValidMatchSettleSingleprover { witness, statement } => {
                 Self::valid_match_settle(witness, statement)
             },
+            ProofJob::ValidMatchSettleAtomic { witness, statement } => {
+                Self::valid_match_settle_atomic(witness, statement)
+            },
             ProofJob::ValidRelayerFeeSettlement { witness, statement } => {
                 Self::valid_relayer_fee_settlement(witness, statement)
             },
@@ -165,6 +172,18 @@ impl MockProofManager {
         let proof = dummy_proof();
         let link_hint = dummy_link_hint();
         Ok(ProofBundle::new_valid_match_settle(statement, proof, link_hint))
+    }
+
+    /// Create a dummy proof of `VALID MATCH SETTLE ATOMIC`
+    fn valid_match_settle_atomic(
+        witness: SizedValidMatchSettleAtomicWitness,
+        statement: SizedValidMatchSettleAtomicStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        Self::check_constraints::<SizedValidMatchSettleAtomic>(&witness, &statement)?;
+
+        let proof = dummy_proof();
+        let link_hint = dummy_link_hint();
+        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_hint))
     }
 
     /// Generate a dummy proof of `VALID RELAYER FEE SETTLEMENT`

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -18,6 +18,10 @@ use circuits::{
         valid_match_settle::{
             SizedValidMatchSettle, SizedValidMatchSettleStatement, SizedValidMatchSettleWitness,
         },
+        valid_match_settle_atomic::{
+            SizedValidMatchSettleAtomic, SizedValidMatchSettleAtomicStatement,
+            SizedValidMatchSettleAtomicWitness,
+        },
         valid_offline_fee_settlement::{
             SizedValidOfflineFeeSettlement, SizedValidOfflineFeeSettlementStatement,
             SizedValidOfflineFeeSettlementWitness,
@@ -143,6 +147,11 @@ impl ProofManager {
                 Self::prove_valid_match_mpc(witness, statement)
             },
 
+            ProofJob::ValidMatchSettleAtomic { witness, statement } => {
+                // Prove `VALID MATCH SETTLE ATOMIC`
+                Self::prove_valid_match_settle_atomic(witness, statement)
+            },
+
             ProofJob::ValidRelayerFeeSettlement { witness, statement } => {
                 // Prove `VALID RELAYER FEE SETTLEMENT`
                 Self::prove_valid_relayer_fee_settlement(witness, statement)
@@ -264,6 +273,20 @@ impl ProofManager {
                 .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
 
         Ok(ProofBundle::new_valid_match_settle(statement, proof, link_hint))
+    }
+
+    /// Create a proof of `VALID MATCH SETTLE ATOMIC`
+    #[instrument(skip_all, err)]
+    fn prove_valid_match_settle_atomic(
+        witness: SizedValidMatchSettleAtomicWitness,
+        statement: SizedValidMatchSettleAtomicStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        // Prove the statement `VALID MATCH SETTLE ATOMIC`
+        let (proof, link_hint) =
+            singleprover_prove_with_hint::<SizedValidMatchSettleAtomic>(witness, statement.clone())
+                .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
+
+        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_hint))
     }
 
     /// Create a proof of `VALID RELAYER FEE SETTLEMENT`

--- a/workers/task-driver/src/tasks/mod.rs
+++ b/workers/task-driver/src/tasks/mod.rs
@@ -19,3 +19,7 @@ pub(crate) const ERR_WALLET_MISSING: &str = "wallet not found in global state";
 pub(crate) const ERR_BALANCE_MISSING: &str = "balance not found in wallet";
 /// The error message emitted when a Merkle proof is not found for a wallet
 pub(crate) const ERR_NO_MERKLE_PROOF: &str = "no merkle proof found for wallet";
+/// The error message emitted when validity proofs are not found for an order
+pub(crate) const ERR_NO_VALIDITY_PROOF: &str = "no validity proofs found for order";
+/// Error message emitted when awaiting a proof fails
+pub(crate) const ERR_AWAITING_PROOF: &str = "error awaiting proof";

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -40,6 +40,8 @@ use util::matching_engine::{
     compute_fee_obligation, compute_max_amount, settle_match_into_wallets,
 };
 
+use super::ERR_AWAITING_PROOF;
+
 // -------------
 // | Constants |
 // -------------
@@ -47,8 +49,6 @@ use util::matching_engine::{
 /// The name of the task
 pub const SETTLE_MATCH_INTERNAL_TASK_NAME: &str = "settle-match-internal";
 
-/// Error message emitted when awaiting a proof fails
-const ERR_AWAITING_PROOF: &str = "error awaiting proof";
 /// Error message emitted when a wallet cannot be found
 const ERR_WALLET_NOT_FOUND: &str = "wallet not found in global state";
 


### PR DESCRIPTION
### Purpose
This PR implements the proof generation and client response steps of the settle external match task. This involves creating the witness and statement for the proof of `VALID MATCH SETTLE ATOMIC`, proving the circuit w/ proof-links, and responding via the system bus to the client.

### Testing
- Unit tests pass
- Hit the API endpoint and got back a settlement bundle