### PR TITLE
renegade-metrics: helpers: Label external matches in volume metrics

### DIFF
--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -55,3 +55,5 @@ pub const NUM_INFLIGHT_TXS_METRIC: &str = "num_inflight_txs";
 
 /// Metric tag for the asset of a deposit/withdrawal
 pub const ASSET_METRIC_TAG: &str = "asset";
+/// Metric tag for whether a match is external
+pub const EXTERNAL_MATCH_METRIC_TAG: &str = "is_external_match";

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -417,8 +417,7 @@ impl HandshakeExecutor {
         self.publish_completion_messages(state.local_order_id, state.peer_order_id).await?;
 
         // Record the volume of the match
-        record_match_volume(match_result);
-
+        record_match_volume(match_result, false /* is_external_match */);
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -495,7 +495,7 @@ impl SettleMatchExternalTask {
             .await
             .map_err(SettleMatchExternalTaskError::State)?;
 
-        renegade_metrics::record_match_volume(match_res);
+        renegade_metrics::record_match_volume(match_res, true /* is_external_match */);
         Ok(())
     }
 }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -255,7 +255,7 @@ impl Task for SettleMatchInternalTask {
                 self.update_proofs().await?;
                 self.task_state = SettleMatchInternalTaskState::Completed;
 
-                record_match_volume(&self.match_result);
+                record_match_volume(&self.match_result, false /* is_external_match */);
             },
 
             SettleMatchInternalTaskState::Completed => {


### PR DESCRIPTION
### Purpose
This PR labels external matches with a tag `is_external_match = true` for external matches. This will help us disambiguate on the metrics dashboard side.

### Testing
- Unit tests pass
- [ ] Testing the metrics in testnet