### PR TITLE
circuits: zk-circuits: valid-wallet-create: Add public blinder check

### DIFF
--- a/common/src/types/tasks/descriptors/new_wallet.rs
+++ b/common/src/types/tasks/descriptors/new_wallet.rs
@@ -1,5 +1,6 @@
 //! Descriptor for the new wallet task
 
+use constants::Scalar;
 use serde::{Deserialize, Serialize};
 
 use crate::types::wallet::Wallet;
@@ -12,17 +13,19 @@ use super::{TaskDescriptor, INVALID_WALLET_SHARES};
 pub struct NewWalletTaskDescriptor {
     /// The wallet to create
     pub wallet: Wallet,
+    /// The blinder seed to use for the new wallet
+    pub blinder_seed: Scalar,
 }
 
 impl NewWalletTaskDescriptor {
     /// Constructor
-    pub fn new(wallet: Wallet) -> Result<Self, String> {
+    pub fn new(wallet: Wallet, blinder_seed: Scalar) -> Result<Self, String> {
         // Validate that the wallet shares are well formed
         if !wallet.check_wallet_shares() {
             return Err(INVALID_WALLET_SHARES.to_string());
         }
 
-        Ok(NewWalletTaskDescriptor { wallet })
+        Ok(NewWalletTaskDescriptor { wallet, blinder_seed })
     }
 }
 

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -84,6 +84,8 @@ pub struct GetWalletResponse {
 pub struct CreateWalletRequest {
     /// The wallet info to be created
     pub wallet: ApiWallet,
+    /// The blinder seed to use for the wallet
+    pub blinder_seed: BigUint,
 }
 
 /// The response type to a request to create a new wallet

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -292,7 +292,8 @@ impl TypedHandler for CreateWalletHandler {
         wallet.blinded_public_shares = public_shares;
 
         wallet.wallet_id = wallet_id;
-        let task = NewWalletTaskDescriptor::new(wallet).map_err(bad_request)?;
+        let blinder_seed = biguint_to_scalar(&req.blinder_seed);
+        let task = NewWalletTaskDescriptor::new(wallet, blinder_seed).map_err(bad_request)?;
 
         // Check rate limits and enqueue the task
         self.rate_limiter.check_rate_limit(wallet_id).await?;

--- a/workers/task-driver/integration/tests/create_new_wallet.rs
+++ b/workers/task-driver/integration/tests/create_new_wallet.rs
@@ -12,8 +12,13 @@ use crate::{helpers::await_task, IntegrationTestArgs};
 
 /// Basic functionality test of creating a valid new wallet
 async fn create_valid_wallet(test_args: IntegrationTestArgs) -> Result<()> {
-    let wallet = mock_empty_wallet();
-    let descriptor = NewWalletTaskDescriptor { wallet };
+    // Create a wallet and reblind it so that we can easily use the previous blinder
+    // private share as the blinder seed
+    let mut wallet = mock_empty_wallet();
+    let blinder_seed = wallet.private_shares.blinder;
+    wallet.reblind_wallet();
+
+    let descriptor = NewWalletTaskDescriptor { wallet, blinder_seed };
 
     await_task(descriptor.into(), &test_args).await
 }

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -474,7 +474,7 @@ impl NodeStartupTask {
     ) -> Result<(), NodeStartupTaskError> {
         info!("Creating new relayer wallet");
         let wallet = Wallet::new_empty_wallet(wallet_id, blinder_seed, share_seed, keychain);
-        let descriptor = NewWalletTaskDescriptor::new(wallet)
+        let descriptor = NewWalletTaskDescriptor::new(wallet, blinder_seed)
             .map_err(err_str!(NodeStartupTaskError::DeriveWallet))?;
 
         await_task(descriptor.into(), &self.state, self.task_queue.clone())


### PR DESCRIPTION
### Purpose
This PR enforces that a new wallet's public blinder is correctly constructed from a blinder seed. This prevents malicious darkpool users from "frontrunning a blinder" and thereby temporarily blocking an _existing_ user's wallet update.

### Testing
- [x] Unit tests pass
- [x] Test creating a new wallet with new verification keys