### PR TITLE
state: caching: order-cache: Add order book cache

### DIFF
--- a/state/src/caching/mod.rs
+++ b/state/src/caching/mod.rs
@@ -1,0 +1,3 @@
+//! Caching mechanisms for the relayer state
+
+pub mod order_cache;

--- a/state/src/caching/order_cache.rs
+++ b/state/src/caching/order_cache.rs
@@ -1,0 +1,65 @@
+//! A cache for common predicates evaluated on the order book
+//!
+//! E.g. querying orders which are (externally) matchable, or querying open
+//! orders on a given asset
+
+use std::collections::HashSet;
+
+use common::types::wallet::OrderIdentifier;
+use tokio::sync::RwLock;
+
+/// The order book cache
+#[derive(Default)]
+pub struct OrderBookCache {
+    /// The set of open orders which are matchable and locally managed
+    matchable_orders: RwLock<HashSet<OrderIdentifier>>,
+    /// The set of open orders which are _externally_ matchable and locally
+    /// managed
+    ///
+    /// This should be a subset of `matchable_orders`
+    externally_matchable_orders: RwLock<HashSet<OrderIdentifier>>,
+}
+
+impl OrderBookCache {
+    /// Construct a new order book cache
+    pub fn new() -> Self {
+        Self {
+            matchable_orders: RwLock::new(HashSet::new()),
+            externally_matchable_orders: RwLock::new(HashSet::new()),
+        }
+    }
+
+    // --- Getters --- //
+
+    /// Get the set of matchable orders
+    pub async fn matchable_orders(&self) -> Vec<OrderIdentifier> {
+        self.matchable_orders.read().await.iter().copied().collect()
+    }
+
+    /// Get the set of externally matchable orders
+    pub async fn externally_matchable_orders(&self) -> Vec<OrderIdentifier> {
+        self.externally_matchable_orders.read().await.iter().copied().collect()
+    }
+
+    // --- Setters --- //
+
+    /// Add a matchable order
+    pub async fn add_matchable_order(&self, order: OrderIdentifier) {
+        self.matchable_orders.write().await.insert(order);
+    }
+
+    /// Add an externally matchable order
+    pub async fn add_externally_matchable_order(&self, order: OrderIdentifier) {
+        self.externally_matchable_orders.write().await.insert(order);
+    }
+
+    /// Remove a matchable order
+    pub async fn remove_matchable_order(&self, order: OrderIdentifier) {
+        self.matchable_orders.write().await.remove(&order);
+    }
+
+    /// Remove an externally matchable order
+    pub async fn remove_externally_matchable_order(&self, order: OrderIdentifier) {
+        self.externally_matchable_orders.write().await.remove(&order);
+    }
+}

--- a/state/src/interface/peer_index.rs
+++ b/state/src/interface/peer_index.rs
@@ -156,7 +156,7 @@ impl StateInner {
                     let is_me = peer.peer_id == my_id;
 
                     // Do not index the peer if the given address is not dialable
-                    if !peer.is_dialable(this.allow_local) {
+                    if !peer.is_dialable(this.config.allow_local) {
                         continue;
                     }
 

--- a/state/src/interface/raft.rs
+++ b/state/src/interface/raft.rs
@@ -21,7 +21,7 @@ impl StateInner {
 
     /// Whether the state machine was recovered from a snapshot
     pub fn was_recovered_from_snapshot(&self) -> bool {
-        self.recovered_from_snapshot
+        self.config.recovered_from_snapshot
     }
 
     /// Whether the raft is initialized (has non-empty voters)


### PR DESCRIPTION
### Purpose
This PR adds an order book cache that will initial support two queries:
- Fetching the locally matchable orders
- Fetching the externally matchable local orders

This cache will evolve into a more complex caching layer in which we can query for orders e.g. by pair and side.

### Testing
- Unit tests pass
- Will test the match cache once it's integrated in a follow-up