### PR TITLE
state: caching: order-metadata-index: Build order metadata index

### DIFF
--- a/circuit-types/src/order.rs
+++ b/circuit-types/src/order.rs
@@ -84,7 +84,7 @@ impl Order {
 }
 
 /// The side of the market a given order is on
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum OrderSide {
     /// Buy side
     #[default]

--- a/common/src/types/wallet/mod.rs
+++ b/common/src/types/wallet/mod.rs
@@ -13,7 +13,7 @@ mod orders;
 mod shares;
 mod types;
 
-pub use orders::{Order, OrderBuilder};
+pub use orders::{pair_from_mints, Order, OrderBuilder, Pair};
 pub use types::*;
 
 // ----------------

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -5,7 +5,7 @@ use circuit_types::{
     fixed_point::FixedPoint,
     max_price,
     order::{Order as CircuitOrder, OrderSide},
-    validate_amount_bitlength, validate_price_bitlength, Amount,
+    validate_amount_bitlength, validate_price_bitlength, Address, Amount,
 };
 use constants::MAX_ORDERS;
 use itertools::Itertools;
@@ -22,6 +22,16 @@ const ERR_ORDERS_FULL: &str = "orders full";
 const ERR_ORDER_AMOUNT_TOO_LARGE: &str = "amount is too large";
 /// Error message when an order worst case price is too large
 const ERR_ORDER_WORST_CASE_PRICE_TOO_LARGE: &str = "worst case price is too large";
+
+/// A type alias for a pair of tokens
+///
+/// Format is (base, quote)
+pub type Pair = (Address, Address);
+
+/// A method to construct a pair from mints
+pub fn pair_from_mints(base_mint: Address, quote_mint: Address) -> Pair {
+    (base_mint, quote_mint)
+}
 
 // --------------
 // | Order Type |
@@ -177,9 +187,14 @@ impl Order {
         }
     }
 
+    /// Get the pair of the order
+    pub fn pair(&self) -> Pair {
+        pair_from_mints(self.base_mint.clone(), self.quote_mint.clone())
+    }
+
     /// Get the pair and side of the order
-    pub fn pair_and_side(&self) -> (BigUint, BigUint, OrderSide) {
-        (self.base_mint.clone(), self.quote_mint.clone(), self.side)
+    pub fn pair_and_side(&self) -> (Pair, OrderSide) {
+        (self.pair(), self.side)
     }
 
     /// Determines whether the given price is within the allowable range for the

--- a/state/src/caching/mod.rs
+++ b/state/src/caching/mod.rs
@@ -1,3 +1,13 @@
 //! Caching mechanisms for the relayer state
 
+use std::collections::{HashMap, HashSet};
+
+use tokio::sync::RwLock;
+
 pub mod order_cache;
+pub mod order_metadata_index;
+
+/// A type alias for a rwlock-ed hashset
+pub(crate) type RwLockHashSet<T> = RwLock<HashSet<T>>;
+/// A type alias for a rwlock-ed hashmap
+pub(crate) type RwLockHashMap<K, V> = RwLock<HashMap<K, V>>;

--- a/state/src/caching/order_cache.rs
+++ b/state/src/caching/order_cache.rs
@@ -10,17 +10,19 @@ use tokio::sync::RwLock;
 
 use crate::storage::{db::DB, error::StorageError};
 
+use super::RwLockHashSet;
+
 /// The order book cache
 #[derive(Default)]
 pub struct OrderBookCache {
     /// The set of open orders which are matchable and locally managed
-    matchable_orders: RwLock<HashSet<OrderIdentifier>>,
+    matchable_orders: RwLockHashSet<OrderIdentifier>,
     /// The set of local orders which have external matches enabled
     ///
     /// This may not be a subset of `matchable_orders`, some externally
     /// matchable orders may not be yet matchable, e.g. if they are waiting for
     /// validity proofs
-    externally_enabled_orders: RwLock<HashSet<OrderIdentifier>>,
+    externally_enabled_orders: RwLockHashSet<OrderIdentifier>,
 }
 
 impl OrderBookCache {

--- a/state/src/caching/order_metadata_index.rs
+++ b/state/src/caching/order_metadata_index.rs
@@ -1,0 +1,262 @@
+//! Indexing of orders by metadata
+//!
+//! Specifically, we build an efficiently queryable mapping from pair -> side ->
+//! (matchable_amount, order_id)
+//!
+//! This allows the matching engine to efficiently query a narrow set of
+//! candidate orders to match against a target order.
+
+use std::collections::HashMap;
+
+use circuit_types::{order::OrderSide, Amount};
+use common::types::wallet::{Order, OrderIdentifier, Pair};
+use tokio::sync::RwLock;
+
+use super::RwLockHashMap;
+
+/// A type alias for a the inner index mapping
+type OrderSideIndex = HashMap<OrderSide, SortedVec<(Amount, OrderIdentifier)>>;
+
+/// The order metadata index
+#[derive(Default)]
+pub struct OrderMetadataIndex {
+    /// The mapping from pair -> side -> (matchable_amount, order_id)
+    index: RwLockHashMap<Pair, OrderSideIndex>,
+}
+
+impl OrderMetadataIndex {
+    /// Construct a new order metadata index
+    pub fn new() -> Self {
+        let index = RwLock::new(HashMap::new());
+        Self { index }
+    }
+
+    // --- Getters --- //
+
+    /// Get all orders for a given pair and side, sorted by matchable amount
+    pub async fn get_orders(&self, pair: &Pair, side: OrderSide) -> Vec<OrderIdentifier> {
+        let index = self.index.read().await;
+        let orders_vec = index.get(pair).and_then(|side_index| side_index.get(&side));
+        match orders_vec {
+            Some(v) => v.iter().map(|(_, oid)| *oid).collect(),
+            None => Vec::new(),
+        }
+    }
+
+    // --- Setters --- //
+
+    /// Add an order to the index
+    pub async fn add_order(
+        &self,
+        order_id: OrderIdentifier,
+        order: &Order,
+        matchable_amount: Amount,
+    ) {
+        let (pair, side) = order.pair_and_side();
+        let mut index = self.index.write().await;
+        let entry = index.entry(pair).or_insert_with(OrderSideIndex::new);
+        entry.entry(side).or_insert_with(SortedVec::new).insert((matchable_amount, order_id));
+    }
+}
+
+/// A vector that is kept sorted on insert
+struct SortedVec<T> {
+    /// The inner vector
+    vec: Vec<T>,
+}
+
+impl<T: Ord> SortedVec<T> {
+    /// Construct a new sorted vector
+    pub fn new() -> Self {
+        Self { vec: Vec::new() }
+    }
+
+    // --- Getters --- //
+
+    /// Get the vector
+    #[allow(unused)]
+    pub fn vec(&self) -> &Vec<T> {
+        &self.vec
+    }
+
+    /// Iterate over the vector
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.vec.iter()
+    }
+
+    // --- Setters --- //
+
+    /// Insert an element into the vector
+    pub fn insert(&mut self, element: T) {
+        // For descending order, we want to insert after all elements that are greater
+        // than or equal to the current element
+        // The `binary_search_by` returns the index at which the element can be found,
+        // or an `Err` containing the index at which the element should be inserted
+        let index = match self.vec.binary_search_by(|probe| element.cmp(probe)) {
+            Ok(i) => i,
+            Err(i) => i,
+        };
+        self.vec.insert(index, element);
+    }
+}
+
+#[cfg(test)]
+mod sorted_vec_tests {
+    use super::*;
+    use rand::{seq::SliceRandom, thread_rng, Rng};
+
+    #[test]
+    fn test_sorted_vec_empty() {
+        let vec: SortedVec<i32> = SortedVec::new();
+        assert!(vec.vec().is_empty());
+    }
+
+    #[test]
+    fn test_sorted_vec_basic() {
+        let mut vec = SortedVec::new();
+        vec.insert(3);
+        vec.insert(1);
+        vec.insert(4);
+        vec.insert(2);
+
+        assert_eq!(vec.vec(), &[4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn test_sorted_vec_duplicates() {
+        let mut vec = SortedVec::new();
+        vec.insert(2);
+        vec.insert(2);
+        vec.insert(2);
+        vec.insert(1);
+        vec.insert(1);
+
+        assert_eq!(vec.vec(), &[2, 2, 2, 1, 1]);
+    }
+
+    #[test]
+    fn test_sorted_vec_single_element() {
+        let mut vec = SortedVec::new();
+        vec.insert(1);
+        assert_eq!(vec.vec(), &[1]);
+    }
+
+    #[test]
+    fn test_sorted_vec_fuzz() {
+        // Create a vector of 100 random numbers
+        let mut rng = thread_rng();
+        let mut numbers: Vec<i32> = (0..100).map(|_| rng.gen_range(-1000..1000)).collect();
+
+        // Insert them into SortedVec
+        let mut sorted_vec = SortedVec::new();
+        for &n in &numbers {
+            sorted_vec.insert(n);
+        }
+
+        // Sort the original vector in descending order for comparison
+        numbers.sort();
+        numbers.reverse();
+        assert_eq!(sorted_vec.vec(), &numbers);
+    }
+
+    #[test]
+    fn test_sorted_vec_random_order() {
+        let mut vec = SortedVec::new();
+        let mut numbers: Vec<i32> = (1..=10).collect();
+        numbers.shuffle(&mut thread_rng());
+
+        // Insert in random order
+        for n in numbers {
+            vec.insert(n);
+        }
+
+        // Should be sorted in descending order
+        assert_eq!(vec.vec(), &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+}
+
+#[cfg(test)]
+mod order_index_tests {
+    use super::*;
+    use circuit_types::Address;
+    use common::types::wallet_mocks::mock_order;
+
+    #[tokio::test]
+    async fn test_empty_index() {
+        let index = OrderMetadataIndex::new();
+        let base = Address::from(1u8);
+        let quote = Address::from(2u8);
+        let pair = (base, quote);
+        let orders = index.get_orders(&pair, OrderSide::Buy).await;
+        assert!(orders.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_add_and_get_single_order() {
+        let index = OrderMetadataIndex::new();
+        let order_id = OrderIdentifier::new_v4();
+        let order = mock_order();
+        let pair = order.pair();
+
+        let fillable_amount = 100;
+        index.add_order(order_id, &order, fillable_amount).await;
+        let orders = index.get_orders(&pair, OrderSide::Buy).await;
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0], order_id);
+    }
+
+    #[tokio::test]
+    async fn test_orders_sorted_by_amount() {
+        let index = OrderMetadataIndex::new();
+        let order = mock_order();
+        let pair = order.pair();
+
+        // Add orders with different matchable amounts
+        let order_id1 = OrderIdentifier::new_v4();
+        let order_id2 = OrderIdentifier::new_v4();
+        let order_id3 = OrderIdentifier::new_v4();
+        let order_id4 = OrderIdentifier::new_v4();
+
+        index.add_order(order_id1, &order, 300).await;
+        index.add_order(order_id2, &order, 100).await;
+        index.add_order(order_id3, &order, 200).await;
+        index.add_order(order_id4, &order, 400).await;
+
+        let orders = index.get_orders(&pair, OrderSide::Buy).await;
+        assert_eq!(orders.len(), 4);
+        assert_eq!(orders[0], order_id4); // 400
+        assert_eq!(orders[1], order_id1); // 300
+        assert_eq!(orders[2], order_id3); // 200
+        assert_eq!(orders[3], order_id2); // 100
+    }
+
+    #[tokio::test]
+    async fn test_different_pairs_and_sides() {
+        let index = OrderMetadataIndex::new();
+        let order1 = mock_order();
+        let mut order2 = mock_order();
+        order2.side = order1.side.opposite();
+        let pair1 = order1.pair();
+        let pair2 = order2.pair();
+
+        let order_id1 = OrderIdentifier::new_v4();
+        let order_id2 = OrderIdentifier::new_v4();
+        let order_id3 = OrderIdentifier::new_v4();
+        let order_id4 = OrderIdentifier::new_v4();
+
+        index.add_order(order_id1, &order1, 100).await;
+        index.add_order(order_id2, &order2, 200).await;
+        index.add_order(order_id3, &order1, 300).await;
+        index.add_order(order_id4, &order2, 400).await;
+
+        let orders1_correct_side = index.get_orders(&pair1, order1.side).await;
+        let orders1_incorrect_side = index.get_orders(&pair1, order1.side.opposite()).await;
+        let orders2_correct_side = index.get_orders(&pair2, order2.side).await;
+        let orders2_incorrect_side = index.get_orders(&pair2, order2.side.opposite()).await;
+
+        assert_eq!(orders1_correct_side.len(), 2);
+        assert!(orders1_incorrect_side.is_empty());
+        assert_eq!(orders2_correct_side.len(), 2);
+        assert!(orders2_incorrect_side.is_empty());
+    }
+}


### PR DESCRIPTION
### Purpose
This PR builds an `OrderMetadataIndex` that will operate as part of the order book cache. The metadata index allows us to query open orders by pair and side, sorted by matchable amount. This will allow for more efficient access in the matching engine and prevent small fills when a larger fill is possible.

### Testing
- [x] Unit tests pass
- Will test in a follow-up when the cache is integrated with the state and matching engine