### PR TITLE
external-api: auth: Add auth v2 helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "constants 0.1.0",
  "ethers",
  "hex 0.4.3",
+ "http 0.2.12",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
@@ -3582,6 +3583,7 @@ dependencies = [
  "renegade-crypto 0.1.0",
  "serde",
  "serde_json",
+ "thiserror",
  "util 0.1.0",
  "uuid 1.10.0",
 ]

--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -3,9 +3,16 @@ name = "external-api"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+auth = ["http", "thiserror"]
+
 [dependencies]
 # === Arithmetic === #
 num-bigint = { workspace = true }
+
+# === Auth Dependencies === #
+http = { version = "0.2.12", optional = true }
+thiserror = { version = "1.0.61", optional = true }
 
 # === Workspace Dependencies === #
 circuit-types = { path = "../circuit-types" }

--- a/external-api/src/auth/auth_helpers.rs
+++ b/external-api/src/auth/auth_helpers.rs
@@ -1,0 +1,127 @@
+//! Auth helpers for the external API
+
+use base64::engine::{general_purpose as b64_general_purpose, Engine};
+use common::types::wallet::keychain::HmacKey;
+use http::HeaderMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::{
+    RENEGADE_AUTH_HEADER_NAME, RENEGADE_AUTH_HMAC_HEADER_NAME, RENEGADE_SIG_EXPIRATION_HEADER_NAME,
+};
+
+use super::{AuthError, HMAC_LEN};
+
+/// The header namespace to include in the HMAC
+const RENEGADE_HEADER_NAMESPACE: &str = "x-renegade";
+
+// --------------------
+// | Public Interface |
+// --------------------
+
+/// Validate a request signature with an expiration
+pub fn validate_expiring_auth(
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+) -> Result<(), AuthError> {
+    // First check the expiration
+    let expiration_ts = parse_auth_expiration_from_headers(headers)?;
+    check_auth_timestamp(expiration_ts)?;
+
+    // Then check the signature
+    validate_auth(path, headers, body, key)
+}
+
+/// Validate a request signature without an expiration
+pub fn validate_auth(
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+) -> Result<(), AuthError> {
+    // Parse the MAC from headers
+    let mac = parse_hmac_from_headers(headers)?;
+
+    // Compute the expected HMAC
+    let expected_mac = create_request_signature(path, headers, body, key);
+    if expected_mac != mac {
+        return Err(AuthError::InvalidSignature);
+    }
+
+    Ok(())
+}
+
+/// Create a request signature
+pub fn create_request_signature(
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+) -> Vec<u8> {
+    // Compute the expected HMAC
+    let path_bytes = path.as_bytes();
+    let header_bytes = get_header_bytes(headers);
+    let payload = [path_bytes, &header_bytes, body].concat();
+
+    key.compute_mac(&payload)
+}
+
+/// Parse an HMAC from headers
+pub fn parse_hmac_from_headers(headers: &HeaderMap) -> Result<[u8; HMAC_LEN], AuthError> {
+    let b64_hmac: &str = headers
+        .get(RENEGADE_AUTH_HMAC_HEADER_NAME)
+        .ok_or(AuthError::HmacMissing)?
+        .to_str()
+        .map_err(|_| AuthError::HmacFormatInvalid)?;
+    b64_general_purpose::STANDARD_NO_PAD
+        .decode(b64_hmac)
+        .map_err(|_| AuthError::HmacFormatInvalid)?
+        .try_into()
+        .map_err(|_| AuthError::HmacFormatInvalid)
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Parse an expiration timestamp from headers
+fn parse_auth_expiration_from_headers(headers: &HeaderMap) -> Result<u64, AuthError> {
+    let sig_expiration = headers
+        .get(RENEGADE_SIG_EXPIRATION_HEADER_NAME)
+        .ok_or(AuthError::SignatureExpirationMissing)?;
+    sig_expiration
+        .to_str()
+        .map_err(|_| AuthError::ExpirationFormatInvalid)
+        .and_then(|s| s.parse::<u64>().map_err(|_| AuthError::ExpirationFormatInvalid))
+}
+
+/// Check a timestamp on a signature
+fn check_auth_timestamp(expiration_ts: u64) -> Result<(), AuthError> {
+    let now = SystemTime::now();
+    let target_duration = Duration::from_millis(expiration_ts);
+    let target_time = UNIX_EPOCH + target_duration;
+
+    if now >= target_time {
+        return Err(AuthError::SignatureExpired);
+    }
+
+    Ok(())
+}
+
+/// Get the header bytes to validate in an HMAC
+fn get_header_bytes(headers: &HeaderMap) -> Vec<u8> {
+    let mut header_bytes = Vec::new();
+
+    for (key, value) in headers.iter() {
+        let key_str = key.as_str().to_lowercase();
+
+        // Filter by prefix and skip the mac header itself
+        if key_str.starts_with(RENEGADE_HEADER_NAMESPACE) && key_str != RENEGADE_AUTH_HEADER_NAME {
+            header_bytes.extend_from_slice(key_str.as_bytes());
+            header_bytes.extend_from_slice(value.as_bytes());
+        }
+    }
+
+    header_bytes
+}

--- a/external-api/src/auth/error.rs
+++ b/external-api/src/auth/error.rs
@@ -1,0 +1,26 @@
+//! Error types for authentication helpers
+
+use thiserror::Error;
+
+/// Error type for authentication helpers
+#[derive(Error, Debug)]
+pub enum AuthError {
+    /// Error displayed when the signature is invalid
+    #[error("invalid signature")]
+    InvalidSignature,
+    /// Error displayed when the expiration format is invalid
+    #[error("could not parse signature expiration timestamp")]
+    ExpirationFormatInvalid,
+    /// Error displayed when the HMAC is missing from the request
+    #[error("HMAC is missing from the request")]
+    HmacMissing,
+    /// Error displayed when the HMAC format is invalid
+    #[error("HMAC format invalid")]
+    HmacFormatInvalid,
+    /// Error displayed when the signature expiration header is missing
+    #[error("signature expiration missing from headers")]
+    SignatureExpirationMissing,
+    /// Error displayed when a signature has expired
+    #[error("signature expired")]
+    SignatureExpired,
+}

--- a/external-api/src/auth/mod.rs
+++ b/external-api/src/auth/mod.rs
@@ -1,0 +1,12 @@
+//! Auth helpers for the external API
+#![cfg(feature = "auth")]
+
+mod auth_helpers;
+mod error;
+
+// Re-export the public interface
+pub use auth_helpers::*;
+pub use error::*;
+
+/// The number of bytes in an HMAC
+pub const HMAC_LEN: usize = 32;

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -13,18 +13,20 @@ use serde::{
 };
 use util::hex::{biguint_from_hex_string, biguint_to_hex_addr};
 
+#[cfg(feature = "auth")]
+pub mod auth;
 pub mod bus_message;
 pub mod http;
 pub mod types;
 pub mod websocket;
 
-/// Header name for the HTTP auth signature
-pub const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
-/// Header name for the expiration timestamp of a signature
-pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
+/// Header name for the HTTP auth signature; lower cased
+pub const RENEGADE_AUTH_HEADER_NAME: &str = "x-renegade-auth";
+/// Header name for the expiration timestamp of a signature; lower cased
+pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiration";
 
 /// Header name for the HTTP auth HMAC
-pub const RENEGADE_AUTH_HMAC_HEADER_NAME: &str = "renegade-auth-symmetric";
+pub const RENEGADE_AUTH_HMAC_HEADER_NAME: &str = "x-renegade-auth-symmetric";
 
 /// An empty request/response type
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -33,7 +33,7 @@ renegade-compliance-api = { git = "https://github.com/renegade-fi/relayer-extens
 common = { path = "../../common" }
 constants = { path = "../../constants" }
 renegade-crypto = { path = "../../renegade-crypto" }
-external-api = { path = "../../external-api" }
+external-api = { path = "../../external-api", features = ["auth"] }
 gossip-api = { path = "../../gossip-api" }
 job-types = { path = "../job-types" }
 state = { path = "../../state" }

--- a/workers/api-server/src/auth/helpers.rs
+++ b/workers/api-server/src/auth/helpers.rs
@@ -1,32 +1,16 @@
 //! Helpers for the authentication module
 
+use base64::engine::{general_purpose as b64_general_purpose, Engine};
+use external_api::auth::HMAC_LEN;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use common::types::wallet::keychain::HmacKey;
-use external_api::RENEGADE_SIG_EXPIRATION_HEADER_NAME;
 use hyper::HeaderMap;
 
 use crate::error::{bad_request, unauthorized, ApiServerError};
 
-/// Error displayed when the signature expiration header is missing
-const ERR_SIG_EXPIRATION_MISSING: &str = "signature expiration missing from headers";
-/// Error displayed when the expiration format is invalid
-const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiration timestamp";
 /// Error displayed when a signature has expired
 const ERR_EXPIRED: &str = "signature expired";
-
-/// Parse an expiration timestamp from headers
-pub(crate) fn parse_sig_expiration(headers: &HeaderMap) -> Result<u64, ApiServerError> {
-    let sig_expiration = headers
-        .get(RENEGADE_SIG_EXPIRATION_HEADER_NAME)
-        .ok_or_else(|| bad_request(ERR_SIG_EXPIRATION_MISSING.to_string()))?;
-    sig_expiration
-        .to_str()
-        .map_err(|_| bad_request(ERR_EXPIRATION_FORMAT_INVALID.to_string()))
-        .and_then(|s| {
-            s.parse::<u64>().map_err(|_| bad_request(ERR_EXPIRATION_FORMAT_INVALID.to_string()))
-        })
-}
 
 /// Check a timestamp on a signature
 pub(crate) fn check_auth_timestamp(expiration_ts: u64) -> Result<(), ApiServerError> {
@@ -46,4 +30,74 @@ pub(crate) fn compute_expiring_hmac(key: &HmacKey, payload: &[u8], expiration: u
     // Check the MAC on the payload concatenated with the expiration timestamp
     let msg_bytes = [payload, &expiration.to_le_bytes()].concat();
     key.compute_mac(&msg_bytes)
+}
+
+// ---------------------------
+// | Old Auth Implementation |
+// ---------------------------
+
+// TODO: Delete the old auth implementation
+
+/// Error displayed when the signature format is invalid
+const ERR_SIG_FORMAT_INVALID: &str = "signature format invalid";
+/// Error displayed when the signature header is missing
+const ERR_SIG_HEADER_MISSING: &str = "signature missing from headers";
+/// Error displayed when the expiration format is invalid
+const ERR_EXPIRATION_FORMAT_INVALID: &str = "could not parse signature expiration timestamp";
+/// Error displayed when the expiration header is missing
+const ERR_EXPIRATION_HEADER_MISSING: &str = "signature expiration missing from headers";
+/// Error displayed when the HMAC format is invalid
+const ERR_HMAC_FORMAT_INVALID: &str = "could not parse HMAC";
+/// Error displayed when the HMAC header is missing
+const ERR_HMAC_MISSING: &str = "HMAC missing from headers";
+
+/// Header name for the HTTP auth signature
+pub(crate) const RENEGADE_AUTH_HEADER_NAME: &str = "renegade-auth";
+/// Header name for the HTTP auth expiration
+pub(crate) const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "renegade-auth-expiration";
+/// Header name for the HTTP auth HMAC
+pub(crate) const RENEGADE_AUTH_HMAC_HEADER_NAME: &str = "renegade-auth-symmetric";
+
+/// Parse an expiration timestamp from headers
+///
+/// TODO: Delete this once we move to the new authentication scheme
+pub(crate) fn parse_sig_expiration(headers: &HeaderMap) -> Result<u64, ApiServerError> {
+    let sig_expiration = headers
+        .get(RENEGADE_SIG_EXPIRATION_HEADER_NAME)
+        .ok_or_else(|| bad_request(ERR_EXPIRATION_HEADER_MISSING.to_string()))?;
+    sig_expiration
+        .to_str()
+        .map_err(|_| bad_request(ERR_EXPIRATION_FORMAT_INVALID.to_string()))
+        .and_then(|s| {
+            s.parse::<u64>().map_err(|_| bad_request(ERR_EXPIRATION_FORMAT_INVALID.to_string()))
+        })
+}
+
+/// Parse a signature from the given header
+///
+/// TODO: Delete this once we move to the new authentication scheme
+pub(crate) fn parse_signature_from_header(headers: &HeaderMap) -> Result<Vec<u8>, ApiServerError> {
+    let b64_signature: &str = headers
+        .get(RENEGADE_AUTH_HEADER_NAME)
+        .ok_or_else(|| bad_request(ERR_SIG_HEADER_MISSING.to_string()))?
+        .to_str()
+        .map_err(|_| bad_request(ERR_SIG_FORMAT_INVALID.to_string()))?;
+    b64_general_purpose::STANDARD_NO_PAD
+        .decode(b64_signature)
+        .map_err(|_| bad_request(ERR_SIG_FORMAT_INVALID.to_string()))
+}
+
+/// Parse an HMAC from headers
+pub(crate) fn parse_hmac(headers: &HeaderMap) -> Result<[u8; HMAC_LEN], ApiServerError> {
+    let b64_hmac: &str = headers
+        .get(RENEGADE_AUTH_HMAC_HEADER_NAME)
+        .ok_or_else(|| bad_request(ERR_HMAC_MISSING.to_string()))?
+        .to_str()
+        .map_err(|_| bad_request(ERR_HMAC_FORMAT_INVALID.to_string()))?;
+
+    b64_general_purpose::STANDARD_NO_PAD
+        .decode(b64_hmac)
+        .map_err(|_| bad_request(ERR_HMAC_FORMAT_INVALID.to_string()))?
+        .try_into()
+        .map_err(|_| bad_request(ERR_HMAC_FORMAT_INVALID.to_string()))
 }

--- a/workers/api-server/src/auth/mod.rs
+++ b/workers/api-server/src/auth/mod.rs
@@ -17,8 +17,6 @@ mod wallet_auth;
 
 /// Error message emitted when the admin API is disabled
 const ERR_ADMIN_API_DISABLED: &str = "Admin API is disabled";
-/// The number of bytes in an HMAC
-const HMAC_LEN: usize = 32;
 
 /// Represents the auth type required for a request
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+use external_api::auth::AuthError;
 use hyper::{Body, Response, StatusCode};
 use state::error::StateError;
 
@@ -53,6 +54,12 @@ impl From<ApiServerError> for Response<Body> {
             ),
             _ => build_500_response(err.to_string()),
         }
+    }
+}
+
+impl From<AuthError> for ApiServerError {
+    fn from(value: AuthError) -> Self {
+        ApiServerError::HttpStatusCode(StatusCode::UNAUTHORIZED, value.to_string())
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds auth v2 helpers to the `external-api` crate available behind the `auth` feature flag. These headers change the MAC payload to be `[path_bytes, header_bytes, body_bytes]` rather than just the body, and prefix renegade headers with `x-renegade`.

I'll upgrade the relayer to check first for a v2 auth then for a v1 auth in the next pr. We will leave the relayer backwards compatible until clients can upgrade.

### Testing
- Tested both the wallet and admin APIs