### PR TITLE
api-server: admin: Add endpoint to refresh external match fees

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -14,7 +14,8 @@ abigen!(
         function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool)
         function getRoot() external view returns (uint256)
         function getFee() external view returns (uint256)
-        function getExternalMatchFeeForAsset(address memory asset) external view returns (uint256)function getPubkey() external view returns (uint256[2])
+        function getExternalMatchFeeForAsset(address memory asset) external view returns (uint256)
+        function getPubkey() external view returns (uint256[2])
         function getProtocolExternalFeeCollectionAddress() external view returns (address)
         function rootInHistory(uint256 memory root) external view returns (bool)
 

--- a/external-api/src/http/admin.rs
+++ b/external-api/src/http/admin.rs
@@ -41,6 +41,8 @@ pub const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE: &str =
 pub const ADMIN_ASSIGN_ORDER_ROUTE: &str = "/v0/admin/orders/:order_id/assign-pool/:matching_pool";
 /// Route to refresh the token mapping
 pub const ADMIN_REFRESH_TOKEN_MAPPING_ROUTE: &str = "/v0/admin/refresh-token-mapping";
+/// Route to refresh the external match fee constants from the contract
+pub const ADMIN_REFRESH_EXTERNAL_MATCH_FEES_ROUTE: &str = "/v0/admin/refresh-external-match-fees";
 
 /// The response to an "is leader" request
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/workers/api-server/src/error.rs
+++ b/workers/api-server/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+use arbitrum_client::errors::ArbitrumClientError;
 use external_api::auth::AuthError;
 use hyper::{Body, Response, StatusCode};
 use state::error::StateError;
@@ -39,6 +40,12 @@ impl Display for ApiServerError {
 impl From<StateError> for ApiServerError {
     fn from(value: StateError) -> Self {
         ApiServerError::State(value)
+    }
+}
+
+impl From<ArbitrumClientError> for ApiServerError {
+    fn from(value: ArbitrumClientError) -> Self {
+        internal_error(value)
     }
 }
 

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -10,7 +10,8 @@ mod task;
 mod wallet;
 
 use admin::{
-    AdminGetOrderMatchingPoolHandler, AdminRefreshTokenMappingHandler, AdminTriggerSnapshotHandler,
+    AdminGetOrderMatchingPoolHandler, AdminRefreshExternalMatchFeesHandler,
+    AdminRefreshTokenMappingHandler, AdminTriggerSnapshotHandler,
     AdminWalletMatchableOrderIdsHandler, IsLeaderHandler,
 };
 use async_trait::async_trait;
@@ -26,8 +27,8 @@ use external_api::{
             ADMIN_ASSIGN_ORDER_ROUTE, ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE,
             ADMIN_GET_ORDER_MATCHING_POOL_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
             ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_OPEN_ORDERS_ROUTE, ADMIN_ORDER_METADATA_ROUTE,
-            ADMIN_REFRESH_TOKEN_MAPPING_ROUTE, ADMIN_TRIGGER_SNAPSHOT_ROUTE,
-            ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_REFRESH_EXTERNAL_MATCH_FEES_ROUTE, ADMIN_REFRESH_TOKEN_MAPPING_ROUTE,
+            ADMIN_TRIGGER_SNAPSHOT_ROUTE, ADMIN_WALLET_MATCHABLE_ORDER_IDS_ROUTE, IS_LEADER_ROUTE,
         },
         external_match::{
             ASSEMBLE_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_MATCH_ROUTE,
@@ -567,6 +568,13 @@ impl HttpServer {
             &Method::POST,
             ADMIN_REFRESH_TOKEN_MAPPING_ROUTE.to_string(),
             AdminRefreshTokenMappingHandler::new(config.chain),
+        );
+
+        // The "/admin/refresh-external-match-fees" route
+        router.add_admin_authenticated_route(
+            &Method::POST,
+            ADMIN_REFRESH_EXTERNAL_MATCH_FEES_ROUTE.to_string(),
+            AdminRefreshExternalMatchFeesHandler::new(config.arbitrum_client.clone()),
         );
 
         router


### PR DESCRIPTION
### Purpose
This PR adds an endpoint to refresh external match fees with admin authentication

### Testing
- [x] Unit tests pass
- [x] Tested locally
- [ ] Will test in testnet once admin lambda is upgraded to support fee overrides