### PR TITLE
state: replication: snapshot: Check if table exists before reading

### DIFF
--- a/state/src/replication/state_machine/snapshot.rs
+++ b/state/src/replication/state_machine/snapshot.rs
@@ -278,6 +278,11 @@ impl StateMachine {
                 continue;
             }
 
+            // Skip the table if it doesn't exist in the snapshot
+            if !src_tx.inner().table_exists(table)? {
+                continue;
+            }
+
             // Clear the table on the destination
             let dest_tx = dest.new_write_tx()?;
             dest_tx.clear_table(table)?;


### PR DESCRIPTION
### Purpose
This PR checks if a table exists before attempting to read it from the snapshot. This is necessary when creating a new table.

### Testing
- Unit tests pass
- Currently testing an upgrade with a new table in testnet