### PR TITLE
api-server: external-match: Allow `min_fill` in quote units

### DIFF
--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -428,7 +428,11 @@ impl TypedHandler for RequestExternalQuoteHandler {
         }
 
         let order = req.external_order;
-        let match_res = self.processor.request_external_quote(order.clone()).await?;
+        let mut match_res = self.processor.request_external_quote(order.clone()).await?;
+
+        if order.trades_native_asset() {
+            match_res.base_mint = get_native_asset_address();
+        }
         let signed_quote = self.sign_external_quote(order, &match_res)?;
         Ok(ExternalQuoteResponse { signed_quote })
     }


### PR DESCRIPTION
### Purpose
This PR allows the `min_fill_size` to be specified in quote units in the external matching engine. Specifically, if the size of the order is specified by `quote_amount`, we expect `min_fill_size` in units of the quote asset. Whereas if the order size is specified by `base_amount`, we expect it in units of base.

### Testing
- [x] Unit tests pass
- [x] Tested all cases locally