### PR TITLE
common: token: get supported exchanges from token mapping

### DIFF
--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -9,10 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{token::Token, Price, TimestampedPrice};
 
-/// List of all supported exchanges
-pub static ALL_EXCHANGES: &[Exchange] =
-    &[Exchange::Binance, Exchange::Coinbase, Exchange::Kraken, Exchange::Okx, Exchange::UniswapV3];
-
 /// The identifier of an exchange
 #[allow(clippy::missing_docs_in_private_items, missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -16,18 +16,26 @@
 //! In general, Named Tokens use all exchanges where they are listed, whereas
 //! Unnamed Tokens only use Uniswap V3 for the price feed.
 use bimap::BiMap;
-use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Display},
-    iter,
     sync::OnceLock,
 };
 use util::hex::biguint_to_hex_addr;
 
-use super::exchange::{Exchange, ALL_EXCHANGES};
+use super::exchange::Exchange;
+
+// ---------
+// | Types |
+// ---------
+
+/// A type alias representing the set of supported exchanges for a
+/// given token.
+/// The type is a mapping from exchanges to the ticker used to fetch the
+/// token's price from that exchange
+type ExchangeSupport = HashMap<Exchange, String>;
 
 // ----------------
 // | Quote Tokens |
@@ -48,333 +56,6 @@ pub const USD_TICKER: &str = "USD";
 /// be invoked if they are the quote
 pub const STABLECOIN_TICKERS: &[&str] = &[USDC_TICKER, USDT_TICKER];
 
-// ---------------
-// | Base Tokens |
-// ---------------
-
-/// WBTC ticker
-pub const WBTC_TICKER: &str = "WBTC";
-/// WETH ticker
-pub const WETH_TICKER: &str = "WETH";
-/// BNB ticker
-pub const BNB_TICKER: &str = "BNB";
-/// MATIC ticker
-pub const MATIC_TICKER: &str = "MATIC";
-/// ARB ticker
-pub const ARB_TICKER: &str = "ARB";
-/// LDO ticker
-pub const LDO_TICKER: &str = "LDO";
-/// LINK ticker
-pub const LINK_TICKER: &str = "LINK";
-/// UNI ticker
-pub const UNI_TICKER: &str = "UNI";
-/// GMX ticker
-pub const GMX_TICKER: &str = "GMX";
-/// CRV ticker
-pub const CRV_TICKER: &str = "CRV";
-/// DYDX ticker
-pub const DYDX_TICKER: &str = "DYDX";
-/// AAVE ticker
-pub const AAVE_TICKER: &str = "AAVE";
-/// SUSHI ticker
-pub const SUSHI_TICKER: &str = "SUSHI";
-/// 1INCH ticker
-pub const _1INCH_TICKER: &str = "1INCH";
-/// COMP ticker
-pub const COMP_TICKER: &str = "COMP";
-/// MKR ticker
-pub const MKR_TICKER: &str = "MKR";
-/// PENDLE ticker
-pub const PENDLE_TICKER: &str = "PENDLE";
-/// RDNT ticker
-pub const RDNT_TICKER: &str = "RDNT";
-/// TORN ticker
-pub const TORN_TICKER: &str = "TORN";
-/// REN ticker
-pub const REN_TICKER: &str = "REN";
-/// ZRO ticker
-pub const ZRO_TICKER: &str = "ZRO";
-/// SHIB ticker
-pub const SHIB_TICKER: &str = "SHIB";
-/// PEPE ticker
-pub const PEPE_TICKER: &str = "PEPE";
-/// ENS ticker
-pub const ENS_TICKER: &str = "ENS";
-/// MANA ticker
-pub const MANA_TICKER: &str = "MANA";
-/// LPT ticker
-pub const LPT_TICKER: &str = "LPT";
-/// GRT ticker
-pub const GRT_TICKER: &str = "GRT";
-/// XAI ticker
-pub const XAI_TICKER: &str = "XAI";
-/// ETHFI ticker
-pub const ETHFI_TICKER: &str = "ETHFI";
-
-/// A helper enum to describe the state of each ticker on each Exchange.
-///
-/// `Same` means that the ERC-20 and Exchange tickers are the same, `Renamed`
-/// means that the Exchange ticker is different from the underlying ERC-20, and
-/// the Exchange ticker is different from the underlying ERC-20, and Unsupported
-/// means that the asset is not supported on the Exchange.
-#[derive(Clone, Copy, Debug)]
-pub enum ExchangeTicker {
-    /// The Exchange-native ticker is the same as the ERC-20 ticker.
-    Same,
-    /// The Exchange-native ticker is different from the ERC-20 ticker.
-    Renamed(&'static str),
-    /// The Exchange does not support this Token.
-    Unsupported,
-}
-
-/// The remapping of tickers between exchanges.
-///
-/// The layout of `TICKER_NAMES` is (Renegade Ticker, Binance Ticker, Coinbase
-/// Ticker, Kraken Ticker, Okx Ticker), where "Renegade Ticker" denotes the
-/// ticker expected in the Renegade token remapping used.
-pub static TICKER_NAMES: &[(
-    &str,
-    ExchangeTicker,
-    ExchangeTicker,
-    ExchangeTicker,
-    ExchangeTicker,
-)] = &[
-    // L1
-    (
-        WBTC_TICKER,
-        ExchangeTicker::Renamed("WBTC"),
-        ExchangeTicker::Renamed("BTC"),
-        ExchangeTicker::Renamed("BTC"),
-        ExchangeTicker::Renamed("WBTC"),
-    ),
-    (
-        WETH_TICKER,
-        ExchangeTicker::Renamed("ETH"),
-        ExchangeTicker::Renamed("ETH"),
-        ExchangeTicker::Renamed("ETH"),
-        ExchangeTicker::Renamed("ETH"),
-    ),
-    // L2
-    (
-        BNB_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-    ),
-    (
-        MATIC_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        ARB_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // LSDs
-    (
-        LDO_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // Stables
-    (
-        USDC_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Same,
-    ),
-    (
-        USDT_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Renamed("USD"),
-        ExchangeTicker::Same,
-    ),
-    (
-        USD_TICKER,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    // Oracles
-    (
-        LINK_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // DeFi Trading
-    (
-        UNI_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        GMX_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        CRV_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        DYDX_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        SUSHI_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        _1INCH_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // DeFi Lending
-    (
-        AAVE_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        COMP_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        MKR_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        PENDLE_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        RDNT_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-    ),
-    // DeFi Other
-    (
-        TORN_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-    ),
-    // Bridges
-    (
-        REN_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        ZRO_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    // Misc
-    (
-        SHIB_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        PEPE_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        ENS_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        MANA_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        LPT_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        GRT_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-        ExchangeTicker::Same,
-    ),
-    (
-        XAI_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-    ),
-    (
-        ETHFI_TICKER,
-        ExchangeTicker::Same,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Unsupported,
-        ExchangeTicker::Same,
-    ),
-];
-
 /// The token remapping for the given environment, maps from the token address
 /// to the ticker of the token
 pub static TOKEN_REMAPS: OnceLock<BiMap<String, String>> = OnceLock::new();
@@ -383,51 +64,9 @@ pub static TOKEN_REMAPS: OnceLock<BiMap<String, String>> = OnceLock::new();
 /// to the number of decimals the token uses (fixed-point offset)
 pub static ADDR_DECIMALS_MAP: OnceLock<HashMap<String, u8>> = OnceLock::new();
 
-lazy_static! {
-    /// The mapping of ERC-20 ticker to the expected ticker names on each Exchange.
-    static ref EXCHANGE_TICKERS: HashMap<Exchange, HashMap<String, String>> = {
-        let mut exchange_tickers = HashMap::<Exchange, HashMap<String, String>>::new();
-        for exchange in [Exchange::Binance, Exchange::Coinbase, Exchange::Kraken, Exchange::Okx] {
-            exchange_tickers.insert(exchange, HashMap::<String, String>::new());
-        }
-        for (erc20_ticker, binance_ticker, coinbase_ticker, kraken_ticker, okx_ticker) in
-            TICKER_NAMES.iter()
-        {
-            let process_ticker = move |ticker: ExchangeTicker| -> Option<&'static str> {
-                match ticker {
-                    ExchangeTicker::Same => Some(erc20_ticker),
-                    ExchangeTicker::Renamed(ticker) => Some(ticker),
-                    ExchangeTicker::Unsupported => None,
-                }
-            };
-            if let Some(binance_ticker) = process_ticker(*binance_ticker) {
-                exchange_tickers
-                    .get_mut(&Exchange::Binance)
-                    .unwrap()
-                    .insert(String::from(*erc20_ticker), String::from(binance_ticker));
-            }
-            if let Some(coinbase_ticker) = process_ticker(*coinbase_ticker) {
-                exchange_tickers
-                    .get_mut(&Exchange::Coinbase)
-                    .unwrap()
-                    .insert(String::from(*erc20_ticker), String::from(coinbase_ticker));
-            }
-            if let Some(kraken_ticker) = process_ticker(*kraken_ticker) {
-                exchange_tickers
-                    .get_mut(&Exchange::Kraken)
-                    .unwrap()
-                    .insert(String::from(*erc20_ticker), String::from(kraken_ticker));
-            }
-            if let Some(okx_ticker) = process_ticker(*okx_ticker) {
-                exchange_tickers
-                    .get_mut(&Exchange::Okx)
-                    .unwrap()
-                    .insert(String::from(*erc20_ticker), String::from(okx_ticker));
-            }
-        }
-        exchange_tickers
-    };
-}
+/// The mapping from ERC-20 ticker to the set of exchanges that list the token,
+/// along with the the ticker used to fetch the token's price from the exchange
+pub static EXCHANGE_SUPPORT_MAP: OnceLock<HashMap<String, ExchangeSupport>> = OnceLock::new();
 
 /// The core Token abstraction, used for unambiguous definition of an ERC-20
 /// asset.
@@ -495,46 +134,35 @@ impl Token {
 
     /// Returns the set of Exchanges that support this token.
     pub fn supported_exchanges(&self) -> HashSet<Exchange> {
-        // Uniswap is always supported
-        let mut exchanges: HashSet<Exchange> = iter::once(Exchange::UniswapV3).collect();
         if !self.is_named() {
-            return exchanges;
+            // Uniswap is always supported
+            return HashSet::from([Exchange::UniswapV3]);
         }
 
         let ticker = self.get_ticker().unwrap();
-        ALL_EXCHANGES
-            .iter()
-            .filter(|&&exchange| exchange != Exchange::UniswapV3)
-            .filter(|&exchange| EXCHANGE_TICKERS.get(exchange).unwrap().contains_key(ticker))
-            .for_each(|&exchange| {
-                exchanges.insert(exchange);
-            });
+        let mut supported_exchanges: HashSet<Exchange> = get_exchange_support()
+            .get(ticker)
+            .map(|exchanges| exchanges.keys().copied().collect())
+            .unwrap_or_default();
+        supported_exchanges.insert(Exchange::UniswapV3);
 
-        exchanges
+        supported_exchanges
     }
 
     /// Returns the ticker, in accordance with what each Exchange expects. This
-    /// requires hard-coding and manual lookup, since CEXes typically do not
-    /// support indexing by ERC-20 address. If the ticker is not supported
-    /// by the Exchange, returns None.
-    pub fn get_exchange_ticker(&self, exchange: Exchange) -> String {
+    /// requires manual lookup, since CEXes typically do not support indexing
+    /// by ERC-20 address. If the ticker is not supported by the Exchange,
+    /// returns None.
+    pub fn get_exchange_ticker(&self, exchange: Exchange) -> Option<String> {
         // If there is not a Renegade-native ticker, then the token must be Unnamed.
         if !self.is_named() {
             panic!("Tried to get_exchange_ticker({}) for an unnamed Token.", exchange);
         }
 
-        EXCHANGE_TICKERS
-            .get(&exchange)
-            .unwrap()
-            .get(self.get_ticker().unwrap())
-            .cloned()
-            .unwrap_or_else(|| {
-                panic!(
-                    "Tried to get_exchange_ticker({}) for a named token, \
-                    but the token is not supported by the Exchange.",
-                    exchange
-                )
-            })
+        let ticker = self.get_ticker().unwrap();
+        get_exchange_support()
+            .get(ticker)
+            .and_then(|supported_exchanges| supported_exchanges.get(&exchange).cloned())
     }
 
     /// Converts the amount of the token as an f64, accounting for the
@@ -551,6 +179,12 @@ impl Token {
 // -----------
 // | HELPERS |
 // -----------
+
+/// Returns a reference to the exchange support map,
+/// unwrapping the `OnceLock`.
+pub fn get_exchange_support<'a>() -> &'a HashMap<String, ExchangeSupport> {
+    EXCHANGE_SUPPORT_MAP.get().unwrap()
+}
 
 /// Returns true if the given pair of Tokens is named, indicating that
 /// the pair should be supported on centralized exchanges.

--- a/workers/price-reporter/src/exchange.rs
+++ b/workers/price-reporter/src/exchange.rs
@@ -69,6 +69,32 @@ pub async fn supports_pair(
     })
 }
 
+/// Get the exchange ticker for the base token in the given pair
+pub fn get_base_exchange_ticker(
+    base_token: Token,
+    quote_token: Token,
+    exchange: Exchange,
+) -> Result<String, ExchangeConnectionError> {
+    base_token.get_exchange_ticker(exchange).ok_or(ExchangeConnectionError::UnsupportedPair(
+        base_token,
+        quote_token,
+        exchange,
+    ))
+}
+
+/// Get the exchange ticker for the quote token in the given pair
+pub fn get_quote_exchange_ticker(
+    base_token: Token,
+    quote_token: Token,
+    exchange: Exchange,
+) -> Result<String, ExchangeConnectionError> {
+    quote_token.get_exchange_ticker(exchange).ok_or(ExchangeConnectionError::UnsupportedPair(
+        base_token,
+        quote_token,
+        exchange,
+    ))
+}
+
 /// The type that a price stream should return
 pub type PriceStreamType = Result<Price, ExchangeConnectionError>;
 

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use bimap::BiMap;
 use common::types::exchange::{PriceReport, PriceReporterState};
-use common::types::token::{Token, TICKER_NAMES, TOKEN_REMAPS};
+use common::types::token::{Token, TOKEN_REMAPS, USDC_TICKER, USDT_TICKER, USD_TICKER};
 use common::types::Price;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
@@ -14,17 +14,39 @@ use util::get_current_time_millis;
 
 use crate::errors::PriceReporterError;
 
+/// Ticker names to use in setting up the mock token remap
+const MOCK_TICKER_NAMES: &[&str] = &[
+    USDC_TICKER,
+    USDT_TICKER,
+    USD_TICKER,
+    "WBTC",
+    "WETH",
+    "ARB",
+    "GMX",
+    "PENDLE",
+    "LDO",
+    "LINK",
+    "CRV",
+    "UNI",
+    "ZRO",
+    "LPT",
+    "GRT",
+    "COMP",
+    "AAVE",
+    "XAI",
+    "RDNT",
+    "ETHFI",
+];
+
 /// Setup the static token remap as a mock for testing
 #[allow(unused_must_use)]
 pub fn setup_mock_token_remap() {
     // Setup the mock token map
     let mut token_map = BiMap::new();
-    for (i, token_data) in TICKER_NAMES.iter().enumerate() {
-        // Pull the ticker, the index 0 field
-        let ticker = token_data.0.to_string();
+    for (i, &ticker) in MOCK_TICKER_NAMES.iter().enumerate() {
         let addr = format!("{i:x}");
 
-        token_map.insert(addr, ticker);
+        token_map.insert(addr, ticker.to_string());
     }
 
     // Do not unwrap in case another test set the remap


### PR DESCRIPTION
This PR removes the relayer's mapping of supported exchanges for each token ticker in favor of parsing this information from the new token mapping format.

This was tested w/ a couple quick unit tests where we fetch the testnet token mapping, and try instantiating token objects / reading their supported exchanges & tickers, and by running a price reporter that ingested these changes and asserting that all price streams were initialized correctly.

I also tested a number of trades in testnet using this version of the relayer & the associated price reporter version, both buys & sells, high-cap & low-cap tokens. Everything worked smoothly.