### PR TITLE
state, workers: allow for actively-managed historical state

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -176,8 +176,7 @@ pub struct Cli {
     #[clap(long, value_parser, default_value = "/raft_snapshots")]
     pub raft_snapshot_path: String,
     /// Whether to record historical state locally
-    // TODO: Unset default `true` once event export implementation is complete
-    #[clap(long, value_parser, default_value = "true")]
+    #[clap(long, value_parser)]
     pub record_historical_state: bool,
     /// The maximum number of wallet operations a user is allowed to perform per hour
     /// 

--- a/config/src/parsing.rs
+++ b/config/src/parsing.rs
@@ -299,8 +299,15 @@ fn read_config_file(path: &str) -> Result<Vec<String>, String> {
 
         // Parse the values for this TOML entry into a CLI-style vector of strings
         let values: Vec<String> = match value {
-            // Just the flag, i.e. --flag
-            Value::Boolean(_) => vec![cli_arg],
+            // Just the flag, i.e. --flag, if the value is true.
+            // Otherwise, omit the flag
+            Value::Boolean(val) => {
+                if *val {
+                    vec![cli_arg]
+                } else {
+                    vec![]
+                }
+            },
             // Parse all values into multiple repetitions, i.e. --key val1 --key val2 ...
             Value::Array(arr) => {
                 let mut res: Vec<String> = Vec::new();

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -113,27 +113,24 @@ impl StateApplicator {
     // | Helpers |
     // -----------
 
-    /// Update the order metadata into the `Matching` state, if historical state
-    /// is enabled
+    /// Update the order metadata into the `Matching` state
     fn transition_order_matching(
         &self,
         order_id: OrderIdentifier,
         tx: &StateTxn<RW>,
     ) -> Result<()> {
-        if tx.get_historical_state_enabled()? {
-            let wallet = tx
-                .get_wallet_id_for_order(&order_id)?
-                .ok_or(StateApplicatorError::MissingEntry(ERR_WALLET_MISSING))?;
+        let wallet = tx
+            .get_wallet_id_for_order(&order_id)?
+            .ok_or(StateApplicatorError::MissingEntry(ERR_WALLET_MISSING))?;
 
-            let mut meta = tx
-                .get_order_metadata(wallet, order_id)?
-                .ok_or(StateApplicatorError::MissingEntry(ERR_ORDER_META_MISSING))?;
+        let mut meta = tx
+            .get_order_metadata(wallet, order_id)?
+            .ok_or(StateApplicatorError::MissingEntry(ERR_ORDER_META_MISSING))?;
 
-            if !meta.state.is_terminal() {
-                meta.state = OrderState::Matching;
-            }
-            self.update_order_metadata_with_tx(meta, tx)?;
+        if !meta.state.is_terminal() {
+            meta.state = OrderState::Matching;
         }
+        self.update_order_metadata_with_tx(meta, tx)?;
 
         Ok(())
     }

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -7,6 +7,7 @@ use common::types::{
 };
 use config::{RelayerConfig, RelayerFeeKey};
 use libp2p::{core::Multiaddr, identity::Keypair};
+use tracing::warn;
 use util::res_some;
 
 use crate::{error::StateError, StateInner, NODE_METADATA_TABLE};
@@ -144,6 +145,10 @@ impl StateInner {
         let relayer_wallet_id =
             derive_wallet_id(config.relayer_arbitrum_key()).map_err(StateError::InvalidUpdate)?;
         let historical_state_enabled = config.record_historical_state;
+
+        if !historical_state_enabled {
+            warn!("Historical state is disabled")
+        }
 
         self.with_write_tx(move |tx| {
             tx.create_table(NODE_METADATA_TABLE)?;

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -66,8 +66,6 @@ const ERR_ORDER_ALREADY_EXISTS: &str = "order id already exists";
 const ERR_BALANCE_NOT_FOUND: &str = "balance not found in wallet";
 /// Error message emitted when price data cannot be found for a token pair
 const ERR_NO_PRICE_DATA: &str = "no price data found for token pair";
-/// Error message emitted when historical state is disabled
-const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
 
 // -----------------------
 // | Raft Route Handlers |
@@ -205,10 +203,6 @@ impl TypedHandler for AdminOrderMetadataHandler {
         params: UrlParams,
         query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        if !self.state.historical_state_enabled().await? {
-            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
-        }
-
         let order_id = parse_order_id_from_params(&params)?;
         let order_metadata = self
             .state

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -159,6 +159,9 @@ const ERR_MIN_WITHDRAWAL_AMOUNT: &str = "cannot withdraw less than the minimum a
 /// the minimum allowed
 const ERR_MIN_DEPOSIT_AMOUNT: &str = "cannot deposit less than the minimum allowed amount";
 
+/// Error message emitted when historical state is disabled
+const ERR_HISTORICAL_STATE_DISABLED: &str = "historical state is disabled";
+
 // -------------------------
 // | Wallet Route Handlers |
 // -------------------------
@@ -1064,6 +1067,10 @@ impl TypedHandler for GetOrderHistoryHandler {
         params: UrlParams,
         mut query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        if !self.state.historical_state_enabled().await? {
+            return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
+        }
+
         let wallet_id = parse_wallet_id_from_params(&params)?;
         let len = query_params
             .remove(ORDER_HISTORY_LEN_PARAM)

--- a/workers/api-server/src/websocket/task.rs
+++ b/workers/api-server/src/websocket/task.rs
@@ -98,6 +98,9 @@ impl WebsocketTopicHandler for TaskHistoryHandler {
         _topic: String,
         route_params: &UrlParams,
     ) -> Result<TopicReader<SystemBusMessage>, ApiServerError> {
+        // We allow this topic to be accessible even when historical state is disabled,
+        // as it is a reliable source of task status updates
+
         // Parse the wallet ID from the route params
         let wallet_id = parse_wallet_id_from_params(route_params)?;
 

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -15,10 +15,6 @@ pub async fn transition_order_settling(
     order_id: OrderIdentifier,
     state: &State,
 ) -> Result<(), String> {
-    if !state.historical_state_enabled().await? {
-        return Ok(());
-    }
-
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;
     metadata.state = OrderState::SettlingMatch;
@@ -34,10 +30,6 @@ pub async fn record_order_fill(
     price: TimestampedPrice,
     state: &State,
 ) -> Result<(), String> {
-    if !state.historical_state_enabled().await? {
-        return Ok(());
-    }
-
     // Get the order metadata
     let mut metadata =
         state.get_order_metadata(&order_id).await?.ok_or(ERR_NO_ORDER_METADATA.to_string())?;


### PR DESCRIPTION
This PR tweaks the state & API code paths dependent on historical state being enabled. We allow for tracking "actively-managed historical state," i.e. historical state pertaining to objects (order metadata, tasks) which may still be updated by the relayer. Concretely, this means:
- Tasks
    - We continue streaming task status updates over websocket via _both_ the task status and task history topics. We continue to enable the task history topic since it is a reliable source of all task status updates for a given wallet.
    - We do not write tasks to the task history table if historical state is disabled.
- Orders
    - We now allow writing to / reading from the order history table even if historical state is disabled. However, if historical state is disabled we remove orders from the table once they reach a terminal state.
    - This allows us to continue streaming order metadata updates over the associated websocket topic

### Testing
- [x] All unit tests pass
- [x] Testing in testnet w/ historical state enabled
- [x] Testing in testnet w/ historical state disabled - requires testnet frontend integration w/ historical state engine (https://github.com/renegade-fi/renegade-frontend/pull/223)
- [ ] Parity testing w/ current frontend / historical state - requires migration to be complete