### PR TITLE
api-server: router: Add `Content-Type` header to http responses

### DIFF
--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::ApiNetworkOrder;
+use crate::types::{ApiNetworkOrder, ApiToken};
 
 // ---------------
 // | HTTP Routes |
@@ -12,6 +12,9 @@ use crate::types::ApiNetworkOrder;
 pub const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
 /// Returns the network order information of the specified order
 pub const GET_NETWORK_ORDER_BY_ID_ROUTE: &str = "/v0/order_book/orders/:order_id";
+
+/// Returns the supported token list
+pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
 
 // -------------
 // | API Types |
@@ -29,4 +32,11 @@ pub struct GetNetworkOrdersResponse {
 pub struct GetNetworkOrderByIdResponse {
     /// The requested network order
     pub order: ApiNetworkOrder,
+}
+
+/// The response type to fetch the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetSupportedTokensResponse {
+    /// The supported tokens
+    pub tokens: Vec<ApiToken>,
 }

--- a/external-api/src/types/api_order_book.rs
+++ b/external-api/src/types/api_order_book.rs
@@ -44,3 +44,19 @@ impl From<NetworkOrder> for ApiNetworkOrder {
         }
     }
 }
+
+/// A token in the the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiToken {
+    /// The token address
+    pub address: String,
+    /// The token symbol
+    pub symbol: String,
+}
+
+impl ApiToken {
+    /// Constructor
+    pub fn new(addr: String, sym: String) -> Self {
+        Self { address: addr, symbol: sym }
+    }
+}

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -34,7 +34,9 @@ use external_api::{
             REQUEST_EXTERNAL_QUOTE_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
-        order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
+        order_book::{
+            GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE, GET_SUPPORTED_TOKENS_ROUTE,
+        },
         price_report::PRICE_REPORT_ROUTE,
         task::{GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         task_history::TASK_HISTORY_ROUTE,
@@ -60,6 +62,7 @@ use hyper::{
 };
 use num_bigint::BigUint;
 use num_traits::Num;
+use order_book::GetSupportedTokensHandler;
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
@@ -452,6 +455,13 @@ impl HttpServer {
             &Method::GET,
             GET_NETWORK_ORDER_BY_ID_ROUTE.to_string(),
             GetNetworkOrderByIdHandler::new(state.clone()),
+        );
+
+        // The "/supported-tokens" route
+        router.add_unauthenticated_route(
+            &Method::GET,
+            GET_SUPPORTED_TOKENS_ROUTE.to_string(),
+            GetSupportedTokensHandler,
         );
 
         // --- Network Routes --- //

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -1,8 +1,12 @@
 //! Groups routes and handlers for order book API operations
 
 use async_trait::async_trait;
+use common::types::token::{read_token_remap, USDT_TICKER, USD_TICKER};
 use external_api::{
-    http::order_book::{GetNetworkOrderByIdResponse, GetNetworkOrdersResponse},
+    http::order_book::{
+        GetNetworkOrderByIdResponse, GetNetworkOrdersResponse, GetSupportedTokensResponse,
+    },
+    types::ApiToken,
     EmptyRequestResponse,
 };
 use hyper::HeaderMap;
@@ -15,6 +19,9 @@ use crate::{
 };
 
 use super::parse_order_id_from_params;
+
+/// Tokens filtered from the supported token endpoint
+const FILTERED_TOKENS: [&str; 2] = [USD_TICKER, USDT_TICKER];
 
 // ------------------
 // | Error Messages |
@@ -93,5 +100,32 @@ impl TypedHandler for GetNetworkOrderByIdHandler {
         } else {
             Err(not_found(ERR_ORDER_NOT_FOUND.to_string()))
         }
+    }
+}
+
+/// Handler for the GET /supported-tokens route
+#[derive(Clone)]
+pub struct GetSupportedTokensHandler;
+
+#[async_trait]
+impl TypedHandler for GetSupportedTokensHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetSupportedTokensResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        _req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let token_map = read_token_remap();
+        let tokens = token_map
+            .iter()
+            .map(|(addr, sym)| ApiToken::new(addr.clone(), sym.clone()))
+            .filter(|token| !FILTERED_TOKENS.contains(&token.symbol.as_str()))
+            .collect_vec();
+
+        Ok(GetSupportedTokensResponse { tokens })
     }
 }

--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -4,7 +4,10 @@ use std::{collections::HashMap, iter};
 
 use async_trait::async_trait;
 use common::types::wallet::keychain::HmacKey;
-use hyper::{body::to_bytes, Body, HeaderMap, Method, Request, Response, StatusCode, Uri};
+use hyper::{
+    body::to_bytes, header::CONTENT_TYPE, Body, HeaderMap, Method, Request, Response, StatusCode,
+    Uri,
+};
 use itertools::Itertools;
 use matchit::Router as MatchRouter;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -156,7 +159,9 @@ impl<
 
         // Forward to the typed handler
         let res = self.handle_typed(headers, req_body, url_params, query_params).await;
-        let builder = Response::builder().header("Access-Control-Allow-Origin", "*");
+        let builder = Response::builder()
+            .header("Access-Control-Allow-Origin", "*")
+            .header(CONTENT_TYPE, "application/json");
         match res {
             Ok(resp) => {
                 // Serialize the response into a body. We explicitly allow for all cross-origin
@@ -310,7 +315,6 @@ impl Router {
         };
 
         tracing::Span::current().record("http.status_code", res.status().as_str());
-
         res
     }
 


### PR DESCRIPTION
### Purpose
This PR sets the `Content-Type` header to "application/json" on all HTTP `GET` or `POST` responses. 

### Testing
- [x] Tested locally