### PR TITLE
task-driver: settle-match-external: Send full tx payload to client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,6 +3572,7 @@ dependencies = [
  "circuit-types 0.1.0",
  "common 0.1.0",
  "constants 0.1.0",
+ "ethers",
  "hex 0.4.3",
  "itertools 0.10.5",
  "num-bigint",

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -15,11 +15,13 @@ abigen!(
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
         function getPubkey() external view returns (uint256[2])
+        function getProtocolExternalFeeCollectionAddress() external view returns (address)
         function rootInHistory(uint256 memory root) external view returns (bool)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
@@ -44,11 +46,13 @@ abigen!(
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
         function getPubkey() external view returns (uint256[2])
+        function getProtocolExternalFeeCollectionAddress() external view returns (address)
         function rootInHistory(uint256 memory root) external view returns (bool)
 
         function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -27,7 +27,7 @@ use circuits::zk_circuits::{
     valid_wallet_update::SizedValidWalletUpdateStatement,
 };
 use common::types::{
-    proof_bundles::{MatchBundle, OrderValidityProofBundle},
+    proof_bundles::{AtomicMatchSettleBundle, MatchBundle, OrderValidityProofBundle},
     transfer_auth::TransferAuth,
 };
 use constants::{Scalar, ScalarField};
@@ -38,8 +38,11 @@ use contracts_common::{
         BabyJubJubPoint as ContractBabyJubJubPoint,
         ExternalMatchResult as ContractExternalMatchResult,
         ExternalTransfer as ContractExternalTransfer, FeeTake as ContractFeeTake,
-        LinkingProof as ContractLinkingProof, MatchLinkingProofs as ContractMatchLinkingProofs,
-        MatchProofs as ContractMatchProofs, NoteCiphertext as ContractNoteCiphertext,
+        LinkingProof as ContractLinkingProof,
+        MatchAtomicLinkingProofs as ContractMatchAtomicLinkingProofs,
+        MatchAtomicProofs as ContractMatchAtomicProofs,
+        MatchLinkingProofs as ContractMatchLinkingProofs, MatchProofs as ContractMatchProofs,
+        NoteCiphertext as ContractNoteCiphertext,
         OrderSettlementIndices as ContractOrderSettlementIndices, Proof as ContractProof,
         PublicEncryptionKey as ContractPublicEncryptionKey,
         PublicSigningKey as ContractPublicSigningKey, TransferAuxData as ContractTransferAuxData,
@@ -316,6 +319,37 @@ pub fn build_match_linking_proofs(
         valid_reblind_commitments_1: to_contract_link_proof(&party1_validity_proofs.linking_proof)?,
         valid_commitments_match_settle_0: to_contract_link_proof(&match_bundle.commitments_link0)?,
         valid_commitments_match_settle_1: to_contract_link_proof(&match_bundle.commitments_link1)?,
+    })
+}
+
+/// Build a [`MatchAtomicProofs`] contract type from a set of atomic match
+/// proofs
+pub fn build_atomic_match_proofs(
+    internal_party_validity_proofs: &OrderValidityProofBundle,
+    atomic_match_proof: &PlonkProof,
+) -> Result<ContractMatchAtomicProofs, ConversionError> {
+    Ok(ContractMatchAtomicProofs {
+        valid_commitments: to_contract_proof(
+            &internal_party_validity_proofs.commitment_proof.proof,
+        )?,
+        valid_reblind: to_contract_proof(&internal_party_validity_proofs.reblind_proof.proof)?,
+        valid_match_settle_atomic: to_contract_proof(atomic_match_proof)?,
+    })
+}
+
+/// Build a [`MatchAtomicLinkingProofs`] contract type from a set of atomic
+/// match linking proofs
+pub fn build_atomic_match_linking_proofs(
+    internal_party_validity_proofs: &OrderValidityProofBundle,
+    match_bundle: &AtomicMatchSettleBundle,
+) -> Result<ContractMatchAtomicLinkingProofs, ConversionError> {
+    Ok(ContractMatchAtomicLinkingProofs {
+        valid_reblind_commitments: to_contract_link_proof(
+            &internal_party_validity_proofs.linking_proof,
+        )?,
+        valid_commitments_match_settle_atomic: to_contract_link_proof(
+            &match_bundle.commitments_link,
+        )?,
     })
 }
 

--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -16,6 +16,7 @@ util = { path = "../util" }
 
 # === Misc Dependencies === #
 base64 = "0.22.1"
+ethers = { workspace = true }
 itertools = { workspace = true }
 hex = "0.4"
 serde = { workspace = true }

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -4,7 +4,6 @@ use common::types::{
     exchange::PriceReport,
     gossip::{PeerInfo, WrappedPeerId},
     network_order::NetworkOrder,
-    proof_bundles::AtomicMatchSettleBundle,
     tasks::TaskIdentifier,
     token::Token,
     wallet::{
@@ -15,7 +14,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::{
-    http::task::ApiTaskStatus,
+    http::{external_match::AtomicMatchApiBundle, task::ApiTaskStatus},
     types::{ApiHistoricalTask, ApiWallet},
 };
 
@@ -156,7 +155,7 @@ pub enum SystemBusMessage {
     /// to its client
     AtomicMatchFound {
         /// The atomic match bundle that should be forwarded to the client
-        match_bundle: AtomicMatchSettleBundle,
+        match_bundle: AtomicMatchApiBundle,
     },
     /// A message indicating that no atomic match was found for a request
     NoAtomicMatchFound,

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -8,8 +8,11 @@
 //! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
 //! for consenting liquidity on a given token pair.
 
-use circuit_types::{fixed_point::FixedPoint, max_price, order::OrderSide, Amount};
-use common::types::{proof_bundles::AtomicMatchSettleBundle, wallet::Order};
+use circuit_types::{
+    fixed_point::FixedPoint, max_price, order::OrderSide, r#match::ExternalMatchResult, Amount,
+};
+use common::types::wallet::Order;
+use ethers::types::transaction::eip2718::TypedTransaction;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +40,7 @@ pub struct ExternalMatchRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExternalMatchResponse {
     /// The match bundle
-    pub match_bundle: AtomicMatchSettleBundle,
+    pub match_bundle: AtomicMatchApiBundle,
 }
 
 // ------------------
@@ -82,4 +85,14 @@ impl From<ExternalOrder> for Order {
             worst_case_price,
         }
     }
+}
+
+/// An atomic match settlement bundle, sent to the client so that they may
+/// settle the match on-chain
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AtomicMatchApiBundle {
+    /// The match result
+    pub match_result: ExternalMatchResult,
+    /// The transaction which settles the match on-chain
+    pub settlement_tx: TypedTransaction,
 }


### PR DESCRIPTION
### Purpose
This PR changes the return type for atomic match settlement to include:
- The match result directly
- The exact transaction payload needed to submit the match on-chain

### Testing
- Unit tests pass
- Hit the API endpoint, verified the response