### PR TITLE
workspace: Gate long tests behind `ci` feature flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with: 
         command: test
-        args: --workspace --release --all-features --verbose -- --skip integration
+        args: --workspace --features "ci" --verbose -- --skip integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,8 +1993,6 @@ dependencies = [
  "serde_json",
  "test-helpers",
  "tokio",
- "tracing",
- "tracing-subscriber 0.3.19",
  "util 0.1.0",
 ]
 

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test_helpers = ["dep:tracing-subscriber", "dep:ctor", "util/mocks"]
+test_helpers = ["dep:ctor", "util/mocks"]
 large_benchmarks = []
-large_tests = []
 stats = ["ark-mpc/stats"]
+ci = ["test_helpers"]
 
 [[test]]
 name = "integration"
@@ -97,16 +97,12 @@ util = { path = "../util" }
 # === Misc Dependencies === #
 bitvec = "1.0"
 ctor = { version = "0.1", optional = true }
-tracing-subscriber = { version = "0.3", features = [
-    "env-filter",
-], optional = true }
 futures = { workspace = true }
 itertools = "0.10"
 lazy_static = { workspace = true }
 rand = { version = "0.8" }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = "1.0"
-tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]
 ark-ec = "0.4"

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -157,7 +157,6 @@ pub async fn multiprover_prove_and_verify<C: MultiProverCircuit>(
         .open_authenticated()
         .await
         .map_err(ProverError::Plonk)?;
-    tracing::log::info!("done proving");
 
     let statement = statement.open().await.map_err(ProverError::Mpc)?;
     C::verify(statement, &proof).map_err(ProverError::Verification)
@@ -189,12 +188,6 @@ pub mod test_helpers {
     use itertools::Itertools;
     use rand::{thread_rng, Rng, RngCore};
     use renegade_crypto::fields::scalar_to_biguint;
-    use tracing_subscriber::{
-        filter::{EnvFilter, LevelFilter},
-        fmt,
-        layer::SubscriberExt,
-        util::SubscriberInitExt,
-    };
     use util::matching_engine::match_orders_with_max_min_amounts;
 
     use crate::zk_circuits::test_helpers::{MAX_BALANCES, MAX_ORDERS};
@@ -217,16 +210,6 @@ pub mod test_helpers {
         ($x:expr) => {
             $crate::test_helpers::joint_open($x).await.unwrap()
         };
-    }
-
-    /// Initialize a logger
-    pub fn init_logger() {
-        let filter_layer =
-            EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy();
-
-        let fmt_layer = fmt::layer();
-
-        tracing_subscriber::registry().with(filter_layer).with(fmt_layer).init();
     }
 
     /// Create a random sequence of field elements

--- a/circuits/src/zk_circuits/proof_linking.rs
+++ b/circuits/src/zk_circuits/proof_linking.rs
@@ -362,7 +362,7 @@ where
     Ok(layout.get_group_layout(VALID_COMMITMENTS_MATCH_SETTLE_LINK0))
 }
 
-#[cfg(all(test, feature = "large_tests"))]
+#[cfg(test)]
 mod test {
     use ark_mpc::{network::PartyId, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
     use circuit_types::{
@@ -743,6 +743,7 @@ mod test {
 
     /// Tests a valid link between a proof of VALID REBLIND and a proof of VALID
     /// COMMITMENTS
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     fn test_reblind_commitments_valid_link() {
         let mut wallet = INITIAL_WALLET.clone();
@@ -765,6 +766,7 @@ mod test {
 
     /// Tests an invalid link between a proof of VALID REBLIND and a proof of
     /// VALID COMMITMENTS
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     #[should_panic(expected = "ProofLinkVerification")]
     fn test_reblind_commitments_invalid_link() {
@@ -803,6 +805,7 @@ mod test {
 
     /// Tests a valid link between a proof of VALID COMMITMENTS and a proof of
     /// VALID MATCH SETTLE on the first party's side
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     async fn test_commitments_match_settle_valid_party0() {
         let (comm_witness, comm_statement, match_settle_witness, match_settle_statement) =
@@ -821,6 +824,7 @@ mod test {
 
     /// Tests a valid link between a proof of VALID COMMITMENTS and a proof of
     /// VALID MATCH SETTLE on the second party's side
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     async fn test_commitments_match_settle_valid_party1() {
         let (comm_witness, comm_statement, match_settle_witness, match_settle_statement) =
@@ -840,6 +844,7 @@ mod test {
     /// Tests an invalid link between a proof of VALID COMMITMENTS and a proof
     /// of VALID MATCH SETTLE wherein the shares are modified between the
     /// two proofs
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     #[should_panic(expected = "ProofLinkVerification")]
     #[allow(non_snake_case)]
@@ -878,6 +883,7 @@ mod test {
     ///
     /// Test this modification on the second party's side in the VALID MATCH
     /// SETTLE circuit
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     #[should_panic(expected = "ProofLinkVerification")]
     #[allow(non_snake_case)]
@@ -904,6 +910,7 @@ mod test {
     ///
     /// Test this modification on the first party's side in the VALID MATCH
     /// SETTLE circuit
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     #[should_panic(expected = "ProofLinkVerification")]
     #[allow(non_snake_case)]
@@ -931,6 +938,7 @@ mod test {
 
     /// Tests a valid link between a proof of VALID COMMITMENTS and a proof of
     /// VALID MATCH SETTLE ATOMIC
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     fn test_commitments_match_settle_atomic_valid_link() {
         let (comm_witness, comm_statement, match_atomic_witness, match_atomic_statement) =
@@ -947,6 +955,7 @@ mod test {
 
     /// Tests an invalid link between a proof of VALID COMMITMENTS and a proof
     /// of VALID MATCH SETTLE ATOMIC with modified shares
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     #[should_panic(expected = "ProofLinkVerification")]
     fn test_commitments_match_settle_atomic_invalid_link_modified_shares() {
@@ -979,6 +988,7 @@ mod test {
 
     /// Tests an invalid link between a proof of VALID COMMITMENTS and a proof
     /// of VALID MATCH SETTLE ATOMIC with a modified balance
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     #[should_panic(expected = "ProofLinkVerification")]
     fn test_commitments_match_settle_atomic_invalid_link_modified_balance() {
@@ -998,6 +1008,7 @@ mod test {
 
     /// Tests an invalid link between a proof of VALID COMMITMENTS and a
     /// of VALID MATCH SETTLE ATOMIC with a modified order
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     #[should_panic(expected = "ProofLinkVerification")]
     fn test_commitments_match_settle_atomic_invalid_link_modified_order() {

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -466,6 +466,7 @@ mod tests {
     }
 
     /// Tests proving a valid match on the singleprover circuit
+    #[cfg_attr(feature = "ci", ignore)]
     #[test]
     fn test_valid_match__singleprover() {
         let (witness, statement) = dummy_witness_and_statement();

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [features]
 # Used to enable mocks from other crates in tests
-all-tests = ["common/mocks"]
 mocks = ["dep:tempfile", "dep:test-helpers"]
 task-queue-len = []
+ci = ["mocks"]
 
 [[bench]]
 name = "storage"

--- a/state/src/applicator/order_book.rs
+++ b/state/src/applicator/order_book.rs
@@ -140,7 +140,7 @@ impl StateApplicator {
 // | Tests |
 // ---------
 
-#[cfg(all(test, feature = "all-tests"))]
+#[cfg(test)]
 mod test {
     use common::types::{
         network_order::NetworkOrderState,

--- a/state/src/applicator/wallet_index.rs
+++ b/state/src/applicator/wallet_index.rs
@@ -212,7 +212,7 @@ impl StateApplicator {
 // | Tests |
 // ---------
 
-#[cfg(all(test, feature = "all-tests"))]
+#[cfg(test)]
 pub(crate) mod test {
     use common::types::{
         wallet::Wallet,

--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -430,6 +430,7 @@ mod test {
     }
 
     /// Tests adding a new node to the raft
+    #[cfg_attr(feature = "ci", ignore)]
     #[tokio::test]
     #[allow(non_snake_case)]
     async fn test_add_node__to_singleton() {


### PR DESCRIPTION
### Purpose
This PR gates long-running unit tests behind a `ci` feature flag, and enables that flag (disabling the tests) in github workflows. This allows us to run tests in debug mode, so that the total time taken to run all tests does not exceed what the test runners allow

### Testing
- [x] All tests pass
- [x] CI passes 🥳 