### PR TITLE
common: remove contracts dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "ark-ec",
+ "ark-ff 0.4.2",
  "ark-mpc",
  "ark-poly",
  "async-trait",
@@ -2232,7 +2233,6 @@ dependencies = [
  "circuit-types 0.1.0",
  "circuits 0.1.0",
  "constants 0.1.0",
- "contracts-common",
  "crossbeam",
  "derivative",
  "ecdsa 0.16.9",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = ["all-types"]
 hmac = []
-wallet = ["hmac", "proof-system-types", "util/matching-engine"]
+wallet = ["hmac", "proof-system-types", "util/matching-engine", "ark-ff"]
 proof-system-types = ["dep:circuits", "constants/default"]
 # Types used by the relayer for internal operation
 # We add this feature flag to allow external clients to opt-out of these types
@@ -27,6 +27,7 @@ mocks = [
 ark-mpc = { workspace = true }
 ark-ec = { version = "0.4", optional = true }
 ark-poly = { version = "0.4", optional = true }
+ark-ff = { version = "0.4", optional = true }
 
 ecdsa = { version = "0.16", optional = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
@@ -55,9 +56,6 @@ circuit-types = { path = "../circuit-types", default-features = false }
 constants = { path = "../constants", default-features = false }
 renegade-crypto = { path = "../renegade-crypto" }
 util = { path = "../util" }
-
-# === Contracts Repo Dependencies === #
-contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
 
 # === Misc Dependencies === #
 base64 = { version = "0.22" }

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -210,7 +210,6 @@ impl TaskDescriptor {
 pub mod mocks {
     use circuit_types::keychain::SecretSigningKey;
     use constants::Scalar;
-    use contracts_common::custom_serde::BytesSerializable;
     use ethers::core::utils::keccak256;
     use ethers::signers::Wallet as EthersWallet;
     use k256::ecdsa::SigningKey as K256SigningKey;
@@ -227,9 +226,7 @@ pub mod mocks {
     pub fn gen_wallet_update_sig(wallet: &Wallet, key: &SecretSigningKey) -> Vec<u8> {
         let new_wallet_comm = wallet.get_wallet_share_commitment();
 
-        // Serialize the commitment, uses the contract's serialization here:
-        //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-        let comm_bytes = new_wallet_comm.inner().serialize_to_bytes();
+        let comm_bytes = Wallet::serialize_commitment(new_wallet_comm);
         let digest = keccak256(comm_bytes);
 
         // Sign the message

--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -2,7 +2,6 @@
 
 use circuit_types::{keychain::PublicSigningKey, Amount};
 use constants::Scalar;
-use contracts_common::custom_serde::BytesSerializable;
 use ethers::core::types::Signature;
 use ethers::utils::{keccak256, public_key_to_address};
 use k256::ecdsa::VerifyingKey as K256VerifyingKey;
@@ -212,9 +211,7 @@ pub fn verify_wallet_update_signature(
     let key: K256VerifyingKey = key.into();
     let new_wallet_comm = wallet.get_wallet_share_commitment();
 
-    // Serialize the commitment, uses the contract's serialization here:
-    //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-    let comm_bytes = new_wallet_comm.inner().serialize_to_bytes();
+    let comm_bytes = Wallet::serialize_commitment(new_wallet_comm);
     let digest = keccak256(comm_bytes);
 
     // Verify the signature


### PR DESCRIPTION
This PR removes the dependency on the `contracts-common` crate in `common` by internalizing the serialization pattern for `ScalarField` types - this is the only usage we have for the dependency. This is necessary to remove a cyclic dependency between these two crates.

### Testing
- [x] All unit tests pass