### PR TITLE
state: storage: wallet-index: Track nullifier <-> wallet mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "gossip-api",
  "job-types",
  "lazy_static",
+ "rand 0.8.5",
  "renegade-crypto 0.1.0",
  "state",
  "tokio",

--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -23,7 +23,7 @@ use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
 use super::{
     keychain::{HmacKey, KeyChain, PrivateKeyChain},
-    orders::Order,
+    orders::{Order, OrderBuilder},
     Wallet,
 };
 
@@ -72,13 +72,15 @@ pub fn mock_empty_wallet() -> Wallet {
 /// Create a mock order
 pub fn mock_order() -> Order {
     let mut rng = thread_rng();
-    let quote_mint = rand_addr_biguint();
-    let base_mint = rand_addr_biguint();
-    let amount = rng.next_u64().into();
-    let worst_case_price = FixedPoint::from_integer(rng.gen());
-    let min_fill_size = rng.gen();
-
-    Order { quote_mint, base_mint, amount, worst_case_price, side: OrderSide::Buy, min_fill_size }
+    OrderBuilder::new()
+        .quote_mint(rand_addr_biguint())
+        .base_mint(rand_addr_biguint())
+        .side(OrderSide::Buy)
+        .amount(rng.next_u64().into())
+        .worst_case_price(FixedPoint::from_integer(rng.gen()))
+        .min_fill_size(rng.gen())
+        .build()
+        .unwrap()
 }
 
 /// Create a mock Merkle path for a wallet

--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -13,7 +13,7 @@ mod orders;
 mod shares;
 mod types;
 
-pub use orders::Order;
+pub use orders::{Order, OrderBuilder};
 pub use types::*;
 
 // ----------------
@@ -30,7 +30,7 @@ mod test {
 
     use crate::types::wallet::mocks::{mock_empty_wallet, mock_order};
 
-    use super::orders::Order;
+    use super::OrderBuilder;
 
     /// Tests adding a balance to an empty wallet
     #[test]
@@ -144,18 +144,14 @@ mod test {
     fn test_add_order_invalid() {
         let mut wallet = mock_empty_wallet();
         let id = Uuid::new_v4();
-        let base_mint = BigUint::from(1u8);
-        let quote_mint = BigUint::from(2u8);
-        let amount = u128::MAX;
-        let worst_case_price = FixedPoint::from_f64_round_down(0.1);
-        let o = Order::new_unchecked(
-            base_mint,
-            quote_mint,
-            OrderSide::Buy,
-            amount,
-            worst_case_price,
-            0,
-        );
+        let o = OrderBuilder::new()
+            .base_mint(BigUint::from(1u8))
+            .quote_mint(BigUint::from(2u8))
+            .side(OrderSide::Buy)
+            .amount(Amount::MAX)
+            .worst_case_price(FixedPoint::from_f64_round_down(0.1))
+            .build()
+            .unwrap();
 
         // Try to add the order
         wallet.add_order(id, o).unwrap();

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -83,6 +83,7 @@ impl From<ExternalOrder> for Order {
             amount: order.amount,
             min_fill_size: order.min_fill_size,
             worst_case_price,
+            allow_external_matches: true,
         }
     }
 }

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -162,6 +162,9 @@ pub struct ApiOrder {
     /// The minimum fill size for the order
     #[serde(default)]
     pub min_fill_size: Amount,
+    /// Whether or not to allow external matches
+    #[serde(default)]
+    pub allow_external_matches: bool,
 }
 
 impl From<(OrderIdentifier, Order)> for ApiOrder {
@@ -175,6 +178,7 @@ impl From<(OrderIdentifier, Order)> for ApiOrder {
             worst_case_price: order.worst_case_price,
             amount: order.amount,
             min_fill_size: order.min_fill_size,
+            allow_external_matches: order.allow_external_matches,
         }
     }
 }
@@ -190,6 +194,7 @@ impl TryFrom<ApiOrder> for Order {
             order.amount,
             order.worst_case_price,
             order.min_fill_size,
+            order.allow_external_matches,
         )
     }
 }

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -3,7 +3,7 @@
 //! Wallet index updates must go through raft consensus so that the leader may
 //! order them
 
-use circuit_types::balance::Balance;
+use circuit_types::{balance::Balance, wallet::Nullifier};
 use common::types::{
     tasks::QueuedTask,
     wallet::{Order, OrderIdentifier, Wallet, WalletIdentifier},
@@ -90,6 +90,19 @@ impl StateInner {
         self.with_read_tx(move |tx| {
             let wallet_id = tx.get_wallet_for_order(&oid)?;
             Ok(wallet_id)
+        })
+        .await
+    }
+
+    /// Get the wallet for a given nullifier
+    pub async fn get_wallet_for_nullifier(
+        &self,
+        nullifier: &Nullifier,
+    ) -> Result<Option<WalletIdentifier>, StateError> {
+        let n = *nullifier;
+        self.with_read_tx(move |tx| {
+            let res = tx.get_wallet_for_nullifier(&n)?;
+            Ok(res)
         })
         .await
     }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 // -------------
 
 /// The number of tables to open in the database
-const NUM_TABLES: usize = 17;
+const NUM_TABLES: usize = 18;
 
 /// The name of the db table that stores node metadata
 pub(crate) const NODE_METADATA_TABLE: &str = "node-metadata";
@@ -69,6 +69,8 @@ pub(crate) const POOL_TABLE: &str = "matching-pools";
 
 /// The name of the db table that maps order to their encapsulating wallet
 pub(crate) const ORDER_TO_WALLET_TABLE: &str = "order-to-wallet";
+/// The name of the db table that maps nullifiers to wallets
+pub(crate) const NULLIFIER_TO_WALLET_TABLE: &str = "nullifier-to-wallet";
 /// The name of the db table that stores wallet information
 pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
@@ -99,6 +101,7 @@ pub const ALL_TABLES: [&str; NUM_TABLES] = [
     ORDER_HISTORY_TABLE,
     POOL_TABLE,
     ORDER_TO_WALLET_TABLE,
+    NULLIFIER_TO_WALLET_TABLE,
     WALLETS_TABLE,
     TASK_QUEUE_TABLE,
     TASK_TO_KEY_TABLE,

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -397,7 +397,7 @@ impl HttpServer {
         // --- External Match Routes --- //
 
         // The "/external-match/request" route
-        router.add_unauthenticated_route(
+        router.add_admin_authenticated_route(
             &Method::POST,
             REQUEST_EXTERNAL_MATCH_ROUTE.to_string(),
             RequestExternalMatchHandler::new(

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -9,8 +9,7 @@ use common::types::{
     exchange::PriceReporterState,
     tasks::{
         LookupWalletTaskDescriptor, NewWalletTaskDescriptor, PayOfflineFeeTaskDescriptor,
-        RedeemFeeTaskDescriptor, RefreshWalletTaskDescriptor, TaskDescriptor, TaskIdentifier,
-        UpdateWalletTaskDescriptor,
+        RedeemFeeTaskDescriptor, TaskDescriptor, TaskIdentifier, UpdateWalletTaskDescriptor,
     },
     token::Token,
     transfer_auth::{DepositAuth, ExternalTransferWithAuth, WithdrawalAuth},
@@ -391,8 +390,7 @@ impl TypedHandler for RefreshWalletHandler {
 
         // Check rate limits and enqueue the task
         self.rate_limiter.check_rate_limit(wallet_id).await?;
-        let descriptor = RefreshWalletTaskDescriptor::new(wallet_id);
-        let task_id = append_task_and_await(descriptor.into(), &self.state).await?;
+        let task_id = self.state.append_wallet_refresh_task(wallet_id).await?;
 
         Ok(RefreshWalletResponse { task_id })
     }

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -25,4 +25,5 @@ util = { path = "../../util" }
 # === Misc Dependencies === #
 lazy_static = { workspace = true }
 async-trait = { workspace = true }
+rand = { workspace = true }
 tracing = { workspace = true }

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -1,8 +1,10 @@
 //! Defines the core implementation of the on-chain event listener
 
-use std::thread::JoinHandle;
+use rand::{rngs::OsRng, Rng};
+use std::{thread::JoinHandle, time::Duration};
 
 use arbitrum_client::{abi::NullifierSpentFilter, client::ArbitrumClient};
+use circuit_types::wallet::Nullifier;
 use common::types::CancelChannel;
 use constants::in_bootstrap_mode;
 use ethers::prelude::StreamExt;
@@ -17,6 +19,11 @@ use tracing::{error, info};
 use util::runtime::sleep_forever_async;
 
 use super::error::OnChainEventListenerError;
+
+/// The minimum delay in seconds for wallet refresh
+const MIN_NULLIFIER_REFRESH_DELAY_S: u64 = 20; // 20 seconds
+/// The maximum delay in seconds for wallet refresh
+const MAX_NULLIFIER_REFRESH_DELAY_S: u64 = 40; // 40 seconds
 
 // ----------
 // | Worker |
@@ -74,6 +81,11 @@ impl OnChainEventListenerExecutor {
         &self.config.arbitrum_client
     }
 
+    /// Shorthand for fetching a reference to the global state
+    fn state(&self) -> &State {
+        &self.config.global_state
+    }
+
     /// The main execution loop for the executor
     pub async fn execute(self) -> Result<(), OnChainEventListenerError> {
         // If the node is running in bootstrap mode, sleep forever
@@ -119,7 +131,62 @@ impl OnChainEventListenerExecutor {
             .map_err(|err| OnChainEventListenerError::SendMessage(err.to_string()))?;
 
         // Nullify any orders that used this nullifier in their validity proof
-        self.config.global_state.nullify_orders(nullifier).await?;
+        self.state().nullify_orders(nullifier).await?;
+
+        // Check if the wallet that this nullifier belongs to needs a refresh
+        self.check_wallet_refresh(nullifier).await?;
+        Ok(())
+    }
+
+    /// Check if the wallet that this nullifier belongs to needs a refresh
+    async fn check_wallet_refresh(
+        &self,
+        nullifier: Nullifier,
+    ) -> Result<(), OnChainEventListenerError> {
+        // Get the wallet ID that this nullifier belongs to
+        let maybe_wallet = self.state().get_wallet_for_nullifier(&nullifier).await?;
+        if maybe_wallet.is_none() {
+            return Ok(());
+        }
+
+        let state_clone = self.state().clone();
+        tokio::spawn(async move {
+            if let Err(e) = Self::enqueue_wallet_refresh_if_needed(nullifier, state_clone).await {
+                error!("error checking for wallet nullifier refresh: {e}");
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Wait for a randomized delay then enqueue a wallet refresh if the wallet
+    /// is still indexed by an old nullifier
+    ///
+    /// We do not immediately refresh the wallet, but instead wait for a
+    /// randomized timeout to pass. This allows time for other components of the
+    /// relayer to process the nullifier spend and update the wallet state
+    /// accordingly. Randomizing the timeout prevents a thundering herd
+    ///
+    /// As such, after the timeout, we check whether the wallet is still indexed
+    /// by the nullifier, and if so we refresh it
+    async fn enqueue_wallet_refresh_if_needed(
+        nullifier: Nullifier,
+        state: State,
+    ) -> Result<(), OnChainEventListenerError> {
+        // Generate a random delay and sleep for that duration
+        let mut rng = OsRng;
+        let delay_seconds =
+            rng.gen_range(MIN_NULLIFIER_REFRESH_DELAY_S..=MAX_NULLIFIER_REFRESH_DELAY_S);
+        let delay = Duration::from_secs(delay_seconds);
+        tokio::time::sleep(delay).await;
+
+        // Check if a wallet is still indexed by the nullifier
+        let maybe_wallet = state.get_wallet_for_nullifier(&nullifier).await?;
+        if let Some(id) = maybe_wallet {
+            info!("refreshing wallet {id} after nullifier spend");
+            state.append_wallet_refresh_task(id).await?;
+        }
+
         Ok(())
     }
 }

--- a/workers/handshake-manager-tests/src/mpc_match.rs
+++ b/workers/handshake-manager-tests/src/mpc_match.rs
@@ -3,7 +3,7 @@
 use ark_mpc::{PARTY0, PARTY1};
 use circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide};
 use common::types::{
-    wallet::{Order, Wallet},
+    wallet::{Order, OrderBuilder, Wallet},
     wallet_mocks::mock_empty_wallet,
 };
 use eyre::Result;
@@ -61,14 +61,14 @@ fn get_order(side: OrderSide) -> Order {
         OrderSide::Sell => MOCK_EXECUTION_PRICE - 1.,
     };
 
-    Order {
-        quote_mint,
-        base_mint,
-        side,
-        amount: DEFAULT_ORDER_AMOUNT,
-        worst_case_price: FixedPoint::from_f64_round_down(worst_case_price),
-        min_fill_size: 0,
-    }
+    OrderBuilder::new()
+        .quote_mint(quote_mint)
+        .base_mint(base_mint)
+        .side(side)
+        .amount(DEFAULT_ORDER_AMOUNT)
+        .worst_case_price(FixedPoint::from_f64_round_down(worst_case_price))
+        .build()
+        .unwrap()
 }
 
 /// Get the balance to insert into the wallet to cover the order

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -44,7 +44,7 @@ use renegade_metrics::helpers::record_match_volume;
 use state::State;
 use std::thread::JoinHandle;
 use system_bus::SystemBus;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{error, info, info_span, instrument, Instrument};
 use util::{err_str, get_current_time_millis, runtime::sleep_forever_async};
 use uuid::Uuid;
 
@@ -185,6 +185,7 @@ impl HandshakeExecutor {
 /// threadpool
 impl HandshakeExecutor {
     /// Handle a handshake message from the peer
+    #[instrument(name = "handle_handshake_job", skip_all)]
     pub async fn handle_handshake_job(
         &self,
         job: HandshakeManagerJob,

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -19,13 +19,14 @@ use constants::Scalar;
 use external_api::bus_message::SystemBusMessage;
 use job_types::task_driver::TaskDriverJob;
 use renegade_crypto::fields::scalar_to_u128;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 use util::err_str;
 
 use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
 
 impl HandshakeExecutor {
     /// Execute an external match
+    #[instrument(name = "run_external_matching_engine", skip_all)]
     pub async fn run_external_matching_engine(
         &self,
         order: Order,
@@ -95,7 +96,7 @@ impl HandshakeExecutor {
     async fn get_external_match_candidates(
         &self,
     ) -> Result<HashSet<OrderIdentifier>, HandshakeManagerError> {
-        let matchable_orders = self.state.get_locally_matchable_orders().await?;
+        let matchable_orders = self.state.get_externally_matchable_orders().await?;
         Ok(HashSet::from_iter(matchable_orders))
     }
 

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -11,7 +11,7 @@ use common::types::{
     TimestampedPrice,
 };
 use job_types::task_driver::TaskDriverJob;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 use util::err_str;
 
 use crate::{
@@ -38,6 +38,7 @@ impl HandshakeExecutor {
     ///     1. Determine this code path to be a bottleneck
     ///     2. Have a better state management abstraction that makes
     ///        denormalization easier
+    #[instrument(name = "run_internal_matching_engine", skip_all)]
     pub async fn run_internal_matching_engine(
         &self,
         order_id: OrderIdentifier,

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -24,7 +24,7 @@ use common::types::{
         ValidMatchSettleBundle,
     },
     tasks::{SettleMatchInternalTaskDescriptor, SettleMatchTaskDescriptor},
-    wallet::{Order, Wallet},
+    wallet::{Order, OrderBuilder, Wallet},
     wallet_mocks::mock_empty_wallet,
     TimestampedPrice,
 };
@@ -69,14 +69,14 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
         OrderSide::Sell => SELL_ORDER_AMOUNT,
     };
 
-    Order {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr0).unwrap(),
-        base_mint: biguint_from_hex_string(&test_args.erc20_addr1).unwrap(),
-        side,
-        amount: order_amount,
-        worst_case_price: FixedPoint::from_integer(worst_cast_price),
-        min_fill_size: 0,
-    }
+    OrderBuilder::new()
+        .quote_mint(biguint_from_hex_string(&test_args.erc20_addr0).unwrap())
+        .base_mint(biguint_from_hex_string(&test_args.erc20_addr1).unwrap())
+        .side(side)
+        .amount(order_amount)
+        .worst_case_price(FixedPoint::from_integer(worst_cast_price))
+        .build()
+        .unwrap()
 }
 
 /// Create a dummy balance

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -10,7 +10,7 @@ use circuit_types::{
 use common::types::{
     tasks::{mocks::gen_wallet_update_sig, UpdateWalletTaskDescriptor, WalletUpdateType},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::{Order, OrderIdentifier, Wallet},
+    wallet::{Order, OrderBuilder, OrderIdentifier, Wallet},
     wallet_mocks::{mock_empty_wallet, mock_order},
 };
 use constants::Scalar;
@@ -36,14 +36,14 @@ use crate::{
 
 lazy_static! {
     /// A dummy order that is allocated in a wallet as an update
-    static ref DUMMY_ORDER: Order = Order {
-        quote_mint: 1u8.into(),
-        base_mint: 2u8.into(),
-        side: OrderSide::Buy,
-        amount: 10,
-        worst_case_price: FixedPoint::from_integer(10),
-        min_fill_size: 0,
-    };
+    static ref DUMMY_ORDER: Order = OrderBuilder::new()
+        .quote_mint(1u8.into())
+        .base_mint(2u8.into())
+        .side(OrderSide::Buy)
+        .amount(10)
+        .worst_case_price(FixedPoint::from_integer(10))
+        .build()
+        .unwrap();
 }
 
 // -----------

--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -1,10 +1,7 @@
 //! Encapsulates the running task's bookkeeping structure to simplify the driver
 //! logic
 
-use common::types::{
-    tasks::{RefreshWalletTaskDescriptor, TaskIdentifier},
-    wallet::WalletIdentifier,
-};
+use common::types::{tasks::TaskIdentifier, wallet::WalletIdentifier};
 use state::{error::StateError, State};
 use tracing::{error, info};
 
@@ -148,8 +145,7 @@ impl<T: Task> RunnableTask<T> {
         // code paths will clear task queues in the case of a failure.
         if !success && self.state().committed() {
             for wallet_id in affected_wallets {
-                let refresh_task = RefreshWalletTaskDescriptor::new(wallet_id);
-                let (task_id, _) = self.state.append_task(refresh_task.into()).await?;
+                let task_id = self.state.append_wallet_refresh_task(wallet_id).await?;
                 info!("enqueued wallet refresh task ({task_id}) for {wallet_id}");
             }
         }

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -21,7 +21,7 @@ use common::types::proof_bundles::{
     AtomicMatchSettleBundle, OrderValidityProofBundle, OrderValidityWitnessBundle, ProofBundle,
     ValidMatchSettleAtomicBundle,
 };
-use common::types::tasks::{RefreshWalletTaskDescriptor, SettleExternalMatchTaskDescriptor};
+use common::types::tasks::SettleExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use external_api::bus_message::SystemBusMessage;
 use external_api::http::external_match::AtomicMatchApiBundle;
@@ -372,11 +372,9 @@ impl SettleMatchExternalTask {
     /// and be discarded
     async fn refresh_wallet(&mut self) -> Result<(), SettleMatchExternalTaskError> {
         let wallet_id = self.internal_wallet_id;
-        let task = RefreshWalletTaskDescriptor::new(wallet_id);
-        let (task_id, waiter) = self.state.append_task(task.into()).await?;
-        waiter.await?;
-
+        let task_id = self.state.append_wallet_refresh_task(wallet_id).await?;
         info!("enqueued wallet refresh task ({task_id}) for {wallet_id}");
+
         Ok(())
     }
 


### PR DESCRIPTION
### Purpose
This PR adds a `wallet_id` <-> `nullifier` double sided mapping. This mapping is updated when a wallet is written. It will allow us to determine which wallets need refreshing when a nullifier is seen on-chain.

We will allow this mapping to backfill naturally through wallet writes in deployment; its use in the events listener will require no backfill.

### Testing
- Unit tests pass
- Added a test for the new mapping