### PR TITLE
task-driver: settle-match-external: Use correct relayer fee for witness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 **/flamegraph.svg
 rustc-ice-*
 
+# Git Patches
+**/*.patch
+
 # Config
 **/no_commit
 **/deployments.json

--- a/workers/proof-manager/src/proof_manager.rs
+++ b/workers/proof-manager/src/proof_manager.rs
@@ -91,7 +91,9 @@ impl ProofManager {
         }
 
         // Preprocess the circuits
-        ProofManager::preprocess_circuits()?;
+        thread_pool.spawn_fifo(|| {
+            ProofManager::preprocess_circuits().unwrap();
+        });
 
         loop {
             // Check the cancel channel before blocking on a job

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -474,9 +474,10 @@ impl SettleMatchExternalTask {
 
         // Compute the fees due by the external party in the match
         let relayer_fee_address = self.state.get_external_fee_addr().await?.unwrap();
-        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
+        let external_party_relayer_fee =
+            FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
         let external_party_fees = compute_fee_obligation_with_protocol_fee(
-            relayer_fee,
+            external_party_relayer_fee,
             protocol_fee,
             internal_party_order.side.opposite(),
             &self.match_res,


### PR DESCRIPTION
### Purpose
This PR fixes a small bug wherein the relayer fee used in the `VALID MATCH SETTLE ATOMIC` witness is overridden with the external party's fee. This was introduced in #902.

### Testing
- [x] Unit tests pass
- [x] Tested in testnet