### PR TITLE
external-api: network-info: Mark raft leader as such

### DIFF
--- a/external-api/src/types/api_network_info.rs
+++ b/external-api/src/types/api_network_info.rs
@@ -48,6 +48,12 @@ pub struct Peer {
     pub cluster_id: String,
     /// The dialable, libp2p address of the peer
     pub addr: String,
+    /// Whether or not the peer is believed to be the raft leader for its
+    /// cluster
+    ///
+    /// For remote clusters, this will always be false, as a local peer will not
+    /// generally have visibility into remote raft state
+    pub is_leader: bool,
 }
 
 impl From<IndexedPeerInfo> for Peer {
@@ -56,6 +62,7 @@ impl From<IndexedPeerInfo> for Peer {
             id: peer_info.get_peer_id().to_string(),
             cluster_id: peer_info.get_cluster_id().to_string(),
             addr: peer_info.get_addr().to_string(),
+            is_leader: false,
         }
     }
 }

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -67,6 +67,18 @@ impl TypedHandler for GetNetworkTopologyHandler {
             peers_by_cluster.entry(peer.cluster_id.clone()).or_default().push(peer);
         }
 
+        // Mark the local cluster's leader as such
+        if let Some(leader_id) = self.state.get_leader()
+            && let Some(peers) = peers_by_cluster.get_mut(&local_cluster_id)
+        {
+            let leader_str = leader_id.to_string();
+            peers.iter_mut().for_each(|peer| {
+                if peer.id == leader_str {
+                    peer.is_leader = true;
+                }
+            });
+        }
+
         // Reformat into response
         Ok(GetNetworkTopologyResponse { local_cluster_id, network: peers_by_cluster.into() })
     }


### PR DESCRIPTION
### Purpose
This PR add an `is_leader` field to the network topology API response. This allows consumers to direct requests to the leader. Internally, we will use this functionality to request a snapshot from the leader when a cluster upgrade begins.

### Testing
- [x] Tested locally
- [ ] Tested in testnet