### PR TITLE
arbitrum-client: event-indexing: Recover shares from atomic match settle

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -71,6 +71,7 @@ sol! {
     function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
+    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -17,7 +17,8 @@ use num_bigint::BigUint;
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
 use tracing::{error, instrument};
 
-use crate::abi::MerkleInsertionFilter;
+use crate::abi::{processAtomicMatchSettleCall, MerkleInsertionFilter};
+use crate::helpers::parse_shares_from_process_atomic_match_settle;
 use crate::{
     abi::{
         newWalletCall, processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall,
@@ -200,6 +201,9 @@ impl ArbitrumClient {
             <updateWalletCall as SolCall>::SELECTOR => parse_shares_from_update_wallet(&calldata),
             <processMatchSettleCall as SolCall>::SELECTOR => {
                 parse_shares_from_process_match_settle(&calldata, public_blinder_share)
+            },
+            <processAtomicMatchSettleCall as SolCall>::SELECTOR => {
+                parse_shares_from_process_atomic_match_settle(&calldata)
             },
             <settleOnlineRelayerFeeCall as SolCall>::SELECTOR => {
                 parse_shares_from_settle_online_relayer_fee(&calldata, public_blinder_share)


### PR DESCRIPTION
### Purpose
This PR adds a helper to recover wallet shares from an atomic match settlement transaction, e.g. by refreshing a wallet after one has succeeded.

### Testing
- Unit tests pass
- Built a client to query and submit atomic matches, used it to submit an atomic match, then refreshed the internal wallet to get the up-to-date shares.