### PR TITLE
config, workers: event-manager: event manager worker config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,10 +3580,12 @@ dependencies = [
 name = "event-manager"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "circuit-types 0.1.0",
  "common 0.1.0",
- "serde",
- "uuid 1.11.0",
+ "job-types",
+ "libp2p",
+ "tokio",
 ]
 
 [[package]]
@@ -5130,6 +5132,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libp2p-core",
+ "serde",
  "tokio",
  "util 0.1.0",
  "uuid 1.11.0",
@@ -7896,6 +7899,7 @@ dependencies = [
  "constants 0.1.0",
  "crossbeam",
  "ethers",
+ "event-manager",
  "external-api 0.1.0",
  "gossip-api",
  "gossip-server",

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -171,6 +171,12 @@ pub struct Cli {
     /// The path at which to save raft snapshots
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
+    /// Whether to record historical state locally
+    #[clap(long, value_parser)]
+    pub record_historical_state: bool,
+    /// The address to export relayer events to, in multiaddr format
+    #[clap(long, value_parser)]
+    pub event_export_addr: Option<String>,
     /// The maximum number of wallet operations a user is allowed to perform per hour
     /// 
     /// Defaults to 500
@@ -347,6 +353,10 @@ pub struct RelayerConfig {
     pub db_path: String,
     /// The path at which to save raft snapshots
     pub raft_snapshot_path: String,
+    /// Whether to record historical state locally
+    pub record_historical_state: bool,
+    /// The address to export relayer events to, in multiaddr format
+    pub event_export_addr: Option<Multiaddr>,
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour
     pub wallet_task_rate_limit: u32,
@@ -471,6 +481,8 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
+            record_historical_state: self.record_historical_state,
+            event_export_addr: self.event_export_addr.clone(),
             wallet_task_rate_limit: self.wallet_task_rate_limit,
             min_transfer_amount: self.min_transfer_amount,
             max_merkle_staleness: self.max_merkle_staleness,

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -172,7 +172,8 @@ pub struct Cli {
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
-    #[clap(long, value_parser)]
+    // TODO: Unset default `true` once event export implementation is complete
+    #[clap(long, value_parser, default_value = "true")]
     pub record_historical_state: bool,
     /// The address to export relayer events to, in multiaddr format.
     /// If ommitted, the event manager is disabled.

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -174,7 +174,8 @@ pub struct Cli {
     /// Whether to record historical state locally
     #[clap(long, value_parser)]
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format
+    /// The address to export relayer events to, in multiaddr format.
+    /// If ommitted, the event manager is disabled.
     #[clap(long, value_parser)]
     pub event_export_addr: Option<String>,
     /// The maximum number of wallet operations a user is allowed to perform per hour
@@ -355,7 +356,8 @@ pub struct RelayerConfig {
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format
+    /// The address to export relayer events to, in multiaddr format.
+    /// If ommitted, the event manager is disabled.
     pub event_export_addr: Option<Multiaddr>,
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -96,6 +96,11 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 
+    // Parse the event export address, if there is one
+    let event_export_addr = cli_args
+        .event_export_addr
+        .map(|addr| addr.parse().expect("Invalid address passed as --event-export-addr"));
+
     // Parse the price reporter URL, if there is one
     let price_reporter_url = cli_args
         .price_reporter_url
@@ -124,6 +129,8 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         p2p_key,
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
+        record_historical_state: cli_args.record_historical_state,
+        event_export_addr,
         wallet_task_rate_limit: cli_args.wallet_task_rate_limit,
         min_transfer_amount: cli_args.min_transfer_amount,
         bind_addr: cli_args.bind_addr,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -97,7 +97,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
     }
 
     // Parse the event export address, if there is one
-    let event_export_addr = cli_args
+    let event_export_addr: Option<Multiaddr> = cli_args
         .event_export_addr
         .map(|addr| addr.parse().expect("Invalid address passed as --event-export-addr"));
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
 price-reporter = { path = "../workers/price-reporter" }
 proof-manager = { path = "../workers/proof-manager" }
+event-manager = { path = "../workers/event-manager" }
 state = { path = "../state" }
 system-bus = { path = "../system-bus" }
 system-clock = { path = "../system-clock" }

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -551,7 +551,9 @@ impl StateApplicator {
         task: QueuedTask,
         tx: &StateTxn<'_, RW>,
     ) -> Result<()> {
-        if let Some(t) = HistoricalTask::from_queued_task(key, task) {
+        if let Some(t) = HistoricalTask::from_queued_task(key, task)
+            && tx.get_historical_state_enabled()?
+        {
             tx.append_task_to_history(&key, t)?;
         }
 

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -81,6 +81,11 @@ impl StateInner {
         self.with_read_tx(|tx| tx.get_auto_redeem_fees().map_err(StateError::Db)).await
     }
 
+    /// Get the local relayer's historical state enabled flag
+    pub async fn historical_state_enabled(&self) -> Result<bool, StateError> {
+        self.with_read_tx(|tx| tx.get_historical_state_enabled().map_err(StateError::Db)).await
+    }
+
     // -----------
     // | Setters |
     // -----------
@@ -138,6 +143,7 @@ impl StateInner {
         let need_relayer_wallet = config.needs_relayer_wallet();
         let relayer_wallet_id =
             derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
+        let historical_state_enabled = config.record_historical_state;
 
         self.with_write_tx(move |tx| {
             tx.create_table(NODE_METADATA_TABLE)?;
@@ -146,6 +152,7 @@ impl StateInner {
             tx.set_node_keypair(&p2p_key)?;
             tx.set_fee_key(&fee_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
+            tx.set_historical_state_enabled(historical_state_enabled)?;
             if let Some(addr) = external_fee_addr {
                 tx.set_external_fee_addr(&addr)?;
             }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -274,6 +274,7 @@ pub mod test_helpers {
         // Setup the tables
         let tx = db.new_write_tx().unwrap();
         tx.setup_tables().unwrap();
+        tx.set_historical_state_enabled(true).unwrap();
         tx.commit().unwrap();
 
         db

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -21,6 +21,11 @@ pub enum StorageError {
     OpenDb(MdbxError),
     /// Failure opening a table in the database
     OpenTable(MdbxError),
+    /// Attempt to access a disabled table, which may be the case if it is
+    /// used to track state for a feature that is disabled in the relayer.
+    /// An example of this is the order history table being disabled if the
+    /// relayer is not configured to record historical state.
+    TableDisabled(String),
     /// An uncategorized error
     Other(String),
     /// Error serializing a value for storage

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -39,6 +39,9 @@ const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
 const EXTERNAL_FEE_ADDR_KEY: &str = "external-fee-addr";
 /// The key for the local relayer's auto-redeem fees flag in the node metadata
 const AUTO_REDEEM_FEES_KEY: &str = "auto-redeem-fees";
+/// The key for the local relayer's historical state enabled flag in the node
+/// metadata table
+const HISTORICAL_STATE_ENABLED_KEY: &str = "historical-state-enabled";
 
 // -----------
 // | Helpers |
@@ -120,6 +123,13 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
             .read(NODE_METADATA_TABLE, &AUTO_REDEEM_FEES_KEY.to_string())?
             .ok_or_else(|| err_not_found(AUTO_REDEEM_FEES_KEY))
     }
+
+    /// Get the local relayer's historical state enabled flag
+    pub fn get_historical_state_enabled(&self) -> Result<bool, StorageError> {
+        self.inner()
+            .read(NODE_METADATA_TABLE, &HISTORICAL_STATE_ENABLED_KEY.to_string())?
+            .ok_or_else(|| err_not_found(HISTORICAL_STATE_ENABLED_KEY))
+    }
 }
 
 // -----------
@@ -175,5 +185,10 @@ impl<'db> StateTxn<'db, RW> {
             &AUTO_REDEEM_FEES_KEY.to_string(),
             &auto_redeem_fees,
         )
+    }
+
+    /// Set the local relayer's historical state enabled flag
+    pub fn set_historical_state_enabled(&self, enabled: bool) -> Result<(), StorageError> {
+        self.inner().write(NODE_METADATA_TABLE, &HISTORICAL_STATE_ENABLED_KEY.to_string(), &enabled)
     }
 }

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -66,6 +66,8 @@ const ERR_ORDER_ALREADY_EXISTS: &str = "order id already exists";
 const ERR_BALANCE_NOT_FOUND: &str = "balance not found in wallet";
 /// Error message emitted when price data cannot be found for a token pair
 const ERR_NO_PRICE_DATA: &str = "no price data found for token pair";
+/// Error message emitted when historical state is disabled
+const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
 
 // -----------------------
 // | Raft Route Handlers |
@@ -203,6 +205,10 @@ impl TypedHandler for AdminOrderMetadataHandler {
         params: UrlParams,
         query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        if !self.state.historical_state_enabled().await? {
+            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
+        }
+
         let order_id = parse_order_id_from_params(&params)?;
         let order_metadata = self
             .state
@@ -451,14 +457,6 @@ impl TypedHandler for AdminAssignOrderToMatchingPoolHandler {
         let order_id = parse_order_id_from_params(&params)?;
         let matching_pool = parse_matching_pool_from_url_params(&params)?;
 
-        // Check that the order exists. We do this by checking the order
-        // metadata, as filled orders (which a client may still want to reassign
-        // ahead of subsequent order updates) are removed from the network
-        // orderbook.
-        if self.state.get_order_metadata(&order_id).await?.is_none() {
-            return Err(not_found(ERR_ORDER_NOT_FOUND));
-        }
-
         // Check that the matching pool exists
         if !self.state.matching_pool_exists(matching_pool.clone()).await? {
             return Err(not_found(ERR_NO_MATCHING_POOL));
@@ -502,15 +500,6 @@ impl TypedHandler for AdminGetOrderMatchingPoolHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let order_id = parse_order_id_from_params(&params)?;
-
-        // Check that the order exists. We do this by checking the order
-        // metadata, as filled orders (which a client may still want to
-        // see the matching pool of, ahead of subsequent order updates)
-        // are removed from the network orderbook.
-        if self.state.get_order_metadata(&order_id).await?.is_none() {
-            return Err(not_found(ERR_ORDER_NOT_FOUND));
-        }
-
         let matching_pool = self.state.get_matching_pool_for_order(&order_id).await?;
 
         Ok(AdminGetOrderMatchingPoolResponse { matching_pool })

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -34,6 +34,8 @@ const DEFAULT_TASK_HISTORY_LEN: usize = 50;
 
 /// Error message displayed when a given task cannot be found
 const ERR_TASK_NOT_FOUND: &str = "task not found";
+/// Error message emitted when historical state is disabled
+const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
 
 /// -----------------------
 /// | Task Route Handlers |
@@ -138,6 +140,10 @@ impl TypedHandler for GetTaskHistoryHandler {
         params: UrlParams,
         mut query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        if !self.state.historical_state_enabled().await? {
+            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
+        }
+
         // Lookup the task status in the task driver's state
         let wallet_id = parse_wallet_id_from_params(&params)?;
         let len = query_params

--- a/workers/event-manager/Cargo.toml
+++ b/workers/event-manager/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Async + Concurrency === #
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# === Networking === #
+libp2p = { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
 circuit-types = { path = "../../circuit-types" }
-
-# === Misc Dependencies === #
-uuid = { version = "1.1.2", features = ["v4", "serde"] }
-serde = { workspace = true }
+job-types = { path = "../job-types" }

--- a/workers/event-manager/src/error.rs
+++ b/workers/event-manager/src/error.rs
@@ -1,0 +1,5 @@
+//! Defines errors for the event manager
+
+/// An error that occurred in the event manager
+#[derive(Clone, Debug)]
+pub enum EventManagerError {}

--- a/workers/event-manager/src/lib.rs
+++ b/workers/event-manager/src/lib.rs
@@ -10,4 +10,5 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
-pub mod event_types;
+pub mod error;
+pub mod worker;

--- a/workers/event-manager/src/worker.rs
+++ b/workers/event-manager/src/worker.rs
@@ -1,0 +1,67 @@
+//! Defines the worker implementation for the event manager
+
+use std::thread::JoinHandle;
+
+use async_trait::async_trait;
+use common::{types::CancelChannel, worker::Worker};
+use job_types::event_manager::EventManagerReceiver;
+use libp2p::Multiaddr;
+
+use crate::error::EventManagerError;
+
+// ----------
+// | Config |
+// ----------
+
+/// The configuration for the event manager
+pub struct EventManagerConfig {
+    /// The address to export relayer events to
+    pub event_export_addr: Option<Multiaddr>,
+    /// The queue on which to receive events
+    pub event_queue: EventManagerReceiver,
+    /// The channel on which the coordinator may mandate that the
+    /// event manager cancel its execution
+    pub cancel_channel: CancelChannel,
+}
+
+// ----------
+// | Worker |
+// ----------
+
+/// The event manager worker
+pub struct EventManager {
+    /// The configuration for the event manager
+    pub config: EventManagerConfig,
+    /// The handle on the event manager
+    pub handle: Option<JoinHandle<EventManagerError>>,
+}
+
+#[async_trait]
+impl Worker for EventManager {
+    type WorkerConfig = EventManagerConfig;
+    type Error = EventManagerError;
+
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+        Ok(Self { config, handle: None })
+    }
+
+    fn name(&self) -> String {
+        "event-manager".to_string()
+    }
+
+    fn is_recoverable(&self) -> bool {
+        true
+    }
+
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        vec![self.handle.take().unwrap()]
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        todo!()
+    }
+}

--- a/workers/event-manager/src/worker.rs
+++ b/workers/event-manager/src/worker.rs
@@ -54,7 +54,7 @@ impl Worker for EventManager {
     }
 
     fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
-        vec![self.handle.take().unwrap()]
+        vec![]
     }
 
     fn cleanup(&mut self) -> Result<(), Self::Error> {
@@ -62,6 +62,6 @@ impl Worker for EventManager {
     }
 
     fn start(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -24,6 +24,7 @@ util = { path = "../../util" }
 crossbeam = { workspace = true }
 tokio = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -1,4 +1,5 @@
-//! Type definitions for system events handled by the event manager.
+//! Job types for the event manager, representing system events to be received &
+//! exported by the event manager worker
 
 use std::time::SystemTime;
 
@@ -12,7 +13,27 @@ use common::types::{
     MatchingPoolName, TimestampedPrice,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioSender};
+use util::metered_channels::MeteredTokioReceiver;
 use uuid::Uuid;
+
+// ---------------
+// | Queue Types |
+// ---------------
+
+/// The name of the event manager queue, used to label queue length metrics
+const EVENT_MANAGER_QUEUE_NAME: &str = "event_manager";
+
+/// The queue sender type to send events to the event manager
+pub type EventManagerQueue = TokioSender<RelayerEvent>;
+/// The queue receiver type to receive events in the event manager
+pub type EventManagerReceiver = MeteredTokioReceiver<RelayerEvent>;
+
+/// Create a new event manager queue and receiver
+pub fn new_event_manager_queue() -> (EventManagerQueue, EventManagerReceiver) {
+    let (send, recv) = unbounded_channel();
+    (send, MeteredTokioReceiver::new(recv, EVENT_MANAGER_QUEUE_NAME))
+}
 
 // ------------------------
 // | Top-level Event Enum |

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -72,8 +72,8 @@ pub struct WalletCreationEvent {
 
     /// The ID of the wallet that was created
     pub wallet_id: WalletIdentifier,
-    /// The wallet's symmetric key, encrypted at rest and base64-encoded
-    pub encrypted_symmetric_key: String,
+    /// The wallet's symmetric key, base64-encoded
+    pub symmetric_key: String,
 }
 
 /// An external transfer event

--- a/workers/job-types/src/lib.rs
+++ b/workers/job-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Groups worker job types to expose them as a third party crate to the workers
 
+pub mod event_manager;
 pub mod gossip_server;
 pub mod handshake_manager;
 pub mod network_manager;

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -15,6 +15,10 @@ pub async fn transition_order_settling(
     order_id: OrderIdentifier,
     state: &State,
 ) -> Result<(), String> {
+    if !state.historical_state_enabled().await? {
+        return Ok(());
+    }
+
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;
     metadata.state = OrderState::SettlingMatch;
@@ -30,6 +34,10 @@ pub async fn record_order_fill(
     price: TimestampedPrice,
     state: &State,
 ) -> Result<(), String> {
+    if !state.historical_state_enabled().await? {
+        return Ok(());
+    }
+
     // Get the order metadata
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;


### PR DESCRIPTION
This PR adds the necessary config options for the event manager worker and massages them into the relayer. This includes scaffolding the event manager worker itself, and optionally disabling access to the historical state tables if the associated config option is unset.

Even when historical state is disabled, we intend to maintain an updated view of order metadata for actively-managed (not filled nor cancelled) orders. The logic for disabling historical state does not currently capture this nuance, as the implementation is deferred for later.

All unit tests pass assuming local historical state is enabled, the config option for which has been defaulted to true for now. End-to-end testing w/ historical state disabled will be done when event exporting is implemented.