### PR TITLE
api-server: external-match: Return 400 if order size too small

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use common::types::{
     exchange::Exchange,
     gossip::{ClusterId, WrappedPeerId},
+    token::Token,
     wallet::keychain::HmacKey,
 };
 use ed25519_dalek::Keypair as DalekKeypair;
@@ -419,6 +420,12 @@ impl RelayerConfig {
     /// If it does not, the relayer may skip the wallet creation/lookup step
     pub fn needs_relayer_wallet(&self) -> bool {
         self.auto_redeem_fees
+    }
+
+    /// Get the minimum fill size as a decimal adjusted USDC value
+    pub fn min_fill_size_decimal_adjusted(&self) -> f64 {
+        let token = Token::from_ticker("USDC");
+        token.convert_to_decimal(self.min_fill_size)
     }
 
     /// Configure the telemetry layers from the relayer config

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<(), CoordinatorError> {
         .expect("error parsing command line args");
     let setup_config = args.clone();
     args.configure_telemetry().expect("failed to configure telemetry");
+    let min_order_size = args.min_fill_size_decimal_adjusted();
 
     info!(
         "Relayer running with\n\t version: {}\n\t port: {}\n\t cluster: {:?}",
@@ -320,6 +321,7 @@ async fn main() -> Result<(), CoordinatorError> {
         websocket_port: args.websocket_port,
         admin_api_key: args.admin_api_key,
         min_transfer_amount: args.min_transfer_amount,
+        min_order_size,
         compliance_service_url: args.compliance_service_url,
         wallet_task_rate_limit: args.wallet_task_rate_limit,
         network_sender: network_sender.clone(),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -485,6 +485,7 @@ impl MockNodeController {
             websocket_port: config.websocket_port,
             admin_api_key: config.admin_api_key,
             min_transfer_amount: config.min_transfer_amount,
+            min_order_size: config.min_fill_size_decimal_adjusted(),
             compliance_service_url: config.compliance_service_url.clone(),
             wallet_task_rate_limit: config.wallet_task_rate_limit,
             network_sender,

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -404,9 +404,11 @@ impl HttpServer {
             &Method::POST,
             REQUEST_EXTERNAL_MATCH_ROUTE.to_string(),
             RequestExternalMatchHandler::new(
+                config.min_order_size,
                 handshake_queue,
                 config.system_bus.clone(),
                 state.clone(),
+                config.price_reporter_work_queue.clone(),
             ),
         );
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -115,7 +115,7 @@ pub(crate) fn maybe_rotate_root_key(
 ///
 /// Note that this function may have precision issues for large balances, it is
 /// intended as a simple implementation at the expense of some precision
-async fn get_usdc_denominated_value(
+pub(crate) async fn get_usdc_denominated_value(
     mint: &BigUint,
     amount: Amount,
     price_reporter_queue: &PriceReporterQueue,

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -53,6 +53,8 @@ pub struct ApiServerConfig {
     pub wallet_task_rate_limit: u32,
     /// The minimum usdc denominated value for a deposit or withdrawal
     pub min_transfer_amount: f64,
+    /// The minimum usdc denominated order size
+    pub min_order_size: f64,
     /// The URL of the compliance service to use for wallet screening
     ///
     /// Compliance screening is disabled if this is not set


### PR DESCRIPTION
### Purpose
This PR returns 400 in the external match endpoint if an `ExternalOrder` is sent with an order size below the minimum fill size. This is as opposed to soft blocking these requests by failing to match them.

### Testing
- Unit tests pass
- Tested the endpoint with a small order