### PR TITLE
external-api: admin: add token mapping refresh endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "circuit-types 0.1.0",
  "common 0.1.0",
  "compliance-api",
+ "config",
  "constants 0.1.0",
  "crossbeam",
  "ecdsa 0.16.9",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -322,6 +322,7 @@ async fn main() -> Result<(), CoordinatorError> {
         admin_api_key: args.admin_api_key,
         min_transfer_amount: args.min_transfer_amount,
         min_order_size,
+        chain: args.chain_id,
         compliance_service_url: args.compliance_service_url,
         wallet_task_rate_limit: args.wallet_task_rate_limit,
         arbitrum_client: arbitrum_client.clone(),

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -39,6 +39,8 @@ pub const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE: &str =
     "/v0/admin/wallet/:wallet_id/order-in-pool";
 /// Route to assign an order to a matching pool
 pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
+/// Route to refresh the token mapping
+pub const ADMIN_REFRESH_TOKEN_MAPPING_ROUTE: &str = "/v0/admin/refresh-token-mapping";
 
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -488,6 +488,7 @@ impl MockNodeController {
             admin_api_key: config.admin_api_key,
             min_transfer_amount: config.min_transfer_amount,
             min_order_size: config.min_fill_size_decimal_adjusted(),
+            chain: config.chain_id,
             compliance_service_url: config.compliance_service_url.clone(),
             wallet_task_rate_limit: config.wallet_task_rate_limit,
             arbitrum_client,

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -26,7 +26,7 @@ use crate::{global_metrics::IN_FLIGHT_TASKS, labels::NUM_COMPLETED_TASKS_METRIC}
 /// lossy f64 conversion via the associated number of decimals
 fn get_asset_and_volume(mint: &BigUint, amount: u128) -> (String, f64) {
     let token = Token::from_addr_biguint(mint);
-    let asset = token.get_ticker().unwrap_or(&biguint_to_hex_addr(mint)).to_string();
+    let asset = token.get_ticker().unwrap_or(biguint_to_hex_addr(mint));
     let volume = token.convert_to_decimal(amount);
 
     (asset, volume)

--- a/workers/api-server/Cargo.toml
+++ b/workers/api-server/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true }
 arbitrum-client = { path = "../../arbitrum-client" }
 circuit-types = { path = "../../circuit-types" }
 renegade-compliance-api = { git = "https://github.com/renegade-fi/relayer-extensions", package = "compliance-api" }
+config = { path = "../../config" }
 common = { path = "../../common" }
 constants = { path = "../../constants" }
 renegade-crypto = { path = "../../renegade-crypto" }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -10,7 +10,7 @@ mod task;
 mod wallet;
 
 use admin::{
-    AdminGetOrderMatchingPoolHandler, AdminTriggerSnapshotHandler,
+    AdminGetOrderMatchingPoolHandler, AdminRefreshTokenMappingHandler, AdminTriggerSnapshotHandler,
     AdminWalletMatchableOrderIdsHandler, IsLeaderHandler,
 };
 use async_trait::async_trait;
@@ -26,7 +26,8 @@ use external_api::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
             ADMIN_GET_ORDER_MATCHING_POOL_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
             ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
-            ADMIN_TRIGGER_SNAPSHOT_ROUTE, ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_REFRESH_TOKEN_MAPPING_ROUTE, ADMIN_TRIGGER_SNAPSHOT_ROUTE,
+            ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
         },
         external_match::{REQUEST_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_QUOTE_ROUTE},
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
@@ -538,6 +539,13 @@ impl HttpServer {
             &Method::GET,
             ADMIN_GET_ORDER_MATCHING_POOL_ROUTE.to_string(),
             AdminGetOrderMatchingPoolHandler::new(state),
+        );
+
+        // The "/admin/refresh-token-mapping" route
+        router.add_admin_authenticated_route(
+            &Method::POST,
+            ADMIN_REFRESH_TOKEN_MAPPING_ROUTE.to_string(),
+            AdminRefreshTokenMappingHandler::new(config.chain),
         );
 
         router

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -1,6 +1,6 @@
 //! Defines the implementation of the `Worker` trait for the ApiServer
 
-use arbitrum_client::client::ArbitrumClient;
+use arbitrum_client::{client::ArbitrumClient, constants::Chain};
 use async_trait::async_trait;
 use common::{
     types::{wallet::keychain::HmacKey, CancelChannel},
@@ -56,6 +56,8 @@ pub struct ApiServerConfig {
     pub min_transfer_amount: f64,
     /// The minimum usdc denominated order size
     pub min_order_size: f64,
+    /// The chain that the relayer is running on
+    pub chain: Chain,
     /// The URL of the compliance service to use for wallet screening
     ///
     /// Compliance screening is disabled if this is not set

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -2,9 +2,8 @@
 
 use std::thread;
 
-use bimap::BiMap;
 use common::types::exchange::{PriceReport, PriceReporterState};
-use common::types::token::{Token, TOKEN_REMAPS, USDC_TICKER, USDT_TICKER, USD_TICKER};
+use common::types::token::{write_token_remap, Token, USDC_TICKER, USDT_TICKER, USD_TICKER};
 use common::types::Price;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
@@ -42,15 +41,12 @@ const MOCK_TICKER_NAMES: &[&str] = &[
 #[allow(unused_must_use)]
 pub fn setup_mock_token_remap() {
     // Setup the mock token map
-    let mut token_map = BiMap::new();
+    let mut token_map = write_token_remap();
     for (i, &ticker) in MOCK_TICKER_NAMES.iter().enumerate() {
         let addr = format!("{i:x}");
 
         token_map.insert(addr, ticker.to_string());
     }
-
-    // Do not unwrap in case another test set the remap
-    TOKEN_REMAPS.set(token_map);
 }
 
 /// The mock price reporter, reports a constant price

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -18,7 +18,6 @@ use arbitrum_client::{
 };
 use circuit_types::{elgamal::DecryptionKey, fixed_point::FixedPoint};
 use clap::Parser;
-use common::types::token::{ADDR_DECIMALS_MAP, TOKEN_REMAPS};
 use crossbeam::channel::Sender as CrossbeamSender;
 use ethers::{
     middleware::Middleware,
@@ -201,10 +200,6 @@ fn setup_arbitrum_client_mock(test_args: &CliArgs) -> ArbitrumClient {
 
 /// Setup code for the integration tests
 fn setup_integration_tests(test_args: &CliArgs) {
-    // Setup token remaps, this is used in metrics collection, will panic if not set
-    TOKEN_REMAPS.set(Default::default()).unwrap();
-    ADDR_DECIMALS_MAP.set(Default::default()).unwrap();
-
     // Set the protocol fee and pubkey
     let protocol_fee = FixedPoint::from_f64_round_down(0.0006); // 6 bps
     PROTOCOL_FEE.set(protocol_fee).expect("protocol fee already set");


### PR DESCRIPTION
This PR adds a new admin endpoint that refreshes the token mapping from the remote source (Github repo). Implementing this required changing the way in which we store the static token mapping objects (address -> ticker mapping, address -> decimals mapping, ticker -> supported exchanges mapping). Namely, instead of using a `OnceLock` that is initialized at startup, we wrap a `RwLock` with a `LazyLock` so we can have a mutable statics that can be overwritten by the refresh endpoint.
Mutable static structures may raise eyebrows, but this approach felt simpler than lifting the mappings into heap-allocated objects that we pass around references to, particularly when one considers that consumers of the relayer library crates (i.e., the price reporter) also rely on these statics being set.

This was tested by running a local relayer w/ a test endpoint that returns the ticker, decimals, and supported exchanges for a token. I used a testing branch for the token mapping repo where I removed the ETHFI token, confirming that the endpoint could not return any info for it. I then re-added the token to the mapping, hit the refresh endpoint, and confirmed that the testing endpoint returned all the correct info for the token.