### PR TITLE
external-api, workers: api-server: websocket: add admin websocket endpoint for all wallet updates

### DIFF
--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     http::{external_match::AtomicMatchApiBundle, task::ApiTaskStatus},
-    types::{ApiHistoricalTask, ApiWallet},
+    types::{AdminWalletUpdate, ApiHistoricalTask, ApiWallet},
 };
 
 // ----------------------------
@@ -160,32 +160,13 @@ pub enum SystemBusMessage {
         /// The atomic match bundle that should be forwarded to the client
         match_bundle: AtomicMatchApiBundle,
     },
+    /// A message indicating that no atomic match was found for a request
+    NoAtomicMatchFound,
 
     // --- Admin -- //
-    /// An opaque message indicating that a wallet has been updated,
-    /// without leaking unnecessary information about the wallet
-    AdminWalletUpdate {
-        /// The ID of the wallet that was updated
-        wallet_id: WalletIdentifier,
-    },
-
-    /// An opaque message indicating that an order has been placed,
-    /// without leaking unnecessary information about the order
-    AdminOrderPlacement {
-        /// The ID of the order that was placed
-        order_id: OrderIdentifier,
-        /// The ID of the wallet containing the order
-        wallet_id: WalletIdentifier,
-    },
-
-    /// An opaque message indicating that an order has been cancelled,
-    /// without leaking unnecessary information about the order
-    AdminOrderCancellation {
-        /// The ID of the order that was cancelled
-        order_id: OrderIdentifier,
-        /// The ID of the wallet containing the order
-        wallet_id: WalletIdentifier,
-    },
+    /// A message indicating that a wallet has been updated, intended for
+    /// consumption by the admin API
+    AdminWalletUpdate(AdminWalletUpdate),
 }
 
 /// A wrapper around a SystemBusMessage containing the topic, used for

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -27,6 +27,9 @@ pub const NETWORK_TOPOLOGY_TOPIC: &str = "network-topology";
 /// The system bus topic published to for all wallet updates, not those given by
 /// Id
 pub const ALL_WALLET_UPDATES_TOPIC: &str = "wallet-updates";
+/// The system bus topic published to for all admin wallet updates, including
+/// order placements and cancellations
+pub const ADMIN_WALLET_UPDATES_TOPIC: &str = "admin-wallet-updates";
 
 /// Get the topic name for a given wallet
 pub fn wallet_topic(wallet_id: &WalletIdentifier) -> String {
@@ -157,8 +160,32 @@ pub enum SystemBusMessage {
         /// The atomic match bundle that should be forwarded to the client
         match_bundle: AtomicMatchApiBundle,
     },
-    /// A message indicating that no atomic match was found for a request
-    NoAtomicMatchFound,
+
+    // --- Admin -- //
+    /// An opaque message indicating that a wallet has been updated,
+    /// without leaking unnecessary information about the wallet
+    AdminWalletUpdate {
+        /// The ID of the wallet that was updated
+        wallet_id: WalletIdentifier,
+    },
+
+    /// An opaque message indicating that an order has been placed,
+    /// without leaking unnecessary information about the order
+    AdminOrderPlacement {
+        /// The ID of the order that was placed
+        order_id: OrderIdentifier,
+        /// The ID of the wallet containing the order
+        wallet_id: WalletIdentifier,
+    },
+
+    /// An opaque message indicating that an order has been cancelled,
+    /// without leaking unnecessary information about the order
+    AdminOrderCancellation {
+        /// The ID of the order that was cancelled
+        order_id: OrderIdentifier,
+        /// The ID of the wallet containing the order
+        wallet_id: WalletIdentifier,
+    },
 }
 
 /// A wrapper around a SystemBusMessage containing the topic, used for

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -4,14 +4,10 @@
 // | HTTP Routes |
 // ---------------
 
-use circuit_types::Amount;
-use common::types::{
-    wallet::{order_metadata::OrderMetadata, OrderIdentifier, WalletIdentifier},
-    MatchingPoolName, Price,
-};
+use common::types::{wallet::OrderIdentifier, MatchingPoolName};
 use serde::{Deserialize, Serialize};
 
-use crate::types::ApiOrder;
+use crate::types::{AdminOrderMetadata, ApiOrder};
 
 use super::wallet::WalletUpdateAuthorization;
 
@@ -48,21 +44,6 @@ pub struct IsLeaderResponse {
 pub struct OpenOrdersResponse {
     /// The open order IDs
     pub orders: Vec<OrderIdentifier>,
-}
-
-/// An order's metadata, augmented with the containing
-/// wallet's ID, and optionally the fillable amount
-/// of the order and the price used to calculate it
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AdminOrderMetadata {
-    /// The order metadata
-    pub order: OrderMetadata,
-    /// The ID of the wallet containing the order
-    pub wallet_id: WalletIdentifier,
-    /// The fillable amount of the order, if calculated
-    pub fillable: Option<Amount>,
-    /// The price used to calculate the fillable amount
-    pub price: Option<Price>,
 }
 
 /// The request type to add a new order to a given wallet, within a non-global

--- a/external-api/src/types/admin.rs
+++ b/external-api/src/types/admin.rs
@@ -1,0 +1,49 @@
+//! API types for admin requests
+
+use circuit_types::Amount;
+use common::types::{
+    wallet::{order_metadata::OrderMetadata, OrderIdentifier, WalletIdentifier},
+    Price,
+};
+use serde::{Deserialize, Serialize};
+
+/// An order's metadata, augmented with the containing
+/// wallet's ID, and optionally the fillable amount
+/// of the order and the price used to calculate it
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdminOrderMetadata {
+    /// The order metadata
+    pub order: OrderMetadata,
+    /// The ID of the wallet containing the order
+    pub wallet_id: WalletIdentifier,
+    /// The fillable amount of the order, if calculated
+    pub fillable: Option<Amount>,
+    /// The price used to calculate the fillable amount
+    pub price: Option<Price>,
+}
+
+/// An opaque message type for the admin wallet updates
+/// websocket route, indicating wallet updates without
+/// leaking unnecessary information
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AdminWalletUpdate {
+    /// Any update to a wallet
+    WalletUpdate {
+        /// The ID of the wallet that was updated
+        wallet_id: WalletIdentifier,
+    },
+    /// An order placement
+    OrderPlacement {
+        /// The ID of the wallet containing the order
+        wallet_id: WalletIdentifier,
+        /// The ID of the order that was placed
+        order_id: OrderIdentifier,
+    },
+    /// An order cancellation
+    OrderCancellation {
+        /// The ID of the wallet containing the order
+        wallet_id: WalletIdentifier,
+        /// The ID of the order that was cancelled
+        order_id: OrderIdentifier,
+    },
+}

--- a/external-api/src/types/mod.rs
+++ b/external-api/src/types/mod.rs
@@ -1,10 +1,12 @@
 //! API types for the relayer's websocket and HTTP APIs
 
+mod admin;
 mod api_network_info;
 mod api_order_book;
 mod api_task_history;
 mod api_wallet;
 
+pub use admin::*;
 pub use api_network_info::*;
 pub use api_order_book::*;
 pub use api_task_history::*;

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -7,7 +7,10 @@ use common::types::{
         Wallet,
     },
 };
-use external_api::bus_message::{wallet_topic, SystemBusMessage, ADMIN_WALLET_UPDATES_TOPIC};
+use external_api::{
+    bus_message::{wallet_topic, SystemBusMessage, ADMIN_WALLET_UPDATES_TOPIC},
+    types::AdminWalletUpdate,
+};
 use itertools::Itertools;
 use libmdbx::RW;
 
@@ -74,7 +77,9 @@ impl StateApplicator {
 
         self.system_bus().publish(
             ADMIN_WALLET_UPDATES_TOPIC.to_string(),
-            SystemBusMessage::AdminWalletUpdate { wallet_id: wallet.wallet_id },
+            SystemBusMessage::AdminWalletUpdate(AdminWalletUpdate::WalletUpdate {
+                wallet_id: wallet.wallet_id,
+            }),
         );
 
         Ok(ApplicatorReturnType::None)
@@ -147,10 +152,10 @@ impl StateApplicator {
                 // Publish an order placement message to the admin wallet updates topic
                 self.system_bus().publish(
                     ADMIN_WALLET_UPDATES_TOPIC.to_string(),
-                    SystemBusMessage::AdminOrderPlacement {
+                    SystemBusMessage::AdminWalletUpdate(AdminWalletUpdate::OrderPlacement {
                         wallet_id: wallet.wallet_id,
                         order_id: id,
-                    },
+                    }),
                 );
             }
         }
@@ -177,13 +182,13 @@ impl StateApplicator {
                         tx.mark_order_cancelled(&id)?;
                     }
 
-                    // Publish an order placement message to the admin wallet updates topic
+                    // Publish an order cancellation message to the admin wallet updates topic
                     self.system_bus().publish(
                         ADMIN_WALLET_UPDATES_TOPIC.to_string(),
-                        SystemBusMessage::AdminOrderCancellation {
+                        SystemBusMessage::AdminWalletUpdate(AdminWalletUpdate::OrderCancellation {
                             wallet_id: wallet.wallet_id,
                             order_id: id,
-                        },
+                        }),
                     );
                 }
             }

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -16,11 +16,12 @@ use common::types::{
 use external_api::{
     http::{
         admin::{
-            AdminGetOrderMatchingPoolResponse, AdminOrderMetadata, AdminOrderMetadataResponse,
+            AdminGetOrderMatchingPoolResponse, AdminOrderMetadataResponse,
             CreateOrderInMatchingPoolRequest, IsLeaderResponse, OpenOrdersResponse,
         },
         wallet::CreateOrderResponse,
     },
+    types::AdminOrderMetadata,
     EmptyRequestResponse,
 };
 use hyper::HeaderMap;

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -4,7 +4,10 @@ use std::{net::SocketAddr, sync::Arc};
 
 use constants::{in_bootstrap_mode, HANDSHAKE_STATUS_TOPIC, ORDER_STATE_CHANGE_TOPIC};
 use external_api::{
-    bus_message::{SystemBusMessage, SystemBusMessageWithTopic, NETWORK_TOPOLOGY_TOPIC},
+    bus_message::{
+        SystemBusMessage, SystemBusMessageWithTopic, ADMIN_WALLET_UPDATES_TOPIC,
+        NETWORK_TOPOLOGY_TOPIC,
+    },
     websocket::{ClientWebsocketMessage, SubscriptionResponse, WebsocketMessage},
 };
 use futures::{stream::SplitSink, SinkExt, StreamExt};
@@ -17,7 +20,7 @@ use tokio_tungstenite::{accept_async, WebSocketStream};
 use tungstenite::Message;
 
 use crate::{
-    auth::AuthMiddleware,
+    auth::{AuthMiddleware, AuthType},
     error::{bad_request, not_found},
 };
 
@@ -70,6 +73,9 @@ const NETWORK_INFO_ROUTE: &str = "/v0/network";
 const TASK_STATUS_ROUTE: &str = "/v0/tasks/:task_id";
 /// The task history topic, streams information about historical tasks
 const TASK_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/task-history";
+/// The admin wallet updates topic, streams opaque information about all wallet
+/// updates
+const ADMIN_WALLET_UPDATES_ROUTE: &str = "/v0/admin/wallet-updates";
 
 // --------------------
 // | Websocket Server |
@@ -103,7 +109,7 @@ impl WebsocketServer {
             .insert(
                 HANDSHAKE_ROUTE,
                 Box::new(DefaultHandler::new_with_remap(
-                    false, // authenticated
+                    AuthType::None,
                     HANDSHAKE_STATUS_TOPIC.to_string(),
                     config.system_bus.clone(),
                 )),
@@ -142,7 +148,7 @@ impl WebsocketServer {
             .insert(
                 ORDER_BOOK_ROUTE,
                 Box::new(DefaultHandler::new_with_remap(
-                    false, // authenticated
+                    AuthType::None,
                     ORDER_STATE_CHANGE_TOPIC.to_string(),
                     config.system_bus.clone(),
                 )),
@@ -154,7 +160,7 @@ impl WebsocketServer {
             .insert(
                 NETWORK_INFO_ROUTE,
                 Box::new(DefaultHandler::new_with_remap(
-                    false, // authenticated
+                    AuthType::None,
                     NETWORK_TOPOLOGY_TOPIC.to_string(),
                     config.system_bus.clone(),
                 )),
@@ -174,6 +180,18 @@ impl WebsocketServer {
             .insert(
                 TASK_HISTORY_ROUTE,
                 Box::new(TaskHistoryHandler::new(config.state.clone(), config.system_bus.clone())),
+            )
+            .unwrap();
+
+        // The "/v0/admin/wallet-updates" route
+        router
+            .insert(
+                ADMIN_WALLET_UPDATES_ROUTE,
+                Box::new(DefaultHandler::new_with_remap(
+                    AuthType::Admin,
+                    ADMIN_WALLET_UPDATES_TOPIC.to_string(),
+                    config.system_bus.clone(),
+                )),
             )
             .unwrap();
 
@@ -318,12 +336,9 @@ impl WebsocketServer {
                 // Find the handler for the given topic
                 let (params, route_handler) = self.parse_route_and_params(topic)?;
 
-                // TODO: Admin auth somewhere near here
-
                 // Validate auth
-                if route_handler.requires_wallet_auth() {
-                    self.authenticate_subscription(&params, &message).await?;
-                }
+                self.authenticate_subscription(route_handler.auth_type(), &params, &message)
+                    .await?;
 
                 // Register the topic subscription in the system bus and in the stream
                 // map that the listener loop polls
@@ -367,14 +382,17 @@ impl WebsocketServer {
         Ok((params, route.value.as_ref()))
     }
 
-    /// Authenticate a request by verifying a signature of the body by `sk_root`
+    /// Authenticate a websocket subscription
     async fn authenticate_subscription(
         &self,
+        auth_type: AuthType,
         params: &UrlParams,
         message: &ClientWebsocketMessage,
     ) -> Result<(), ApiServerError> {
-        // Parse the wallet ID from the params
-        let wallet_id = parse_wallet_id_from_params(params)?;
+        if matches!(auth_type, AuthType::None) {
+            return Ok(());
+        }
+
         let headers: HeaderMap<HeaderValue> = HeaderMap::try_from(&message.headers)
             .map_err(|_| bad_request(ERR_HEADER_PARSE.to_string()))?;
 
@@ -382,9 +400,19 @@ impl WebsocketServer {
         let body_serialized =
             serde_json::to_vec(&message.body).expect("re-serialization should not fail");
 
-        self.auth_middleware
-            .authenticate_wallet_request(wallet_id, &headers, &body_serialized)
-            .await
+        match auth_type {
+            AuthType::Wallet => {
+                // Parse the wallet ID from the params
+                let wallet_id = parse_wallet_id_from_params(params)?;
+                self.auth_middleware
+                    .authenticate_wallet_request(wallet_id, &headers, &body_serialized)
+                    .await
+            },
+            AuthType::Admin => {
+                self.auth_middleware.authenticate_admin_request(&headers, &body_serialized)
+            },
+            AuthType::None => unreachable!(),
+        }
     }
 
     /// Push an internal event that the client is subscribed to onto the

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -318,6 +318,8 @@ impl WebsocketServer {
                 // Find the handler for the given topic
                 let (params, route_handler) = self.parse_route_and_params(topic)?;
 
+                // TODO: Admin auth somewhere near here
+
                 // Validate auth
                 if route_handler.requires_wallet_auth() {
                     self.authenticate_subscription(&params, &message).await?;

--- a/workers/api-server/src/websocket/order_status.rs
+++ b/workers/api-server/src/websocket/order_status.rs
@@ -6,6 +6,7 @@ use state::State;
 use system_bus::{SystemBus, TopicReader};
 
 use crate::{
+    auth::AuthType,
     error::{not_found, ApiServerError},
     http::parse_wallet_id_from_params,
     router::{UrlParams, ERR_WALLET_NOT_FOUND},
@@ -58,7 +59,7 @@ impl WebsocketTopicHandler for OrderStatusHandler {
         Ok(())
     }
 
-    fn requires_wallet_auth(&self) -> bool {
-        true
+    fn auth_type(&self) -> AuthType {
+        AuthType::Wallet
     }
 }

--- a/workers/api-server/src/websocket/price_report.rs
+++ b/workers/api-server/src/websocket/price_report.rs
@@ -7,6 +7,7 @@ use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};
 use system_bus::{SystemBus, TopicReader};
 
 use crate::{
+    auth::AuthType,
     error::{bad_request, ApiServerError},
     router::UrlParams,
 };
@@ -108,7 +109,7 @@ impl WebsocketTopicHandler for PriceReporterHandler {
         Ok(())
     }
 
-    fn requires_wallet_auth(&self) -> bool {
-        false
+    fn auth_type(&self) -> AuthType {
+        AuthType::None
     }
 }

--- a/workers/api-server/src/websocket/task.rs
+++ b/workers/api-server/src/websocket/task.rs
@@ -10,6 +10,7 @@ use state::State;
 use system_bus::{SystemBus, TopicReader};
 
 use crate::{
+    auth::AuthType,
     error::{not_found, ApiServerError},
     http::{parse_task_id_from_params, parse_wallet_id_from_params},
     router::UrlParams,
@@ -69,8 +70,8 @@ impl WebsocketTopicHandler for TaskStatusHandler {
         Ok(())
     }
 
-    fn requires_wallet_auth(&self) -> bool {
-        false
+    fn auth_type(&self) -> AuthType {
+        AuthType::None
     }
 }
 
@@ -117,7 +118,7 @@ impl WebsocketTopicHandler for TaskHistoryHandler {
         Ok(())
     }
 
-    fn requires_wallet_auth(&self) -> bool {
-        true
+    fn auth_type(&self) -> AuthType {
+        AuthType::Wallet
     }
 }

--- a/workers/api-server/src/websocket/wallet.rs
+++ b/workers/api-server/src/websocket/wallet.rs
@@ -5,6 +5,7 @@ use state::State;
 use system_bus::{SystemBus, TopicReader};
 
 use crate::{
+    auth::AuthType,
     error::{not_found, ApiServerError},
     http::parse_wallet_id_from_params,
     router::UrlParams,
@@ -68,7 +69,7 @@ impl WebsocketTopicHandler for WalletTopicHandler {
         Ok(())
     }
 
-    fn requires_wallet_auth(&self) -> bool {
-        true
+    fn auth_type(&self) -> AuthType {
+        AuthType::Wallet
     }
 }


### PR DESCRIPTION
This PR introduces an admin websocket endpoint for subscribing to wallet updates without filtering by wallet ID. This endpoint doesn't stream out any substantive information about the updates themselves, rather just the wallet / order IDs.

This required adding an admin authentication method for the websocket server, as well as a new system bus topic / message for these opaque updates.

This will be tested downstream of implementing the consumption of this API in the JS SDK