### PR TITLE
api-server: auth: Add authv2 shims while clients migrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
  "ark-mpc",
  "ark-poly",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bimap",
  "circuit-types 0.1.0",
  "circuits 0.1.0",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -52,7 +52,7 @@ util = { path = "../util" }
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
 
 # === Misc Dependencies === #
-base64 = { version = "0.13" }
+base64 = { version = "0.22" }
 bimap = "0.6.2"
 derivative = "2.2"
 indexmap = { workspace = true }

--- a/common/src/types/wallet/keychain.rs
+++ b/common/src/types/wallet/keychain.rs
@@ -1,5 +1,6 @@
 //! Keychain helpers for the wallet
 
+use base64::engine::{general_purpose as b64_general_purpose, Engine};
 use circuit_types::keychain::{
     PublicIdentificationKey, PublicKeyChain, PublicSigningKey, SecretIdentificationKey,
     SecretSigningKey,
@@ -23,12 +24,15 @@ use util::{
 
 use super::Wallet;
 
+/// The length of an HMAC key in bytes
+pub const HMAC_KEY_LEN: usize = 32;
+
 /// Type alias for the hmac core implementation
 type HmacSha256 = hmac::Hmac<Sha256>;
 
 /// A type representing a symmetric HMAC key
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HmacKey(pub [u8; 32]);
+pub struct HmacKey(pub [u8; HMAC_KEY_LEN]);
 impl HmacKey {
     /// Create a new HMAC key from a hex string
     pub fn new(hex: &str) -> Result<Self, String> {
@@ -36,14 +40,14 @@ impl HmacKey {
     }
 
     /// Get the inner bytes
-    pub fn inner(&self) -> &[u8; 32] {
+    pub fn inner(&self) -> &[u8; HMAC_KEY_LEN] {
         &self.0
     }
 
     /// Create a new random HMAC key
     pub fn random() -> Self {
         let mut rng = thread_rng();
-        let mut bytes = [0; 32];
+        let mut bytes = [0; HMAC_KEY_LEN];
         rng.fill_bytes(&mut bytes);
 
         Self(bytes)
@@ -57,8 +61,24 @@ impl HmacKey {
     /// Try to convert a hex string to an HMAC key
     pub fn from_hex_string(hex: &str) -> Result<Self, String> {
         let bytes = bytes_from_hex_string(hex)?;
-        if bytes.len() != 32 {
-            return Err(format!("expected 32 byte HMAC key, got {}", bytes.len()));
+        if bytes.len() != HMAC_KEY_LEN {
+            return Err(format!("expected {HMAC_KEY_LEN} byte HMAC key, got {}", bytes.len()));
+        }
+
+        Ok(Self(bytes.try_into().unwrap()))
+    }
+
+    /// Convert the HMAC key to a base64 string
+    pub fn to_base64_string(&self) -> String {
+        b64_general_purpose::STANDARD_NO_PAD.encode(self.0)
+    }
+
+    /// Try to convert a base64 string to an HMAC key
+    pub fn from_base64_string(base64: &str) -> Result<Self, String> {
+        let bytes =
+            b64_general_purpose::STANDARD_NO_PAD.decode(base64).map_err(|e| e.to_string())?;
+        if bytes.len() != HMAC_KEY_LEN {
+            return Err(format!("expected {HMAC_KEY_LEN} byte HMAC key, got {}", bytes.len()));
         }
 
         Ok(Self(bytes.try_into().unwrap()))

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -25,9 +25,6 @@ pub const RENEGADE_AUTH_HEADER_NAME: &str = "x-renegade-auth";
 /// Header name for the expiration timestamp of a signature; lower cased
 pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiration";
 
-/// Header name for the HTTP auth HMAC
-pub const RENEGADE_AUTH_HMAC_HEADER_NAME: &str = "x-renegade-auth-symmetric";
-
 /// An empty request/response type
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmptyRequestResponse {}

--- a/workers/api-server/src/auth/mod.rs
+++ b/workers/api-server/src/auth/mod.rs
@@ -1,6 +1,7 @@
 //! Defines authentication primitives for the API server
 
 use common::types::wallet::{keychain::HmacKey, WalletIdentifier};
+use external_api::auth::validate_expiring_auth;
 use hyper::HeaderMap;
 use state::State;
 
@@ -53,6 +54,7 @@ impl AuthMiddleware {
     pub async fn authenticate_wallet_request(
         &self,
         wallet_id: WalletIdentifier,
+        path: &str,
         headers: &HeaderMap,
         payload: &[u8],
     ) -> Result<(), ApiServerError> {
@@ -64,12 +66,29 @@ impl AuthMiddleware {
             .ok_or_else(|| not_found(ERR_WALLET_NOT_FOUND.to_string()))?;
         let symmetric_key = wallet.key_chain.symmetric_key();
 
+        // Try v2 auth first, then fall back to v1
+        if Self::authenticate_wallet_request_v2(path, headers, payload, &symmetric_key).is_ok() {
+            return Ok(());
+        }
+
         authenticate_wallet_request(headers, payload, &symmetric_key)
+    }
+
+    /// Authenticate a wallet request using v2 auth
+    pub(crate) fn authenticate_wallet_request_v2(
+        path: &str,
+        headers: &HeaderMap,
+        payload: &[u8],
+        key: &HmacKey,
+    ) -> Result<(), ApiServerError> {
+        validate_expiring_auth(path, headers, payload, key)?;
+        Ok(())
     }
 
     /// Authenticate an admin request
     pub fn authenticate_admin_request(
         &self,
+        path: &str,
         headers: &HeaderMap,
         payload: &[u8],
     ) -> Result<(), ApiServerError> {
@@ -77,6 +96,143 @@ impl AuthMiddleware {
             return Err(not_found(ERR_ADMIN_API_DISABLED));
         }
 
-        authenticate_admin_request(&self.admin_key.unwrap(), headers, payload)
+        // Try v2 auth first, then fall back to v1
+        let admin_key = self.admin_key.as_ref().unwrap();
+        if Self::authenticate_admin_request_v2(path, headers, payload, admin_key).is_ok() {
+            return Ok(());
+        }
+
+        authenticate_admin_request(admin_key, headers, payload)
+    }
+
+    /// Authenticate an admin request using v2 auth
+    pub(crate) fn authenticate_admin_request_v2(
+        path: &str,
+        headers: &HeaderMap,
+        payload: &[u8],
+        key: &HmacKey,
+    ) -> Result<(), ApiServerError> {
+        validate_expiring_auth(path, headers, payload, key)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use base64::{engine::general_purpose::STANDARD_NO_PAD as b64, Engine};
+    use external_api::{
+        auth::{add_expiring_auth_to_headers, create_request_signature},
+        RENEGADE_AUTH_HEADER_NAME, RENEGADE_SIG_EXPIRATION_HEADER_NAME,
+    };
+    use hyper::header::HeaderValue;
+    use util::get_current_time_millis;
+
+    use super::*;
+
+    /// Get a dummy path, header map, and payload
+    fn get_dummy_path_header_map_payload() -> (&'static str, HeaderMap, &'static [u8]) {
+        ("/test", HeaderMap::new(), b"test request")
+    }
+
+    /// Sign a request and add the signature and expiration to the headers
+    fn sign_request_add_expiration(
+        path: &str,
+        headers: &mut HeaderMap,
+        payload: &[u8],
+        key: &HmacKey,
+    ) {
+        // Add an expiration timestamp to the headers
+        let expiration = Duration::from_secs(1);
+        add_expiring_auth_to_headers(path, headers, payload, key, expiration);
+    }
+
+    /// Sign a request and add the signature to the headers, without an
+    /// expiration
+    fn sign_request(path: &str, headers: &mut HeaderMap, payload: &[u8], key: &HmacKey) {
+        // Create the signature and add it to the headers as a base64 encoded string
+        let signature = create_request_signature(path, headers, payload, key);
+        let b64_signature = b64.encode(signature);
+        let sig_header = HeaderValue::from_str(&b64_signature).unwrap();
+        headers.insert(RENEGADE_AUTH_HEADER_NAME, sig_header);
+    }
+
+    /// Test that v2 wallet auth works correctly
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_v2_wallet_auth__successful() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+
+        sign_request_add_expiration(path, &mut headers, payload, &key);
+        AuthMiddleware::authenticate_wallet_request_v2(path, &headers, payload, &key).unwrap();
+    }
+
+    /// Test that v2 wallet auth fails correctly when the signature is expired
+    #[test]
+    #[should_panic(expected = "signature expired")]
+    #[allow(non_snake_case)]
+    fn test_v2_wallet_auth__expired() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+        let ts = get_current_time_millis() - 1000; // Expired one second ago
+        headers.insert(RENEGADE_SIG_EXPIRATION_HEADER_NAME, ts.into());
+
+        sign_request(path, &mut headers, payload, &key);
+        AuthMiddleware::authenticate_wallet_request_v2(path, &headers, payload, &key).unwrap();
+    }
+
+    /// Test that v2 wallet auth fails correctly when the signature is invalid
+    #[test]
+    #[should_panic(expected = "invalid signature")]
+    #[allow(non_snake_case)]
+    fn test_v2_wallet_auth__invalid_signature() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+        sign_request_add_expiration(path, &mut headers, payload, &key);
+
+        // Add an extra header to change the mac payload
+        headers.insert("x-renegade-extra-header", "extra".parse().unwrap());
+        AuthMiddleware::authenticate_wallet_request_v2(path, &headers, payload, &key).unwrap();
+    }
+
+    /// Test that admin auth works correctly
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_admin_auth__successful() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+
+        sign_request_add_expiration(path, &mut headers, payload, &key);
+        AuthMiddleware::authenticate_admin_request_v2(path, &headers, payload, &key).unwrap();
+    }
+
+    /// Test that admin auth fails correctly when the signature is expired
+    #[test]
+    #[should_panic(expected = "signature expired")]
+    #[allow(non_snake_case)]
+    fn test_admin_auth__expired() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+        let ts = get_current_time_millis() - 1000; // Expired one second ago
+        headers.insert(RENEGADE_SIG_EXPIRATION_HEADER_NAME, ts.into());
+
+        sign_request(path, &mut headers, payload, &key);
+        AuthMiddleware::authenticate_admin_request_v2(path, &headers, payload, &key).unwrap();
+    }
+
+    /// Test that admin auth fails correctly when the signature is invalid
+    #[test]
+    #[should_panic(expected = "invalid signature")]
+    #[allow(non_snake_case)]
+    fn test_admin_auth__invalid_signature() {
+        let key = HmacKey::random();
+        let (path, mut headers, payload) = get_dummy_path_header_map_payload();
+        sign_request_add_expiration(path, &mut headers, payload, &key);
+
+        // Add an extra header to change the mac payload
+        headers.insert("x-renegade-extra-header", "extra".parse().unwrap());
+        AuthMiddleware::authenticate_admin_request_v2(path, &headers, payload, &key).unwrap();
     }
 }

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -299,7 +299,7 @@ impl Router {
                 };
 
                 // Auth check and handler
-                if let Err(e) = self.check_auth(*auth, &params_map, &mut req).await {
+                if let Err(e) = self.check_auth(*auth, path, &params_map, &mut req).await {
                     return e.into();
                 }
 
@@ -345,6 +345,7 @@ impl Router {
     async fn check_auth(
         &self,
         auth_type: AuthType,
+        path: &str,
         url_params: &HashMap<String, String>,
         req: &mut Request<Body>,
     ) -> Result<(), ApiServerError> {
@@ -361,11 +362,11 @@ impl Router {
                 // Parse the wallet ID from the URL params
                 let wallet_id = parse_wallet_id_from_params(url_params)?;
                 self.auth_middleware
-                    .authenticate_wallet_request(wallet_id, req.headers(), &req_body)
+                    .authenticate_wallet_request(wallet_id, path, req.headers(), &req_body)
                     .await?;
             },
             AuthType::Admin => {
-                self.auth_middleware.authenticate_admin_request(req.headers(), &req_body)?;
+                self.auth_middleware.authenticate_admin_request(path, req.headers(), &req_body)?;
             },
             AuthType::None => unreachable!(),
         }

--- a/workers/api-server/src/websocket.rs
+++ b/workers/api-server/src/websocket.rs
@@ -320,7 +320,7 @@ impl WebsocketServer {
 
                 // Validate auth
                 if route_handler.requires_wallet_auth() {
-                    self.authenticate_subscription(&params, &message).await?;
+                    self.authenticate_subscription(topic, &params, &message).await?;
                 }
 
                 // Register the topic subscription in the system bus and in the stream
@@ -368,6 +368,7 @@ impl WebsocketServer {
     /// Authenticate a request by verifying a signature of the body by `sk_root`
     async fn authenticate_subscription(
         &self,
+        topic: &str,
         params: &UrlParams,
         message: &ClientWebsocketMessage,
     ) -> Result<(), ApiServerError> {
@@ -381,7 +382,7 @@ impl WebsocketServer {
             serde_json::to_vec(&message.body).expect("re-serialization should not fail");
 
         self.auth_middleware
-            .authenticate_wallet_request(wallet_id, &headers, &body_serialized)
+            .authenticate_wallet_request(wallet_id, topic, &headers, &body_serialized)
             .await
     }
 


### PR DESCRIPTION
### Purpose
This PR migrates the relayer authentication to use v2 authentication. Specifically, I introduce shim code to first try v2 auth then fall back to v1 if v2 is not available. This preserves backwards compatibility while the clients are being updated.

### Testing
- Tested with an old client using v1 auth
- Tested with a new client using v2 auth
- All unit tests pass