### PR TITLE
external-api; workers: api-server: add task queue paused route

### DIFF
--- a/external-api/src/http/task.rs
+++ b/external-api/src/http/task.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 pub const GET_TASK_STATUS_ROUTE: &str = "/v0/tasks/:task_id";
 /// Get the task queue of a given wallet
 pub const GET_TASK_QUEUE_ROUTE: &str = "/v0/task_queue/:wallet_id";
+/// Get whether or not a given wallet's task queue is paused
+pub const GET_TASK_QUEUE_PAUSED_ROUTE: &str = "/v0/task_queue/:wallet_id/is_paused";
 
 // -------------
 // | API Types |
@@ -51,4 +53,11 @@ impl From<QueuedTask> for ApiTaskStatus {
 pub struct TaskQueueListResponse {
     /// The list of tasks on a wallet
     pub tasks: Vec<ApiTaskStatus>,
+}
+
+/// The response type for a request to fetch whether a task queue is paused
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskQueuePausedResponse {
+    /// Whether the task queue is paused
+    pub is_paused: bool,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -39,7 +39,7 @@ use external_api::{
             GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE, GET_SUPPORTED_TOKENS_ROUTE,
         },
         price_report::PRICE_REPORT_ROUTE,
-        task::{GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
+        task::{GET_TASK_QUEUE_PAUSED_ROUTE, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         task_history::TASK_HISTORY_ROUTE,
         wallet::{
             BACK_OF_QUEUE_WALLET_ROUTE, CANCEL_ORDER_ROUTE, CREATE_WALLET_ROUTE,
@@ -67,6 +67,7 @@ use order_book::GetSupportedTokensHandler;
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use task::GetTaskQueuePausedHandler;
 use util::get_current_time_millis;
 use uuid::Uuid;
 
@@ -270,6 +271,13 @@ impl HttpServer {
             &Method::GET,
             GET_TASK_QUEUE_ROUTE.to_string(),
             GetTaskQueueHandler::new(state.clone()),
+        );
+
+        // The "/task_queue/:wallet_id/is_paused" route
+        router.add_wallet_authenticated_route(
+            &Method::GET,
+            GET_TASK_QUEUE_PAUSED_ROUTE.to_string(),
+            GetTaskQueuePausedHandler::new(state.clone()),
         );
 
         // The "/wallet/:wallet_id/task-history" route


### PR DESCRIPTION
This PR adds an API endpoint for checking if a wallet's queue is paused.

### Testing:
- [x] Testing in testnet