### PR TITLE
task-driver: refresh-wallet: Match order ids on same pair and side

### DIFF
--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -177,6 +177,11 @@ impl Order {
         }
     }
 
+    /// Get the pair and side of the order
+    pub fn pair_and_side(&self) -> (BigUint, BigUint, OrderSide) {
+        (self.base_mint.clone(), self.quote_mint.clone(), self.side)
+    }
+
     /// Determines whether the given price is within the allowable range for the
     /// order
     pub fn price_in_range(&self, price: FixedPoint) -> bool {


### PR DESCRIPTION
### Purpose
This PR updates the order ID matching logic to consider orders equivalent if they are on the same pair and side; rather than direct equality. This allows us to match order IDs after a partial fill, e.g. by an atomic settlement.

### Testing
- Unit tests pass
- [ ] Testing in testnet