### PR TITLE
circuit: zk-circuits: Use `constrain_equal_floor` in matching engine

### DIFF
--- a/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
@@ -107,7 +107,7 @@ where
         // Here we round down to the nearest integer
         let expected_quote_amount =
             witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
-        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+        MultiproverFixedPointGadget::constrain_equal_floor(
             expected_quote_amount,
             witness.match_res.quote_amount,
             fabric,
@@ -318,14 +318,14 @@ where
         let expected_relayer_fee = relayer_fee.mul_integer(received_amount, cs)?;
         let expected_protocol_fee = protocol_fee.mul_integer(received_amount, cs)?;
 
-        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+        MultiproverFixedPointGadget::constrain_equal_floor(
             expected_relayer_fee,
             fee_take.relayer_fee,
             fabric,
             cs,
         )?;
 
-        MultiproverFixedPointGadget::constrain_equal_integer_ignore_fraction(
+        MultiproverFixedPointGadget::constrain_equal_floor(
             expected_protocol_fee,
             fee_take.protocol_fee,
             fabric,

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -108,7 +108,7 @@ where
         // Here we round down to the nearest integer
         let expected_quote_amount =
             witness.price1.mul_integer(witness.match_res.base_amount, cs)?;
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(
+        FixedPointGadget::constrain_equal_floor(
             expected_quote_amount,
             witness.match_res.quote_amount,
             cs,
@@ -311,17 +311,8 @@ where
         let expected_relayer_fee = relayer_fee.mul_integer(received_amount, cs)?;
         let expected_protocol_fee = protocol_fee.mul_integer(received_amount, cs)?;
 
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(
-            expected_relayer_fee,
-            fee_take.relayer_fee,
-            cs,
-        )?;
-
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(
-            expected_protocol_fee,
-            fee_take.protocol_fee,
-            cs,
-        )
+        FixedPointGadget::constrain_equal_floor(expected_relayer_fee, fee_take.relayer_fee, cs)?;
+        FixedPointGadget::constrain_equal_floor(expected_protocol_fee, fee_take.protocol_fee, cs)
     }
 
     /// Verify that the balance updates to a wallet are valid

--- a/circuits/src/zk_circuits/valid_match_settle_atomic.rs
+++ b/circuits/src/zk_circuits/valid_match_settle_atomic.rs
@@ -125,7 +125,7 @@ where
         let base_amount = match_res.base_amount;
         let quote_amount = match_res.quote_amount;
         let expected_quote = price.mul_integer(base_amount, cs)?;
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(expected_quote, quote_amount, cs)
+        FixedPointGadget::constrain_equal_floor(expected_quote, quote_amount, cs)
     }
 
     /// Validate that the internal party's balance capitalizes their side of the
@@ -248,11 +248,7 @@ where
 
         // Validate the protocol fee value
         let expected_protocol_fee = statement.protocol_fee.mul_integer(receive_amount, cs)?;
-        FixedPointGadget::constrain_equal_integer_ignore_fraction(
-            expected_protocol_fee,
-            fee_take.protocol_fee,
-            cs,
-        )
+        FixedPointGadget::constrain_equal_floor(expected_protocol_fee, fee_take.protocol_fee, cs)
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR replaces the use of `FixedPointGadget::constrain_equal_integer_ignore_fraction` with `FixedPointGadget::constrain_equal_floor` in all matching engine locations. The former allows integral values that are _either_ the floor or the ceiling of the fixed point value. The ladder restricts this to the floor, which is simpler.

### Testing
- All tests pass