### PR TITLE
circuits: zk-gadgets: poseidion: Fuse Poseidon rounds across gates

### DIFF
--- a/circuits/src/zk_gadgets/poseidon/gates.rs
+++ b/circuits/src/zk_gadgets/poseidon/gates.rs
@@ -1,0 +1,123 @@
+//! Poseidon hash gadget gates
+
+use std::marker::PhantomData;
+
+use ark_ff::Field;
+use ark_mpc::algebra::FieldWrapper;
+use mpc_relation::{constants::GATE_WIDTH, gates::Gate, traits::Circuit};
+
+// ------------------------
+// | External Round Gates |
+// ------------------------
+
+/// Represents a fused external sbox and  external MDS matrix multiplication per
+/// state element
+///
+/// Implements a_1^5 + a_2^5 + a_3^5 + a_4^5
+#[derive(Copy, Clone)]
+pub struct FusedExternalSboxMDSGate<F>(PhantomData<F>);
+impl<F: Field> FusedExternalSboxMDSGate<F> {
+    /// Create a new fused external sbox and MDS gate
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    /// Compute the output of the gate given the input wire assignments
+    pub fn compute_output<C: Circuit<F>>(
+        state_curr: C::Wire,
+        state0: C::Wire,
+        state1: C::Wire,
+        state2: C::Wire,
+    ) -> C::Wire {
+        let state_curr = pow5::<F, C>(state_curr);
+        let state0 = pow5::<F, C>(state0);
+        let state1 = pow5::<F, C>(state1);
+        let state2 = pow5::<F, C>(state2);
+        state_curr + state0 + state1 + state2
+    }
+}
+
+impl<F: Field> Gate<F> for FusedExternalSboxMDSGate<F> {
+    fn name(&self) -> &'static str {
+        "FusedExternalSboxMDSGate"
+    }
+
+    fn q_hash(&self) -> [F; GATE_WIDTH] {
+        [F::one(), F::one(), F::one(), F::one()]
+    }
+
+    fn q_o(&self) -> F {
+        F::one()
+    }
+}
+
+/// Compute the fifth power of a wire
+fn pow5<F: Field, C: Circuit<F>>(x: C::Wire) -> C::Wire {
+    let x2 = x.clone() * x.clone();
+    let x4 = x2.clone() * x2.clone();
+    x4 * x
+}
+
+// ------------------------
+// | Internal Round Gates |
+// ------------------------
+
+/// Represents a fused internal sbox and the first step in the internal MDS
+/// matmul, summing the inputs
+///
+/// Implements (a_1 * state0^5 + a_2 * state1 + a_3 * state2)
+#[derive(Copy, Clone)]
+pub struct FusedInternalSboxMDSGate<F: Field> {
+    /// The coefficients of the linear combination
+    state_elem_coeff: F,
+    /// Whether or not to apply the sbox to the state element
+    apply_sbox: bool,
+}
+
+impl<F: Field> FusedInternalSboxMDSGate<F> {
+    /// Create a new fused internal sbox and MDS gate
+    pub fn new(state_elem_coeff: F, apply_sbox: bool) -> Self {
+        Self { state_elem_coeff, apply_sbox }
+    }
+
+    /// Compute the output of the gate given the input wire assignments
+    pub fn compute_output<C: Circuit<F>>(
+        &self,
+        state_curr: C::Wire,
+        state0: C::Wire,
+        state1: C::Wire,
+        state2: C::Wire,
+    ) -> C::Wire {
+        let curr_coeff = C::Constant::from_field(&self.state_elem_coeff);
+        let state_elem = if self.apply_sbox { pow5::<F, C>(state_curr) } else { state_curr };
+        curr_coeff * state_elem + pow5::<F, C>(state0) + state1 + state2
+    }
+}
+
+impl<F: Field> Gate<F> for FusedInternalSboxMDSGate<F> {
+    fn name(&self) -> &'static str {
+        "FusedInternalSboxMDSGate"
+    }
+
+    fn q_hash(&self) -> [F; GATE_WIDTH] {
+        // If we are applying the sbox to the state element, we enable the first
+        // hash gate
+        if self.apply_sbox {
+            [self.state_elem_coeff, F::one(), F::zero(), F::zero()]
+        } else {
+            [F::zero(), F::one(), F::zero(), F::zero()]
+        }
+    }
+
+    fn q_lc(&self) -> [F; GATE_WIDTH] {
+        if self.apply_sbox {
+            [F::zero(), F::zero(), F::one(), F::one()]
+        } else {
+            [self.state_elem_coeff, F::zero(), F::one(), F::one()]
+        }
+    }
+
+    fn q_o(&self) -> F {
+        F::one()
+    }
+}

--- a/circuits/src/zk_gadgets/poseidon/mod.rs
+++ b/circuits/src/zk_gadgets/poseidon/mod.rs
@@ -1,0 +1,79 @@
+//! Poseidon hash gadget
+
+pub(super) mod gates;
+mod hash;
+
+pub use hash::*;
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod test {
+    use circuit_types::{traits::CircuitBaseType, PlonkCircuit};
+    use constants::Scalar;
+    use itertools::Itertools;
+    use mpc_relation::traits::Circuit;
+    use rand::thread_rng;
+    use renegade_crypto::hash::{compute_poseidon_hash, Poseidon2Sponge};
+
+    use crate::zk_gadgets::poseidon::PoseidonHashGadget;
+
+    /// Tests absorbing a series of elements into the hasher and comparing to
+    /// the hasher in `renegade-crypto`
+    #[test]
+    fn test_sponge() {
+        const N: usize = 100;
+        let mut rng = thread_rng();
+        let values = (0..N).map(|_| Scalar::random(&mut rng)).collect_vec();
+
+        let expected = compute_poseidon_hash(&values);
+
+        // Constrain the gadget result
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let mut gadget = PoseidonHashGadget::new(cs.zero());
+
+        // Allocate the values in the constraint system
+        let input_vars = values.iter().map(|v| v.create_witness(&mut cs)).collect_vec();
+        let output_var = expected.create_public_var(&mut cs);
+
+        gadget.hash(&input_vars, output_var, &mut cs).unwrap();
+
+        // Check that the constraints are satisfied
+        assert!(cs.check_circuit_satisfiability(&[expected.inner()]).is_ok());
+    }
+
+    /// Tests a batch absorb and squeeze of the hasher
+    #[test]
+    fn test_batch_absorb_squeeze() {
+        const N: usize = 5;
+        let mut rng = thread_rng();
+        let absorb_values = (0..N).map(|_| Scalar::random(&mut rng)).collect_vec();
+
+        // Compute the expected result
+        let mut hasher = Poseidon2Sponge::new();
+        hasher.absorb_batch(&absorb_values.iter().map(Scalar::inner).collect_vec());
+        let expected_squeeze_values =
+            hasher.squeeze_batch(N).into_iter().map(Scalar::new).collect_vec();
+
+        // Compute the result in-circuit
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let mut gadget = PoseidonHashGadget::new(cs.zero());
+        let absorb_vars = absorb_values.iter().map(|v| v.create_witness(&mut cs)).collect_vec();
+
+        gadget.batch_absorb(&absorb_vars, &mut cs).unwrap();
+        let squeeze_vars = gadget.batch_squeeze(N, &mut cs).unwrap();
+
+        // Check that the squeezed values match the expected values
+        for (squeeze_var, expected_value) in
+            squeeze_vars.into_iter().zip(expected_squeeze_values.into_iter())
+        {
+            let expected_var = expected_value.create_witness(&mut cs);
+            cs.enforce_equal(squeeze_var, expected_var).unwrap();
+        }
+
+        // Check that the constraints are satisfied
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+    }
+}


### PR DESCRIPTION
### Purpose
This PR makes a series of optimizations to the Poseidon2 gadgets that fuse multiple permutation rounds across gates, to minimize the gate footprint.

The result is a significant decrease in the gates used for the following circuits. This results in decrease in the power of two rounding used for most circuits, halving their prover time.
- **Single Poseidon Hash**: 359 -> 199 gates
- `VALID WALLET CREATE`: 13575 -> 7655 gates
- `VALID WALLET UPDATE`: 54715 -> 32155 gates
- `VALID REBLIND`: 75857 -> 42097 gates
- `VALID OFFLINE FEE SETTLEMENT`: 80145 -> 46065 gates
- `VALID RELAYER FEE SETTLEMENT`: 128289 -> 72449 gates
- `VALID FEE REDEMPTION`: 65792 -> 37792 gates

### Testing
- [x] All unit tests pass