### PR TITLE
arbitrum-client: event-indexing: Parse shares from nested transactions

### DIFF
--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -111,8 +111,9 @@ pub fn parse_shares_from_process_match_settle(
 /// Parses wallet shares from the calldata of a `processAtomicMatchSettle` call
 pub fn parse_shares_from_process_atomic_match_settle(
     calldata: &[u8],
+    validate: bool,
 ) -> Result<SizedWalletShare, ArbitrumClientError> {
-    let call = processAtomicMatchSettleCall::abi_decode(calldata, true /* validate */)
+    let call = processAtomicMatchSettleCall::abi_decode(calldata, validate)
         .map_err(err_str!(ArbitrumClientError::Serde))?;
     let statement = deserialize_calldata::<ContractValidMatchSettleAtomicStatement>(
         &call.valid_match_settle_atomic_statement,


### PR DESCRIPTION
### Purpose
This PR adds logic to the `arbitrum-client` to parse shares from an unknown selector as a fallback. This may occur if, for example, the darkpool is called as part of a nested transaction.

### Todo
- Upgrade RPC provider and use a tracing API for a more robust solution

### Testing
- Unit tests pass
- Looked up quoters that are stuck in mainnet successfully