### PR TITLE
arbitrum-client: event-indexing: Use debug traces for unknown selectors

### DIFF
--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -9,6 +9,8 @@ pub enum ArbitrumClientError {
     Config(ArbitrumClientConfigError),
     /// Error thrown when a contract call fails
     ContractInteraction(String),
+    /// Error thrown when a darkpool sub-call cannot be found in a tx
+    DarkpoolSubcallNotFound(String),
     /// Error thrown when serializing/deserializing calldata/retdata
     Serde(String),
     /// Error thrown when converting between relayer & smart contract types

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -111,9 +111,8 @@ pub fn parse_shares_from_process_match_settle(
 /// Parses wallet shares from the calldata of a `processAtomicMatchSettle` call
 pub fn parse_shares_from_process_atomic_match_settle(
     calldata: &[u8],
-    validate: bool,
 ) -> Result<SizedWalletShare, ArbitrumClientError> {
-    let call = processAtomicMatchSettleCall::abi_decode(calldata, validate)
+    let call = processAtomicMatchSettleCall::abi_decode(calldata, true /* validate */)
         .map_err(err_str!(ArbitrumClientError::Serde))?;
     let statement = deserialize_calldata::<ContractValidMatchSettleAtomicStatement>(
         &call.valid_match_settle_atomic_statement,


### PR DESCRIPTION
### Purpose
This PR changes the unknown selector wallet share parsing logic to use the `debug_traceTransaction` RPC method. Previously we were scanning the calldata for a known selector, which is not robust.

The new approach walks the call tree, finding all transactions to the darkpool, then attempts to parse wallet shares from each one. We also check that the parsed wallet shares' public blinder matches the expected blinder, in case multiple darkpool transactions were submitted in one parent frame.

### Testing
- [x] Unit tests
- [x] Test basic lookup functionality
- [x]  Test with a wrapper contract in testnet