### PR TITLE
state: storage: order-book: Delete orders when cancelled

### DIFF
--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -162,10 +162,9 @@ impl StateApplicator {
                     // Remove the order from its matching pool
                     tx.remove_order_from_matching_pool(&id)?;
 
-                    // Remove the order from the local orders set and mark as cancelled
-                    tx.remove_local_order(&id)?;
+                    // Remove the order from the order book
                     if tx.get_order_info(&id)?.is_some() {
-                        tx.mark_order_cancelled(&id)?;
+                        tx.delete_order(&id)?;
                     }
                 }
             }


### PR DESCRIPTION
### Purpose
This PR deletes orders when they are cancelled. We have the order history now so keeping around cancelled orders merely pollutes the table.

### Todo
- Prune phantom orders from state with migration

### Testing
- Unit tests pass
- Tested the case in which an order is deleted
- [ ] Currently testing deleting an order with a locally running relayer
