### PR TITLE
api-sever: order-book: Add external match fee endpoint

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -59,6 +59,11 @@ pub const MERKLE_HEIGHT: usize = 32;
 /// The number of historical roots the contract stores as being valid
 pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 
+/// The external match fee charged by the relayer
+///
+/// TODO: This is currently zero, remove this and add per-asset fees
+pub const EXTERNAL_MATCH_RELAYER_FEE: f64 = 0.;
+
 // ------------------------------------
 // | System Specific Type Definitions |
 // ------------------------------------

--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -12,6 +12,8 @@ use crate::types::ApiNetworkOrder;
 pub const GET_NETWORK_ORDERS_ROUTE: &str = "/v0/order_book/orders";
 /// Returns the network order information of the specified order
 pub const GET_NETWORK_ORDER_BY_ID_ROUTE: &str = "/v0/order_book/orders/:order_id";
+/// Returns the external match fee for a given asset
+pub const GET_EXTERNAL_MATCH_FEE_ROUTE: &str = "/v0/order_book/external-match-fee";
 
 // -------------
 // | API Types |
@@ -29,4 +31,22 @@ pub struct GetNetworkOrdersResponse {
 pub struct GetNetworkOrderByIdResponse {
     /// The requested network order
     pub order: ApiNetworkOrder,
+}
+
+/// The response type to fetch the fee on a given asset
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetExternalMatchFeeResponse {
+    /// The relayer fee on the given asset
+    pub relayer_fee: String,
+    /// The protocol fee on the given asset
+    pub protocol_fee: String,
+}
+
+impl GetExternalMatchFeeResponse {
+    /// Get the total fee
+    pub fn total(&self) -> f64 {
+        let relayer_fee = self.relayer_fee.parse::<f64>().unwrap();
+        let protocol_fee = self.protocol_fee.parse::<f64>().unwrap();
+        relayer_fee + protocol_fee
+    }
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -35,7 +35,9 @@ use external_api::{
             REQUEST_EXTERNAL_QUOTE_ROUTE,
         },
         network::{GET_CLUSTER_INFO_ROUTE, GET_NETWORK_TOPOLOGY_ROUTE, GET_PEER_INFO_ROUTE},
-        order_book::{GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE},
+        order_book::{
+            GET_EXTERNAL_MATCH_FEE_ROUTE, GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE,
+        },
         price_report::PRICE_REPORT_ROUTE,
         task::{GET_TASK_QUEUE_PAUSED_ROUTE, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         task_history::TASK_HISTORY_ROUTE,
@@ -61,7 +63,7 @@ use hyper::{
 };
 use num_bigint::BigUint;
 use num_traits::Num;
-use order_book::GetSupportedTokensHandler;
+use order_book::{GetExternalMatchFeesHandler, GetSupportedTokensHandler};
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
@@ -469,6 +471,13 @@ impl HttpServer {
             &Method::GET,
             GET_SUPPORTED_TOKENS_ROUTE.to_string(),
             GetSupportedTokensHandler,
+        );
+
+        // The "/order_book/external-match-fee" route
+        router.add_unauthenticated_route(
+            &Method::GET,
+            GET_EXTERNAL_MATCH_FEE_ROUTE.to_string(),
+            GetExternalMatchFeesHandler,
         );
 
         // --- Network Routes --- //

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -23,7 +23,9 @@ use common::types::{
     wallet::Order,
     TimestampedPrice,
 };
-use constants::{Scalar, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER};
+use constants::{
+    Scalar, EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER,
+};
 use ethers::{
     middleware::Middleware,
     types::{transaction::eip2718::TypedTransaction, Address, U256},
@@ -207,7 +209,7 @@ impl ExternalMatchProcessor {
             .map_err(internal_error)?;
 
         // TODO: Currently we set the relayer fee to zero, remove this
-        let relayer_fee = FixedPoint::zero();
+        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
         let order = o.to_internal_order(decimal_corrected_price, relayer_fee);
 
         // Enforce an exact quote amount if specified

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -28,6 +28,7 @@ use common::types::proof_bundles::{
 use common::types::tasks::SettleExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use common::types::TimestampedPrice;
+use constants::EXTERNAL_MATCH_RELAYER_FEE;
 use external_api::bus_message::SystemBusMessage;
 use job_types::event_manager::{
     try_send_event, EventManagerQueue, ExternalFillEvent, RelayerEvent,
@@ -473,10 +474,9 @@ impl SettleMatchExternalTask {
 
         // Compute the fees due by the external party in the match
         let relayer_fee_address = self.state.get_external_fee_addr().await?.unwrap();
-
-        // TODO: We set the external party's relayer fee to 0 for now, check on this
+        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
         let external_party_fees = compute_fee_obligation_with_protocol_fee(
-            FixedPoint::default(), // relayer_fee
+            relayer_fee,
             protocol_fee,
             internal_party_order.side.opposite(),
             &self.match_res,


### PR DESCRIPTION
### Purpose
This PR adds the an endpoint for fetching external match fees on an asset: `/v0/order_book/external-match-fee?mint=0xdeadbeef`. This returns both the relayer and protocol fee.

### Testing
- [x] Unit tests pass
- [x] Tested locally
- [ ] Testing in testnet