### PR TITLE
state: Fix unit tests after historical state CLI flag added

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -260,7 +260,12 @@ pub mod test_helpers {
 
     /// Create a mock relayer config for testing
     pub fn mock_relayer_config() -> RelayerConfig {
-        RelayerConfig { db_path: tmp_db_path(), allow_local: true, ..Default::default() }
+        RelayerConfig {
+            db_path: tmp_db_path(),
+            allow_local: true,
+            record_historical_state: true,
+            ..Default::default()
+        }
     }
 
     /// Create a mock database in a temporary location


### PR DESCRIPTION
### Purpose
This PR fixes red CI tests in `main`. The state unit tests need to set `record_historical_state=true` after this CLI flag was added to the config.

### Testing
- [x] All unit tests pass