### PR TITLE
workers: api-server: auth, router: include query string in path for auth

### DIFF
--- a/workers/api-server/src/router.rs
+++ b/workers/api-server/src/router.rs
@@ -33,6 +33,8 @@ const PREFLIGHT_CACHE_TIME: &str = "7200"; // 2 hours, Chromium max
 pub(super) const ERR_WALLET_NOT_FOUND: &str = "wallet not found";
 /// Error message returned when query params are invalid
 const ERR_INVALID_QUERY_PARAMS: &str = "invalid query params";
+/// Error message returned when the path is invalid
+const ERR_INVALID_PATH: &str = "invalid path";
 
 // -----------
 // | Helpers |
@@ -304,7 +306,13 @@ impl Router {
                 };
 
                 // Auth check and handler
-                if let Err(e) = self.check_auth(*auth, path, &params_map, &mut req).await {
+                let path_with_query = match route.path_and_query() {
+                    Some(path_and_query) => path_and_query.as_str(),
+                    None => return build_400_response(ERR_INVALID_PATH.to_string()),
+                };
+
+                if let Err(e) = self.check_auth(*auth, path_with_query, &params_map, &mut req).await
+                {
                     return e.into();
                 }
 


### PR DESCRIPTION
This PR tweaks the wallet & admin auth handlers to expect the query string to be included in the path when validating an authenticated request's HMAC.

However, since there are clients that are currently implemented with the assumption that query strings should be excluded from the HMAC signature, we introduce some shim code here that first attempts to validate auth with the expectation that query strings are included in the path, then falls back to to validating auth while excluding query strings from the path. This is a temporary provision to ensure that deploying this change in the relayer does not require coupled client-side upgrades.

### Testing
I tested this by running a local relayer & local frontend, and attempted to invoke the task history endpoint for a wallet with the `task_history_len` parameter set. I tested this both ways, with the query string included & excluded from the client-side request HMAC, and asserted that we got successful responses from the relayer in both cases.