### PR TITLE
state: replication: snapshot: Backfill order book cache from snapshot

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -125,7 +125,7 @@ impl StateApplicator {
     }
 
     /// Get a reference to the order cache
-    fn order_cache(&self) -> &OrderBookCache {
+    pub(crate) fn order_cache(&self) -> &OrderBookCache {
         &self.config.order_cache
     }
 }

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -87,7 +87,7 @@ impl StateApplicator {
 
         // Update the order metadata into the `Matching` state
         let wallet = tx
-            .get_wallet_for_order(&order_id)?
+            .get_wallet_id_for_order(&order_id)?
             .ok_or(StateApplicatorError::MissingEntry(ERR_WALLET_MISSING))?;
         let mut meta = tx
             .get_order_metadata(wallet, order_id)?

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -31,7 +31,7 @@ impl StateApplicator {
         tx: &StateTxn<RW>,
     ) -> Result<(), StateApplicatorError> {
         let wallet = tx
-            .get_wallet_for_order(&meta.id)?
+            .get_wallet_id_for_order(&meta.id)?
             .ok_or(StateApplicatorError::MissingEntry(ERR_MISSING_WALLET))?;
 
         // Add the order to the history if it doesn't exist

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -365,7 +365,7 @@ impl StateInner {
     ) -> Result<bool, StateError> {
         // Check that there are no tasks in the queue for the containing wallet
         // This avoids unnecessary preemptions or possible dropped matches
-        let wallet_id = match tx.get_wallet_for_order(order_id)? {
+        let wallet_id = match tx.get_wallet_id_for_order(order_id)? {
             None => return Ok(false),
             Some(wallet) => wallet,
         };

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -24,7 +24,7 @@ impl StateInner {
         let oid = *order_id;
         self.with_read_tx(move |tx| {
             let wallet_id = tx
-                .get_wallet_for_order(&oid)?
+                .get_wallet_id_for_order(&oid)?
                 .ok_or(StateError::Db(StorageError::NotFound(ERR_MISSING_WALLET.to_string())))?;
             let md = res_some!(tx.get_order_metadata(wallet_id, oid)?);
             Ok(Some(md))

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -55,8 +55,7 @@ impl StateInner {
     ) -> Result<Option<Order>, StateError> {
         let id = *id;
         self.with_read_tx(move |tx| {
-            let wallet_id = res_some!(tx.get_wallet_for_order(&id)?);
-            let wallet = res_some!(tx.get_wallet(&wallet_id)?);
+            let wallet = res_some!(tx.get_wallet_for_order(&id)?);
             Ok(wallet.orders.get(&id).cloned())
         })
         .await
@@ -69,8 +68,7 @@ impl StateInner {
     ) -> Result<Option<(Order, Balance)>, StateError> {
         let id = *id;
         self.with_read_tx(move |tx| {
-            let wallet_id = res_some!(tx.get_wallet_for_order(&id)?);
-            let wallet = res_some!(tx.get_wallet(&wallet_id)?);
+            let wallet = res_some!(tx.get_wallet_for_order(&id)?);
             let order = res_some!(wallet.orders.get(&id)).clone();
 
             // Get the balance that capitalizes the order
@@ -81,15 +79,28 @@ impl StateInner {
         .await
     }
 
-    /// Get the wallet that contains the given order ID
-    pub async fn get_wallet_for_order(
+    /// Get the wallet ID that contains the given order ID
+    pub async fn get_wallet_id_for_order(
         &self,
         order_id: &OrderIdentifier,
     ) -> Result<Option<WalletIdentifier>, StateError> {
         let oid = *order_id;
         self.with_read_tx(move |tx| {
-            let wallet_id = tx.get_wallet_for_order(&oid)?;
+            let wallet_id = tx.get_wallet_id_for_order(&oid)?;
             Ok(wallet_id)
+        })
+        .await
+    }
+
+    /// Get the wallet that contains the given order ID
+    pub async fn get_wallet_for_order(
+        &self,
+        order_id: &OrderIdentifier,
+    ) -> Result<Option<Wallet>, StateError> {
+        let oid = *order_id;
+        self.with_read_tx(move |tx| {
+            let wallet = tx.get_wallet_for_order(&oid)?;
+            Ok(wallet)
         })
         .await
     }

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -211,7 +211,7 @@ impl TypedHandler for AdminOrderMetadataHandler {
 
         let wallet_id = self
             .state
-            .get_wallet_for_order(&order_id)
+            .get_wallet_id_for_order(&order_id)
             .await?
             .ok_or(not_found(ERR_WALLET_NOT_FOUND))?;
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -468,7 +468,7 @@ impl HandshakeExecutor {
         // Enqueue a task to settle the match
         let wallet_id = self
             .state
-            .get_wallet_for_order(&handshake_state.local_order_id)
+            .get_wallet_id_for_order(&handshake_state.local_order_id)
             .await?
             .ok_or_else(|| HandshakeManagerError::State(ERR_NO_WALLET.to_string()))?;
 

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -115,9 +115,6 @@ impl HandshakeExecutor {
     }
 
     /// Get the match candidates for an external order
-    ///
-    /// TODO: Replace this with a correct implementation that filters out orders
-    /// which do not consent to external matching
     async fn get_external_match_candidates(
         &self,
     ) -> Result<HashSet<OrderIdentifier>, HandshakeManagerError> {

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -191,7 +191,7 @@ impl HandshakeExecutor {
         order_id: &OrderIdentifier,
     ) -> Result<WalletIdentifier, HandshakeManagerError> {
         self.state
-            .get_wallet_for_order(order_id)
+            .get_wallet_id_for_order(order_id)
             .await?
             .ok_or_else(|| HandshakeManagerError::state(ERR_NO_WALLET))
     }
@@ -208,10 +208,9 @@ impl HandshakeExecutor {
             .ok_or_else(|| HandshakeManagerError::State(ERR_NO_ORDER.to_string()))?;
 
         let wallet = match state.get_wallet_for_order(&order.id).await? {
-            Some(wallet) => state.get_wallet(&wallet).await?,
-            None => None,
-        }
-        .ok_or_else(|| HandshakeManagerError::State(ERR_NO_WALLET.to_string()))?;
+            Some(wallet) => wallet,
+            None => return Err(HandshakeManagerError::State(ERR_NO_WALLET.to_string())),
+        };
 
         Ok((order, wallet))
     }

--- a/workers/task-driver/src/state_migration/remove_phantom_orders.rs
+++ b/workers/task-driver/src/state_migration/remove_phantom_orders.rs
@@ -59,14 +59,7 @@ async fn find_missing_local_orders(state: &State) -> Result<Vec<OrderIdentifier>
 /// Check whether an order is missing from its wallet
 async fn check_order_missing(state: &State, order_id: &OrderIdentifier) -> Result<bool, String> {
     // Check that the order has a wallet ID mapped to it
-    let wallet_id = state.get_wallet_for_order(order_id).await?;
-    if wallet_id.is_none() {
-        return Ok(true);
-    }
-
-    // Check that the wallet exists and contains the order
-    let wallet_id = wallet_id.unwrap();
-    let maybe_wallet = state.get_wallet(&wallet_id).await?;
+    let maybe_wallet = state.get_wallet_for_order(order_id).await?;
     if maybe_wallet.is_none() || !maybe_wallet.unwrap().contains_order(order_id) {
         return Ok(true);
     }


### PR DESCRIPTION
### Purpose
This PR adds logic to backfill an orderbook cache from a received snapshot. This will bring cache consistency between nodes when a new node comes online.

### Todo
- Test extensively in testnet

### Testing
- Unit tests pass
- Added a test applying a snapshot to the cache