### PR TITLE
circuits: zk-circuits: valid-malleable-match: Define skeleton

### DIFF
--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -8,9 +8,10 @@ use ark_bn254::g1::Config as G1Config;
 use ark_ec::short_weierstrass::Affine;
 use circuit_types::{
     elgamal::{ElGamalCiphertext, EncryptionKey},
+    fees::FeeTake,
     keychain::PublicSigningKey,
     note::NOTE_CIPHERTEXT_SIZE,
-    r#match::{ExternalMatchResult, FeeTake, OrderSettlementIndices},
+    r#match::{ExternalMatchResult, OrderSettlementIndices},
     traits::BaseType,
     transfers::{ExternalTransfer, ExternalTransferDirection},
     Amount, PlonkLinkProof, PlonkProof, PolynomialCommitment, SizedWalletShare,

--- a/circuit-types/src/balance.rs
+++ b/circuit-types/src/balance.rs
@@ -22,7 +22,7 @@ use {
 };
 
 use crate::{
-    biguint_from_hex_string, biguint_to_hex_addr, note::Note, r#match::FeeTake,
+    biguint_from_hex_string, biguint_to_hex_addr, fees::FeeTake, note::Note,
     validate_amount_bitlength, Address, Amount,
 };
 

--- a/circuit-types/src/fees.rs
+++ b/circuit-types/src/fees.rs
@@ -1,0 +1,71 @@
+//! Fee types for circuits in the Renegade system
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::{fixed_point::FixedPoint, Amount};
+
+#[cfg(feature = "proof-system-types")]
+use {
+    crate::{
+        traits::{
+            BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType,
+            MultiproverCircuitBaseType,
+        },
+        Fabric,
+    },
+    circuit_macros::circuit_type,
+    constants::{AuthenticatedScalar, Scalar, ScalarField},
+    mpc_relation::{traits::Circuit, Variable},
+};
+
+/// A pair of fee take rates
+///
+/// Note that these are different from the fee takes, they represent fee rates
+/// charged by the relayer and protocol, not the actual fee takes from a match
+#[cfg_attr(
+    feature = "proof-system-types",
+    circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)
+)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeTakeRate {
+    /// The relayer fee rate
+    pub relayer_fee_rate: FixedPoint,
+    /// The protocol fee rate
+    pub protocol_fee_rate: FixedPoint,
+}
+
+impl FeeTakeRate {
+    /// Get the total fee rate
+    pub fn total(&self) -> FixedPoint {
+        self.relayer_fee_rate + self.protocol_fee_rate
+    }
+}
+
+/// The fee takes from a match
+#[cfg_attr(
+    feature = "proof-system-types",
+    circuit_type(serde, singleprover_circuit, mpc, multiprover_circuit)
+)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeTake {
+    /// The fee the relayer takes
+    pub relayer_fee: Amount,
+    /// The fee the protocol takes
+    pub protocol_fee: Amount,
+}
+
+impl FeeTake {
+    /// Get the total fee
+    pub fn total(&self) -> Amount {
+        self.relayer_fee + self.protocol_fee
+    }
+}
+
+#[cfg(feature = "proof-system-types")]
+impl AuthenticatedFeeTake {
+    /// Get the total fee
+    pub fn total(&self) -> AuthenticatedScalar {
+        &self.relayer_fee + &self.protocol_fee
+    }
+}

--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod balance;
 pub mod elgamal;
 #[cfg(feature = "proof-system-types")]
 pub mod errors;
+pub mod fees;
 pub mod fixed_point;
 pub mod keychain;
 #[cfg(feature = "proof-system-types")]

--- a/circuits/benches/match.rs
+++ b/circuits/benches/match.rs
@@ -10,9 +10,10 @@ use std::time::{Duration, Instant};
 use ark_mpc::{PARTY0, PARTY1};
 use circuit_types::{
     balance::Balance,
+    fees::FeeTake,
     fixed_point::FixedPoint,
     order::Order,
-    r#match::{FeeTake, MatchResult},
+    r#match::MatchResult,
     traits::{MpcBaseType, MpcType, MultiProverCircuit, MultiproverCircuitBaseType},
     MpcPlonkCircuit,
 };

--- a/circuits/src/mpc_circuits/settle.rs
+++ b/circuits/src/mpc_circuits/settle.rs
@@ -1,8 +1,9 @@
 //! Settles a match into secret shared wallets
 
 use circuit_types::{
+    fees::AuthenticatedFeeTake,
     fixed_point::AuthenticatedFixedPoint,
-    r#match::{AuthenticatedFeeTake, AuthenticatedMatchResult, OrderSettlementIndices},
+    r#match::{AuthenticatedMatchResult, OrderSettlementIndices},
     wallet::AuthenticatedWalletShare,
     Fabric,
 };
@@ -117,9 +118,10 @@ mod test {
 
     use ark_mpc::{PARTY0, PARTY1};
     use circuit_types::{
+        fees::FeeTake,
         fixed_point::FixedPoint,
         order::OrderSide,
-        r#match::{FeeTake, MatchResult, OrderSettlementIndices},
+        r#match::{MatchResult, OrderSettlementIndices},
         traits::{BaseType, MpcBaseType, MpcType},
         SizedWalletShare,
     };

--- a/circuits/src/zk_circuits/mod.rs
+++ b/circuits/src/zk_circuits/mod.rs
@@ -5,6 +5,7 @@
 pub mod proof_linking;
 pub mod valid_commitments;
 pub mod valid_fee_redemption;
+pub mod valid_malleable_match_settle_atomic;
 pub mod valid_match_settle;
 pub mod valid_match_settle_atomic;
 pub mod valid_offline_fee_settlement;

--- a/circuits/src/zk_circuits/valid_malleable_match_settle_atomic.rs
+++ b/circuits/src/zk_circuits/valid_malleable_match_settle_atomic.rs
@@ -1,0 +1,130 @@
+//! Defines a malleable version of the `VALID MATCH SETTLE ATOMIC` circuit
+//!
+//! Malleable here means that the match amount is not known at the time the
+//! witness and statement are created. Instead, we constrain a valid range of
+//! amounts that the internal order and balance can support
+
+// ----------------------
+// | Circuit Definition |
+// ----------------------
+
+use circuit_macros::circuit_type;
+use circuit_types::{
+    balance::Balance,
+    fees::FeeTakeRate,
+    order::Order,
+    r#match::BoundedMatchResult,
+    traits::{BaseType, CircuitBaseType, CircuitVarType, SingleProverCircuit},
+    wallet::WalletShare,
+    Address, PlonkCircuit,
+};
+use constants::{Scalar, ScalarField, MAX_BALANCES, MAX_ORDERS};
+use mpc_plonk::errors::PlonkError;
+use mpc_relation::{errors::CircuitError, proof_linking::GroupLayout, traits::Circuit, Variable};
+use serde::{Deserialize, Serialize};
+
+/// The circuit implementation of `VALID MALLEABLE MATCH SETTLE ATOMIC`
+pub struct ValidMalleableMatchSettleAtomic<const MAX_BALANCES: usize, const MAX_ORDERS: usize>;
+/// A `VALID MALLEABLE MATCH SETTLE ATOMIC` with default state element sizing
+pub type SizedValidMalleableMatchSettleAtomic =
+    ValidMalleableMatchSettleAtomic<MAX_BALANCES, MAX_ORDERS>;
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize>
+    ValidMalleableMatchSettleAtomic<MAX_BALANCES, MAX_ORDERS>
+where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    /// The circuit constraints for `VALID MALLEABLE MATCH SETTLE ATOMIC`
+    pub fn circuit(
+        statement: ValidMalleableMatchSettleAtomicStatementVar<MAX_BALANCES, MAX_ORDERS>,
+        witness: ValidMalleableMatchSettleAtomicWitnessVar<MAX_BALANCES, MAX_ORDERS>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        todo!("define constraints")
+    }
+}
+
+// ---------------------------
+// | Witness Type Definition |
+// ---------------------------
+
+/// The witness type for `VALID MALLEABLE MATCH SETTLE ATOMIC`
+#[circuit_type(serde, singleprover_circuit)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidMalleableMatchSettleAtomicWitness<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    /// The internal party's order
+    pub internal_party_order: Order,
+    /// The internal party's balance
+    pub internal_party_balance: Balance,
+    /// The internal party's receive balance
+    pub internal_party_receive_balance: Balance,
+    /// The internal party's public shares before settlement
+    pub internal_party_public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS>,
+}
+
+/// The statement type for `VALID MALLEABLE MATCH SETTLE ATOMIC`
+#[circuit_type(singleprover_circuit)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidMalleableMatchSettleAtomicStatement<
+    const MAX_BALANCES: usize,
+    const MAX_ORDERS: usize,
+> where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    /// The result of the match
+    pub match_result: BoundedMatchResult,
+    /// The fee rates charged to the external party
+    pub external_fee_rates: FeeTakeRate,
+    /// The fee rates charged to the internal party
+    pub internal_fee_rates: FeeTakeRate,
+    /// The public wallet shares of the internal party
+    pub internal_party_public_shares: WalletShare<MAX_BALANCES, MAX_ORDERS>,
+    /// The address at which the relayer wishes to receive their fee due from
+    /// the external party
+    pub relayer_fee_address: Address,
+}
+
+// ---------------------
+// | Prove Verify Flow |
+// ---------------------
+
+impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize> SingleProverCircuit
+    for ValidMalleableMatchSettleAtomic<MAX_BALANCES, MAX_ORDERS>
+where
+    [(); MAX_BALANCES + MAX_ORDERS]: Sized,
+{
+    type Statement = ValidMalleableMatchSettleAtomicStatement<MAX_BALANCES, MAX_ORDERS>;
+    type Witness = ValidMalleableMatchSettleAtomicWitness<MAX_BALANCES, MAX_ORDERS>;
+
+    fn name() -> String {
+        format!("VALID MALLEABLE MATCH SETTLE ATOMIC ({MAX_BALANCES}, {MAX_ORDERS})")
+    }
+
+    fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
+        Ok(vec![])
+    }
+
+    fn apply_constraints(
+        witness_var: ValidMalleableMatchSettleAtomicWitnessVar<MAX_BALANCES, MAX_ORDERS>,
+        statement_var: ValidMalleableMatchSettleAtomicStatementVar<MAX_BALANCES, MAX_ORDERS>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), PlonkError> {
+        Self::circuit(statement_var, witness_var, cs).map_err(PlonkError::CircuitError)
+    }
+}
+
+// ---------
+// | Tests |
+// ---------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO: Add tests
+}

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -9,9 +9,10 @@ pub mod single_prover;
 
 use circuit_types::{
     balance::Balance,
+    fees::FeeTake,
     fixed_point::FixedPoint,
     order::Order,
-    r#match::{FeeTake, MatchResult, OrderSettlementIndices},
+    r#match::{MatchResult, OrderSettlementIndices},
     traits::{
         BaseType, CircuitBaseType, CircuitVarType, MpcBaseType, MpcType, MultiProverCircuit,
         MultiproverCircuitBaseType, SingleProverCircuit,

--- a/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/multi_prover.rs
@@ -3,9 +3,10 @@
 use ark_ff::{One, Zero};
 use circuit_types::{
     balance::BalanceVar,
+    fees::FeeTakeVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::{FeeTakeVar, MatchResultVar, OrderSettlementIndicesVar},
+    r#match::{MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     Fabric, MpcPlonkCircuit, AMOUNT_BITS,
 };

--- a/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/single_prover.rs
@@ -3,9 +3,10 @@
 use ark_ff::{One, Zero};
 use circuit_types::{
     balance::BalanceVar,
+    fees::FeeTakeVar,
     fixed_point::{FixedPointVar, DEFAULT_FP_PRECISION},
     order::OrderVar,
-    r#match::{FeeTakeVar, MatchResultVar, OrderSettlementIndicesVar},
+    r#match::{MatchResultVar, OrderSettlementIndicesVar},
     wallet::WalletShareVar,
     PlonkCircuit, AMOUNT_BITS,
 };

--- a/circuits/src/zk_circuits/valid_match_settle_atomic.rs
+++ b/circuits/src/zk_circuits/valid_match_settle_atomic.rs
@@ -24,9 +24,10 @@ use crate::{
 use circuit_macros::circuit_type;
 use circuit_types::{
     balance::{Balance, BalanceVar},
+    fees::FeeTake,
     fixed_point::{FixedPoint, FixedPointVar},
     order::{Order, OrderVar},
-    r#match::{ExternalMatchResult, ExternalMatchResultVar, FeeTake, OrderSettlementIndices},
+    r#match::{ExternalMatchResult, ExternalMatchResultVar, OrderSettlementIndices},
     traits::{BaseType, CircuitBaseType, CircuitVarType},
     wallet::WalletShare,
     Address, PlonkCircuit, AMOUNT_BITS,

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -9,11 +9,8 @@
 //! for consenting liquidity on a given token pair.
 
 use circuit_types::{
-    fixed_point::FixedPoint,
-    max_price,
-    order::OrderSide,
-    r#match::{ExternalMatchResult, FeeTake},
-    Amount,
+    fees::FeeTake, fixed_point::FixedPoint, max_price, order::OrderSide,
+    r#match::ExternalMatchResult, Amount,
 };
 use common::types::TimestampedPrice;
 use constants::{Scalar, NATIVE_ASSET_ADDRESS};

--- a/util/src/matching_engine.rs
+++ b/util/src/matching_engine.rs
@@ -2,9 +2,10 @@
 
 use circuit_types::{
     balance::Balance,
+    fees::FeeTake,
     fixed_point::FixedPoint,
     order::{Order, OrderSide},
-    r#match::{FeeTake, MatchResult, OrderSettlementIndices},
+    r#match::{MatchResult, OrderSettlementIndices},
     wallet::WalletShare,
     Amount,
 };

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -12,10 +12,7 @@ use std::{sync::Arc, time::Duration};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use circuit_types::{
-    fixed_point::FixedPoint,
-    r#match::{ExternalMatchResult, FeeTake},
-};
+use circuit_types::{fees::FeeTake, fixed_point::FixedPoint, r#match::ExternalMatchResult};
 use common::types::{
     hmac::HmacKey,
     proof_bundles::{AtomicMatchSettleBundle, OrderValidityProofBundle},

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -4,7 +4,8 @@
 use std::time::SystemTime;
 
 use circuit_types::{
-    r#match::{ExternalMatchResult, FeeTake, MatchResult},
+    fees::FeeTake,
+    r#match::{ExternalMatchResult, MatchResult},
     transfers::ExternalTransfer,
     Amount,
 };


### PR DESCRIPTION
### Purpose
This PR defines the skeleton for the `VALID MALLEABLE MATCH SETTLE ATOMIC` circuit, including its witness and statement types.

### Todo
- Define constraints for the circuit (see spec)
- Write tests for the circuit
- Benchmark circuit performance

### Testing
- [x] All unit tests pass