### PR TITLE
arbitrum-client: Add `receiver_address` to external match settlement calldata

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -22,6 +22,7 @@ abigen!(
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
@@ -53,6 +54,7 @@ abigen!(
         function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
@@ -72,6 +74,7 @@ sol! {
     function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
     function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -370,7 +370,8 @@ impl ArbitrumClient {
         ))
     }
 
-    /// Build `process_atomic_match_settle` from calldata serialized values
+    /// Build a `process_atomic_match_settle` transaction from calldata
+    /// serialized values
     fn build_atomic_match_from_serialized_data(
         &self,
         receiver: Option<Address>,

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -26,8 +26,10 @@ use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
 use tracing::{error, info, instrument};
 use util::err_str;
 
-use crate::abi::{processAtomicMatchSettleCall, MerkleInsertionFilter, NullifierSpentFilter};
-use crate::helpers::parse_shares_from_process_atomic_match_settle;
+use crate::abi::{
+    processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall, MerkleInsertionFilter,
+    NullifierSpentFilter,
+};
 use crate::{
     abi::{
         newWalletCall, processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall,
@@ -37,20 +39,23 @@ use crate::{
     constants::SELECTOR_LEN,
     errors::ArbitrumClientError,
     helpers::{
-        parse_shares_from_new_wallet, parse_shares_from_process_match_settle,
-        parse_shares_from_redeem_fee, parse_shares_from_settle_offline_fee,
-        parse_shares_from_settle_online_relayer_fee, parse_shares_from_update_wallet,
+        parse_shares_from_new_wallet, parse_shares_from_process_atomic_match_settle,
+        parse_shares_from_process_atomic_match_settle_with_receiver,
+        parse_shares_from_process_match_settle, parse_shares_from_redeem_fee,
+        parse_shares_from_settle_offline_fee, parse_shares_from_settle_online_relayer_fee,
+        parse_shares_from_update_wallet,
     },
 };
 
 use super::ArbitrumClient;
 
 /// A list of known selectors for the darkpool contract
-const KNOWN_SELECTORS: [[u8; SELECTOR_LEN]; 7] = [
+const KNOWN_SELECTORS: [[u8; SELECTOR_LEN]; 8] = [
     <newWalletCall as SolCall>::SELECTOR,
     <updateWalletCall as SolCall>::SELECTOR,
     <processMatchSettleCall as SolCall>::SELECTOR,
     <processAtomicMatchSettleCall as SolCall>::SELECTOR,
+    <processAtomicMatchSettleWithReceiverCall as SolCall>::SELECTOR,
     <settleOnlineRelayerFeeCall as SolCall>::SELECTOR,
     <settleOfflineFeeCall as SolCall>::SELECTOR,
     <redeemFeeCall as SolCall>::SELECTOR,
@@ -352,6 +357,9 @@ impl ArbitrumClient {
             },
             <processAtomicMatchSettleCall as SolCall>::SELECTOR => {
                 parse_shares_from_process_atomic_match_settle(calldata)
+            },
+            <processAtomicMatchSettleWithReceiverCall as SolCall>::SELECTOR => {
+                parse_shares_from_process_atomic_match_settle_with_receiver(calldata)
             },
             <settleOnlineRelayerFeeCall as SolCall>::SELECTOR => {
                 parse_shares_from_settle_online_relayer_fee(calldata, public_blinder_share)

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -49,6 +49,9 @@ pub struct ExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
     /// The external order
     pub external_order: ExternalOrder,
 }
@@ -81,6 +84,9 @@ pub struct AssembleExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
     /// The signed quote
     pub signed_quote: SignedExternalQuote,
 }


### PR DESCRIPTION
### Purpose
This PR adds support for a non-sender receiver address in the tx calldata generated for an external match. If one is specified the calldata generated targets the `processAtomicMatchSettleWithReceiver` selector, otherwise the calldata targets the `processAtomicMatchSettle` selector as before.

### Testing
- [x] Unit tests
- [ ] Test against a testnet-deployed version of the contracts