### PR TITLE
external-api: wallet, task_history: add pagination token to historical APIs

### DIFF
--- a/external-api/src/http/task_history.rs
+++ b/external-api/src/http/task_history.rs
@@ -20,4 +20,6 @@ pub const TASK_HISTORY_ROUTE: &str = "/v0/wallet/:wallet_id/task-history";
 pub struct GetTaskHistoryResponse {
     /// A list of historical tasks
     pub tasks: Vec<ApiHistoricalTask>,
+    /// A token to use for pagination in subsequent requests
+    pub pagination_token: Option<String>,
 }

--- a/external-api/src/http/wallet.rs
+++ b/external-api/src/http/wallet.rs
@@ -322,4 +322,6 @@ pub struct PayFeesResponse {
 pub struct GetOrderHistoryResponse {
     /// A history of orders in the wallet
     pub orders: Vec<OrderMetadata>,
+    /// A token to use for pagination in subsequent requests
+    pub pagination_token: Option<String>,
 }

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -157,6 +157,6 @@ impl TypedHandler for GetTaskHistoryHandler {
         let tasks = self.state.get_task_history(len, &wallet_id).await?;
         let api_tasks: Vec<ApiHistoricalTask> = tasks.into_iter().map(|t| t.into()).collect();
 
-        Ok(GetTaskHistoryResponse { tasks: api_tasks })
+        Ok(GetTaskHistoryResponse { tasks: api_tasks, pagination_token: None })
     }
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -1073,6 +1073,6 @@ impl TypedHandler for GetOrderHistoryHandler {
             .unwrap_or(DEFAULT_ORDER_HISTORY_LEN);
 
         let orders = self.state.get_order_history(len, &wallet_id).await.map_err(internal_error)?;
-        Ok(GetOrderHistoryResponse { orders })
+        Ok(GetOrderHistoryResponse { orders, pagination_token: None })
     }
 }


### PR DESCRIPTION
This PR adds a `pagination_token` field to the `GetOrderHistoryResponse` and `GetTaskHistoryResponse` structs. This allows for these APIs to support pagination, though we leave it safely unimplemented for now.