### PR TITLE
common: descriptors: new-wallet: Add serde default for blinder seed

### DIFF
--- a/common/src/types/tasks/descriptors/new_wallet.rs
+++ b/common/src/types/tasks/descriptors/new_wallet.rs
@@ -14,6 +14,7 @@ pub struct NewWalletTaskDescriptor {
     /// The wallet to create
     pub wallet: Wallet,
     /// The blinder seed to use for the new wallet
+    #[serde(default)]
     pub blinder_seed: Scalar,
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a default deserialization for the blinder seed on a new wallet task