### PR TITLE
api-server: external-match: Do gas estimation if requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "constants 0.1.0",
  "crossbeam",
  "ecdsa 0.16.9",
+ "ethers",
  "external-api 0.1.0",
  "futures",
  "futures-util",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -324,6 +324,7 @@ async fn main() -> Result<(), CoordinatorError> {
         min_order_size,
         compliance_service_url: args.compliance_service_url,
         wallet_task_rate_limit: args.wallet_task_rate_limit,
+        arbitrum_client: arbitrum_client.clone(),
         network_sender: network_sender.clone(),
         state: global_state.clone(),
         system_bus,

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -34,6 +34,9 @@ pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-exte
 /// The request type for requesting an external match
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
     /// The external order
     pub external_order: ExternalOrder,
 }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -472,6 +472,8 @@ impl MockNodeController {
     /// Add an API server to the mock node
     pub fn with_api_server(self) -> Self {
         let config = &self.config;
+        let arbitrum_client =
+            self.arbitrum_client.clone().expect("Arbitrum client not initialized");
         let network_sender = self.network_queue.0.clone();
         let state = self.state.clone().expect("State not initialized");
         let system_bus = self.bus.clone();
@@ -488,6 +490,7 @@ impl MockNodeController {
             min_order_size: config.min_fill_size_decimal_adjusted(),
             compliance_service_url: config.compliance_service_url.clone(),
             wallet_task_rate_limit: config.wallet_task_rate_limit,
+            arbitrum_client,
             network_sender,
             state,
             system_bus,

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -44,6 +44,7 @@ util = { path = "../../util" }
 # === Misc Dependencies === #
 async-trait = { workspace = true }
 base64 = "0.21"
+ethers = { workspace = true }
 itertools = "0.11"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -406,6 +406,7 @@ impl HttpServer {
             RequestExternalMatchHandler::new(
                 config.min_order_size,
                 handshake_queue,
+                config.arbitrum_client.clone(),
                 config.system_bus.clone(),
                 state.clone(),
                 config.price_reporter_work_queue.clone(),

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -1,5 +1,6 @@
 //! Defines the implementation of the `Worker` trait for the ApiServer
 
+use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
 use common::{
     types::{wallet::keychain::HmacKey, CancelChannel},
@@ -59,6 +60,8 @@ pub struct ApiServerConfig {
     ///
     /// Compliance screening is disabled if this is not set
     pub compliance_service_url: Option<String>,
+    /// A handle on the Arbitrum RPC client
+    pub arbitrum_client: ArbitrumClient,
     /// A sender to the network manager's work queue
     pub network_sender: NetworkManagerQueue,
     /// The worker job queue for the PriceReporter


### PR DESCRIPTION
### Purpose
This PR does gas estimation on an external match transaction if requested by the client.

### Testing
- [x] Unit tests pass
- [ ] Testing with the `rust-sdk`