### PR TITLE
api-server: external-match: Add endpoint to generate an external quote

### DIFF
--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -1,5 +1,6 @@
 //! Defines types broadcast onto the system bus and thereby websockets
 
+use circuit_types::r#match::ExternalMatchResult;
 use common::types::{
     exchange::PriceReport,
     gossip::{PeerInfo, WrappedPeerId},
@@ -151,6 +152,11 @@ pub enum SystemBusMessage {
     },
 
     // --- Jobs --- //
+    /// A message containing a quote for an external order
+    ExternalOrderQuote {
+        /// The quote
+        quote: ExternalMatchResult,
+    },
     /// A message containing an atomic match settlement bundle for an external
     /// caller to execute
     ///

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -25,6 +25,8 @@ use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
 // | HTTP Routes |
 // ---------------
 
+/// The route for requesting a quote on an external match
+pub const REQUEST_EXTERNAL_QUOTE_ROUTE: &str = "/v0/matching-engine/quote";
 /// The route for requesting an atomic match
 pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-external-match";
 
@@ -47,6 +49,20 @@ pub struct ExternalMatchRequest {
 pub struct ExternalMatchResponse {
     /// The match bundle
     pub match_bundle: AtomicMatchApiBundle,
+}
+
+/// The request type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteRequest {
+    /// The external order
+    pub external_order: ExternalOrder,
+}
+
+/// The response type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteResponse {
+    /// The match result
+    pub match_result: ApiExternalMatchResult,
 }
 
 // ------------------

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -27,7 +27,7 @@ use external_api::{
             ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
             ADMIN_TRIGGER_SNAPSHOT_ROUTE, ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
         },
-        external_match::REQUEST_EXTERNAL_MATCH_ROUTE,
+        external_match::{REQUEST_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_QUOTE_ROUTE},
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
         order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
         price_report::PRICE_REPORT_ROUTE,
@@ -44,7 +44,7 @@ use external_api::{
     },
     EmptyRequestResponse,
 };
-use external_match::RequestExternalMatchHandler;
+use external_match::{RequestExternalMatchHandler, RequestExternalQuoteHandler};
 use hyper::{
     server::conn::AddrStream,
     service::{make_service_fn, service_fn},
@@ -398,6 +398,19 @@ impl HttpServer {
         );
 
         // --- External Match Routes --- //
+
+        // The "/external-match/quote" route
+        router.add_admin_authenticated_route(
+            &Method::POST,
+            REQUEST_EXTERNAL_QUOTE_ROUTE.to_string(),
+            RequestExternalQuoteHandler::new(
+                config.min_order_size,
+                handshake_queue.clone(),
+                config.price_reporter_work_queue.clone(),
+                state.clone(),
+                config.system_bus.clone(),
+            ),
+        );
 
         // The "/external-match/request" route
         router.add_admin_authenticated_route(

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -201,8 +201,8 @@ impl HandshakeExecutor {
             },
 
             // A request to run the external matching engine
-            HandshakeManagerJob::ExternalMatchingEngine { order, response_topic } => {
-                self.run_external_matching_engine(order, response_topic).await
+            HandshakeManagerJob::ExternalMatchingEngine { order, response_topic, only_quote } => {
+                self.run_external_matching_engine(order, response_topic, only_quote).await
             },
 
             // Indicates that a peer has sent a message during the course of a handshake

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -59,6 +59,9 @@ pub enum HandshakeManagerJob {
         ///    to use in the task driver, which is not possible
         /// 2. Sending via the bus avoids needing to clone a oneshot to retry
         response_topic: String,
+        /// Whether or not to only generate a quote, without proving validity
+        /// for the order's match
+        only_quote: bool,
     },
     /// Process a handshake request
     ProcessHandshakeMessage {
@@ -123,9 +126,26 @@ pub enum HandshakeManagerJob {
 }
 
 impl HandshakeManagerJob {
+    /// Get a quote for an external order
+    pub fn get_external_quote(order: Order) -> (Self, String) {
+        Self::new_external_matching_job(order, true /* quote_only */)
+    }
+
+    /// Run the external matching engine and create a bundle
+    pub fn get_external_match_bundle(order: Order) -> (Self, String) {
+        Self::new_external_matching_job(order, false /* quote_only */)
+    }
+
     /// Create a new external matching job
-    pub fn new_external_matching_job(order: Order) -> (Self, String) {
+    pub fn new_external_matching_job(order: Order, quote_only: bool) -> (Self, String) {
         let topic = gen_atomic_match_response_topic();
-        (Self::ExternalMatchingEngine { order, response_topic: topic.clone() }, topic)
+        (
+            Self::ExternalMatchingEngine {
+                order,
+                response_topic: topic.clone(),
+                only_quote: quote_only,
+            },
+            topic,
+        )
     }
 }

--- a/workers/price-reporter/src/manager/native_executor.rs
+++ b/workers/price-reporter/src/manager/native_executor.rs
@@ -116,7 +116,6 @@ impl PriceReporterExecutor {
 
         for (exchange, base, quote) in req_streams {
             self.start_exchange_connection(exchange, base, quote)
-                .await
                 .map_err(PriceReporterError::ExchangeConnection)?;
         }
 
@@ -152,7 +151,7 @@ impl PriceReporterExecutor {
 
     /// Initializes a connection to an exchange for the given token pair
     /// by spawning a new ExchangeConnectionManager.
-    async fn start_exchange_connection(
+    fn start_exchange_connection(
         &self,
         exchange: Exchange,
         base_token: Token,


### PR DESCRIPTION
### Purpose
This PR adds an endpoint to generate a quote for an external match. This does not require proving a valid atomic match settlement, nor locking up an order for an atomic match. It is intended to allow clients to quickly gauge a price for an intended external match.

### Testing
- [x] Tested against a locally running relayer