### PR TITLE
task-driver: settle-match-external: Record historical fill and metrics

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,5 +1,6 @@
 //! Defines common types that many crates can depend on
 
+use circuit_types::fixed_point::FixedPoint;
 use serde::{Deserialize, Serialize};
 
 pub mod exchange;
@@ -50,6 +51,11 @@ impl TimestampedPrice {
     pub fn new(price: Price) -> Self {
         let timestamp = get_current_time_millis();
         Self { price, timestamp }
+    }
+
+    /// Get the price as a fixed point number
+    pub fn as_fixed_point(&self) -> FixedPoint {
+        FixedPoint::from_f64_round_down(self.price)
     }
 }
 

--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -1,6 +1,6 @@
 //! Descriptors for the match settlement tasks
 
-use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
+use circuit_types::r#match::MatchResult;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
@@ -83,7 +83,7 @@ pub struct SettleExternalMatchTaskDescriptor {
     /// The ID of the wallet that the local node matched an order from
     pub internal_wallet_id: WalletIdentifier,
     /// The price at which the match was executed
-    pub execution_price: FixedPoint,
+    pub execution_price: TimestampedPrice,
     /// The match result from the external matching engine
     pub match_res: MatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
@@ -95,7 +95,7 @@ impl SettleExternalMatchTaskDescriptor {
     pub fn new(
         internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
-        execution_price: FixedPoint,
+        execution_price: TimestampedPrice,
         match_res: MatchResult,
         atomic_match_bundle_topic: String,
     ) -> Self {

--- a/renegade-metrics/src/lib.rs
+++ b/renegade-metrics/src/lib.rs
@@ -11,3 +11,5 @@ pub mod gauge;
 pub mod global_metrics;
 pub mod helpers;
 pub mod labels;
+
+pub use helpers::*;

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -13,7 +13,7 @@ use crate::utils::validity_proofs::{
 use arbitrum_client::client::ArbitrumClient;
 use ark_mpc::{PARTY0, PARTY1};
 use async_trait::async_trait;
-use circuit_types::{fixed_point::FixedPoint, r#match::MatchResult};
+use circuit_types::r#match::MatchResult;
 use circuits::zk_circuits::proof_linking::link_sized_commitments_match_settle;
 use circuits::zk_circuits::valid_match_settle::{
     SizedValidMatchSettleStatement, SizedValidMatchSettleWitness,
@@ -430,7 +430,7 @@ impl SettleMatchInternalTask {
         let commitment_witness0 = &self.order1_validity_witness.commitment_witness;
         let commitment_witness1 = &self.order2_validity_witness.commitment_witness;
 
-        let price = FixedPoint::from_f64_round_down(self.execution_price.price);
+        let price = self.execution_price.as_fixed_point();
         let order0 = commitment_witness0.order.clone();
         let balance0 = commitment_witness0.balance_send.clone();
         let balance_receive0 = commitment_witness0.balance_receive.clone();


### PR DESCRIPTION
### Purpose
This PR updates the `settle-external-match` task to record order fill metrics when an atomic match is witnessed on-chain. Note that if a client fails to submit the atomic match bundle on-chain the fill will be missed. For now, we choose not to solve this problem under the assumption that this is a sufficiently unlikely edge case. We can reevaluate if this makes sense once the atomic match system is deployed.

### Testing
- Unit tests pass
- Submitted an atomic match and printed the fill history after the match