### PR TITLE
task-driver: settle-match-external: Await atomic match settlement

### DIFF
--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -50,6 +50,7 @@ postcard = { version = "1", features = ["alloc"] }
 # === Misc === #
 itertools = "0.12"
 lazy_static = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
 


### PR DESCRIPTION
### Purpose
This PR implements the last step of the `settle-external-match` task; waiting for the atomic settlement to land on-chain. We do so by listening for a nullifier spent event with a timeout. 

If the timeout is exceeded, the task completes immediately under assumption that the bundle was not sent to the contract. If the nullifier is seen within the timeout, we refresh the wallet to pick up the newly modified shares.

### Todo
- Add refresh logic in the `chain-events` worker to pick up any missed settlements

### Testing
- Unit tests pass
- Tested both cases:
    - Had the solver client drop the match (no submission on-chain). I verified that the task timed out and did not refresh the wallet
    - Had the solver client submit the match, I verified that the nullifier was seen by the relayer and the wallet correctly refreshed.