### PR TITLE
external-api: external-match: Allow quote denominated external orders

### DIFF
--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{token::Token, Price};
+use super::{token::Token, Price, TimestampedPrice};
 
 /// List of all supported exchanges
 pub static ALL_EXCHANGES: &[Exchange] =
@@ -87,6 +87,17 @@ pub enum PriceReporterState {
     TooMuchDeviation(PriceReport, f64),
     /// No reporter state, price pair is unsupported
     UnsupportedPair(Token, Token),
+}
+
+impl PriceReporterState {
+    /// Get the price for a given reporter state, converting non-nominal states
+    /// to error
+    pub fn price(&self) -> Result<TimestampedPrice, String> {
+        match self {
+            PriceReporterState::Nominal(report) => Ok(TimestampedPrice::new(report.price)),
+            _ => Err(format!("{self:?}")),
+        }
+    }
 }
 
 /// The state of an ExchangeConnection. Note that the ExchangeConnection itself

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -43,10 +43,7 @@ pub fn init_price_streams(
         }
 
         price_reporter_job_queue
-            .send(PriceReporterJob::StreamPrice {
-                base_token: base.clone(),
-                quote_token: quote.clone(),
-            })
+            .stream_price(base.clone(), quote.clone())
             .map_err(err_str!(HandshakeManagerError::PriceReporter))?;
     }
 


### PR DESCRIPTION
### Purpose
This PR allows for quote-denominated external orders at the api layer. We do this by sampling a price and converting a quote-denominated order to a base-denominated one before passing the order to the matching engine.

I also refactored some logic in the price reporter's queue to give a cleaner interface.

### Testing
- Unit tests pass
- Tested with both quote denominated and base denominated orders