### PR TITLE
util: add metrics config

### DIFF
--- a/util/src/telemetry/metrics.rs
+++ b/util/src/telemetry/metrics.rs
@@ -11,30 +11,51 @@ use super::{
     TelemetrySetupError,
 };
 
-/// The prefix to used for metrics emitted by the relayer
-pub const RELAYER_METRICS_PREFIX: &str = "renegade_relayer";
+/// Default metrics prefix used for the relayer
+pub const DEFAULT_RELAYER_METRICS_PREFIX: &str = "renegade_relayer";
+/// Default buffer size for metrics in bytes
+pub const DEFAULT_METRICS_BUFFER_SIZE: usize = 1024;
+/// Default queue size for metrics in number of elements
+pub const DEFAULT_METRICS_QUEUE_SIZE: usize = 1024 * 1024;
 
-/// The size (in bytes) of the buffer which metrics data must fill before being
-/// flushed out over UDP
-pub const METRICS_BUFFER_SIZE: usize = 1024;
-/// The size (in # of elements) of the queue which the metrics exporter
-/// maintains.
-///
-/// If the queue is full, metrics data will be dropped.
-///
-/// We effectively want an unbounded queue, but the `StatsdBuilder` doesn't
-/// support this, so we set a suffiiently large value here.
-pub const METRICS_QUEUE_SIZE: usize = 1024 * 1024;
+/// Configuration for metrics collection
+#[derive(Debug, Clone)]
+pub struct MetricsConfig {
+    /// The prefix to use for metrics emitted by the relayer
+    pub metrics_prefix: String,
+    /// The size (in bytes) of the buffer which metrics data must fill before
+    /// being flushed out over UDP
+    pub buffer_size: usize,
+    /// The size (in # of elements) of the queue which the metrics exporter
+    /// maintains.
+    ///
+    /// If the queue is full, metrics data will be dropped.
+    ///
+    /// We effectively want an unbounded queue, but the `StatsdBuilder` doesn't
+    /// support this, so we set a sufficiently large value here.
+    pub queue_size: usize,
+}
 
-/// Configures a statsd metrics recorder
-pub fn configure_metrics_statsd_recorder(
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            metrics_prefix: DEFAULT_RELAYER_METRICS_PREFIX.to_string(),
+            buffer_size: DEFAULT_METRICS_BUFFER_SIZE,
+            queue_size: DEFAULT_METRICS_QUEUE_SIZE,
+        }
+    }
+}
+
+/// Configures a statsd metrics recorder with custom configuration
+pub fn configure_metrics_statsd_recorder_with_config(
     datadog_enabled: bool,
     statsd_host: &str,
     statsd_port: u16,
+    config: &MetricsConfig,
 ) -> Result<(), TelemetrySetupError> {
     let mut builder = StatsdBuilder::from(statsd_host, statsd_port)
-        .with_buffer_size(METRICS_BUFFER_SIZE)
-        .with_queue_size(METRICS_QUEUE_SIZE);
+        .with_buffer_size(config.buffer_size)
+        .with_queue_size(config.queue_size);
 
     if datadog_enabled {
         let UnifiedServiceTags { service, env, version } = get_unified_service_tags()?;
@@ -46,11 +67,25 @@ pub fn configure_metrics_statsd_recorder(
 
     let recorder = TracingContextLayer::all().layer(
         builder
-            .build(Some(RELAYER_METRICS_PREFIX))
+            .build(Some(&config.metrics_prefix))
             .map_err(err_str!(TelemetrySetupError::Metrics))?,
     );
 
     metrics::set_global_recorder(recorder).unwrap();
 
     Ok(())
+}
+
+/// Configures a statsd metrics recorder with default configuration
+pub fn configure_metrics_statsd_recorder(
+    datadog_enabled: bool,
+    statsd_host: &str,
+    statsd_port: u16,
+) -> Result<(), TelemetrySetupError> {
+    configure_metrics_statsd_recorder_with_config(
+        datadog_enabled,
+        statsd_host,
+        statsd_port,
+        &MetricsConfig::default(),
+    )
 }


### PR DESCRIPTION
### Purpose
This PR adds ability to configure metrics parameters (prefix, buffer size, queue size) while maintaining backwards compatibility. The existing `configure_telemetry` function remains unchanged, while a new `configure_telemetry_with_metrics_config` function allows optional configuration of these parameters.

### Testing
- [x] Tested backwards compatibility locally in auth-server