### PR TITLE
common: wallet: orders: Add `allow_external_matches` flag

### DIFF
--- a/common/src/types/wallet/mocks.rs
+++ b/common/src/types/wallet/mocks.rs
@@ -23,7 +23,7 @@ use crate::{keyed_list::KeyedList, types::merkle::MerkleAuthenticationPath};
 
 use super::{
     keychain::{HmacKey, KeyChain, PrivateKeyChain},
-    orders::Order,
+    orders::{Order, OrderBuilder},
     Wallet,
 };
 
@@ -72,13 +72,15 @@ pub fn mock_empty_wallet() -> Wallet {
 /// Create a mock order
 pub fn mock_order() -> Order {
     let mut rng = thread_rng();
-    let quote_mint = rand_addr_biguint();
-    let base_mint = rand_addr_biguint();
-    let amount = rng.next_u64().into();
-    let worst_case_price = FixedPoint::from_integer(rng.gen());
-    let min_fill_size = rng.gen();
-
-    Order { quote_mint, base_mint, amount, worst_case_price, side: OrderSide::Buy, min_fill_size }
+    OrderBuilder::new()
+        .quote_mint(rand_addr_biguint())
+        .base_mint(rand_addr_biguint())
+        .side(OrderSide::Buy)
+        .amount(rng.next_u64().into())
+        .worst_case_price(FixedPoint::from_integer(rng.gen()))
+        .min_fill_size(rng.gen())
+        .build()
+        .unwrap()
 }
 
 /// Create a mock Merkle path for a wallet

--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -13,7 +13,7 @@ mod orders;
 mod shares;
 mod types;
 
-pub use orders::Order;
+pub use orders::{Order, OrderBuilder};
 pub use types::*;
 
 // ----------------
@@ -30,7 +30,7 @@ mod test {
 
     use crate::types::wallet::mocks::{mock_empty_wallet, mock_order};
 
-    use super::orders::Order;
+    use super::OrderBuilder;
 
     /// Tests adding a balance to an empty wallet
     #[test]
@@ -144,18 +144,14 @@ mod test {
     fn test_add_order_invalid() {
         let mut wallet = mock_empty_wallet();
         let id = Uuid::new_v4();
-        let base_mint = BigUint::from(1u8);
-        let quote_mint = BigUint::from(2u8);
-        let amount = u128::MAX;
-        let worst_case_price = FixedPoint::from_f64_round_down(0.1);
-        let o = Order::new_unchecked(
-            base_mint,
-            quote_mint,
-            OrderSide::Buy,
-            amount,
-            worst_case_price,
-            0,
-        );
+        let o = OrderBuilder::new()
+            .base_mint(BigUint::from(1u8))
+            .quote_mint(BigUint::from(2u8))
+            .side(OrderSide::Buy)
+            .amount(Amount::MAX)
+            .worst_case_price(FixedPoint::from_f64_round_down(0.1))
+            .build()
+            .unwrap();
 
         // Try to add the order
         wallet.add_order(id, o).unwrap();

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -83,6 +83,7 @@ impl From<ExternalOrder> for Order {
             amount: order.amount,
             min_fill_size: order.min_fill_size,
             worst_case_price,
+            allow_external_matches: true,
         }
     }
 }

--- a/external-api/src/types/api_wallet.rs
+++ b/external-api/src/types/api_wallet.rs
@@ -162,6 +162,9 @@ pub struct ApiOrder {
     /// The minimum fill size for the order
     #[serde(default)]
     pub min_fill_size: Amount,
+    /// Whether or not to allow external matches
+    #[serde(default)]
+    pub allow_external_matches: bool,
 }
 
 impl From<(OrderIdentifier, Order)> for ApiOrder {
@@ -175,6 +178,7 @@ impl From<(OrderIdentifier, Order)> for ApiOrder {
             worst_case_price: order.worst_case_price,
             amount: order.amount,
             min_fill_size: order.min_fill_size,
+            allow_external_matches: order.allow_external_matches,
         }
     }
 }
@@ -190,6 +194,7 @@ impl TryFrom<ApiOrder> for Order {
             order.amount,
             order.worst_case_price,
             order.min_fill_size,
+            order.allow_external_matches,
         )
     }
 }

--- a/workers/handshake-manager-tests/src/mpc_match.rs
+++ b/workers/handshake-manager-tests/src/mpc_match.rs
@@ -3,7 +3,7 @@
 use ark_mpc::{PARTY0, PARTY1};
 use circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide};
 use common::types::{
-    wallet::{Order, Wallet},
+    wallet::{Order, OrderBuilder, Wallet},
     wallet_mocks::mock_empty_wallet,
 };
 use eyre::Result;
@@ -61,14 +61,14 @@ fn get_order(side: OrderSide) -> Order {
         OrderSide::Sell => MOCK_EXECUTION_PRICE - 1.,
     };
 
-    Order {
-        quote_mint,
-        base_mint,
-        side,
-        amount: DEFAULT_ORDER_AMOUNT,
-        worst_case_price: FixedPoint::from_f64_round_down(worst_case_price),
-        min_fill_size: 0,
-    }
+    OrderBuilder::new()
+        .quote_mint(quote_mint)
+        .base_mint(base_mint)
+        .side(side)
+        .amount(DEFAULT_ORDER_AMOUNT)
+        .worst_case_price(FixedPoint::from_f64_round_down(worst_case_price))
+        .build()
+        .unwrap()
 }
 
 /// Get the balance to insert into the wallet to cover the order

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -44,7 +44,7 @@ use renegade_metrics::helpers::record_match_volume;
 use state::State;
 use std::thread::JoinHandle;
 use system_bus::SystemBus;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{error, info, info_span, instrument, Instrument};
 use util::{err_str, get_current_time_millis, runtime::sleep_forever_async};
 use uuid::Uuid;
 
@@ -185,6 +185,7 @@ impl HandshakeExecutor {
 /// threadpool
 impl HandshakeExecutor {
     /// Handle a handshake message from the peer
+    #[instrument(name = "handle_handshake_job", skip_all)]
     pub async fn handle_handshake_job(
         &self,
         job: HandshakeManagerJob,

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -19,13 +19,14 @@ use constants::Scalar;
 use external_api::bus_message::SystemBusMessage;
 use job_types::task_driver::TaskDriverJob;
 use renegade_crypto::fields::scalar_to_u128;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 use util::err_str;
 
 use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
 
 impl HandshakeExecutor {
     /// Execute an external match
+    #[instrument(name = "run_external_matching_engine", skip_all)]
     pub async fn run_external_matching_engine(
         &self,
         order: Order,
@@ -95,7 +96,7 @@ impl HandshakeExecutor {
     async fn get_external_match_candidates(
         &self,
     ) -> Result<HashSet<OrderIdentifier>, HandshakeManagerError> {
-        let matchable_orders = self.state.get_locally_matchable_orders().await?;
+        let matchable_orders = self.state.get_externally_matchable_orders().await?;
         Ok(HashSet::from_iter(matchable_orders))
     }
 

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -11,7 +11,7 @@ use common::types::{
     TimestampedPrice,
 };
 use job_types::task_driver::TaskDriverJob;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 use util::err_str;
 
 use crate::{
@@ -38,6 +38,7 @@ impl HandshakeExecutor {
     ///     1. Determine this code path to be a bottleneck
     ///     2. Have a better state management abstraction that makes
     ///        denormalization easier
+    #[instrument(name = "run_internal_matching_engine", skip_all)]
     pub async fn run_internal_matching_engine(
         &self,
         order_id: OrderIdentifier,

--- a/workers/task-driver/integration/tests/settle_match.rs
+++ b/workers/task-driver/integration/tests/settle_match.rs
@@ -24,7 +24,7 @@ use common::types::{
         ValidMatchSettleBundle,
     },
     tasks::{SettleMatchInternalTaskDescriptor, SettleMatchTaskDescriptor},
-    wallet::{Order, Wallet},
+    wallet::{Order, OrderBuilder, Wallet},
     wallet_mocks::mock_empty_wallet,
     TimestampedPrice,
 };
@@ -69,14 +69,14 @@ fn dummy_order(side: OrderSide, test_args: &IntegrationTestArgs) -> Order {
         OrderSide::Sell => SELL_ORDER_AMOUNT,
     };
 
-    Order {
-        quote_mint: biguint_from_hex_string(&test_args.erc20_addr0).unwrap(),
-        base_mint: biguint_from_hex_string(&test_args.erc20_addr1).unwrap(),
-        side,
-        amount: order_amount,
-        worst_case_price: FixedPoint::from_integer(worst_cast_price),
-        min_fill_size: 0,
-    }
+    OrderBuilder::new()
+        .quote_mint(biguint_from_hex_string(&test_args.erc20_addr0).unwrap())
+        .base_mint(biguint_from_hex_string(&test_args.erc20_addr1).unwrap())
+        .side(side)
+        .amount(order_amount)
+        .worst_case_price(FixedPoint::from_integer(worst_cast_price))
+        .build()
+        .unwrap()
 }
 
 /// Create a dummy balance

--- a/workers/task-driver/integration/tests/update_wallet.rs
+++ b/workers/task-driver/integration/tests/update_wallet.rs
@@ -10,7 +10,7 @@ use circuit_types::{
 use common::types::{
     tasks::{mocks::gen_wallet_update_sig, UpdateWalletTaskDescriptor, WalletUpdateType},
     transfer_auth::ExternalTransferWithAuth,
-    wallet::{Order, OrderIdentifier, Wallet},
+    wallet::{Order, OrderBuilder, OrderIdentifier, Wallet},
     wallet_mocks::{mock_empty_wallet, mock_order},
 };
 use constants::Scalar;
@@ -36,14 +36,14 @@ use crate::{
 
 lazy_static! {
     /// A dummy order that is allocated in a wallet as an update
-    static ref DUMMY_ORDER: Order = Order {
-        quote_mint: 1u8.into(),
-        base_mint: 2u8.into(),
-        side: OrderSide::Buy,
-        amount: 10,
-        worst_case_price: FixedPoint::from_integer(10),
-        min_fill_size: 0,
-    };
+    static ref DUMMY_ORDER: Order = OrderBuilder::new()
+        .quote_mint(1u8.into())
+        .base_mint(2u8.into())
+        .side(OrderSide::Buy)
+        .amount(10)
+        .worst_case_price(FixedPoint::from_integer(10))
+        .build()
+        .unwrap();
 }
 
 // -----------


### PR DESCRIPTION
### Purpose
This PR adds an `allow_external_matches` field to the `Order` struct and filters external match candidates by this value. I also made the following changes with this:
- Added an `OrderBuilder` struct now that there are a number of optionally configurable fields
- Added tracing to a few of the matching engine methods so that we can watch their latency as the order state grows

### Testing
- Unit tests pass
- Created an order with `allow_external_matches = false` and verified that the external match client got no match
- Created an order with `allow_external_matches = true` and verified that the client received an external match