### PR TITLE
workers: api-server: http: admin: return matchable order IDs for wallet

### DIFF
--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -21,8 +21,9 @@ pub const ADMIN_OPEN_ORDERS_ROUTE: &str = "/v0/admin/open-orders";
 pub const ADMIN_ORDER_METADATA_ROUTE: &str = "/v0/admin/orders/:order_id/metadata";
 /// Route to get the matching pool for an order
 pub const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE: &str = "/v0/admin/orders/:order_id/matching-pool";
-/// Route to get all the order IDs for a given wallet
-pub const ADMIN_WALLET_ORDER_IDS_ROUTE: &str = "/v0/admin/wallet/:wallet_id/order-ids";
+/// Route to get all the matchable order IDs for a given wallet
+pub const ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE: &str =
+    "/v0/admin/wallet/:wallet_id/matchable-order-ids";
 
 // Setter routes
 
@@ -80,9 +81,9 @@ pub struct AdminGetOrderMatchingPoolResponse {
     pub matching_pool: MatchingPoolName,
 }
 
-/// The response to a "get wallet order IDs" request
+/// The response to a "get wallet matchable order IDs" request
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AdminWalletOrderIdsResponse {
+pub struct AdminWalletMatchableOrderIdsResponse {
     /// The order IDs
     pub order_ids: Vec<OrderIdentifier>,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -10,8 +10,8 @@ mod task;
 mod wallet;
 
 use admin::{
-    AdminGetOrderMatchingPoolHandler, AdminTriggerSnapshotHandler, AdminWalletOrderIdsHandler,
-    IsLeaderHandler,
+    AdminGetOrderMatchingPoolHandler, AdminTriggerSnapshotHandler,
+    AdminWalletMatchableOrderIdsHandler, IsLeaderHandler,
 };
 use async_trait::async_trait;
 use common::types::{
@@ -25,7 +25,7 @@ use external_api::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
             ADMIN_GET_ORDER_MATCHING_POOL_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
             ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
-            ADMIN_TRIGGER_SNAPSHOT_ROUTE, ADMIN_WALLET_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_TRIGGER_SNAPSHOT_ROUTE, ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
         },
         external_match::REQUEST_EXTERNAL_MATCH_ROUTE,
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
@@ -479,11 +479,11 @@ impl HttpServer {
             AdminOrderMetadataHandler::new(state.clone(), config.price_reporter_work_queue.clone()),
         );
 
-        // The "/admin/wallet/:id/order-ids" route
+        // The "/admin/wallet/:id/matchable-order-ids" route
         router.add_admin_authenticated_route(
             &Method::GET,
-            ADMIN_WALLET_ORDER_IDS_ROUTE.to_string(),
-            AdminWalletOrderIdsHandler::new(state.clone()),
+            ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE.to_string(),
+            AdminWalletMatchableOrderIdsHandler::new(state.clone()),
         );
 
         // The "/admin/matching_pools/:matching_pool" route

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -17,8 +17,8 @@ use external_api::{
     http::{
         admin::{
             AdminGetOrderMatchingPoolResponse, AdminOrderMetadataResponse,
-            AdminWalletOrderIdsResponse, CreateOrderInMatchingPoolRequest, IsLeaderResponse,
-            OpenOrdersResponse,
+            AdminWalletMatchableOrderIdsResponse, CreateOrderInMatchingPoolRequest,
+            IsLeaderResponse, OpenOrdersResponse,
         },
         wallet::CreateOrderResponse,
     },
@@ -244,13 +244,13 @@ impl TypedHandler for AdminOrderMetadataHandler {
 // | Wallet Handlers |
 // -------------------
 
-/// Handler for the GET /v0/admin/wallet/:id/order-ids route
-pub struct AdminWalletOrderIdsHandler {
+/// Handler for the GET /v0/admin/wallet/:id/matchable-order-ids route
+pub struct AdminWalletMatchableOrderIdsHandler {
     /// A handle to the relayer state
     state: State,
 }
 
-impl AdminWalletOrderIdsHandler {
+impl AdminWalletMatchableOrderIdsHandler {
     /// Constructor
     pub fn new(state: State) -> Self {
         Self { state }
@@ -258,9 +258,9 @@ impl AdminWalletOrderIdsHandler {
 }
 
 #[async_trait]
-impl TypedHandler for AdminWalletOrderIdsHandler {
+impl TypedHandler for AdminWalletMatchableOrderIdsHandler {
     type Request = EmptyRequestResponse;
-    type Response = AdminWalletOrderIdsResponse;
+    type Response = AdminWalletMatchableOrderIdsResponse;
 
     async fn handle_typed(
         &self,
@@ -272,9 +272,10 @@ impl TypedHandler for AdminWalletOrderIdsHandler {
         let wallet_id = parse_wallet_id_from_params(&params)?;
         let wallet =
             self.state.get_wallet(&wallet_id).await?.ok_or(not_found(ERR_WALLET_NOT_FOUND))?;
-        let order_ids = wallet.orders.keys().cloned().collect();
 
-        Ok(AdminWalletOrderIdsResponse { order_ids })
+        let order_ids = wallet.get_matchable_orders().into_iter().map(|(id, _order)| id).collect();
+
+        Ok(AdminWalletMatchableOrderIdsResponse { order_ids })
     }
 }
 


### PR DESCRIPTION
This PR tweaks the `/admin/wallet/:id/order-ids` endpoint to only return the IDs of _matchable_ orders in the wallet. This is preferable to returning all order IDs, including those of default / empty orders.

This has been tested in testnet.