### PR TITLE
docker: sequencer: deploy_contracts: use new erc20 deploy script

### DIFF
--- a/docker/sequencer/deploy_contracts.sh
+++ b/docker/sequencer/deploy_contracts.sh
@@ -42,34 +42,48 @@ cargo run \
 
 # Deploy the dummy ERC20 contracts
 # The funding amount here is 1 million of a token with 18 decimal places
-cargo run \
-    --package scripts -- \
-    --priv-key $DEVNET_PKEY \
-    --rpc-url $DEVNET_RPC_URL \
-    --deployments-path $DEPLOYMENTS_PATH \
-    deploy-erc20s \
-    --account-skeys $DEVNET_PKEY \
-    --tickers \
-        WBTC \
-        WETH \
-        BNB \
-        MATIC \
-        LDO \
-        USDC \
-        USDT \
-        LINK \
-        UNI \
-        SUSHI \
-        1INCH \
-        AAVE \
-        COMP \
-        MKR \
-        REN \
-        MANA \
-        ENS \
-        DYDX \
-        CRV \
-    --funding-amount 1000000000000000000000000
+
+erc20s=(
+    "USDC" "USD Coin" 6
+    "USDT" "Tether USD" 6
+    "WBTC" "Wrapped BTC" 8
+    "WETH" "Wrapped Ether" 18
+    "ARB" "Arbitrum" 18
+    "GMX" "GMX" 18
+    "PENDLE" "Pendle" 18
+    "LDO" "Lido DAO Token" 18
+    "LINK" "ChainLink Token" 18
+    "CRV" "Curve DAO Token" 18
+    "UNI" "Uniswap" 18
+    "ZRO" "LayerZero" 18
+    "LPT" "Livepeer Token" 18
+    "GRT" "Graph Token" 18
+    "COMP" "Compound" 18
+    "AAVE" "Aave Token" 18
+    "XAI" "Xai" 18
+    "RDNT" "Radiant" 18
+    "ETHFI" "Ether.fi" 18
+)
+num_tokens=${#erc20s[@]}
+num_fields=3  # Number of fields in each tuple
+
+for ((i=0; i<num_tokens; i+=num_fields)); do
+    symbol="${erc20s[i]}"
+    name="${erc20s[i+1]}"
+    decimals="${erc20s[i+2]}"
+
+    cargo run \
+        --package scripts -- \
+        --priv-key $DEVNET_PKEY \
+        --rpc-url $DEVNET_RPC_URL \
+        --deployments-path $DEPLOYMENTS_PATH \
+        deploy-erc20 \
+        --symbol "$symbol" \
+        --name "$name" \
+        --decimals "$decimals" \
+        --account-skeys $DEVNET_PKEY \
+        --funding-amount 1000000000000000000000000
+done
 
 # If $NO_VERIFY is set, write dummy addresses to the deployments file.
 # Otherwise, deploy the verification keys.

--- a/util/src/arbitrum.rs
+++ b/util/src/arbitrum.rs
@@ -7,12 +7,14 @@ use eyre::{eyre, Result};
 
 /// The deployments key in the `deployments.json` file
 pub const DEPLOYMENTS_KEY: &str = "deployments";
+/// The ERC-20s sub-key in the `deployments.json` file
+pub const ERC20S_KEY: &str = "erc20s";
 /// The darkpool proxy contract key in the `deployments.json` file
 pub const DARKPOOL_PROXY_CONTRACT_KEY: &str = "darkpool_proxy_contract";
-/// The first dummy erc20 contract key in a `deployments.json` file
-pub const DUMMY_ERC20_0_CONTRACT_KEY: &str = "DUMMY1";
-/// The second dummy erc20 contract key in a `deployments.json` file
-pub const DUMMY_ERC20_1_CONTRACT_KEY: &str = "DUMMY2";
+/// The first dummy erc20 ticker
+pub const DUMMY_ERC20_0_TICKER: &str = "DUMMY1";
+/// The second dummy erc20 ticker
+pub const DUMMY_ERC20_1_TICKER: &str = "DUMMY2";
 /// The permit2 contract key in a `deployments.json` file
 pub const PERMIT2_CONTRACT_KEY: &str = "permit2_contract";
 /// The protocol fee that the contract charges on a match
@@ -30,6 +32,19 @@ pub fn parse_addr_from_deployments_file(file_path: &str, contract_key: &str) -> 
         .as_str()
         .map(|s| s.to_string())
         .ok_or_else(|| eyre!("Could not parse {contract_key} address from deployments file"))
+}
+
+/// Parse the address of an ERC-20 contract from the `deployments.json` file
+#[cfg(feature = "mocks")]
+pub fn parse_erc20_addr_from_deployments_file(file_path: &str, ticker: &str) -> Result<String> {
+    let mut file_contents = String::new();
+    File::open(file_path)?.read_to_string(&mut file_contents)?;
+
+    let parsed_json = json::parse(&file_contents)?;
+    parsed_json[DEPLOYMENTS_KEY][ERC20S_KEY][ticker]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| eyre!("Could not parse {ticker} address from deployments file"))
 }
 
 /// Get the protocol fee from the static variable

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -44,8 +44,9 @@ use test_helpers::{
 };
 use util::{
     arbitrum::{
-        parse_addr_from_deployments_file, DARKPOOL_PROXY_CONTRACT_KEY, DUMMY_ERC20_0_CONTRACT_KEY,
-        DUMMY_ERC20_1_CONTRACT_KEY, PERMIT2_CONTRACT_KEY, PROTOCOL_FEE, PROTOCOL_PUBKEY,
+        parse_addr_from_deployments_file, parse_erc20_addr_from_deployments_file,
+        DARKPOOL_PROXY_CONTRACT_KEY, DUMMY_ERC20_0_TICKER, DUMMY_ERC20_1_TICKER,
+        PERMIT2_CONTRACT_KEY, PROTOCOL_FEE, PROTOCOL_PUBKEY,
     },
     runtime::block_current,
     telemetry::LevelFilter,
@@ -136,14 +137,14 @@ impl From<CliArgs> for IntegrationTestArgs {
             state.clone(),
         );
 
-        let erc20_addr0 = parse_addr_from_deployments_file(
+        let erc20_addr0 = parse_erc20_addr_from_deployments_file(
             &test_args.deployments_path,
-            DUMMY_ERC20_0_CONTRACT_KEY,
+            DUMMY_ERC20_0_TICKER,
         )
         .unwrap();
-        let erc20_addr1 = parse_addr_from_deployments_file(
+        let erc20_addr1 = parse_erc20_addr_from_deployments_file(
             &test_args.deployments_path,
-            DUMMY_ERC20_1_CONTRACT_KEY,
+            DUMMY_ERC20_1_TICKER,
         )
         .unwrap();
         let permit2_addr =


### PR DESCRIPTION
This PR updates the `deploy_contracts.sh` script in the testing sequencer image to use the new ERC20 deployment command as per https://github.com/renegade-fi/renegade-contracts/pull/269.

Our integration testing stack is outdated at the moment, so I'm deferring running the integration tests with these changes until it is fixed.