### PR TITLE
api-server: external-match: Sign external match quotes

### DIFF
--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use common::types::{
     gossip::{ClusterId, WrappedPeerId},
     tasks::TaskIdentifier,
+    wallet::keychain::HmacKey,
     MatchingPoolName,
 };
 use external_api::{
@@ -400,11 +401,14 @@ impl HttpServer {
         // --- External Match Routes --- //
 
         // The "/external-match/quote" route
+        // The endpoint will be disabled if no admin key is set, hence the dummy value
+        let admin_key = config.admin_api_key.unwrap_or(HmacKey::random());
         router.add_admin_authenticated_route(
             &Method::POST,
             REQUEST_EXTERNAL_QUOTE_ROUTE.to_string(),
             RequestExternalQuoteHandler::new(
                 config.min_order_size,
+                admin_key,
                 handshake_queue.clone(),
                 config.price_reporter_work_queue.clone(),
                 state.clone(),


### PR DESCRIPTION
### Purpose
This PR signs the external quote handed back to the external party. This allows the external party to submit the quote to be assembled with the signature as proof that the quote is valid. This allows the relayer to keep the quote's price firm between quote and assembly.

### Testing
- [x] Unit tests pass
- [x] Tested locally