### PR TITLE
api-server: http: external-match: Improve price reporter error message

### DIFF
--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -58,7 +58,7 @@ use crate::{
     router::{QueryParams, TypedHandler, UrlParams},
 };
 
-use super::wallet::get_usdc_denominated_value;
+use super::wallet::{get_usdc_denominated_value, ERR_FAILED_TO_FETCH_PRICE};
 
 /// The gas estimation to use if fetching a gas estimation fails
 const DEFAULT_GAS_ESTIMATION: u64 = 4_000_000; // 4m
@@ -203,7 +203,7 @@ impl ExternalMatchProcessor {
             .await
             .and_then(|p| p.get_decimal_corrected_price(&base, &quote))
             .map(|p| p.as_fixed_point())
-            .map_err(internal_error)?;
+            .map_err(|_| internal_error(ERR_FAILED_TO_FETCH_PRICE))?;
 
         // TODO: Currently we set the relayer fee to zero, remove this
         let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -61,6 +61,10 @@ const DEFAULT_ORDER_HISTORY_LEN: usize = 100;
 /// to return
 const ORDER_HISTORY_LEN_PARAM: &str = "order_history_len";
 
+/// The error message emitted when a price cannot be fetched
+pub(crate) const ERR_FAILED_TO_FETCH_PRICE: &str =
+    "price too stale for matching, try again shortly";
+
 /// Find the wallet in global state and apply any tasks to its state
 pub(crate) async fn find_wallet_for_update(
     wallet_id: WalletIdentifier,
@@ -128,8 +132,10 @@ pub(crate) async fn get_usdc_denominated_value(
     }
 
     // Peek at the price report from the price reporter
-    let ts_price =
-        price_reporter_queue.peek_price(base_token, quote_token).await.map_err(internal_error)?;
+    let ts_price = price_reporter_queue
+        .peek_price(base_token, quote_token)
+        .await
+        .map_err(|_| internal_error(ERR_FAILED_TO_FETCH_PRICE))?;
     let price = ts_price.price;
 
     // Compute the usdc denominated value


### PR DESCRIPTION
### Purpose
This PR improves the error message emitted when the relayer is unable to fetch a price reporter at the API layer. Rather than `{ "code": 500, "error": "NotEnoughDataReported(0)" }` we respond with `{ "code": 500, "error": "price too stale for matching, try again shortly" }`.

### Testing
- [x] Testing in testnet