### PR TITLE
task-driver: settle-match-external: Filter settlement by selector

### DIFF
--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -30,6 +30,7 @@ use crate::abi::{
     processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall, MerkleInsertionFilter,
     NullifierSpentFilter,
 };
+use crate::constants::{Selector, KNOWN_SELECTORS};
 use crate::{
     abi::{
         newWalletCall, processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall,
@@ -48,18 +49,6 @@ use crate::{
 };
 
 use super::ArbitrumClient;
-
-/// A list of known selectors for the darkpool contract
-const KNOWN_SELECTORS: [[u8; SELECTOR_LEN]; 8] = [
-    <newWalletCall as SolCall>::SELECTOR,
-    <updateWalletCall as SolCall>::SELECTOR,
-    <processMatchSettleCall as SolCall>::SELECTOR,
-    <processAtomicMatchSettleCall as SolCall>::SELECTOR,
-    <processAtomicMatchSettleWithReceiverCall as SolCall>::SELECTOR,
-    <settleOnlineRelayerFeeCall as SolCall>::SELECTOR,
-    <settleOfflineFeeCall as SolCall>::SELECTOR,
-    <redeemFeeCall as SolCall>::SELECTOR,
-];
 
 /// The error message emitted when not enough Merkle path siblings are found
 const ERR_MERKLE_PATH_SIBLINGS: &str = "not enough Merkle path siblings found";
@@ -202,11 +191,21 @@ impl ArbitrumClient {
             .ok_or(ArbitrumClientError::CommitmentNotFound)
     }
 
-    /// Await a nullifier spent event on a given nullifier
-    #[instrument(skip_all, err, fields(nullifier = %nullifier))]
+    /// Await a nullifier spent event on a given nullifier from a given selector
     pub async fn await_nullifier_spent(
         &self,
         nullifier: Nullifier,
+        timeout: Duration,
+    ) -> Result<(), ArbitrumClientError> {
+        self.await_nullifier_spent_from_selectors(nullifier, &[] /* selectors */, timeout).await
+    }
+
+    /// Await a nullifier spent event on a given nullifier
+    #[instrument(skip_all, err, fields(nullifier = %nullifier))]
+    pub async fn await_nullifier_spent_from_selectors(
+        &self,
+        nullifier: Nullifier,
+        selectors: &[Selector],
         timeout: Duration,
     ) -> Result<(), ArbitrumClientError> {
         // Build an event filter on the nullifier
@@ -218,20 +217,31 @@ impl ArbitrumClient {
             .address(address)
             .topic1(nullifier_u256)
             .from_block(self.deploy_block);
-        let mut stream =
-            filter.stream().await.map_err(err_str!(ArbitrumClientError::EventQuerying))?;
+
+        // Create a stream that includes event metadata
+        let mut stream = filter
+            .stream_with_meta()
+            .await
+            .map_err(err_str!(ArbitrumClientError::EventQuerying))?;
 
         // Await the event with a timeout
         let next_event = tokio::time::timeout(timeout, stream.next()).await;
-        match next_event {
-            Ok(Some(_)) => Ok(()),
-            Ok(None) => {
-                Err(ArbitrumClientError::EventQuerying(ERR_EVENT_STREAM_CLOSED.to_string()))
-            },
-            Err(_) => {
-                Err(ArbitrumClientError::EventQuerying(ERR_NULLIFIER_SPENT_TIMEOUT.to_string()))
-            },
+        let (_event, meta) = next_event
+            .map_err(|_| ArbitrumClientError::event_querying(ERR_NULLIFIER_SPENT_TIMEOUT))? // timeout
+            .ok_or(ArbitrumClientError::event_querying(ERR_EVENT_STREAM_CLOSED))? // no event
+            .map_err(err_str!(ArbitrumClientError::EventQuerying))?; // query error
+
+        // Check if the transaction selector matches one of the given selectors
+        if !selectors.is_empty() {
+            let tx_selector = self.fetch_selector_from_tx(meta.transaction_hash).await?;
+            if !selectors.contains(&tx_selector) {
+                return Err(ArbitrumClientError::EventQuerying(
+                    "Nullifier spent with wrong selector".to_string(),
+                ));
+            }
         }
+
+        Ok(())
     }
 
     /// Fetch and parse the public secret shares from the calldata of the
@@ -267,6 +277,32 @@ impl ArbitrumClient {
     // -----------
     // | Helpers |
     // -----------
+
+    /// Fetch the selector from a transaction
+    async fn fetch_selector_from_tx(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<[u8; SELECTOR_LEN], ArbitrumClientError> {
+        let tx: Transaction = self
+            .get_darkpool_client()
+            .client()
+            .get_transaction(tx_hash)
+            .await
+            .map_err(|e| ArbitrumClientError::TxQuerying(e.to_string()))?
+            .ok_or(ArbitrumClientError::TxNotFound(tx_hash.to_string()))?;
+
+        // Ensure the input data is at least as long as a selector
+        let input_data = tx.input.as_ref();
+        if input_data.len() < SELECTOR_LEN {
+            return Err(ArbitrumClientError::InvalidSelector);
+        }
+
+        // Parse the selector from the input data
+        let selector = input_data[..SELECTOR_LEN]
+            .try_into()
+            .map_err(|_| ArbitrumClientError::InvalidSelector)?;
+        Ok(selector)
+    }
 
     /// Fetch the public shares from a transaction that has an unknown selector
     async fn fetch_public_shares_for_unknown_selector(

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -2,11 +2,18 @@
 
 use std::{fmt::Display, marker::PhantomData, str::FromStr};
 
+use alloy_sol_types::SolCall;
 use ark_ff::{BigInt, Fp};
 use constants::{Scalar, MERKLE_HEIGHT};
 use lazy_static::lazy_static;
 use renegade_crypto::hash::compute_poseidon_hash;
 use serde::{Deserialize, Serialize};
+
+use crate::abi::{
+    newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+    processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,
+    updateWalletCall,
+};
 
 /// The chain environment
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -42,8 +49,41 @@ impl FromStr for Chain {
     }
 }
 
+/// A type alias for a selector
+pub type Selector = [u8; SELECTOR_LEN];
 /// The number of bytes in a Solidity function selector
 pub const SELECTOR_LEN: usize = 4;
+/// A list of known selectors for the darkpool contract
+pub(crate) const KNOWN_SELECTORS: [[u8; SELECTOR_LEN]; 8] = [
+    NEW_WALLET_SELECTOR,
+    UPDATE_WALLET_SELECTOR,
+    PROCESS_MATCH_SETTLE_SELECTOR,
+    PROCESS_ATOMIC_MATCH_SETTLE_SELECTOR,
+    PROCESS_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR,
+    SETTLE_ONLINE_RELAYER_FEE_SELECTOR,
+    SETTLE_OFFLINE_FEE_SELECTOR,
+    REDEEM_FEE_SELECTOR,
+];
+
+/// Selector for `newWallet`
+pub const NEW_WALLET_SELECTOR: [u8; SELECTOR_LEN] = newWalletCall::SELECTOR;
+/// Selector for `updateWallet`
+pub const UPDATE_WALLET_SELECTOR: [u8; SELECTOR_LEN] = updateWalletCall::SELECTOR;
+/// Selector for `processMatchSettle`
+pub const PROCESS_MATCH_SETTLE_SELECTOR: [u8; SELECTOR_LEN] = processMatchSettleCall::SELECTOR;
+/// Selector for `processAtomicMatchSettle`
+pub const PROCESS_ATOMIC_MATCH_SETTLE_SELECTOR: [u8; SELECTOR_LEN] =
+    processAtomicMatchSettleCall::SELECTOR;
+/// Selector for `processAtomicMatchSettleWithReceiver`
+pub const PROCESS_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR: [u8; SELECTOR_LEN] =
+    processAtomicMatchSettleWithReceiverCall::SELECTOR;
+/// Selector for `settleOnlineRelayerFee`
+pub const SETTLE_ONLINE_RELAYER_FEE_SELECTOR: [u8; SELECTOR_LEN] =
+    settleOnlineRelayerFeeCall::SELECTOR;
+/// Selector for `settleOfflineFee`
+pub const SETTLE_OFFLINE_FEE_SELECTOR: [u8; SELECTOR_LEN] = settleOfflineFeeCall::SELECTOR;
+/// Selector for `redeemFee`
+pub const REDEEM_FEE_SELECTOR: [u8; SELECTOR_LEN] = redeemFeeCall::SELECTOR;
 
 // The following are used for cases in which runtime type-based event filtering
 // is not possible. In these cases, we must construct filters manually using ABI

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -36,6 +36,14 @@ pub enum ArbitrumClientError {
     BlinderNotFound,
 }
 
+impl ArbitrumClientError {
+    /// Create a new event querying error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn event_querying<T: ToString>(msg: T) -> Self {
+        Self::EventQuerying(msg.to_string())
+    }
+}
+
 impl Display for ArbitrumClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")


### PR DESCRIPTION
### Purpose
This PR filters the settlement waiter in `settle-match-external` by the selectors used for atomic matches.

### Testing
- [x] Unit tests pass
 - [ ] Testing in testnet