### PR TITLE
workers: task-driver: emit events from tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,9 +3583,13 @@ dependencies = [
  "async-trait",
  "circuit-types 0.1.0",
  "common 0.1.0",
+ "constants 0.1.0",
  "job-types",
  "libp2p",
+ "serde_json",
  "tokio",
+ "tracing",
+ "util 0.1.0",
 ]
 
 [[package]]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (proof_generation_worker_sender, proof_generation_worker_receiver) =
         new_proof_manager_queue();
     let (task_sender, task_receiver) = new_task_driver_queue();
-    let (_event_manager_sender, event_manager_receiver) = new_event_manager_queue();
+    let (event_manager_sender, event_manager_receiver) = new_event_manager_queue();
 
     // Construct a global state
     let (state_failure_send, mut state_failure_recv) = new_worker_failure_channel();
@@ -181,6 +181,7 @@ async fn main() -> Result<(), CoordinatorError> {
         arbitrum_client.clone(),
         network_sender.clone(),
         proof_generation_worker_sender.clone(),
+        event_manager_sender,
         system_bus.clone(),
         global_state.clone(),
     );

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -24,7 +24,7 @@ use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::worker::{new_worker_failure_channel, watch_worker, Worker};
 use common::{default_wrapper::default_option, types::new_cancel_channel};
 use constants::{in_bootstrap_mode, VERSION};
-use event_manager::worker::{EventManager, EventManagerConfig};
+use event_manager::{manager::EventManager, worker::EventManagerConfig};
 use external_api::bus_message::SystemBusMessage;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -28,6 +28,7 @@ use futures::Future;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};
 use job_types::{
+    event_manager::{new_event_manager_queue, EventManagerQueue, EventManagerReceiver},
     gossip_server::{
         new_gossip_server_queue, GossipServerJob, GossipServerQueue, GossipServerReceiver,
     },
@@ -117,6 +118,8 @@ pub struct MockNodeController {
     price_queue: (PriceReporterQueue, DefaultOption<PriceReporterReceiver>),
     /// The proof generation queue
     proof_queue: (ProofManagerQueue, DefaultOption<ProofManagerReceiver>),
+    /// The event manager queue
+    event_queue: (EventManagerQueue, DefaultOption<EventManagerReceiver>),
     /// The task manager queue
     task_queue: (TaskDriverQueue, DefaultOption<TaskDriverReceiver>),
 }
@@ -132,6 +135,7 @@ impl MockNodeController {
         let (handshake_send, handshake_recv) = new_handshake_manager_queue();
         let (price_sender, price_recv) = new_price_reporter_queue();
         let (proof_gen_sender, proof_gen_recv) = new_proof_manager_queue();
+        let (event_sender, event_recv) = new_event_manager_queue();
         let (task_sender, task_recv) = new_task_driver_queue();
 
         Self {
@@ -146,6 +150,7 @@ impl MockNodeController {
             handshake_queue: (handshake_send, default_option(handshake_recv)),
             price_queue: (price_sender, default_option(price_recv)),
             proof_queue: (proof_gen_sender, default_option(proof_gen_recv)),
+            event_queue: (event_sender, default_option(event_recv)),
             task_queue: (task_sender, default_option(task_recv)),
         }
     }
@@ -294,6 +299,7 @@ impl MockNodeController {
             self.arbitrum_client.clone().expect("Arbitrum client not initialized");
         let network_queue = self.network_queue.0.clone();
         let proof_queue = self.proof_queue.0.clone();
+        let event_queue = self.event_queue.0.clone();
         let bus = self.bus.clone();
         let state = self.state.clone().expect("State not initialized");
 
@@ -303,6 +309,7 @@ impl MockNodeController {
             arbitrum_client,
             network_queue,
             proof_queue,
+            event_queue,
             bus,
             state,
         );

--- a/workers/event-manager/Cargo.toml
+++ b/workers/event-manager/Cargo.toml
@@ -13,5 +13,11 @@ libp2p = { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 circuit-types = { path = "../../circuit-types" }
 job-types = { path = "../job-types" }
+util = { path = "../../util" }
+
+# === Misc Dependencies === #
+tracing = { workspace = true }
+serde_json = { workspace = true }

--- a/workers/event-manager/src/error.rs
+++ b/workers/event-manager/src/error.rs
@@ -2,4 +2,17 @@
 
 /// An error that occurred in the event manager
 #[derive(Clone, Debug)]
-pub enum EventManagerError {}
+pub enum EventManagerError {
+    /// The event manager was cancelled
+    Cancelled(String),
+    /// The event export address is invalid
+    InvalidEventExportAddr(String),
+    /// An error occurred while connecting to the event export socket
+    SocketConnection(String),
+    /// An error occurred while serializing an event
+    Serialize(String),
+    /// An error occurred while writing to the event export socket
+    SocketWrite(String),
+    /// An error occurred while setting up the event manager
+    SetupError(String),
+}

--- a/workers/event-manager/src/lib.rs
+++ b/workers/event-manager/src/lib.rs
@@ -11,4 +11,5 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 
 pub mod error;
+pub mod manager;
 pub mod worker;

--- a/workers/event-manager/src/manager.rs
+++ b/workers/event-manager/src/manager.rs
@@ -1,0 +1,111 @@
+//! The core event manager logic, the main loop that receives events
+//! and exports them to the configured address
+
+use std::{path::Path, thread::JoinHandle};
+
+use common::types::CancelChannel;
+use constants::in_bootstrap_mode;
+use job_types::event_manager::EventManagerReceiver;
+use libp2p::{multiaddr::Protocol, Multiaddr};
+use tokio::{io::AsyncWriteExt, net::UnixStream};
+use tracing::{info, warn};
+use util::{err_str, runtime::sleep_forever_async};
+
+use crate::{error::EventManagerError, worker::EventManagerConfig};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The error message for when the event export address is not a Unix socket
+const ERR_NON_UNIX_EVENT_EXPORT_ADDRESS: &str =
+    "Only Unix socket event export addresses are currently supported";
+
+// ----------------------
+// | Manager / Executor |
+// ----------------------
+
+/// The event manager worker
+pub struct EventManager {
+    /// The event manager executor
+    pub executor: Option<EventManagerExecutor>,
+    /// The handle on the event manager
+    pub handle: Option<JoinHandle<EventManagerError>>,
+}
+
+/// Manages the exporting of events to the configured address
+pub struct EventManagerExecutor {
+    /// The channel on which to receive events
+    event_queue: EventManagerReceiver,
+    /// The address to export relayer events to
+    event_export_addr: Option<Multiaddr>,
+    /// The channel on which the coordinator may cancel event manager execution
+    cancel_channel: CancelChannel,
+}
+
+impl EventManagerExecutor {
+    /// Constructs a new event manager executor
+    pub fn new(config: EventManagerConfig) -> Self {
+        let EventManagerConfig { event_queue, event_export_addr, cancel_channel } = config;
+
+        Self { event_queue, event_export_addr, cancel_channel }
+    }
+
+    /// Constructs the export sink for the event manager.
+    ///
+    /// Currently, only Unix socket export addresses are supported.
+    pub async fn construct_export_sink(&mut self) -> Result<Option<UnixStream>, EventManagerError> {
+        if self.event_export_addr.is_none() {
+            return Ok(None);
+        }
+
+        let mut event_export_addr = self.event_export_addr.take().unwrap();
+        let unix_path =
+            match event_export_addr.pop().expect("event export address must not be empty") {
+                Protocol::Unix(path) => path.to_string(),
+                _ => {
+                    return Err(EventManagerError::InvalidEventExportAddr(
+                        ERR_NON_UNIX_EVENT_EXPORT_ADDRESS.to_string(),
+                    ))
+                },
+            };
+
+        let socket = UnixStream::connect(Path::new(&unix_path))
+            .await
+            .map_err(err_str!(EventManagerError::SocketConnection))?;
+
+        Ok(Some(socket))
+    }
+
+    /// The main execution loop; receives events and exports them to the
+    /// configured sink
+    pub async fn execution_loop(mut self) -> Result<(), EventManagerError> {
+        // If the node is running in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_async().await;
+        }
+
+        let disabled = self.event_export_addr.is_none();
+        let mut sink = self.construct_export_sink().await?;
+
+        loop {
+            tokio::select! {
+                Some(event) = self.event_queue.recv() => {
+                    if disabled {
+                        warn!("EventManager received event while disabled, ignoring...");
+                        continue;
+                    }
+
+                    let sink = sink.as_mut().unwrap();
+                    let event_bytes = serde_json::to_vec(&event).map_err(err_str!(EventManagerError::Serialize))?;
+                    sink.write_all(&event_bytes).await.map_err(err_str!(EventManagerError::SocketWrite))?;
+                },
+
+                _ = self.cancel_channel.changed() => {
+                    info!("EventManager received cancel signal, shutting down...");
+                    return Err(EventManagerError::Cancelled("received cancel signal".to_string()));
+                }
+            }
+        }
+    }
+}

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -166,10 +166,10 @@ pub struct MatchEvent {
     pub execution_price: TimestampedPrice,
     /// The match result
     pub match_result: MatchResult,
-    /// The fees paid on the base asset in this match
-    pub base_fee_take: FeeTake,
-    /// The fees paid on the quote asset in this match
-    pub quote_fee_take: FeeTake,
+    /// The fees paid by the first party in this match
+    pub fee_take0: FeeTake,
+    /// The fees paid by the second party in this match
+    pub fee_take1: FeeTake,
 }
 
 /// An external match event
@@ -188,8 +188,8 @@ pub struct ExternalMatchEvent {
     pub execution_price: TimestampedPrice,
     /// The external match result
     pub external_match_result: ExternalMatchResult,
-    /// The fees paid on the base asset in this match
-    pub base_fee_take: FeeTake,
-    /// The fees paid on the quote asset in this match
-    pub quote_fee_take: FeeTake,
+    /// The fees paid by the internal party
+    pub internal_fee_take: FeeTake,
+    /// The fees paid by the external party
+    pub external_fee_take: FeeTake,
 }

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -18,6 +18,7 @@ use constants::Scalar;
 use ethers::{middleware::Middleware, types::Address};
 use eyre::Result;
 use job_types::{
+    event_manager::EventManagerQueue,
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
     task_driver::{new_task_notification, TaskDriverJob, TaskDriverQueue, TaskDriverReceiver},
@@ -215,6 +216,7 @@ pub fn new_mock_task_driver(
     arbitrum_client: ArbitrumClient,
     network_queue: NetworkManagerQueue,
     proof_queue: ProofManagerQueue,
+    event_queue: EventManagerQueue,
     state: State,
 ) {
     let bus = SystemBus::new();
@@ -234,6 +236,7 @@ pub fn new_mock_task_driver(
         arbitrum_client,
         network_queue,
         proof_queue,
+        event_queue,
         state,
     };
 

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -103,6 +103,7 @@ impl TaskExecutor {
             arbitrum_client: config.arbitrum_client,
             network_queue: config.network_queue,
             proof_queue: config.proof_queue,
+            event_queue: config.event_queue,
             task_queue: config.task_queue_sender,
             state: config.state,
             bus: config.system_bus.clone(),

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -10,7 +10,6 @@
 use core::panic;
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::time::SystemTime;
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
@@ -30,7 +29,6 @@ use state::error::StateError;
 use state::State;
 use tracing::instrument;
 use util::err_str;
-use uuid::Uuid;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
@@ -313,12 +311,10 @@ impl NewWalletTask {
 
     /// Emit a wallet creation event to the event manager
     fn emit_event(&self) -> Result<(), NewWalletTaskError> {
-        let event = RelayerEvent::WalletCreation(WalletCreationEvent {
-            event_id: Uuid::new_v4(),
-            event_timestamp: SystemTime::now(),
-            wallet_id: self.wallet.wallet_id,
-            symmetric_key: self.wallet.key_chain.symmetric_key().to_base64_string(),
-        });
+        let event = RelayerEvent::WalletCreation(WalletCreationEvent::new(
+            self.wallet.wallet_id,
+            self.wallet.key_chain.symmetric_key().to_base64_string(),
+        ));
 
         self.event_queue.send(event).map_err(err_str!(NewWalletTaskError::SendMessage))
     }

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
@@ -26,7 +26,9 @@ use common::types::tasks::SettleExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use common::types::TimestampedPrice;
 use external_api::bus_message::SystemBusMessage;
-use job_types::event_manager::{EventManagerQueue, ExternalMatchEvent, RelayerEvent};
+use job_types::event_manager::{
+    EventManagerQueue, ExternalMatchEvent, PartyMatchData, RelayerEvent,
+};
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
 use serde::Serialize;
 use state::error::StateError;
@@ -35,7 +37,6 @@ use system_bus::SystemBus;
 use tracing::{info, instrument, warn};
 use util::arbitrum::get_protocol_fee;
 use util::matching_engine::{apply_match_to_shares, compute_fee_obligation};
-use uuid::Uuid;
 
 use super::ERR_NO_VALIDITY_PROOF;
 
@@ -514,9 +515,15 @@ impl SettleMatchExternalTask {
         let commitments_witness = &self.internal_order_validity_witness.commitment_witness;
         let internal_party_order_side = commitments_witness.order.side;
         let relayer_fee = commitments_witness.relayer_fee;
-
         let internal_fee_take =
             compute_fee_obligation(relayer_fee, internal_party_order_side, &self.match_res);
+
+        let internal_party_data = PartyMatchData {
+            wallet_id: self.internal_wallet_id,
+            order_id: self.internal_order_id,
+            fee_take: internal_fee_take,
+        };
+
         let external_fee_take = compute_fee_obligation(
             FixedPoint::default(),
             internal_party_order_side.opposite(),
@@ -525,16 +532,12 @@ impl SettleMatchExternalTask {
 
         let external_match_result = self.match_res.clone().into();
 
-        let event = RelayerEvent::ExternalMatch(ExternalMatchEvent {
-            event_id: Uuid::new_v4(),
-            event_timestamp: SystemTime::now(),
-            internal_wallet_id: self.internal_wallet_id,
-            internal_order_id: self.internal_order_id,
-            execution_price: self.execution_price,
-            external_match_result,
-            internal_fee_take,
+        let event = RelayerEvent::ExternalMatch(ExternalMatchEvent::new(
+            internal_party_data,
             external_fee_take,
-        });
+            self.execution_price,
+            external_match_result,
+        ));
 
         self.event_queue.send(event).map_err(SettleMatchExternalTaskError::send_event)
     }

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -6,8 +6,8 @@ use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
-    network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue,
-    task_driver::TaskDriverQueue,
+    event_manager::EventManagerQueue, network_manager::NetworkManagerQueue,
+    proof_manager::ProofManagerQueue, task_driver::TaskDriverQueue,
 };
 use serde::{Deserialize, Serialize};
 use state::State;
@@ -111,6 +111,8 @@ pub struct TaskContext {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's queue
     pub proof_queue: ProofManagerQueue,
+    /// A sender to the event manager's queue
+    pub event_queue: EventManagerQueue,
     /// A sender back to the task driver's queue
     pub task_queue: TaskDriverQueue,
     /// A handle on the system bus

--- a/workers/task-driver/src/worker.rs
+++ b/workers/task-driver/src/worker.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use common::{default_wrapper::DefaultOption, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
+    event_manager::EventManagerQueue,
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
     task_driver::{TaskDriverQueue, TaskDriverReceiver},
@@ -39,6 +40,8 @@ pub struct TaskDriverConfig {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's work queue
     pub proof_queue: ProofManagerQueue,
+    /// A sender to the event manager's work queue
+    pub event_queue: EventManagerQueue,
     /// The system bus to publish task updates onto
     pub system_bus: SystemBus<SystemBusMessage>,
     /// A handle on the global state
@@ -47,12 +50,14 @@ pub struct TaskDriverConfig {
 
 impl TaskDriverConfig {
     /// Create a new config with default values
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_queue: TaskDriverReceiver,
         task_queue_sender: TaskDriverQueue,
         arbitrum_client: ArbitrumClient,
         network_queue: NetworkManagerQueue,
         proof_queue: ProofManagerQueue,
+        event_queue: EventManagerQueue,
         system_bus: SystemBus<SystemBusMessage>,
         state: State,
     ) -> Self {
@@ -63,6 +68,7 @@ impl TaskDriverConfig {
             arbitrum_client,
             network_queue,
             proof_queue,
+            event_queue,
             system_bus,
             state,
         }


### PR DESCRIPTION
This PR implements the construction & emitting of events from across the relayer to the new event manager worker.

One thing to note: we emit events right before tasks complete, to obviate any possibility of task retries causing duplicate event emission. I chose this approach for simplicity, and because empirically we have very few failure beyond a task's commit point. With that said, of course we can consider some deduplication scheme / deterministic event IDs, and then emit events right after a task's commit point.

All unit tests pass, and e2e testing is deferred until the receiving side of these events is implemented in the event manager worker