### PR TITLE
workers: task-driver: state_migration: purge historical state startup task

### DIFF
--- a/workers/task-driver/src/state_migration/mod.rs
+++ b/workers/task-driver/src/state_migration/mod.rs
@@ -5,5 +5,7 @@
 //!
 //! These migrations should be idempotent, and defined as need be
 
+mod purge_historical_state;
 mod remove_phantom_orders;
+pub(crate) use purge_historical_state::purge_historical_state;
 pub(crate) use remove_phantom_orders::remove_phantom_orders;

--- a/workers/task-driver/src/state_migration/purge_historical_state.rs
+++ b/workers/task-driver/src/state_migration/purge_historical_state.rs
@@ -1,0 +1,58 @@
+//! Purges historical state
+//!
+//! This includes terminal historical orders and task history
+
+use common::types::wallet::WalletIdentifier;
+use state::State;
+use tracing::error;
+
+/// Purges historical state for all wallets
+pub async fn purge_historical_state(state: &State) -> Result<(), String> {
+    let wallets = state.get_all_wallets().await?;
+    for wallet in wallets {
+        purge_wallet_historical_state(state, wallet.wallet_id).await?;
+    }
+
+    Ok(())
+}
+
+/// Purges historical state for a single wallet
+async fn purge_wallet_historical_state(
+    state: &State,
+    wallet_id: WalletIdentifier,
+) -> Result<(), String> {
+    purge_order_history(state, wallet_id).await?;
+    purge_task_history(state, wallet_id).await
+}
+
+/// Purges all terminal orders from a wallet's order history
+async fn purge_order_history(state: &State, wallet_id: WalletIdentifier) -> Result<(), String> {
+    let res = state
+        .with_write_tx(move |tx| {
+            tx.purge_terminal_orders(&wallet_id)?;
+            Ok(())
+        })
+        .await;
+
+    if let Err(e) = res {
+        error!("error purging order history for wallet {wallet_id}: {e}");
+    }
+
+    Ok(())
+}
+
+/// Purges a wallet's task history
+async fn purge_task_history(state: &State, wallet_id: WalletIdentifier) -> Result<(), String> {
+    let res = state
+        .with_write_tx(move |tx| {
+            tx.purge_task_history(&wallet_id)?;
+            Ok(())
+        })
+        .await;
+
+    if let Err(e) = res {
+        error!("error purging task history for wallet {wallet_id}: {e}");
+    }
+
+    Ok(())
+}

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -37,7 +37,7 @@ use util::{
 
 use crate::{
     await_task,
-    state_migration::remove_phantom_orders,
+    state_migration::{purge_historical_state, remove_phantom_orders},
     task_state::StateWrapper,
     traits::{Task, TaskContext, TaskError, TaskState},
     utils::ERR_WALLET_NOT_FOUND,
@@ -457,6 +457,18 @@ impl NodeStartupTask {
                 info!("done removing phantom orders");
             }
         });
+
+        // Purge historical state for all wallets
+        let state = self.state.clone();
+        tokio::task::spawn(async move {
+            info!("purging historical state for all wallets...");
+            if let Err(e) = purge_historical_state(&state).await {
+                error!("error purging historical state: {e}");
+            } else {
+                info!("done purging historical state");
+            }
+        });
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds a new state migration for purging historical state. Namely, this means removing terminal orders from order history and all task history, for all wallets. We no longer need to track this in the relayer since the historical state engine is active.

### Testing
- [x] Unit tests for new state methods pass
- [x] Testing in testnet