### PR TITLE
handshake-manager: external-engine: Use configurable bundle timeout

### DIFF
--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -1,5 +1,7 @@
 //! Descriptors for the match settlement tasks
 
+use std::time::Duration;
+
 use circuit_types::r#match::MatchResult;
 use serde::{Deserialize, Serialize};
 
@@ -78,6 +80,8 @@ impl From<SettleMatchInternalTaskDescriptor> for TaskDescriptor {
 /// `SettleExternalMatch` task
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettleExternalMatchTaskDescriptor {
+    /// The duration for which the external match bundle is valid
+    pub bundle_duration: Duration,
     /// The ID of the order that the local node matched
     pub internal_order_id: OrderIdentifier,
     /// The ID of the wallet that the local node matched an order from
@@ -93,6 +97,7 @@ pub struct SettleExternalMatchTaskDescriptor {
 impl SettleExternalMatchTaskDescriptor {
     /// Constructor
     pub fn new(
+        bundle_duration: Duration,
         internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
         execution_price: TimestampedPrice,
@@ -100,6 +105,7 @@ impl SettleExternalMatchTaskDescriptor {
         atomic_match_bundle_topic: String,
     ) -> Self {
         SettleExternalMatchTaskDescriptor {
+            bundle_duration,
             internal_order_id,
             internal_wallet_id,
             atomic_match_bundle_topic,

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -203,12 +203,9 @@ impl HandshakeExecutor {
             },
 
             // A request to run the external matching engine
-            HandshakeManagerJob::ExternalMatchingEngine {
-                order,
-                response_topic,
-                only_quote,
-                price,
-            } => self.run_external_matching_engine(order, response_topic, only_quote, price).await,
+            HandshakeManagerJob::ExternalMatchingEngine { order, response_topic, options } => {
+                self.run_external_matching_engine(order, response_topic, &options).await
+            },
 
             // Indicates that a peer has sent a message during the course of a handshake
             HandshakeManagerJob::ProcessHandshakeMessage { peer_id, message, response_channel } => {


### PR DESCRIPTION
### Purpose
This PR makes the bundle timeout configurable as input to the matching engine. The API server uses this option to configure the timeout different based on whether the bundle is produced from the direct match flow versus the assemble flow.

### Testing
- [x] Unit test pass
- [x] Test in testnet