### PR TITLE
wokers: api-server: admin: decimal-adjust fillable price

### DIFF
--- a/workers/handshake-manager/src/manager/matching/match_helpers.rs
+++ b/workers/handshake-manager/src/manager/matching/match_helpers.rs
@@ -88,7 +88,7 @@ impl HandshakeExecutor {
         let base_addr = base.get_addr().to_string();
         let quote_addr = quote.get_addr().to_string();
         let price_recv = self.request_price(base.clone(), quote.clone())?;
-        let price =
+        let price: TimestampedPrice =
             match price_recv.await.map_err(err_str!(HandshakeManagerError::PriceReporter))? {
                 PriceReporterState::Nominal(ref report) => report.into(),
                 err_state => {
@@ -100,7 +100,10 @@ impl HandshakeExecutor {
             };
 
         // Correct the price for decimals
-        let corrected_price = Self::decimal_correct_price(base, quote, price)?;
+        let corrected_price = price
+            .get_decimal_corrected_price(base, quote)
+            .map_err(err_str!(HandshakeManagerError::NoPriceData))?;
+
         Ok(corrected_price)
     }
 }

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -79,12 +79,10 @@ impl HandshakeExecutor {
 
             match midpoint_state {
                 PriceReporterState::Nominal(report) => {
-                    let price = (&report).into();
-                    let corrected_price = Self::decimal_correct_price(
-                        &report.base_token,
-                        &report.quote_token,
-                        price,
-                    )?;
+                    let price: TimestampedPrice = (&report).into();
+                    let corrected_price = price
+                        .get_decimal_corrected_price(&report.base_token, &report.quote_token)
+                        .map_err(err_str!(HandshakeManagerError::NoPriceData))?;
                     midpoint_prices.push((report.base_token, report.quote_token, corrected_price));
                 },
 
@@ -92,12 +90,10 @@ impl HandshakeExecutor {
                 // with large deviation. This largely happens because of Uniswap, and we could
                 // implement a more complex deviation calculation that ignores DEXs
                 PriceReporterState::TooMuchDeviation(report, _) => {
-                    let price = (&report).into();
-                    let corrected_price = Self::decimal_correct_price(
-                        &report.base_token,
-                        &report.quote_token,
-                        price,
-                    )?;
+                    let price: TimestampedPrice = (&report).into();
+                    let corrected_price = price
+                        .get_decimal_corrected_price(&report.base_token, &report.quote_token)
+                        .map_err(err_str!(HandshakeManagerError::NoPriceData))?;
                     midpoint_prices.push((report.base_token, report.quote_token, corrected_price));
                 },
 
@@ -171,26 +167,5 @@ impl HandshakeExecutor {
         }
 
         Ok(true)
-    }
-
-    /// Decimal correct a price for a given token pair
-    pub(super) fn decimal_correct_price(
-        base_token: &Token,
-        quote_token: &Token,
-        ts_price: TimestampedPrice,
-    ) -> Result<TimestampedPrice, HandshakeManagerError> {
-        let base_decimals = base_token.get_decimals().ok_or(HandshakeManagerError::NoPriceData(
-            format!("{ERR_NO_PRICE_STREAM}: {base_token}-{quote_token}"),
-        ))?;
-        let quote_decimals =
-            quote_token.get_decimals().ok_or(HandshakeManagerError::NoPriceData(format!(
-                "{ERR_NO_PRICE_STREAM}: {base_token}-{quote_token}"
-            )))?;
-
-        let original_price = ts_price.price;
-        let decimal_diff = quote_decimals as i32 - base_decimals as i32;
-        let corrected_price = original_price * 10f64.powi(decimal_diff);
-
-        Ok(TimestampedPrice { price: corrected_price, timestamp: ts_price.timestamp })
     }
 }


### PR DESCRIPTION
This PR fixes the calculation of the fillable amount in the admin order metadata endpoint. We need to decimal-correct the price when computing the fillable amount, but we return the "original" price (which effectively assumes the base/quote tokens use the same number of decimals) to the client, as this is easier to interpret. This basically defers the responsibility of decimal-adjusting the fillable amount to the client if it wishes to compute the value by multiplying it with the price.