### PR TITLE
api-server: external-match: Allow order amounts to change in assemble

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -87,6 +87,9 @@ pub struct AssembleExternalMatchRequest {
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,
+    /// The updated order if any changes have been made
+    #[serde(default)]
+    pub updated_order: Option<ExternalOrder>,
     /// The signed quote
     pub signed_quote: SignedExternalQuote,
 }


### PR DESCRIPTION
### Purpose
This PR allows an external order to update in between quote and assembly. Updates are allowed on the following fields:
- `base_amount`: To facilitate base denominated updates
- `quote_amount`: To facilitate quote denominated updates
- `min_fill_size`: To adjust the minimum fill in accordance with the base/quote update
This allows e.g. solvers to tweak a quote after assembling a route while being guaranteed a firm price.

### Testing
- [ ] Testing in testnet