### PR TITLE
external-api, workers: api-server: http: admin: add augmented order endpoint

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -6,7 +6,7 @@
 
 use circuit_types::Amount;
 use common::types::{
-    wallet::{order_metadata::OrderMetadata, WalletIdentifier},
+    wallet::{order_metadata::OrderMetadata, OrderIdentifier, WalletIdentifier},
     MatchingPoolName, Price,
 };
 use serde::{Deserialize, Serialize};
@@ -46,23 +46,22 @@ pub struct IsLeaderResponse {
 /// The response to an "open orders" request
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenOrdersResponse {
-    /// The open orders
-    pub orders: Vec<OpenOrder>,
+    /// The open order IDs
+    pub orders: Vec<OrderIdentifier>,
 }
 
-/// An open order, containing the order's metadata
-/// and potentially the fillable amount of the order
-/// given the underlying wallet's balances and
-/// the current price of the base asset
+/// An order's metadata, augmented with the containing
+/// wallet's ID, and optionally the fillable amount
+/// of the order and the price used to calculate it
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OpenOrder {
+pub struct AdminOrderMetadata {
     /// The order metadata
     pub order: OrderMetadata,
     /// The ID of the wallet containing the order
     pub wallet_id: WalletIdentifier,
     /// The fillable amount of the order, if calculated
     pub fillable: Option<Amount>,
-    /// The price used to calculate the fillable amount, if calculated
+    /// The price used to calculate the fillable amount
     pub price: Option<Price>,
 }
 
@@ -79,11 +78,11 @@ pub struct CreateOrderInMatchingPoolRequest {
     pub matching_pool: MatchingPoolName,
 }
 
-/// The response to an "order metadata" request
+/// The response to an admin "order metadata" request
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AdminOrderMetadataResponse {
     /// The order metadata
-    pub order: OrderMetadata,
+    pub order: AdminOrderMetadata,
 }
 
 /// The response to a "get order matching pool" request

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -466,14 +466,14 @@ impl HttpServer {
         router.add_admin_authenticated_route(
             &Method::GET,
             ADMIN_OPEN_ORDERS_ROUTE.to_string(),
-            AdminOpenOrdersHandler::new(state.clone(), config.price_reporter_work_queue.clone()),
+            AdminOpenOrdersHandler::new(state.clone()),
         );
 
         // The "/admin/orders/:id/metadata" route
         router.add_admin_authenticated_route(
             &Method::GET,
             ADMIN_ORDER_METADATA_ROUTE.to_string(),
-            AdminOrderMetadataHandler::new(state.clone()),
+            AdminOrderMetadataHandler::new(state.clone(), config.price_reporter_work_queue.clone()),
         );
 
         // The "/admin/matching_pools/:matching_pool" route


### PR DESCRIPTION
This PR tweaks the existing admin open orders & order metadata endpoints, shifting the responsibility of potentially calculating an order's fillable amount from the former to the latter.

As a result, the open orders endpoint now simply returns the IDs of open orders, and the order metadata endpoint (now the "augmented order" endpoint) returns an "augmented order" (fka `OpenOrder`) that contains the order metadata, managing wallet ID, and optionally the fillable amount at the current price.

This makes the open orders endpoint significantly lighter, and shifts the expectation of relayer admins to "follow up" with augmented order requests for open orders.

This was tested on a local relayer using the CLI