### PR TITLE
config: cli: Add `external-fee-addr` config parameter

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -4,7 +4,7 @@ use arbitrum_client::constants::Chain;
 use circuit_types::{
     elgamal::{DecryptionKey, EncryptionKey},
     fixed_point::FixedPoint,
-    Amount,
+    Address, Amount,
 };
 use clap::Parser;
 use common::types::{
@@ -58,6 +58,15 @@ pub struct Cli {
     /// Defaults to 8 basis points
     #[clap(long, value_parser, default_value = "0.0002")]
     pub match_take_rate: f64,
+    /// The address at which to collect externally paid fees
+    /// 
+    /// External fees are generated when an atomic match is settled. An atomic match is one between an 
+    /// internal party (one with state in the darkpool) and an external party (one without). 
+    /// The external party pays fees directly to this address.
+    /// 
+    /// If not set, atomic matches are not supported
+    #[clap(long, value_parser, env = "EXTERNAL_FEE_ADDR")]
+    pub external_fee_addr: Option<String>,
     /// The path to the file containing relayer fee whitelist info
     #[clap(long, value_parser)]
     pub relayer_fee_whitelist: Option<String>,
@@ -263,6 +272,8 @@ pub struct RelayerConfig {
     /// The take rate of this relayer on a managed match, i.e. the amount of the
     /// received asset that the relayer takes as a fee
     pub match_take_rate: FixedPoint,
+    /// The address at which to collect externally paid fees
+    pub external_fee_addr: Option<Address>,
     /// When set, the relayer will automatically redeem new fees into its wallet
     pub auto_redeem_fees: bool,
     /// The price reporter from which to stream prices.
@@ -438,6 +449,7 @@ impl Clone for RelayerConfig {
         Self {
             min_fill_size: self.min_fill_size,
             match_take_rate: self.match_take_rate,
+            external_fee_addr: self.external_fee_addr.clone(),
             auto_redeem_fees: self.auto_redeem_fees,
             relayer_fee_whitelist: self.relayer_fee_whitelist.clone(),
             price_reporter_url: self.price_reporter_url.clone(),

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -1,6 +1,6 @@
 //! Storage access methods for the local node's metadata
 
-use circuit_types::fixed_point::FixedPoint;
+use circuit_types::{fixed_point::FixedPoint, Address};
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     wallet::WalletIdentifier,
@@ -34,6 +34,9 @@ const LOCAL_WALLET_ID_KEY: &str = "local-wallet-id";
 const LOCAL_RELAYER_FEE_KEY: &str = "local-relayer-fee-key";
 /// The key for the local relayer's match take rate in the node metadata table
 const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
+/// The key for the local relayer's external fee address in the node metadata
+/// table
+const EXTERNAL_FEE_ADDR_KEY: &str = "external-fee-addr";
 /// The key for the local relayer's auto-redeem fees flag in the node metadata
 const AUTO_REDEEM_FEES_KEY: &str = "auto-redeem-fees";
 
@@ -106,6 +109,11 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
             .ok_or_else(|| err_not_found(RELAYER_TAKE_RATE_KEY))
     }
 
+    /// Get the local relayer's external fee address
+    pub fn get_external_fee_addr(&self) -> Result<Option<Address>, StorageError> {
+        self.inner().read(NODE_METADATA_TABLE, &EXTERNAL_FEE_ADDR_KEY.to_string())
+    }
+
     /// Get the local relayer's auto-redeem fees flag
     pub fn get_auto_redeem_fees(&self) -> Result<bool, StorageError> {
         self.inner()
@@ -153,6 +161,11 @@ impl<'db> StateTxn<'db, RW> {
     /// Set the local relayer's match take rate
     pub fn set_relayer_take_rate(&self, take_rate: &FixedPoint) -> Result<(), StorageError> {
         self.inner().write(NODE_METADATA_TABLE, &RELAYER_TAKE_RATE_KEY.to_string(), take_rate)
+    }
+
+    /// Set the local relayer's external fee address
+    pub fn set_external_fee_addr(&self, addr: &Address) -> Result<(), StorageError> {
+        self.inner().write(NODE_METADATA_TABLE, &EXTERNAL_FEE_ADDR_KEY.to_string(), addr)
     }
 
     /// Set the local relayer's auto-redeem fees flag

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -400,7 +400,11 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::POST,
             REQUEST_EXTERNAL_MATCH_ROUTE.to_string(),
-            RequestExternalMatchHandler::new(handshake_queue, config.system_bus.clone()),
+            RequestExternalMatchHandler::new(
+                handshake_queue,
+                config.system_bus.clone(),
+                state.clone(),
+            ),
         );
 
         // --- Orderbook Routes --- //


### PR DESCRIPTION
### Purpose
This PR adds a parameter `external-fee-addr` to the relayer config; specifying the address at which the relayer will collect externally paid fees (those paid by an external party in an atomic match settlement).

If this address is not specified we disable atomic matches

### Testing
- Unit tests pass
- Tested the API with the addr specified and without, verified functionality in both cases.