### PR TITLE
api-server: external-match: Add extra detail for external match fees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ lto = true
 debug = true
 
 [profile.release]
-opt-level = 3 # Full optimizations
+opt-level = 3     # Full optimizations
+codegen-units = 1
 lto = true
 
 [workspace.dependencies]

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -133,7 +133,31 @@ pub struct ExternalMatchResult {
     ///   base
     /// - `false` implies that the internal party buys the base and sells the
     ///   quote
+    ///
+    /// In effect, this flag can be thought of as `external_party_buys_base`
     pub direction: bool,
+}
+
+impl ExternalMatchResult {
+    /// Get the receive mint and amount of the external party
+    pub fn external_party_receive(&self) -> (Address, Amount) {
+        // If direction is true, the external party buys the base
+        if self.direction {
+            (self.base_mint.clone(), self.base_amount)
+        } else {
+            (self.quote_mint.clone(), self.quote_amount)
+        }
+    }
+
+    /// Get the send mint and amount of the external party
+    pub fn external_party_send(&self) -> (Address, Amount) {
+        // If direction is true, the external party sells the quote
+        if self.direction {
+            (self.quote_mint.clone(), self.quote_amount)
+        } else {
+            (self.base_mint.clone(), self.base_amount)
+        }
+    }
 }
 
 impl From<MatchResult> for ExternalMatchResult {

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -298,8 +298,7 @@ impl ExternalMatchProcessor {
             settlement_tx.set_gas(gas);
         }
 
-        let match_result = match_bundle.atomic_match_proof.statement.match_result.clone().into();
-        Ok(AtomicMatchApiBundle { match_result, settlement_tx })
+        Ok(AtomicMatchApiBundle::new(&match_bundle, settlement_tx))
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds the fee take and two fields indicating the external party's net transfers to the atomic match bundle response. This allows the external party to know exactly the amount they will receive after executing the transaction, without any extra computation on their end.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet