### PR TITLE
handshake-manager: external-engine: Respond to client if match fails

### DIFF
--- a/common/src/types/gossip.rs
+++ b/common/src/types/gossip.rs
@@ -243,6 +243,7 @@ impl ClusterId {
     /// public key into a base64 encoded representation than to use the value
     /// directly
     pub fn new(cluster_pubkey: &PublicKey) -> Self {
+        #[allow(deprecated)]
         let encoded_key = base64::encode(cluster_pubkey.as_bytes());
         Self(encoded_key)
     }
@@ -254,6 +255,7 @@ impl ClusterId {
 
     /// Get the public key represented by this cluster
     pub fn get_public_key(&self) -> Result<PublicKey, SignatureError> {
+        #[allow(deprecated)]
         let decoded_key = base64::decode(&self.0).map_err(|_| SignatureError::new())?;
         PublicKey::from_bytes(&decoded_key)
     }


### PR DESCRIPTION
### Purpose
This PR adds a wrapper function around `run_external_matching_engine` that catches any errors and unblocks the client with a `NoMatch` message. Before this change, the external engine might fail and never respond to the API server, leaving the API server to timeout.

### Testing
- Unit tests pass
- Tested with a client and hardcoded an error, verified that the client received back a no match immediately