### PR TITLE
external-api: types: Move supported tokens from behind feature flag

### DIFF
--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::types::ApiToken;
+
 #[cfg(feature = "admin-api")]
 pub mod admin;
 #[cfg(feature = "external-match-api")]
@@ -19,9 +21,27 @@ pub mod task_history;
 #[cfg(feature = "wallet-api")]
 pub mod wallet;
 
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Returns the supported token list
+pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
+
+// -------------
+// | API Types |
+// -------------
+
 /// A ping response
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PingResponse {
     /// The timestamp when the response is sent
     pub timestamp: u64,
+}
+
+/// The response type to fetch the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetSupportedTokensResponse {
+    /// The supported tokens
+    pub tokens: Vec<ApiToken>,
 }

--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{ApiNetworkOrder, ApiToken};
+use crate::types::ApiNetworkOrder;
 
 // ---------------
 // | HTTP Routes |
@@ -12,9 +12,6 @@ use crate::types::{ApiNetworkOrder, ApiToken};
 pub const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
 /// Returns the network order information of the specified order
 pub const GET_NETWORK_ORDER_BY_ID_ROUTE: &str = "/v0/order_book/orders/:order_id";
-
-/// Returns the supported token list
-pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
 
 // -------------
 // | API Types |
@@ -32,11 +29,4 @@ pub struct GetNetworkOrdersResponse {
 pub struct GetNetworkOrderByIdResponse {
     /// The requested network order
     pub order: ApiNetworkOrder,
-}
-
-/// The response type to fetch the supported token list
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetSupportedTokensResponse {
-    /// The supported tokens
-    pub tokens: Vec<ApiToken>,
 }

--- a/external-api/src/types/api_order_book.rs
+++ b/external-api/src/types/api_order_book.rs
@@ -44,19 +44,3 @@ impl From<NetworkOrder> for ApiNetworkOrder {
         }
     }
 }
-
-/// A token in the the supported token list
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ApiToken {
-    /// The token address
-    pub address: String,
-    /// The token symbol
-    pub symbol: String,
-}
-
-impl ApiToken {
-    /// Constructor
-    pub fn new(addr: String, sym: String) -> Self {
-        Self { address: addr, symbol: sym }
-    }
-}

--- a/external-api/src/types/mod.rs
+++ b/external-api/src/types/mod.rs
@@ -20,3 +20,24 @@ pub use api_order_book::*;
 pub use api_task_history::*;
 #[cfg(feature = "wallet-api")]
 pub use api_wallet::*;
+use serde::{Deserialize, Serialize};
+
+// -------------
+// | API Types |
+// -------------
+
+/// A token in the the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiToken {
+    /// The token address
+    pub address: String,
+    /// The token symbol
+    pub symbol: String,
+}
+
+impl ApiToken {
+    /// Constructor
+    pub fn new(addr: String, sym: String) -> Self {
+        Self { address: addr, symbol: sym }
+    }
+}

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -35,9 +35,7 @@ use external_api::{
             REQUEST_EXTERNAL_QUOTE_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
-        order_book::{
-            GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE, GET_SUPPORTED_TOKENS_ROUTE,
-        },
+        order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
         price_report::PRICE_REPORT_ROUTE,
         task::{GET_TASK_QUEUE_PAUSED_ROUTE, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         task_history::TASK_HISTORY_ROUTE,
@@ -48,7 +46,7 @@ use external_api::{
             ORDER_HISTORY_ROUTE, PAY_FEES_ROUTE, REDEEM_NOTE_ROUTE, REFRESH_WALLET_ROUTE,
             UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
         },
-        PingResponse,
+        PingResponse, GET_SUPPORTED_TOKENS_ROUTE,
     },
     EmptyRequestResponse,
 };

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -3,8 +3,9 @@
 use async_trait::async_trait;
 use common::types::token::{read_token_remap, USDT_TICKER, USD_TICKER};
 use external_api::{
-    http::order_book::{
-        GetNetworkOrderByIdResponse, GetNetworkOrdersResponse, GetSupportedTokensResponse,
+    http::{
+        order_book::{GetNetworkOrderByIdResponse, GetNetworkOrdersResponse},
+        GetSupportedTokensResponse,
     },
     types::ApiToken,
     EmptyRequestResponse,


### PR DESCRIPTION
### Purpose
This PR publishes the types, route definition, and response structure for the supported tokens route out from behind the `order-book-api` feature flag, so that it is available always.

### Testing
- [x] Unit tests pass