### PR TITLE
workers: event-manager: double-write implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,9 +3583,13 @@ dependencies = [
  "async-trait",
  "circuit-types 0.1.0",
  "common 0.1.0",
+ "constants 0.1.0",
  "job-types",
  "libp2p",
+ "serde_json",
  "tokio",
+ "tracing",
+ "util 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,10 +3580,12 @@ dependencies = [
 name = "event-manager"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "circuit-types 0.1.0",
  "common 0.1.0",
- "serde",
- "uuid 1.11.0",
+ "job-types",
+ "libp2p",
+ "tokio",
 ]
 
 [[package]]
@@ -5130,6 +5132,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libp2p-core",
+ "serde",
  "tokio",
  "util 0.1.0",
  "uuid 1.11.0",
@@ -7896,6 +7899,7 @@ dependencies = [
  "constants 0.1.0",
  "crossbeam",
  "ethers",
+ "event-manager",
  "external-api 0.1.0",
  "gossip-api",
  "gossip-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-export-sidecar"
+version = "0.1.0"
+dependencies = [
+ "clap 4.5.21",
+ "common 0.1.0",
+ "config",
+ "event-manager",
+ "external-api 0.1.0",
+ "eyre",
+ "job-types",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,10 +3604,11 @@ dependencies = [
  "common 0.1.0",
  "constants 0.1.0",
  "job-types",
- "libp2p",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
+ "url",
  "util 0.1.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 	"gossip-api",
 	"mock-node",
 	"node-support/snapshot-sidecar",
+	"node-support/event-export-sidecar",
 	"node-support/bootloader",
 	"renegade-crypto",
 	"state",

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -171,6 +171,12 @@ pub struct Cli {
     /// The path at which to save raft snapshots
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
+    /// Whether to record historical state locally
+    #[clap(long, value_parser)]
+    pub record_historical_state: bool,
+    /// The address to export relayer events to, in multiaddr format
+    #[clap(long, value_parser)]
+    pub event_export_addr: Option<String>,
     /// The maximum number of wallet operations a user is allowed to perform per hour
     /// 
     /// Defaults to 500
@@ -347,6 +353,10 @@ pub struct RelayerConfig {
     pub db_path: String,
     /// The path at which to save raft snapshots
     pub raft_snapshot_path: String,
+    /// Whether to record historical state locally
+    pub record_historical_state: bool,
+    /// The address to export relayer events to, in multiaddr format
+    pub event_export_addr: Option<Multiaddr>,
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour
     pub wallet_task_rate_limit: u32,
@@ -471,6 +481,8 @@ impl Clone for RelayerConfig {
             p2p_key: self.p2p_key.clone(),
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
+            record_historical_state: self.record_historical_state,
+            event_export_addr: self.event_export_addr.clone(),
             wallet_task_rate_limit: self.wallet_task_rate_limit,
             min_transfer_amount: self.min_transfer_amount,
             max_merkle_staleness: self.max_merkle_staleness,

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -99,6 +99,10 @@ pub struct Cli {
     ///     https://github.com/renegade-fi/relayer-extensions/tree/master/compliance/compliance-api 
     #[clap(long, value_parser)]
     pub compliance_service_url: Option<String>,
+    /// The URL to export relayer events to.
+    /// If ommitted, the event manager is disabled.
+    #[clap(long, value_parser)]
+    pub event_export_url: Option<String>,
 
     // ----------------------------
     // | Networking Configuration |
@@ -175,10 +179,6 @@ pub struct Cli {
     // TODO: Unset default `true` once event export implementation is complete
     #[clap(long, value_parser, default_value = "true")]
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format.
-    /// If ommitted, the event manager is disabled.
-    #[clap(long, value_parser)]
-    pub event_export_addr: Option<String>,
     /// The maximum number of wallet operations a user is allowed to perform per hour
     /// 
     /// Defaults to 500
@@ -306,6 +306,9 @@ pub struct RelayerConfig {
     /// The API of the compliance service must match that defined here:
     ///     https://github.com/renegade-fi/relayer-extensions/tree/master/compliance/compliance-api
     pub compliance_service_url: Option<String>,
+    /// The URL to export relayer events to.
+    /// If ommitted, the event manager is disabled.
+    pub event_export_url: Option<Url>,
 
     // ----------------------------
     // | Networking Configuration |
@@ -357,9 +360,6 @@ pub struct RelayerConfig {
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format.
-    /// If ommitted, the event manager is disabled.
-    pub event_export_addr: Option<Multiaddr>,
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour
     pub wallet_task_rate_limit: u32,
@@ -485,7 +485,7 @@ impl Clone for RelayerConfig {
             db_path: self.db_path.clone(),
             raft_snapshot_path: self.raft_snapshot_path.clone(),
             record_historical_state: self.record_historical_state,
-            event_export_addr: self.event_export_addr.clone(),
+            event_export_url: self.event_export_url.clone(),
             wallet_task_rate_limit: self.wallet_task_rate_limit,
             min_transfer_amount: self.min_transfer_amount,
             max_merkle_staleness: self.max_merkle_staleness,

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -172,7 +172,8 @@ pub struct Cli {
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
-    #[clap(long, value_parser)]
+    // TODO: Unset default `true` once event export implementation is complete
+    #[clap(long, value_parser, default_value = "true")]
     pub record_historical_state: bool,
     /// The address to export relayer events to, in multiaddr format.
     /// If ommitted, the event manager is disabled.

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -174,7 +174,8 @@ pub struct Cli {
     /// Whether to record historical state locally
     #[clap(long, value_parser)]
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format
+    /// The address to export relayer events to, in multiaddr format.
+    /// If ommitted, the event manager is disabled.
     #[clap(long, value_parser)]
     pub event_export_addr: Option<String>,
     /// The maximum number of wallet operations a user is allowed to perform per hour
@@ -355,7 +356,8 @@ pub struct RelayerConfig {
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
     pub record_historical_state: bool,
-    /// The address to export relayer events to, in multiaddr format
+    /// The address to export relayer events to, in multiaddr format.
+    /// If ommitted, the event manager is disabled.
     pub event_export_addr: Option<Multiaddr>,
     /// The maximum number of wallet operations a user is allowed to perform per
     /// hour

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -96,6 +96,11 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 
+    // Parse the event export address, if there is one
+    let event_export_addr = cli_args
+        .event_export_addr
+        .map(|addr| addr.parse().expect("Invalid address passed as --event-export-addr"));
+
     // Parse the price reporter URL, if there is one
     let price_reporter_url = cli_args
         .price_reporter_url
@@ -124,6 +129,8 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         p2p_key,
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
+        record_historical_state: cli_args.record_historical_state,
+        event_export_addr,
         wallet_task_rate_limit: cli_args.wallet_task_rate_limit,
         min_transfer_amount: cli_args.min_transfer_amount,
         bind_addr: cli_args.bind_addr,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -96,10 +96,9 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         parsed_bootstrap_addrs.push((WrappedPeerId(peer_id), parsed_addr));
     }
 
-    // Parse the event export address, if there is one
-    let event_export_addr: Option<Multiaddr> = cli_args
-        .event_export_addr
-        .map(|addr| addr.parse().expect("Invalid address passed as --event-export-addr"));
+    // Parse the event export URL, if there is one
+    let event_export_url: Option<Url> =
+        cli_args.event_export_url.map(|url| url.parse().expect("Invalid event export URL"));
 
     // Parse the price reporter URL, if there is one
     let price_reporter_url = cli_args
@@ -130,7 +129,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         db_path: cli_args.db_path,
         raft_snapshot_path: cli_args.raft_snapshot_path,
         record_historical_state: cli_args.record_historical_state,
-        event_export_addr,
+        event_export_url,
         wallet_task_rate_limit: cli_args.wallet_task_rate_limit,
         min_transfer_amount: cli_args.min_transfer_amount,
         bind_addr: cli_args.bind_addr,

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -97,7 +97,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
     }
 
     // Parse the event export address, if there is one
-    let event_export_addr = cli_args
+    let event_export_addr: Option<Multiaddr> = cli_args
         .event_export_addr
         .map(|addr| addr.parse().expect("Invalid address passed as --event-export-addr"));
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ job-types = { path = "../workers/job-types" }
 network-manager = { path = "../workers/network-manager" }
 price-reporter = { path = "../workers/price-reporter" }
 proof-manager = { path = "../workers/proof-manager" }
+event-manager = { path = "../workers/event-manager" }
 state = { path = "../state" }
 system-bus = { path = "../system-bus" }
 system-clock = { path = "../system-clock" }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (proof_generation_worker_sender, proof_generation_worker_receiver) =
         new_proof_manager_queue();
     let (task_sender, task_receiver) = new_task_driver_queue();
-    let (_event_manager_sender, event_manager_receiver) = new_event_manager_queue();
+    let (event_manager_sender, event_manager_receiver) = new_event_manager_queue();
 
     // Construct a global state
     let (state_failure_send, mut state_failure_recv) = new_worker_failure_channel();
@@ -181,6 +181,7 @@ async fn main() -> Result<(), CoordinatorError> {
         arbitrum_client.clone(),
         network_sender.clone(),
         proof_generation_worker_sender.clone(),
+        event_manager_sender,
         system_bus.clone(),
         global_state.clone(),
     );

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -24,7 +24,7 @@ use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::worker::{new_worker_failure_channel, watch_worker, Worker};
 use common::{default_wrapper::default_option, types::new_cancel_channel};
 use constants::{in_bootstrap_mode, VERSION};
-use event_manager::worker::{EventManager, EventManagerConfig};
+use event_manager::{manager::EventManager, worker::EventManagerConfig};
 use external_api::bus_message::SystemBusMessage;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -259,7 +259,7 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the event manager
     let (event_manager_cancel_sender, event_manager_cancel_receiver) = new_cancel_channel();
     let mut event_manager = EventManager::new(EventManagerConfig {
-        event_export_addr: args.event_export_addr,
+        event_export_url: args.event_export_url,
         event_queue: event_manager_receiver,
         cancel_channel: event_manager_cancel_receiver,
     })

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -37,12 +37,16 @@ ARG CARGO_FEATURES="default"
 # Build only the dependencies to cache them in this layer
 RUN cargo chef cook --release --recipe-path recipe.json --features "$CARGO_FEATURES"
 
-# Build the bootloader
 COPY . .
+
+# Build the bootloader
 RUN cargo build --release --package bootloader
 
 # Build the snapshot sidecar
 RUN cargo build --release --package snapshot-sidecar
+
+# Build the event export sidecar
+RUN cargo build --release --package event-export-sidecar
 
 # Build the relayer
 RUN cargo build --release --bin renegade-relayer --features "$CARGO_FEATURES"
@@ -58,6 +62,7 @@ RUN apt-get update && \
 # Copy the binaries from the build stage
 COPY --from=builder /build/target/release/bootloader /bin/bootloader
 COPY --from=builder /build/target/release/snapshot-sidecar /bin/snapshot-sidecar
+COPY --from=builder /build/target/release/event-export-sidecar /bin/event-export-sidecar
 COPY --from=builder /build/target/release/renegade-relayer /bin/renegade-relayer
 
 # Set the bootloader as the entrypoint

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -28,6 +28,7 @@ use futures::Future;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
 use handshake_manager::{manager::HandshakeManager, worker::HandshakeManagerConfig};
 use job_types::{
+    event_manager::{new_event_manager_queue, EventManagerQueue, EventManagerReceiver},
     gossip_server::{
         new_gossip_server_queue, GossipServerJob, GossipServerQueue, GossipServerReceiver,
     },
@@ -117,6 +118,8 @@ pub struct MockNodeController {
     price_queue: (PriceReporterQueue, DefaultOption<PriceReporterReceiver>),
     /// The proof generation queue
     proof_queue: (ProofManagerQueue, DefaultOption<ProofManagerReceiver>),
+    /// The event manager queue
+    event_queue: (EventManagerQueue, DefaultOption<EventManagerReceiver>),
     /// The task manager queue
     task_queue: (TaskDriverQueue, DefaultOption<TaskDriverReceiver>),
 }
@@ -132,6 +135,7 @@ impl MockNodeController {
         let (handshake_send, handshake_recv) = new_handshake_manager_queue();
         let (price_sender, price_recv) = new_price_reporter_queue();
         let (proof_gen_sender, proof_gen_recv) = new_proof_manager_queue();
+        let (event_sender, event_recv) = new_event_manager_queue();
         let (task_sender, task_recv) = new_task_driver_queue();
 
         Self {
@@ -146,6 +150,7 @@ impl MockNodeController {
             handshake_queue: (handshake_send, default_option(handshake_recv)),
             price_queue: (price_sender, default_option(price_recv)),
             proof_queue: (proof_gen_sender, default_option(proof_gen_recv)),
+            event_queue: (event_sender, default_option(event_recv)),
             task_queue: (task_sender, default_option(task_recv)),
         }
     }
@@ -294,6 +299,7 @@ impl MockNodeController {
             self.arbitrum_client.clone().expect("Arbitrum client not initialized");
         let network_queue = self.network_queue.0.clone();
         let proof_queue = self.proof_queue.0.clone();
+        let event_queue = self.event_queue.0.clone();
         let bus = self.bus.clone();
         let state = self.state.clone().expect("State not initialized");
 
@@ -303,6 +309,7 @@ impl MockNodeController {
             arbitrum_client,
             network_queue,
             proof_queue,
+            event_queue,
             bus,
             state,
         );

--- a/node-support/event-export-sidecar/Cargo.toml
+++ b/node-support/event-export-sidecar/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "event-export-sidecar"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# === Async + Runtime === #
+tokio = { workspace = true, features = ["full"] }
+
+# === Networking Dependencies === #
+reqwest = { version = "0.11", features = ["json"] }
+
+# === Workspace Dependencies === #
+common = { path = "../../common" }
+config = { path = "../../config" }
+external-api = { path = "../../external-api", features = ["auth"] }
+job-types = { path = "../../workers/job-types" }
+event-manager = { path = "../../workers/event-manager" }
+
+# === Misc Dependencies === #
+url = "2.4"
+clap = { version = "4", features = ["derive"] }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+eyre = { workspace = true }

--- a/node-support/event-export-sidecar/src/event_socket.rs
+++ b/node-support/event-export-sidecar/src/event_socket.rs
@@ -1,0 +1,111 @@
+//! A managed Unix listener that removes the socket file when dropped
+
+use std::{fs, io, path::Path};
+
+use event_manager::manager::extract_unix_socket_path;
+use eyre::{eyre, Error};
+use job_types::event_manager::RelayerEvent;
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{error, info, warn};
+use url::Url;
+
+use crate::hse_client::HseClient;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The maximum message size to read from the event export socket
+const MAX_MESSAGE_SIZE: usize = 1024 * 1024; // 1MB
+
+// ----------------
+// | Event Socket |
+// ----------------
+
+/// A managed Unix socket that listens for events on a given path
+/// and submits them to the historical state engine.
+///
+/// The socket file is removed when the socket is dropped.
+pub struct EventSocket {
+    /// The underlying Unix socket
+    socket: UnixStream,
+
+    /// The path to the Unix socket
+    path: String,
+
+    /// The historical state engine client
+    hse_client: HseClient,
+}
+
+impl EventSocket {
+    /// Creates a new event socket from the given URL
+    pub async fn new(url: &Url, hse_client: HseClient) -> Result<Self, Error> {
+        let path = extract_unix_socket_path(url)?;
+        let socket = Self::establish_socket_connection(&path).await?;
+        Ok(Self { socket, path, hse_client })
+    }
+
+    /// Sets up a Unix socket listening on the given path
+    /// and awaits a single connection on it
+    async fn establish_socket_connection(path: &str) -> Result<UnixStream, Error> {
+        let listener = UnixListener::bind(Path::new(path))?;
+
+        // We only expect one connection, so we can just block on it
+        info!("Waiting for event export socket connection...");
+        match listener.accept().await {
+            Ok((socket, _)) => Ok(socket),
+            Err(e) => Err(eyre!("error accepting Unix socket connection: {e}")),
+        }
+    }
+
+    /// Listens for events on the socket and submits them to the historical
+    /// state engine
+    pub async fn listen_for_events(&self) -> Result<(), Error> {
+        loop {
+            // Wait for the socket to be readable
+            self.socket.readable().await?;
+
+            let mut buf = [0; MAX_MESSAGE_SIZE];
+
+            // Try to read data, this may still fail with `WouldBlock`
+            // if the readiness event is a false positive.
+            match self.socket.try_read(&mut buf) {
+                Ok(0) => {
+                    warn!("Event export socket closed");
+                    return Ok(());
+                },
+                Ok(n) => {
+                    let msg = &buf[..n];
+                    if let Err(e) = self.handle_relayer_event(msg).await {
+                        // Events that fail to be submitted are effectively dropped here.
+                        // We can consider retry logic or a local dead-letter queue, but
+                        // for now we keep things simple.
+                        error!("Error handling relayer event: {e}");
+                    }
+                },
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    continue;
+                },
+                Err(e) => {
+                    return Err(e.into());
+                },
+            }
+        }
+    }
+
+    /// Handles an event received from the event export socket
+    async fn handle_relayer_event(&self, msg: &[u8]) -> Result<(), Error> {
+        let event = serde_json::from_slice::<RelayerEvent>(msg)?;
+        self.hse_client.submit_event(&event).await?;
+
+        Ok(())
+    }
+}
+
+impl Drop for EventSocket {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_file(&self.path) {
+            warn!("Failed to remove Unix socket file: {}", e);
+        }
+    }
+}

--- a/node-support/event-export-sidecar/src/event_socket.rs
+++ b/node-support/event-export-sidecar/src/event_socket.rs
@@ -9,7 +9,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tracing::{error, info, warn};
 use url::Url;
 
-use crate::hse_client::HseClient;
+use crate::hse_client::HistoricalStateClient;
 
 // -------------
 // | Constants |
@@ -34,12 +34,12 @@ pub struct EventSocket {
     path: String,
 
     /// The historical state engine client
-    hse_client: HseClient,
+    hse_client: HistoricalStateClient,
 }
 
 impl EventSocket {
     /// Creates a new event socket from the given URL
-    pub async fn new(url: &Url, hse_client: HseClient) -> Result<Self, Error> {
+    pub async fn new(url: &Url, hse_client: HistoricalStateClient) -> Result<Self, Error> {
         let path = extract_unix_socket_path(url)?;
         let socket = Self::establish_socket_connection(&path).await?;
         Ok(Self { socket, path, hse_client })

--- a/node-support/event-export-sidecar/src/hse_client.rs
+++ b/node-support/event-export-sidecar/src/hse_client.rs
@@ -24,14 +24,14 @@ const EVENT_SUBMISSION_PATH: &str = "/event";
 // ----------
 
 /// A client for the historical state engine
-pub struct HseClient {
+pub struct HistoricalStateClient {
     /// The base URL of the historical state engine
     base_url: String,
     /// The auth key for the historical state engine
     auth_key: HmacKey,
 }
 
-impl HseClient {
+impl HistoricalStateClient {
     /// Create a new historical state engine client
     pub fn new(base_url: String, auth_key: HmacKey) -> Self {
         Self { base_url, auth_key }
@@ -40,7 +40,7 @@ impl HseClient {
     /// Submit an event to the historical state engine
     pub async fn submit_event(&self, event: &RelayerEvent) -> Result<(), Error> {
         send_authenticated_request(
-            &format!("{}{}", self.base_url, EVENT_SUBMISSION_PATH),
+            &self.base_url,
             EVENT_SUBMISSION_PATH,
             Method::POST,
             event,

--- a/node-support/event-export-sidecar/src/hse_client.rs
+++ b/node-support/event-export-sidecar/src/hse_client.rs
@@ -1,0 +1,99 @@
+//! A client for the historical state engine
+
+use std::time::Duration;
+
+use common::types::wallet::keychain::HmacKey;
+use external_api::auth::add_expiring_auth_to_headers;
+use eyre::{eyre, Error};
+use job_types::event_manager::RelayerEvent;
+use reqwest::{header::HeaderMap, Client, Method, Response};
+use serde::Serialize;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The buffer to add to the expiration timestamp for the signature
+const SIG_EXPIRATION_BUFFER_MS: u64 = 5_000; // 5 seconds
+
+/// The path to submit events to
+const EVENT_SUBMISSION_PATH: &str = "/event";
+
+// ----------
+// | Client |
+// ----------
+
+/// A client for the historical state engine
+pub struct HseClient {
+    /// The base URL of the historical state engine
+    base_url: String,
+    /// The auth key for the historical state engine
+    auth_key: HmacKey,
+}
+
+impl HseClient {
+    /// Create a new historical state engine client
+    pub fn new(base_url: String, auth_key: HmacKey) -> Self {
+        Self { base_url, auth_key }
+    }
+
+    /// Submit an event to the historical state engine
+    pub async fn submit_event(&self, event: &RelayerEvent) -> Result<(), Error> {
+        send_authenticated_request(
+            &format!("{}{}", self.base_url, EVENT_SUBMISSION_PATH),
+            EVENT_SUBMISSION_PATH,
+            Method::POST,
+            event,
+            &self.auth_key,
+        )
+        .await
+        .map(|_| ())
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Send a request w/ an expiring auth header
+async fn send_authenticated_request<Req: Serialize>(
+    url: &str,
+    path: &str,
+    method: Method,
+    body: &Req,
+    key: &HmacKey,
+) -> Result<Response, Error> {
+    let expiration = Duration::from_millis(SIG_EXPIRATION_BUFFER_MS);
+
+    let body_bytes = serde_json::to_vec(body).expect("failed to serialize request body");
+
+    let mut headers = HeaderMap::new();
+    add_expiring_auth_to_headers(path, &mut headers, &body_bytes, key, expiration);
+
+    let route = format!("{}{}", url, path);
+    let response = send_request(&route, method, body, headers).await?;
+    Ok(response)
+}
+
+/// Send a basic HTTP request
+async fn send_request<Req: Serialize>(
+    route: &str,
+    method: Method,
+    body: &Req,
+    headers: HeaderMap,
+) -> Result<Response, Error> {
+    let response = Client::new()
+        .request(method, route)
+        .headers(headers)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| eyre!("Failed to send request: {e}"))?;
+
+    // Check if the request was successful
+    if !response.status().is_success() {
+        return Err(eyre!("Request failed with status: {}", response.status()));
+    }
+
+    Ok(response)
+}

--- a/node-support/event-export-sidecar/src/main.rs
+++ b/node-support/event-export-sidecar/src/main.rs
@@ -16,7 +16,7 @@ use common::types::wallet::keychain::HmacKey;
 use config::parsing::parse_config_from_file;
 use event_socket::EventSocket;
 use eyre::Error;
-use hse_client::HseClient;
+use hse_client::HistoricalStateClient;
 use tracing::{info, warn};
 
 // -------
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Error> {
 
     // Construct HSE client
     let hse_key = HmacKey::from_base64_string(&cli.hse_key).expect("invalid hse key");
-    let hse_client = HseClient::new(cli.hse_url, hse_key);
+    let hse_client = HistoricalStateClient::new(cli.hse_url, hse_key);
 
     let event_socket =
         EventSocket::new(&relayer_config.event_export_url.unwrap(), hse_client).await?;

--- a/node-support/event-export-sidecar/src/main.rs
+++ b/node-support/event-export-sidecar/src/main.rs
@@ -1,0 +1,63 @@
+//! A sidecar process that re-exports relayer events for historical state
+//! persistence
+
+#![allow(incomplete_features)]
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+
+mod event_socket;
+mod hse_client;
+
+use clap::Parser;
+use common::types::wallet::keychain::HmacKey;
+use config::parsing::parse_config_from_file;
+use event_socket::EventSocket;
+use eyre::Error;
+use hse_client::HseClient;
+use tracing::{info, warn};
+
+// -------
+// | CLI |
+// -------
+
+/// The event export sidecar CLI
+#[derive(Debug, Parser)]
+struct Cli {
+    /// The path to the relayer's config
+    #[clap(long)]
+    config_path: String,
+    /// The historical state engine URL
+    #[clap(long)]
+    hse_url: String,
+    /// The historical state engine auth key, in base64 format
+    #[clap(long)]
+    hse_key: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Parse CLI & config
+    let cli = Cli::parse();
+    let relayer_config =
+        parse_config_from_file(&cli.config_path).expect("could not parse relayer config");
+    relayer_config.configure_telemetry().expect("failed to configure telemetry");
+
+    if relayer_config.event_export_url.is_none() {
+        warn!("Event export disabled, not creating event sidecar");
+        return Ok(());
+    }
+
+    // Construct HSE client
+    let hse_key = HmacKey::from_base64_string(&cli.hse_key).expect("invalid hse key");
+    let hse_client = HseClient::new(cli.hse_url, hse_key);
+
+    let event_socket =
+        EventSocket::new(&relayer_config.event_export_url.unwrap(), hse_client).await?;
+
+    info!("Event export sidecar connected to socket, awaiting events...");
+
+    event_socket.listen_for_events().await
+}

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -551,7 +551,9 @@ impl StateApplicator {
         task: QueuedTask,
         tx: &StateTxn<'_, RW>,
     ) -> Result<()> {
-        if let Some(t) = HistoricalTask::from_queued_task(key, task) {
+        if let Some(t) = HistoricalTask::from_queued_task(key, task)
+            && tx.get_historical_state_enabled()?
+        {
             tx.append_task_to_history(&key, t)?;
         }
 

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -81,6 +81,11 @@ impl StateInner {
         self.with_read_tx(|tx| tx.get_auto_redeem_fees().map_err(StateError::Db)).await
     }
 
+    /// Get the local relayer's historical state enabled flag
+    pub async fn historical_state_enabled(&self) -> Result<bool, StateError> {
+        self.with_read_tx(|tx| tx.get_historical_state_enabled().map_err(StateError::Db)).await
+    }
+
     // -----------
     // | Setters |
     // -----------
@@ -138,6 +143,7 @@ impl StateInner {
         let need_relayer_wallet = config.needs_relayer_wallet();
         let relayer_wallet_id =
             derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
+        let historical_state_enabled = config.record_historical_state;
 
         self.with_write_tx(move |tx| {
             tx.create_table(NODE_METADATA_TABLE)?;
@@ -146,6 +152,7 @@ impl StateInner {
             tx.set_node_keypair(&p2p_key)?;
             tx.set_fee_key(&fee_key)?;
             tx.set_relayer_take_rate(&match_take_rate)?;
+            tx.set_historical_state_enabled(historical_state_enabled)?;
             if let Some(addr) = external_fee_addr {
                 tx.set_external_fee_addr(&addr)?;
             }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -274,6 +274,7 @@ pub mod test_helpers {
         // Setup the tables
         let tx = db.new_write_tx().unwrap();
         tx.setup_tables().unwrap();
+        tx.set_historical_state_enabled(true).unwrap();
         tx.commit().unwrap();
 
         db

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -21,6 +21,11 @@ pub enum StorageError {
     OpenDb(MdbxError),
     /// Failure opening a table in the database
     OpenTable(MdbxError),
+    /// Attempt to access a disabled table, which may be the case if it is
+    /// used to track state for a feature that is disabled in the relayer.
+    /// An example of this is the order history table being disabled if the
+    /// relayer is not configured to record historical state.
+    TableDisabled(String),
     /// An uncategorized error
     Other(String),
     /// Error serializing a value for storage

--- a/state/src/storage/tx/node_metadata.rs
+++ b/state/src/storage/tx/node_metadata.rs
@@ -39,6 +39,9 @@ const RELAYER_TAKE_RATE_KEY: &str = "relayer-take-rate";
 const EXTERNAL_FEE_ADDR_KEY: &str = "external-fee-addr";
 /// The key for the local relayer's auto-redeem fees flag in the node metadata
 const AUTO_REDEEM_FEES_KEY: &str = "auto-redeem-fees";
+/// The key for the local relayer's historical state enabled flag in the node
+/// metadata table
+const HISTORICAL_STATE_ENABLED_KEY: &str = "historical-state-enabled";
 
 // -----------
 // | Helpers |
@@ -120,6 +123,13 @@ impl<'db, T: TransactionKind> StateTxn<'db, T> {
             .read(NODE_METADATA_TABLE, &AUTO_REDEEM_FEES_KEY.to_string())?
             .ok_or_else(|| err_not_found(AUTO_REDEEM_FEES_KEY))
     }
+
+    /// Get the local relayer's historical state enabled flag
+    pub fn get_historical_state_enabled(&self) -> Result<bool, StorageError> {
+        self.inner()
+            .read(NODE_METADATA_TABLE, &HISTORICAL_STATE_ENABLED_KEY.to_string())?
+            .ok_or_else(|| err_not_found(HISTORICAL_STATE_ENABLED_KEY))
+    }
 }
 
 // -----------
@@ -175,5 +185,10 @@ impl<'db> StateTxn<'db, RW> {
             &AUTO_REDEEM_FEES_KEY.to_string(),
             &auto_redeem_fees,
         )
+    }
+
+    /// Set the local relayer's historical state enabled flag
+    pub fn set_historical_state_enabled(&self, enabled: bool) -> Result<(), StorageError> {
+        self.inner().write(NODE_METADATA_TABLE, &HISTORICAL_STATE_ENABLED_KEY.to_string(), &enabled)
     }
 }

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -66,6 +66,8 @@ const ERR_ORDER_ALREADY_EXISTS: &str = "order id already exists";
 const ERR_BALANCE_NOT_FOUND: &str = "balance not found in wallet";
 /// Error message emitted when price data cannot be found for a token pair
 const ERR_NO_PRICE_DATA: &str = "no price data found for token pair";
+/// Error message emitted when historical state is disabled
+const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
 
 // -----------------------
 // | Raft Route Handlers |
@@ -203,6 +205,10 @@ impl TypedHandler for AdminOrderMetadataHandler {
         params: UrlParams,
         query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        if !self.state.historical_state_enabled().await? {
+            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
+        }
+
         let order_id = parse_order_id_from_params(&params)?;
         let order_metadata = self
             .state
@@ -451,14 +457,6 @@ impl TypedHandler for AdminAssignOrderToMatchingPoolHandler {
         let order_id = parse_order_id_from_params(&params)?;
         let matching_pool = parse_matching_pool_from_url_params(&params)?;
 
-        // Check that the order exists. We do this by checking the order
-        // metadata, as filled orders (which a client may still want to reassign
-        // ahead of subsequent order updates) are removed from the network
-        // orderbook.
-        if self.state.get_order_metadata(&order_id).await?.is_none() {
-            return Err(not_found(ERR_ORDER_NOT_FOUND));
-        }
-
         // Check that the matching pool exists
         if !self.state.matching_pool_exists(matching_pool.clone()).await? {
             return Err(not_found(ERR_NO_MATCHING_POOL));
@@ -502,15 +500,6 @@ impl TypedHandler for AdminGetOrderMatchingPoolHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let order_id = parse_order_id_from_params(&params)?;
-
-        // Check that the order exists. We do this by checking the order
-        // metadata, as filled orders (which a client may still want to
-        // see the matching pool of, ahead of subsequent order updates)
-        // are removed from the network orderbook.
-        if self.state.get_order_metadata(&order_id).await?.is_none() {
-            return Err(not_found(ERR_ORDER_NOT_FOUND));
-        }
-
         let matching_pool = self.state.get_matching_pool_for_order(&order_id).await?;
 
         Ok(AdminGetOrderMatchingPoolResponse { matching_pool })

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -34,6 +34,8 @@ const DEFAULT_TASK_HISTORY_LEN: usize = 50;
 
 /// Error message displayed when a given task cannot be found
 const ERR_TASK_NOT_FOUND: &str = "task not found";
+/// Error message emitted when historical state is disabled
+const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
 
 /// -----------------------
 /// | Task Route Handlers |
@@ -138,6 +140,10 @@ impl TypedHandler for GetTaskHistoryHandler {
         params: UrlParams,
         mut query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        if !self.state.historical_state_enabled().await? {
+            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
+        }
+
         // Lookup the task status in the task driver's state
         let wallet_id = parse_wallet_id_from_params(&params)?;
         let len = query_params

--- a/workers/event-manager/Cargo.toml
+++ b/workers/event-manager/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Async + Concurrency === #
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# === Networking === #
+libp2p = { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
 circuit-types = { path = "../../circuit-types" }
-
-# === Misc Dependencies === #
-uuid = { version = "1.1.2", features = ["v4", "serde"] }
-serde = { workspace = true }
+job-types = { path = "../job-types" }

--- a/workers/event-manager/Cargo.toml
+++ b/workers/event-manager/Cargo.toml
@@ -13,5 +13,11 @@ libp2p = { workspace = true }
 
 # === Workspace Dependencies === #
 common = { path = "../../common" }
+constants = { path = "../../constants" }
 circuit-types = { path = "../../circuit-types" }
 job-types = { path = "../job-types" }
+util = { path = "../../util" }
+
+# === Misc Dependencies === #
+tracing = { workspace = true }
+serde_json = { workspace = true }

--- a/workers/event-manager/Cargo.toml
+++ b/workers/event-manager/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 async-trait = { workspace = true }
 tokio = { workspace = true }
 
-# === Networking === #
-libp2p = { workspace = true }
-
 # === Workspace Dependencies === #
 common = { path = "../../common" }
 constants = { path = "../../constants" }
@@ -19,5 +16,7 @@ job-types = { path = "../job-types" }
 util = { path = "../../util" }
 
 # === Misc Dependencies === #
+url = "2.4"
 tracing = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { version = "1.0.61" }

--- a/workers/event-manager/src/error.rs
+++ b/workers/event-manager/src/error.rs
@@ -1,0 +1,5 @@
+//! Defines errors for the event manager
+
+/// An error that occurred in the event manager
+#[derive(Clone, Debug)]
+pub enum EventManagerError {}

--- a/workers/event-manager/src/error.rs
+++ b/workers/event-manager/src/error.rs
@@ -1,18 +1,26 @@
 //! Defines errors for the event manager
 
+use thiserror::Error;
+
 /// An error that occurred in the event manager
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Error)]
 pub enum EventManagerError {
     /// The event manager was cancelled
+    #[error("event manager cancelled: {0}")]
     Cancelled(String),
     /// The event export address is invalid
+    #[error("invalid event export address: {0}")]
     InvalidEventExportAddr(String),
     /// An error occurred while connecting to the event export socket
+    #[error("error connecting to event export socket: {0}")]
     SocketConnection(String),
     /// An error occurred while serializing an event
+    #[error("error serializing event: {0}")]
     Serialize(String),
     /// An error occurred while writing to the event export socket
+    #[error("error writing to event export socket: {0}")]
     SocketWrite(String),
     /// An error occurred while setting up the event manager
+    #[error("error setting up event manager: {0}")]
     SetupError(String),
 }

--- a/workers/event-manager/src/error.rs
+++ b/workers/event-manager/src/error.rs
@@ -2,4 +2,17 @@
 
 /// An error that occurred in the event manager
 #[derive(Clone, Debug)]
-pub enum EventManagerError {}
+pub enum EventManagerError {
+    /// The event manager was cancelled
+    Cancelled(String),
+    /// The event export address is invalid
+    InvalidEventExportAddr(String),
+    /// An error occurred while connecting to the event export socket
+    SocketConnection(String),
+    /// An error occurred while serializing an event
+    Serialize(String),
+    /// An error occurred while writing to the event export socket
+    SocketWrite(String),
+    /// An error occurred while setting up the event manager
+    SetupError(String),
+}

--- a/workers/event-manager/src/lib.rs
+++ b/workers/event-manager/src/lib.rs
@@ -10,4 +10,5 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
-pub mod event_types;
+pub mod error;
+pub mod worker;

--- a/workers/event-manager/src/lib.rs
+++ b/workers/event-manager/src/lib.rs
@@ -11,4 +11,5 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 
 pub mod error;
+pub mod manager;
 pub mod worker;

--- a/workers/event-manager/src/manager.rs
+++ b/workers/event-manager/src/manager.rs
@@ -1,0 +1,111 @@
+//! The core event manager logic, the main loop that receives events
+//! and exports them to the configured address
+
+use std::{path::Path, thread::JoinHandle};
+
+use common::types::CancelChannel;
+use constants::in_bootstrap_mode;
+use job_types::event_manager::EventManagerReceiver;
+use libp2p::{multiaddr::Protocol, Multiaddr};
+use tokio::{io::AsyncWriteExt, net::UnixStream};
+use tracing::{info, warn};
+use util::{err_str, runtime::sleep_forever_async};
+
+use crate::{error::EventManagerError, worker::EventManagerConfig};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The error message for when the event export address is not a Unix socket
+const ERR_NON_UNIX_EVENT_EXPORT_ADDRESS: &str =
+    "Only Unix socket event export addresses are currently supported";
+
+// ----------------------
+// | Manager / Executor |
+// ----------------------
+
+/// The event manager worker
+pub struct EventManager {
+    /// The event manager executor
+    pub executor: Option<EventManagerExecutor>,
+    /// The handle on the event manager
+    pub handle: Option<JoinHandle<EventManagerError>>,
+}
+
+/// Manages the exporting of events to the configured address
+pub struct EventManagerExecutor {
+    /// The channel on which to receive events
+    event_queue: EventManagerReceiver,
+    /// The address to export relayer events to
+    event_export_addr: Option<Multiaddr>,
+    /// The channel on which the coordinator may cancel event manager execution
+    cancel_channel: CancelChannel,
+}
+
+impl EventManagerExecutor {
+    /// Constructs a new event manager executor
+    pub fn new(config: EventManagerConfig) -> Self {
+        let EventManagerConfig { event_queue, event_export_addr, cancel_channel } = config;
+
+        Self { event_queue, event_export_addr, cancel_channel }
+    }
+
+    /// Constructs the export sink for the event manager.
+    ///
+    /// Currently, only Unix socket export addresses are supported.
+    pub async fn construct_export_sink(&mut self) -> Result<Option<UnixStream>, EventManagerError> {
+        if self.event_export_addr.is_none() {
+            return Ok(None);
+        }
+
+        let mut event_export_addr = self.event_export_addr.take().unwrap();
+        let unix_path =
+            match event_export_addr.pop().expect("event export address must not be empty") {
+                Protocol::Unix(path) => path.to_string(),
+                _ => {
+                    return Err(EventManagerError::InvalidEventExportAddr(
+                        ERR_NON_UNIX_EVENT_EXPORT_ADDRESS.to_string(),
+                    ))
+                },
+            };
+
+        let socket = UnixStream::connect(Path::new(&unix_path))
+            .await
+            .map_err(err_str!(EventManagerError::SocketConnection))?;
+
+        Ok(Some(socket))
+    }
+
+    /// The main execution loop; receives events and exports them to the
+    /// configured sink
+    pub async fn execution_loop(mut self) -> Result<(), EventManagerError> {
+        // If the node is running in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_async().await;
+        }
+
+        let disabled = self.event_export_addr.is_none();
+        let mut sink = self.construct_export_sink().await?;
+
+        loop {
+            tokio::select! {
+                Some(event) = self.event_queue.recv() => {
+                    if disabled {
+                        warn!("EventManager received event while disabled, ignoring...");
+                        continue;
+                    }
+
+                    let sink = sink.as_mut().unwrap();
+                    let event_bytes = serde_json::to_vec(&event).map_err(err_str!(EventManagerError::Serialize))?;
+                    sink.write_all(&event_bytes).await.map_err(err_str!(EventManagerError::SocketWrite))?;
+                },
+
+                _ = self.cancel_channel.changed() => {
+                    info!("EventManager received cancel signal, shutting down...");
+                    return Err(EventManagerError::Cancelled("received cancel signal".to_string()));
+                }
+            }
+        }
+    }
+}

--- a/workers/event-manager/src/worker.rs
+++ b/workers/event-manager/src/worker.rs
@@ -1,0 +1,67 @@
+//! Defines the worker implementation for the event manager
+
+use std::thread::JoinHandle;
+
+use async_trait::async_trait;
+use common::{types::CancelChannel, worker::Worker};
+use job_types::event_manager::EventManagerReceiver;
+use libp2p::Multiaddr;
+
+use crate::error::EventManagerError;
+
+// ----------
+// | Config |
+// ----------
+
+/// The configuration for the event manager
+pub struct EventManagerConfig {
+    /// The address to export relayer events to
+    pub event_export_addr: Option<Multiaddr>,
+    /// The queue on which to receive events
+    pub event_queue: EventManagerReceiver,
+    /// The channel on which the coordinator may mandate that the
+    /// event manager cancel its execution
+    pub cancel_channel: CancelChannel,
+}
+
+// ----------
+// | Worker |
+// ----------
+
+/// The event manager worker
+pub struct EventManager {
+    /// The configuration for the event manager
+    pub config: EventManagerConfig,
+    /// The handle on the event manager
+    pub handle: Option<JoinHandle<EventManagerError>>,
+}
+
+#[async_trait]
+impl Worker for EventManager {
+    type WorkerConfig = EventManagerConfig;
+    type Error = EventManagerError;
+
+    async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
+        Ok(Self { config, handle: None })
+    }
+
+    fn name(&self) -> String {
+        "event-manager".to_string()
+    }
+
+    fn is_recoverable(&self) -> bool {
+        true
+    }
+
+    fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
+        vec![self.handle.take().unwrap()]
+    }
+
+    fn cleanup(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        todo!()
+    }
+}

--- a/workers/event-manager/src/worker.rs
+++ b/workers/event-manager/src/worker.rs
@@ -5,9 +5,9 @@ use std::thread::{Builder, JoinHandle};
 use async_trait::async_trait;
 use common::{types::CancelChannel, worker::Worker};
 use job_types::event_manager::EventManagerReceiver;
-use libp2p::Multiaddr;
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::info;
+use url::Url;
 use util::err_str;
 
 use crate::{
@@ -31,8 +31,8 @@ const EVENT_MANAGER_N_THREADS: usize = 1;
 
 /// The configuration for the event manager
 pub struct EventManagerConfig {
-    /// The address to export relayer events to
-    pub event_export_addr: Option<Multiaddr>,
+    /// The URL to export relayer events to
+    pub event_export_url: Option<Url>,
     /// The queue on which to receive events
     pub event_queue: EventManagerReceiver,
     /// The channel on which the coordinator may mandate that the

--- a/workers/event-manager/src/worker.rs
+++ b/workers/event-manager/src/worker.rs
@@ -54,7 +54,7 @@ impl Worker for EventManager {
     }
 
     fn join(&mut self) -> Vec<JoinHandle<Self::Error>> {
-        vec![self.handle.take().unwrap()]
+        vec![]
     }
 
     fn cleanup(&mut self) -> Result<(), Self::Error> {
@@ -62,6 +62,6 @@ impl Worker for EventManager {
     }
 
     fn start(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -24,6 +24,7 @@ util = { path = "../../util" }
 crossbeam = { workspace = true }
 tokio = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -1,4 +1,5 @@
-//! Type definitions for system events handled by the event manager.
+//! Job types for the event manager, representing system events to be received &
+//! exported by the event manager worker
 
 use std::time::SystemTime;
 
@@ -12,7 +13,27 @@ use common::types::{
     MatchingPoolName, TimestampedPrice,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as TokioSender};
+use util::metered_channels::MeteredTokioReceiver;
 use uuid::Uuid;
+
+// ---------------
+// | Queue Types |
+// ---------------
+
+/// The name of the event manager queue, used to label queue length metrics
+const EVENT_MANAGER_QUEUE_NAME: &str = "event_manager";
+
+/// The queue sender type to send events to the event manager
+pub type EventManagerQueue = TokioSender<RelayerEvent>;
+/// The queue receiver type to receive events in the event manager
+pub type EventManagerReceiver = MeteredTokioReceiver<RelayerEvent>;
+
+/// Create a new event manager queue and receiver
+pub fn new_event_manager_queue() -> (EventManagerQueue, EventManagerReceiver) {
+    let (send, recv) = unbounded_channel();
+    (send, MeteredTokioReceiver::new(recv, EVENT_MANAGER_QUEUE_NAME))
+}
 
 // ------------------------
 // | Top-level Event Enum |

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -238,6 +238,7 @@ pub struct MatchEvent {
 
 /// A convenience type encapsulating the event data for a single party in a
 /// match
+#[derive(Clone, Copy)]
 pub struct PartyMatchData {
     /// The ID of the party's wallet
     pub wallet_id: WalletIdentifier,

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -72,8 +72,8 @@ pub struct WalletCreationEvent {
 
     /// The ID of the wallet that was created
     pub wallet_id: WalletIdentifier,
-    /// The wallet's symmetric key, encrypted at rest and base64-encoded
-    pub encrypted_symmetric_key: String,
+    /// The wallet's symmetric key, base64-encoded
+    pub symmetric_key: String,
 }
 
 /// An external transfer event

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -166,10 +166,10 @@ pub struct MatchEvent {
     pub execution_price: TimestampedPrice,
     /// The match result
     pub match_result: MatchResult,
-    /// The fees paid on the base asset in this match
-    pub base_fee_take: FeeTake,
-    /// The fees paid on the quote asset in this match
-    pub quote_fee_take: FeeTake,
+    /// The fees paid by the first party in this match
+    pub fee_take0: FeeTake,
+    /// The fees paid by the second party in this match
+    pub fee_take1: FeeTake,
 }
 
 /// An external match event
@@ -188,8 +188,8 @@ pub struct ExternalMatchEvent {
     pub execution_price: TimestampedPrice,
     /// The external match result
     pub external_match_result: ExternalMatchResult,
-    /// The fees paid on the base asset in this match
-    pub base_fee_take: FeeTake,
-    /// The fees paid on the quote asset in this match
-    pub quote_fee_take: FeeTake,
+    /// The fees paid by the internal party
+    pub internal_fee_take: FeeTake,
+    /// The fees paid by the external party
+    pub external_fee_take: FeeTake,
 }

--- a/workers/job-types/src/lib.rs
+++ b/workers/job-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Groups worker job types to expose them as a third party crate to the workers
 
+pub mod event_manager;
 pub mod gossip_server;
 pub mod handshake_manager;
 pub mod network_manager;

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -18,6 +18,7 @@ use constants::Scalar;
 use ethers::{middleware::Middleware, types::Address};
 use eyre::Result;
 use job_types::{
+    event_manager::EventManagerQueue,
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
     task_driver::{new_task_notification, TaskDriverJob, TaskDriverQueue, TaskDriverReceiver},
@@ -215,6 +216,7 @@ pub fn new_mock_task_driver(
     arbitrum_client: ArbitrumClient,
     network_queue: NetworkManagerQueue,
     proof_queue: ProofManagerQueue,
+    event_queue: EventManagerQueue,
     state: State,
 ) {
     let bus = SystemBus::new();
@@ -234,6 +236,7 @@ pub fn new_mock_task_driver(
         arbitrum_client,
         network_queue,
         proof_queue,
+        event_queue,
         state,
     };
 

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -103,6 +103,7 @@ impl TaskExecutor {
             arbitrum_client: config.arbitrum_client,
             network_queue: config.network_queue,
             proof_queue: config.proof_queue,
+            event_queue: config.event_queue,
             task_queue: config.task_queue_sender,
             state: config.state,
             bus: config.system_bus.clone(),

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -10,7 +10,6 @@
 use core::panic;
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::time::SystemTime;
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
@@ -30,7 +29,6 @@ use state::error::StateError;
 use state::State;
 use tracing::instrument;
 use util::err_str;
-use uuid::Uuid;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Task, TaskContext, TaskError, TaskState};
@@ -313,12 +311,10 @@ impl NewWalletTask {
 
     /// Emit a wallet creation event to the event manager
     fn emit_event(&self) -> Result<(), NewWalletTaskError> {
-        let event = RelayerEvent::WalletCreation(WalletCreationEvent {
-            event_id: Uuid::new_v4(),
-            event_timestamp: SystemTime::now(),
-            wallet_id: self.wallet.wallet_id,
-            symmetric_key: self.wallet.key_chain.symmetric_key().to_base64_string(),
-        });
+        let event = RelayerEvent::WalletCreation(WalletCreationEvent::new(
+            self.wallet.wallet_id,
+            self.wallet.key_chain.symmetric_key().to_base64_string(),
+        ));
 
         self.event_queue.send(event).map_err(err_str!(NewWalletTaskError::SendMessage))
     }

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
@@ -26,7 +26,9 @@ use common::types::tasks::SettleExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use common::types::TimestampedPrice;
 use external_api::bus_message::SystemBusMessage;
-use job_types::event_manager::{EventManagerQueue, ExternalMatchEvent, RelayerEvent};
+use job_types::event_manager::{
+    EventManagerQueue, ExternalMatchEvent, PartyMatchData, RelayerEvent,
+};
 use job_types::proof_manager::{ProofJob, ProofManagerQueue};
 use serde::Serialize;
 use state::error::StateError;
@@ -35,7 +37,6 @@ use system_bus::SystemBus;
 use tracing::{info, instrument, warn};
 use util::arbitrum::get_protocol_fee;
 use util::matching_engine::{apply_match_to_shares, compute_fee_obligation};
-use uuid::Uuid;
 
 use super::ERR_NO_VALIDITY_PROOF;
 
@@ -514,9 +515,15 @@ impl SettleMatchExternalTask {
         let commitments_witness = &self.internal_order_validity_witness.commitment_witness;
         let internal_party_order_side = commitments_witness.order.side;
         let relayer_fee = commitments_witness.relayer_fee;
-
         let internal_fee_take =
             compute_fee_obligation(relayer_fee, internal_party_order_side, &self.match_res);
+
+        let internal_party_data = PartyMatchData {
+            wallet_id: self.internal_wallet_id,
+            order_id: self.internal_order_id,
+            fee_take: internal_fee_take,
+        };
+
         let external_fee_take = compute_fee_obligation(
             FixedPoint::default(),
             internal_party_order_side.opposite(),
@@ -525,16 +532,12 @@ impl SettleMatchExternalTask {
 
         let external_match_result = self.match_res.clone().into();
 
-        let event = RelayerEvent::ExternalMatch(ExternalMatchEvent {
-            event_id: Uuid::new_v4(),
-            event_timestamp: SystemTime::now(),
-            internal_wallet_id: self.internal_wallet_id,
-            internal_order_id: self.internal_order_id,
-            execution_price: self.execution_price,
-            external_match_result,
-            internal_fee_take,
+        let event = RelayerEvent::ExternalMatch(ExternalMatchEvent::new(
+            internal_party_data,
             external_fee_take,
-        });
+            self.execution_price,
+            external_match_result,
+        ));
 
         self.event_queue.send(event).map_err(SettleMatchExternalTaskError::send_event)
     }

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -6,8 +6,8 @@ use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
-    network_manager::NetworkManagerQueue, proof_manager::ProofManagerQueue,
-    task_driver::TaskDriverQueue,
+    event_manager::EventManagerQueue, network_manager::NetworkManagerQueue,
+    proof_manager::ProofManagerQueue, task_driver::TaskDriverQueue,
 };
 use serde::{Deserialize, Serialize};
 use state::State;
@@ -111,6 +111,8 @@ pub struct TaskContext {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's queue
     pub proof_queue: ProofManagerQueue,
+    /// A sender to the event manager's queue
+    pub event_queue: EventManagerQueue,
     /// A sender back to the task driver's queue
     pub task_queue: TaskDriverQueue,
     /// A handle on the system bus

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -15,6 +15,10 @@ pub async fn transition_order_settling(
     order_id: OrderIdentifier,
     state: &State,
 ) -> Result<(), String> {
+    if !state.historical_state_enabled().await? {
+        return Ok(());
+    }
+
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;
     metadata.state = OrderState::SettlingMatch;
@@ -30,6 +34,10 @@ pub async fn record_order_fill(
     price: TimestampedPrice,
     state: &State,
 ) -> Result<(), String> {
+    if !state.historical_state_enabled().await? {
+        return Ok(());
+    }
+
     // Get the order metadata
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;

--- a/workers/task-driver/src/worker.rs
+++ b/workers/task-driver/src/worker.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use common::{default_wrapper::DefaultOption, worker::Worker};
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
+    event_manager::EventManagerQueue,
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
     task_driver::{TaskDriverQueue, TaskDriverReceiver},
@@ -39,6 +40,8 @@ pub struct TaskDriverConfig {
     pub network_queue: NetworkManagerQueue,
     /// A sender to the proof manager's work queue
     pub proof_queue: ProofManagerQueue,
+    /// A sender to the event manager's work queue
+    pub event_queue: EventManagerQueue,
     /// The system bus to publish task updates onto
     pub system_bus: SystemBus<SystemBusMessage>,
     /// A handle on the global state
@@ -47,12 +50,14 @@ pub struct TaskDriverConfig {
 
 impl TaskDriverConfig {
     /// Create a new config with default values
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_queue: TaskDriverReceiver,
         task_queue_sender: TaskDriverQueue,
         arbitrum_client: ArbitrumClient,
         network_queue: NetworkManagerQueue,
         proof_queue: ProofManagerQueue,
+        event_queue: EventManagerQueue,
         system_bus: SystemBus<SystemBusMessage>,
         state: State,
     ) -> Self {
@@ -63,6 +68,7 @@ impl TaskDriverConfig {
             arbitrum_client,
             network_queue,
             proof_queue,
+            event_queue,
             system_bus,
             state,
         }


### PR DESCRIPTION
This PR is the culmination of all of the event manager changes thus far. With this, we will be double-writing historical state both locally to the relayer (as we currently do), and to the durable historical state engine.

All of the commits on this branch have been independently reviewed.