### PR TITLE
workers: job-types, state: applicator: emit task completion events

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -116,6 +116,7 @@ async fn main() -> Result<(), CoordinatorError> {
         network_sender.clone(),
         task_sender.clone(),
         handshake_worker_sender.clone(),
+        event_manager_sender.clone(),
         system_bus.clone(),
         &system_clock,
         state_failure_send,

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -271,6 +271,7 @@ impl MockNodeController {
         let network_queue = self.network_queue.0.clone();
         let task_sender = self.task_queue.0.clone();
         let handshake_queue = self.handshake_queue.0.clone();
+        let event_queue = self.event_queue.0.clone();
         let bus = self.bus.clone();
         let clock = self.clock.clone();
         let (failure_send, failure_recv) = new_worker_failure_channel();
@@ -280,6 +281,7 @@ impl MockNodeController {
             network_queue,
             task_sender,
             handshake_queue,
+            event_queue,
             bus,
             &clock,
             failure_send,

--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use common::types::gossip::ClusterId;
 use external_api::bus_message::SystemBusMessage;
-use job_types::{handshake_manager::HandshakeManagerQueue, task_driver::TaskDriverQueue};
+use job_types::{
+    event_manager::EventManagerQueue, handshake_manager::HandshakeManagerQueue,
+    task_driver::TaskDriverQueue,
+};
 use system_bus::SystemBus;
 
 use crate::{caching::order_cache::OrderBookCache, storage::db::DB, StateTransition};
@@ -43,6 +46,8 @@ pub struct StateApplicatorConfig {
     pub task_queue: TaskDriverQueue,
     /// The handshake manager's work queue
     pub handshake_manager_queue: HandshakeManagerQueue,
+    /// The event manager's work queue
+    pub event_queue: EventManagerQueue,
     /// The order book cache
     pub order_cache: Arc<OrderBookCache>,
     /// A handle to the database underlying the storage layer
@@ -137,6 +142,7 @@ pub mod test_helpers {
 
     use common::types::gossip::ClusterId;
     use job_types::{
+        event_manager::new_event_manager_queue,
         handshake_manager::new_handshake_manager_queue,
         task_driver::{new_task_driver_queue, TaskDriverQueue},
     };
@@ -159,12 +165,16 @@ pub mod test_helpers {
         let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
         mem::forget(_recv);
 
+        let (event_queue, _recv) = new_event_manager_queue();
+        mem::forget(_recv);
+
         let config = StateApplicatorConfig {
             allow_local: true,
             task_queue,
             order_cache: Arc::new(OrderBookCache::new()),
             db: Arc::new(mock_db()),
             handshake_manager_queue,
+            event_queue,
             system_bus: SystemBus::new(),
             cluster_id: ClusterId::from_str("test-cluster").unwrap(),
         };

--- a/state/src/interface/mod.rs
+++ b/state/src/interface/mod.rs
@@ -19,8 +19,8 @@ use config::RelayerConfig;
 use crossbeam::channel::Sender as UnboundedSender;
 use external_api::bus_message::SystemBusMessage;
 use job_types::{
-    handshake_manager::HandshakeManagerQueue, network_manager::NetworkManagerQueue,
-    task_driver::TaskDriverQueue,
+    event_manager::EventManagerQueue, handshake_manager::HandshakeManagerQueue,
+    network_manager::NetworkManagerQueue, task_driver::TaskDriverQueue,
 };
 use libmdbx::{RO, RW};
 use system_bus::SystemBus;
@@ -72,11 +72,13 @@ pub type ProposalQueue = UnboundedSender<Proposal>;
 pub type State = Arc<StateInner>;
 
 /// Create a new state instance and wrap it in an `Arc`
+#[allow(clippy::too_many_arguments)]
 pub async fn create_global_state(
     config: &RelayerConfig,
     network_queue: NetworkManagerQueue,
     task_queue: TaskDriverQueue,
     handshake_manager_queue: HandshakeManagerQueue,
+    event_queue: EventManagerQueue,
     system_bus: SystemBus<SystemBusMessage>,
     system_clock: &SystemClock,
     failure_send: WorkerFailureSender,
@@ -86,6 +88,7 @@ pub async fn create_global_state(
         network_queue,
         task_queue,
         handshake_manager_queue,
+        event_queue,
         system_bus,
         system_clock,
         failure_send,
@@ -133,11 +136,13 @@ impl StateInner {
     // ----------------
 
     /// Construct a new default state handle using the `GossipNetwork`
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         config: &RelayerConfig,
         network_queue: NetworkManagerQueue,
         task_queue: TaskDriverQueue,
         handshake_manager_queue: HandshakeManagerQueue,
+        event_queue: EventManagerQueue,
         system_bus: SystemBus<SystemBusMessage>,
         system_clock: &SystemClock,
         failure_send: WorkerFailureSender,
@@ -150,6 +155,7 @@ impl StateInner {
             net,
             task_queue,
             handshake_manager_queue,
+            event_queue,
             system_bus,
             system_clock,
             failure_send,
@@ -165,6 +171,7 @@ impl StateInner {
         network: N,
         task_queue: TaskDriverQueue,
         handshake_manager_queue: HandshakeManagerQueue,
+        event_queue: EventManagerQueue,
         system_bus: SystemBus<SystemBusMessage>,
         system_clock: &SystemClock,
         failure_send: WorkerFailureSender,
@@ -186,6 +193,7 @@ impl StateInner {
             cluster_id: relayer_config.cluster_id.clone(),
             task_queue,
             handshake_manager_queue,
+            event_queue,
             order_cache: order_cache.clone(),
             db: db.clone(),
             system_bus: system_bus.clone(),

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -225,6 +225,7 @@ pub mod test_helpers {
     use common::worker::new_worker_failure_channel;
     use config::RelayerConfig;
     use job_types::{
+        event_manager::new_event_manager_queue,
         handshake_manager::new_handshake_manager_queue,
         task_driver::{new_task_driver_queue, TaskDriverQueue},
     };
@@ -323,6 +324,7 @@ pub mod test_helpers {
             MockRaft::create_raft(2 /* n_nodes */, network_delay_ms, false /* init */).await;
         let net = raft.new_network_client();
         let (handshake_manager_queue, _recv) = new_handshake_manager_queue();
+        let (event_queue, _recv) = new_event_manager_queue();
         let (failure_send, _failure_recv) = new_worker_failure_channel();
 
         // Add a client to the mock raft as leader
@@ -333,6 +335,7 @@ pub mod test_helpers {
             net,
             task_queue,
             handshake_manager_queue,
+            event_queue,
             SystemBus::new(),
             &SystemClock::new().await,
             failure_send,


### PR DESCRIPTION
This PR introduces a `TaskCompletion` event type, representing the completion of a task (successful or not). This will be used to index task history, and as such it is basically a wrapper around the `HistoricalTask` type. This event gets emitted in the state applicator in the same code path where we record historical tasks. As such, we check that the local peer is the executor of the task before emitting the event, to prevent duplicate event emission across the cluster.

### Testing
- [x] All unit tests pass (though, with that said, it looks like the new order metadata index tests put each other in deadlock)
- [x] Tested w/ local relayer & event export sidecar, manually inspected events received in SQS to ensure there were no issues in transmission