### PR TITLE
state: interface: Use new order book cache in interface methods

### DIFF
--- a/common/src/types/wallet/balances.rs
+++ b/common/src/types/wallet/balances.rs
@@ -74,6 +74,15 @@ impl Wallet {
         Some(balance)
     }
 
+    /// Get the matchable amount for a given order, in terms of the order's
+    /// sell asset
+    pub fn get_matchable_amount_for_order(&self, order: &Order) -> Amount {
+        let order_mint = order.send_mint();
+        let amount = self.get_balance(order_mint).map(|b| b.amount).unwrap_or_default();
+
+        amount
+    }
+
     /// Return whether the wallet has any fees to pay
     pub fn has_outstanding_fees(&self) -> bool {
         self.balances.values().any(|balance| balance.fees().total() > 0)

--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -30,6 +30,14 @@ pub enum StateApplicatorError {
     QueuePaused(WalletIdentifier),
 }
 
+impl StateApplicatorError {
+    /// Build a rejection message
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn reject<T: ToString>(msg: T) -> Self {
+        Self::Rejected(msg.to_string())
+    }
+}
+
 impl Display for StateApplicatorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")

--- a/state/src/applicator/matching_pools.rs
+++ b/state/src/applicator/matching_pools.rs
@@ -17,7 +17,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
 
         if tx.matching_pool_exists(pool_name)? {
-            return Err(StateApplicatorError::Rejected(MATCHING_POOL_EXISTS_ERR.to_string()));
+            return Err(StateApplicatorError::reject(MATCHING_POOL_EXISTS_ERR));
         }
 
         tx.create_matching_pool(pool_name)?;
@@ -34,9 +34,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
 
         if !tx.matching_pool_exists(pool_name)? {
-            return Err(StateApplicatorError::Rejected(
-                MATCHING_POOL_DOES_NOT_EXIST_ERR.to_string(),
-            ));
+            return Err(StateApplicatorError::reject(MATCHING_POOL_DOES_NOT_EXIST_ERR));
         }
 
         tx.destroy_matching_pool(pool_name)?;

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -131,18 +131,18 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
         let key = tx
             .get_queue_key_for_task(&task_id)?
-            .ok_or_else(|| StateApplicatorError::Rejected(invalid_task_id(task_id)))?;
+            .ok_or_else(|| StateApplicatorError::reject(invalid_task_id(task_id)))?;
 
         // If the task being popped is not at the top of the queue, reject the
         // transition
         let queued_tasks = tx.get_queued_tasks(&key)?;
         let top_of_queue = queued_tasks.first();
         if top_of_queue.is_none() || top_of_queue.unwrap().id != task_id {
-            return Err(StateApplicatorError::Rejected(task_not_in_queue(task_id, key)));
+            return Err(StateApplicatorError::reject(task_not_in_queue(task_id, key)));
         }
 
         if tx.is_queue_paused(&key)? {
-            return Err(StateApplicatorError::Rejected(queue_paused(key)));
+            return Err(StateApplicatorError::reject(queue_paused(key)));
         }
 
         // Pop the task from the queue, remove its assignment, and add it to history
@@ -191,7 +191,7 @@ impl StateApplicator {
         let tx = self.db().new_write_tx()?;
         let key = tx
             .get_queue_key_for_task(&task_id)?
-            .ok_or_else(|| StateApplicatorError::Rejected(invalid_task_id(task_id)))?;
+            .ok_or_else(|| StateApplicatorError::reject(invalid_task_id(task_id)))?;
 
         // If the top task on the queue is not the same as the one being transitioned,
         // reject the transition
@@ -200,11 +200,11 @@ impl StateApplicator {
         if let Some(top_task) = top_task
             && top_task.id != task_id
         {
-            return Err(StateApplicatorError::Rejected(task_not_running(task_id)));
+            return Err(StateApplicatorError::reject(task_not_running(task_id)));
         }
 
         if tx.is_queue_paused(&key)? {
-            return Err(StateApplicatorError::Rejected(already_paused(key)));
+            return Err(StateApplicatorError::reject(already_paused(key)));
         }
 
         tx.transition_task(&key, state)?;
@@ -264,7 +264,7 @@ impl StateApplicator {
             if task.state.is_committed() {
                 error!("cannot preempt committed task: {}", task.id);
                 let err_msg = already_committed(key);
-                return Err(StateApplicatorError::Rejected(err_msg));
+                return Err(StateApplicatorError::reject(err_msg));
             }
 
             // Otherwise transition the task to queued
@@ -275,7 +275,7 @@ impl StateApplicator {
         // If the queue is already paused, a preemptive task is already
         // running, with which we should not conflict
         if tx.is_queue_paused(&key)? {
-            return Err(StateApplicatorError::Rejected(already_paused(key)));
+            return Err(StateApplicatorError::reject(already_paused(key)));
         }
 
         // Pause the queue
@@ -409,7 +409,7 @@ impl StateApplicator {
             // error in the case described
             let queue_key = tx
                 .get_queue_key_for_task(&task_id)?
-                .ok_or_else(|| StateApplicatorError::Rejected(ERR_NO_KEY.to_string()))?;
+                .ok_or_else(|| StateApplicatorError::reject(ERR_NO_KEY.to_string()))?;
             tx.transition_task(&queue_key, new_running_state())?;
             self.maybe_start_task(&task, &tx)?;
         }

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -25,6 +25,7 @@ use tracing::instrument;
 use util::res_some;
 
 use crate::{
+    caching::order_cache::OrderBookFilter,
     error::StateError,
     notifications::ProposalWaiter,
     storage::{error::StorageError, tx::StateTxn},
@@ -183,72 +184,72 @@ impl StateInner {
         .await
     }
 
+    /// Get a list of matchable orders matching the given filter
+    #[instrument(name = "get_matchable_orders", skip_all, fields(filter = ?filter))]
+    pub async fn get_matchable_orders(
+        &self,
+        filter: OrderBookFilter,
+    ) -> Result<Vec<OrderIdentifier>, StateError> {
+        let candidates = self.order_cache.get_orders(filter).await;
+        self.filter_matchable_orders(candidates, None /* matching_pool */).await
+    }
+
     /// Get a list of order IDs that are locally managed and ready for match
     #[instrument(name = "get_locally_matchable_orders", skip_all)]
-    pub async fn get_locally_matchable_orders(&self) -> Result<Vec<OrderIdentifier>, StateError> {
-        todo!("Fix this method");
-        // let matchable_orders = self.order_cache.matchable_orders().await;
-        // self.with_read_tx(move |tx| {
-        //     let mut res = Vec::new();
-        //     for id in matchable_orders.into_iter() {
-        //         if Self::is_task_queue_free(&id, tx)? {
-        //             res.push(id);
-        //         }
-        //     }
-
-        //     Ok(res)
-        // })
-        // .await
+    pub async fn get_all_matchable_orders(&self) -> Result<Vec<OrderIdentifier>, StateError> {
+        let candidates = self.order_cache.get_all_orders().await;
+        self.filter_matchable_orders(candidates, None /* matching_pool */).await
     }
 
     /// Get a list of order IDs that are locally managed and ready for match in
     /// the given matching pool
-    #[instrument(name = "get_locally_matchable_orders_in_matching_pool", skip_all, fields(matching_pool = ?matching_pool))]
-    pub async fn get_locally_matchable_orders_in_matching_pool(
+    #[instrument(name = "get_matchable_orders_in_matching_pool", skip_all, fields(matching_pool = ?matching_pool))]
+    pub async fn get_matchable_orders_in_matching_pool(
+        &self,
+        matching_pool: MatchingPoolName,
+        filter: OrderBookFilter,
+    ) -> Result<Vec<OrderIdentifier>, StateError> {
+        let candidates = self.order_cache.get_orders(filter).await;
+        self.filter_matchable_orders(candidates, Some(matching_pool)).await
+    }
+
+    /// Get all order IDs in a given matching pool
+    #[instrument(name = "get_all_orders_in_matching_pool", skip_all, fields(matching_pool = ?matching_pool))]
+    pub async fn get_all_orders_in_matching_pool(
         &self,
         matching_pool: MatchingPoolName,
     ) -> Result<Vec<OrderIdentifier>, StateError> {
-        todo!("Fix this method");
-        // let matchable_orders = self.order_cache.matchable_orders().await;
-        // self.with_read_tx(move |tx| {
-        //     let mut res = Vec::new();
-        //     for id in matchable_orders.into_iter() {
-        //         let order_matching_pool =
-        // tx.get_matching_pool_for_order(&id)?;         if
-        // order_matching_pool != matching_pool {             continue;
-        //         }
-
-        //         if Self::is_task_queue_free(&id, tx)? {
-        //             res.push(id);
-        //         }
-        //     }
-
-        //     Ok(res)
-        // })
-        // .await
+        let candidates = self.order_cache.get_all_orders().await;
+        self.filter_matchable_orders(candidates, Some(matching_pool)).await
     }
 
-    /// Get the set of orders that are ready for a match and allow external
-    /// matches
-    #[instrument(name = "get_externally_matchable_orders", skip_all)]
-    pub async fn get_externally_matchable_orders(
+    /// Filter a set of matchable orders candidates
+    ///
+    /// Provides two checks:
+    /// - Filters out orders with non-empty task queues
+    /// - Filters out orders in incorrect matching pools
+    async fn filter_matchable_orders(
         &self,
+        orders: Vec<OrderIdentifier>,
+        matching_pool: Option<MatchingPoolName>,
     ) -> Result<Vec<OrderIdentifier>, StateError> {
-        todo!("Fix this method");
-        // let externally_matchable_orders =
-        // self.order_cache.externally_matchable_orders().await;
-        // self.with_read_tx(move |tx| {
-        //     let mut orders = Vec::new();
-        //     for id in externally_matchable_orders.into_iter() {
-        //         // Check that the task queue is free
-        //         if Self::is_task_queue_free(&id, tx)? {
-        //             orders.push(id);
-        //         }
-        //     }
+        self.with_read_tx(move |tx| {
+            let mut res = Vec::new();
+            for id in orders.into_iter() {
+                if let Some(ref pool) = matching_pool {
+                    let order_matching_pool = tx.get_matching_pool_for_order(&id)?;
+                    if order_matching_pool != *pool {
+                        continue;
+                    }
+                }
 
-        //     Ok(orders)
-        // })
-        // .await
+                if Self::is_task_queue_free(&id, tx)? {
+                    res.push(id);
+                }
+            }
+            Ok(res)
+        })
+        .await
     }
 
     /// Choose an order to handshake with according to their priorities

--- a/state/src/replication/error.rs
+++ b/state/src/replication/error.rs
@@ -55,8 +55,6 @@ pub fn new_network_error(err: ReplicationV2Error) -> RPCError<NodeId, Node, Raft
 }
 
 /// The error type emitted by the replication interface
-///
-/// TODO: Rename
 #[derive(Debug)]
 pub enum ReplicationV2Error {
     /// An error deserializing a raft response

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -169,9 +169,9 @@ impl TypedHandler for AdminOpenOrdersHandler {
                     return Err(not_found(ERR_NO_MATCHING_POOL));
                 }
 
-                self.state.get_locally_matchable_orders_in_matching_pool(matching_pool).await?
+                self.state.get_all_orders_in_matching_pool(matching_pool).await?
             } else {
-                self.state.get_locally_matchable_orders().await?
+                self.state.get_all_matchable_orders().await?
             };
 
         Ok(OpenOrdersResponse { orders: order_ids })

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -384,7 +384,7 @@ impl HandshakeExecutor {
         let locked_handshake_cache = self.handshake_cache.read().await;
 
         // Shuffle the locally managed orders to avoid always matching the same order
-        let mut local_verified_orders = self.state.get_locally_matchable_orders().await.ok()?;
+        let mut local_verified_orders = self.state.get_all_matchable_orders().await.ok()?;
         let mut rng = thread_rng();
         local_verified_orders.shuffle(&mut rng);
 

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -29,6 +29,8 @@ use util::err_str;
 
 use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
 
+use super::matching_order_filter;
+
 impl HandshakeExecutor {
     /// Encapsulates the logic for the external matching engine in an error
     /// handler
@@ -85,7 +87,7 @@ impl HandshakeExecutor {
         );
 
         // Get all orders that consent to external matching
-        let mut matchable_orders = self.get_external_match_candidates().await?;
+        let mut matchable_orders = self.get_external_match_candidates(&order).await?;
         let price = ts_price.as_fixed_point();
 
         // Mock a balance for the external order, assuming it's fully capitalized
@@ -156,8 +158,10 @@ impl HandshakeExecutor {
     /// Get the match candidates for an external order
     async fn get_external_match_candidates(
         &self,
+        order: &Order,
     ) -> Result<HashSet<OrderIdentifier>, HandshakeManagerError> {
-        let matchable_orders = self.state.get_externally_matchable_orders().await?;
+        let filter = matching_order_filter(order, true /* external */);
+        let matchable_orders = self.state.get_matchable_orders(filter).await?;
         Ok(HashSet::from_iter(matchable_orders))
     }
 

--- a/workers/handshake-manager/src/manager/matching/mod.rs
+++ b/workers/handshake-manager/src/manager/matching/mod.rs
@@ -1,6 +1,14 @@
 //! Matching engine implementations for the handshake manager
 
+use common::types::wallet::Order;
+use state::caching::order_cache::OrderBookFilter;
+
 pub mod external_engine;
 pub mod internal_engine;
 mod match_helpers;
 pub mod mpc_engine;
+
+/// Build a matching order filter from a given order
+fn matching_order_filter(order: &Order, external: bool) -> OrderBookFilter {
+    OrderBookFilter::new(order.pair(), order.side.opposite(), external)
+}


### PR DESCRIPTION
### Purpose
This PR adds back in write paths for the order book cache and uses the new order book cache in the state interface. This involves two caller locations:
- The admin API, which roughly just uses renamed methods
- The matching engine, which now constructs an order book filter based on the order it is trying to match

### Testing
- [x] Unit tests pass
- [x] Testing in testnet with various match flows