### PR TITLE
arbitrum-client, common: Remove dependency on `contracts-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,6 @@ dependencies = [
  "colored",
  "common 0.1.0",
  "constants 0.1.0",
- "contracts-common",
  "ethers",
  "eyre",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2411,7 +2411,6 @@ dependencies = [
  "circuit-types 0.1.0",
  "circuits 0.1.0",
  "constants 0.1.0",
- "contracts-common",
  "crossbeam",
  "derivative",
  "ecdsa 0.16.9",
@@ -2446,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2591,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3947,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "base64 0.22.1",
  "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
@@ -8267,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -10765,7 +10764,7 @@ dependencies = [
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#8a592342f72e8251ab61bd95543da48ac18e202f"
+source = "git+https://github.com/renegade-fi/renegade.git#36e3b0e5472dd2303304d8e560b475160a1ed40a"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -55,9 +55,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
 
-# === Contracts Repo Dependencies === #
-contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
 eyre = { workspace = true }

--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -16,7 +16,6 @@ use common::types::{
     transfer_auth::TransferAuth,
 };
 use constants::Scalar;
-use contracts_common::types::MatchPayload;
 use ethers::{
     abi::Detokenize,
     contract::ContractCall,
@@ -33,6 +32,7 @@ use util::{err_str, telemetry::helpers::backfill_trace_field};
 use renegade_metrics::helpers::{decr_inflight_txs, incr_inflight_txs};
 
 use crate::{
+    contract_types::MatchPayload,
     conversion::{
         build_atomic_match_linking_proofs, build_atomic_match_proofs, build_match_linking_proofs,
         build_match_proofs, to_contract_proof, to_contract_transfer_aux_data,

--- a/arbitrum-client/src/contract_types/mod.rs
+++ b/arbitrum-client/src/contract_types/mod.rs
@@ -1,0 +1,25 @@
+//! Types from the contracts
+//!
+//! We copy here instead of importing to avoid having to depend on the contracts
+//! repo. The dependencies in the contracts are specified very strictly, and we
+//! wish to decouple the relayer from the contract's dependencies.
+//!
+//! See: https://github.com/renegade-fi/renegade-contracts/tree/main/contracts-common
+//! for the original types
+
+mod serde_def_types;
+mod types;
+pub(crate) use types::*;
+
+// ----------------------------
+// | Contract Types Constants |
+// ----------------------------
+
+/// The number of wire types in the circuit
+pub const NUM_WIRE_TYPES: usize = 5;
+/// The number of selectors in the circuit
+pub const NUM_SELECTORS: usize = 13;
+/// The number of u64s it takes to represent a field element
+pub const NUM_U64S_FELT: usize = 4;
+/// The number of scalars it takes to encode a secp256k1 public key
+pub const NUM_SCALARS_PK: usize = 4;

--- a/arbitrum-client/src/contract_types/serde_def_types.rs
+++ b/arbitrum-client/src/contract_types/serde_def_types.rs
@@ -1,0 +1,168 @@
+//! Types & trait implementations to enable deriving serde::{Serialize,
+//! Deserialize} on the foreign Arkworks, Alloy, and other types that we compose
+//! into complex structs.
+
+use alloy_primitives::{Address, FixedBytes, Uint};
+use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq2Config, FqConfig, FrConfig};
+use ark_ec::short_weierstrass::Affine;
+use ark_ff::{BigInt, Fp, Fp2ConfigWrapper, FpConfig, MontBackend, QuadExtField};
+use core::marker::PhantomData;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
+
+use super::types::{G1Affine, G1BaseField, G2Affine, G2BaseField, ScalarField};
+
+/// This macro implements the `SerializeAs` and `DeserializeAs` traits for a
+/// given type, allowing it to be serialized / deserialized as the remote type
+/// it mirrors.
+macro_rules! impl_serde_as {
+    ($remote_type:ty, $def_type:ty, $($generics:tt)*) => {
+        impl<$($generics)*> SerializeAs<$remote_type> for $def_type {
+            fn serialize_as<S>(source: &$remote_type, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                <$def_type>::serialize(source, serializer)
+            }
+        }
+
+        impl<'de, $($generics)*> DeserializeAs<'de, $remote_type> for $def_type {
+            fn deserialize_as<D>(deserializer: D) -> Result<$remote_type, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <$def_type>::deserialize(deserializer)
+            }
+        }
+    };
+}
+
+/// A serde-compatible type mirroring [`BigInt`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "BigInt")]
+pub struct BigIntDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u64; N]);
+
+impl_serde_as!(BigInt<N>, BigIntDef<N>, const N: usize);
+
+/// A serde-compatible type mirroring [`Fp`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Fp")]
+pub struct FpDef<P: FpConfig<N>, const N: usize>(
+    #[serde_as(as = "BigIntDef<N>")] pub BigInt<N>,
+    pub PhantomData<P>,
+);
+
+impl_serde_as!(Fp<P, N>, FpDef<P, N>, P: FpConfig<N>, const N: usize);
+
+/// A serde-compatible type alias mirroring [`ScalarField`]
+pub type ScalarFieldDef = FpDef<MontBackend<FrConfig, 4>, 4>;
+
+/// A serde-compatible type alias mirroring [`G1BaseField`]
+pub(crate) type G1BaseFieldDef = FpDef<MontBackend<FqConfig, 4>, 4>;
+
+/// A serde-compatible wrapper type around [`ScalarField`],
+/// allowing direct access to the underlying type
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SerdeScalarField(#[serde_as(as = "ScalarFieldDef")] pub ScalarField);
+
+/// A serde-compatible type mirroring [`G2BaseField`],
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "QuadExtField<Fp2ConfigWrapper<Fq2Config>>")]
+pub(crate) struct G2BaseFieldDef {
+    #[doc(hidden)]
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c0: G1BaseField,
+    #[doc(hidden)]
+    #[serde_as(as = "G1BaseFieldDef")]
+    pub c1: G1BaseField,
+}
+
+impl_serde_as!(G2BaseField, G2BaseFieldDef,);
+
+/// A serde-compatible type mirroring [`G1Affine`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G1Config>")]
+pub(crate) struct G1AffineDef {
+    #[doc(hidden)]
+    #[serde_as(as = "G1BaseFieldDef")]
+    x: G1BaseField,
+    #[doc(hidden)]
+    #[serde_as(as = "G1BaseFieldDef")]
+    y: G1BaseField,
+    #[doc(hidden)]
+    infinity: bool,
+}
+
+impl_serde_as!(G1Affine, G1AffineDef,);
+
+/// A serde-compatible wrapper type around [`G1Affine`],
+/// allowing direct access to the underlying type
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct SerdeG1Affine(#[serde_as(as = "G1AffineDef")] pub G1Affine);
+
+/// A serde-compatible type mirroring [`G2Affine`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Affine<G2Config>")]
+pub(crate) struct G2AffineDef {
+    #[doc(hidden)]
+    #[serde_as(as = "G2BaseFieldDef")]
+    x: G2BaseField,
+    #[doc(hidden)]
+    #[serde_as(as = "G2BaseFieldDef")]
+    y: G2BaseField,
+    #[doc(hidden)]
+    infinity: bool,
+}
+
+impl_serde_as!(G2Affine, G2AffineDef,);
+
+/// A serde-compatible wrapper type around [`G2Affine`],
+/// allowing direct access to the underlying type
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct SerdeG2Affine(#[serde_as(as = "G2AffineDef")] pub G2Affine);
+
+/// A serde-compatible type mirroring [`FixedBytes`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "FixedBytes")]
+pub(crate) struct FixedBytesDef<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
+
+impl_serde_as!(FixedBytes<N>, FixedBytesDef<N>, const N: usize);
+
+/// A serde-compatible type mirroring [`Address`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Address")]
+pub struct AddressDef(#[serde_as(as = "FixedBytesDef<20>")] FixedBytes<20>);
+
+impl_serde_as!(Address, AddressDef,);
+
+/// A serde-compatible type mirroring [`Uint`]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Uint")]
+pub(crate) struct UintDef<const BITS: usize, const LIMBS: usize> {
+    #[doc(hidden)]
+    #[serde_as(as = "[_; LIMBS]")]
+    #[serde(getter = "Uint::as_limbs")]
+    limbs: [u64; LIMBS],
+}
+
+impl<const BITS: usize, const LIMBS: usize> From<UintDef<BITS, LIMBS>> for Uint<BITS, LIMBS> {
+    fn from(value: UintDef<BITS, LIMBS>) -> Self {
+        Uint::from_limbs(value.limbs)
+    }
+}
+
+impl_serde_as!(Uint<BITS, LIMBS>, UintDef<BITS, LIMBS>, const BITS: usize, const LIMBS: usize);
+
+/// A serde-compatible type alias mirroring [`U256`]
+pub(crate) type U256Def = UintDef<256, 4>;

--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -1,0 +1,446 @@
+//! Runtime types used in the contract
+
+use alloy_primitives::{Address, U256};
+use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
+use ark_ec::short_weierstrass::Affine;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use super::serde_def_types::*;
+
+use super::NUM_WIRE_TYPES;
+
+/// Type alias for an element of the scalar field of the Bn254 curve
+pub type ScalarField = Fr;
+/// Type alias for an element of the Bn254 curve's G1 pairing group
+pub type G1Affine = Affine<G1Config>;
+/// Type alias for an element of the Bn254 curve's G2 pairing group
+pub type G2Affine = Affine<G2Config>;
+/// Type alias for an element of the Bn254 curve's G1 pairing group's base field
+pub type G1BaseField = Fq;
+/// Type alias for an element of the Bn254 curve's G2 pairing group's base field
+pub type G2BaseField = Fq2;
+
+/// A Plonk proof, using the "fast prover" strategy described in the paper.
+#[serde_as]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+pub struct Proof {
+    /// The commitments to the wire polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
+    pub wire_comms: [G1Affine; NUM_WIRE_TYPES],
+    /// The commitment to the grand product polynomial encoding the permutation
+    /// argument (i.e., copy constraints)
+    #[serde_as(as = "G1AffineDef")]
+    pub z_comm: G1Affine,
+    /// The commitments to the split quotient polynomials
+    #[serde_as(as = "[G1AffineDef; NUM_WIRE_TYPES]")]
+    pub quotient_comms: [G1Affine; NUM_WIRE_TYPES],
+    /// The opening proof of evaluations at challenge point `zeta`
+    #[serde_as(as = "G1AffineDef")]
+    pub w_zeta: G1Affine,
+    /// The opening proof of evaluations at challenge point `zeta * omega`
+    #[serde_as(as = "G1AffineDef")]
+    pub w_zeta_omega: G1Affine,
+    /// The evaluations of the wire polynomials at the challenge point `zeta`
+    #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES]")]
+    pub wire_evals: [ScalarField; NUM_WIRE_TYPES],
+    /// The evaluations of the permutation polynomials at the challenge point
+    /// `zeta`
+    #[serde_as(as = "[ScalarFieldDef; NUM_WIRE_TYPES - 1]")]
+    pub sigma_evals: [ScalarField; NUM_WIRE_TYPES - 1],
+    /// The evaluation of the grand product polynomial at the challenge point
+    /// `zeta * omega` (\bar{z})
+    #[serde_as(as = "ScalarFieldDef")]
+    pub z_bar: ScalarField,
+}
+
+/// The proofs representing the matching and settlement of a trade
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchProofs {
+    /// Party 0's proof of `VALID COMMITMENTS`
+    pub valid_commitments_0: Proof,
+    /// Party 0's proof of `VALID REBLIND`
+    pub valid_reblind_0: Proof,
+    /// Party 1's proof of `VALID COMMITMENTS`
+    pub valid_commitments_1: Proof,
+    /// Party 1's proof of `VALID REBLIND`
+    pub valid_reblind_1: Proof,
+    /// The proof of `VALID MATCH SETTLE`
+    pub valid_match_settle: Proof,
+}
+
+/// A proof of a group of linked inputs between two Plonk proofs
+#[serde_as]
+#[derive(Serialize, Deserialize, Default, Copy, Clone)]
+pub struct LinkingProof {
+    /// The commitment to the linking quotient polynomial
+    #[serde_as(as = "G1AffineDef")]
+    pub linking_quotient_poly_comm: G1Affine,
+    /// The opening proof of the linking polynomial
+    #[serde_as(as = "G1AffineDef")]
+    pub linking_poly_opening: G1Affine,
+}
+
+/// The linking proofs used to ensure input consistency
+/// between the `MatchProofs`
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchLinkingProofs {
+    /// The proof of linked inputs between
+    /// `PARTY 0 VALID REBLIND` <-> `PARTY 0 VALID COMMITMENTS`
+    pub valid_reblind_commitments_0: LinkingProof,
+    /// The proof of linked inputs between
+    /// `PARTY 0 VALID COMMITMENTS` <-> `VALID MATCH SETTLE`
+    pub valid_commitments_match_settle_0: LinkingProof,
+    /// The proof of linked inputs between
+    /// `PARTY 1 VALID REBLIND` <-> `PARTY 1 VALID COMMITMENTS`
+    pub valid_reblind_commitments_1: LinkingProof,
+    /// The proof of linked inputs between
+    /// `PARTY 1 VALID COMMITMENTS` <-> `VALID MATCH SETTLE`
+    pub valid_commitments_match_settle_1: LinkingProof,
+}
+
+/// The proofs representing the matching and settlement of an atomic match
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchAtomicProofs {
+    /// The internal party's proof of `VALID COMMITMENTS`
+    pub valid_commitments: Proof,
+    /// The internal party's proof of `VALID REBLIND`
+    pub valid_reblind: Proof,
+    /// The proof of `VALID MATCH SETTLE ATOMIC`
+    pub valid_match_settle_atomic: Proof,
+}
+
+/// The linking proofs used to ensure input consistency
+/// between the `MatchAtomicProofs`
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct MatchAtomicLinkingProofs {
+    /// The proof of linked inputs between the internal party's
+    /// `VALID REBLIND` <-> `VALID COMMITMENTS`
+    pub valid_reblind_commitments: LinkingProof,
+    /// The proof of linked inputs between the internal party's
+    /// `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC`
+    pub valid_commitments_match_settle_atomic: LinkingProof,
+}
+
+/// Represents an external transfer of an ERC20 token
+#[serde_as]
+#[derive(Serialize, Deserialize, Default)]
+pub struct ExternalTransfer {
+    /// The address of the account contract to deposit from or withdraw to
+    #[serde_as(as = "AddressDef")]
+    pub account_addr: Address,
+    /// The mint (contract address) of the token being transferred
+    #[serde_as(as = "AddressDef")]
+    pub mint: Address,
+    /// The amount of the token transferred
+    #[serde_as(as = "U256Def")]
+    pub amount: U256,
+    /// Whether or not the transfer is a withdrawal (otherwise a deposit)
+    pub is_withdrawal: bool,
+}
+
+/// Auxiliary data passed alongside an external transfer to verify its validity.
+/// This includes a signature over the external transfer, and in the case of a
+/// deposit, the associated Permit2 data ([reference](https://docs.uniswap.org/contracts/permit2/reference/signature-transfer))
+#[serde_as]
+#[derive(Default, Serialize, Deserialize)]
+pub struct TransferAuxData {
+    /// The `PermitTransferFrom` nonce
+    #[serde_as(as = "Option<U256Def>")]
+    pub permit_nonce: Option<U256>,
+    /// The `PermitTransferFrom` deadline
+    #[serde_as(as = "Option<U256Def>")]
+    pub permit_deadline: Option<U256>,
+    /// The signature of the `PermitTransferFrom` typed data
+    pub permit_signature: Option<Vec<u8>>,
+    /// The signature of the external transfer
+    pub transfer_signature: Option<Vec<u8>>,
+}
+
+/// A fee take from a match
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct FeeTake {
+    /// The fee the relayer takes
+    #[serde_as(as = "U256Def")]
+    pub relayer_fee: U256,
+    /// The fee the protocol takes
+    #[serde_as(as = "U256Def")]
+    pub protocol_fee: U256,
+}
+
+/// The result of an atomic match
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ExternalMatchResult {
+    /// The mint (erc20 address) of the quote token
+    #[serde_as(as = "AddressDef")]
+    pub quote_mint: Address,
+    /// The mint (erc20 address) of the base token
+    #[serde_as(as = "AddressDef")]
+    pub base_mint: Address,
+    /// The amount of the quote token
+    #[serde_as(as = "U256Def")]
+    pub quote_amount: U256,
+    /// The amount of the base token
+    #[serde_as(as = "U256Def")]
+    pub base_amount: U256,
+    /// The direction of the trade
+    ///
+    /// `false` (0) corresponds to the internal party buying the base
+    /// `true` (1) corresponds to the internal party selling the base
+    pub direction: bool,
+}
+
+/// Represents the affine coordinates of a secp256k1 ECDSA public key.
+/// Since the secp256k1 base field order is larger than that of Bn254's scalar
+/// field, it takes 2 Bn254 scalar field elements to represent each coordinate.
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct PublicSigningKey {
+    /// The affine x-coordinate of the public key
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
+    pub x: [ScalarField; 2],
+    /// The affine y-coordinate of the public key
+    #[serde_as(as = "[ScalarFieldDef; 2]")]
+    pub y: [ScalarField; 2],
+}
+
+/// Represents an affine point on the BabyJubJub curve,
+/// whose base field is the scalar field of the Bn254 curve.
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+pub struct BabyJubJubPoint {
+    /// The x-coordinate of the point
+    #[serde_as(as = "ScalarFieldDef")]
+    pub x: ScalarField,
+    /// The y-coordinate of the point
+    #[serde_as(as = "ScalarFieldDef")]
+    pub y: ScalarField,
+}
+
+/// A BabyJubJub EC-ElGamal public encryption key
+pub type PublicEncryptionKey = BabyJubJubPoint;
+
+/// Statement for `VALID_WALLET_CREATE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidWalletCreateStatement {
+    /// The commitment to the private secret shares of the wallet
+    #[serde_as(as = "ScalarFieldDef")]
+    pub private_shares_commitment: ScalarField,
+    /// The blinded public secret shares of the wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub public_wallet_shares: Vec<ScalarField>,
+}
+
+/// Statement for `VALID_WALLET_UPDATE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidWalletUpdateStatement {
+    /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub old_shares_nullifier: ScalarField,
+    /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub new_private_shares_commitment: ScalarField,
+    /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub new_public_shares: Vec<ScalarField>,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root: ScalarField,
+    /// The external transfer associated with this update
+    pub external_transfer: Option<ExternalTransfer>,
+    /// The public root key of the old wallet, rotated out after this update
+    pub old_pk_root: PublicSigningKey,
+}
+
+/// Statement for the `VALID_REBLIND` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidReblindStatement {
+    /// The nullifier of the original wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub original_shares_nullifier: ScalarField,
+    /// A commitment to the private secret shares of the reblinded wallet
+    #[serde_as(as = "ScalarFieldDef")]
+    pub reblinded_private_shares_commitment: ScalarField,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the original wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root: ScalarField,
+}
+
+/// The indices that specify where settlement logic should modify the wallet
+/// shares
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderSettlementIndices {
+    /// The index of the balance that holds the mint that the wallet will
+    /// send if a successful match occurs
+    pub balance_send: u64,
+    /// The index of the balance that holds the mint that the wallet will
+    /// receive if a successful match occurs
+    pub balance_receive: u64,
+    /// The index of the order that is to be matched
+    pub order: u64,
+}
+
+/// Statement for the `VALID_COMMITMENTS` circuit
+#[derive(Serialize, Deserialize)]
+pub struct ValidCommitmentsStatement {
+    /// The indices used in settling this order once matched
+    pub indices: OrderSettlementIndices,
+}
+
+/// Statement for the `VALID_MATCH_SETTLE` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleStatement {
+    /// The modified blinded public secret shares of the first party
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub party0_modified_shares: Vec<ScalarField>,
+    /// The modified blinded public secret shares of the second party
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub party1_modified_shares: Vec<ScalarField>,
+    /// The indices that settlement should modify in the first party's wallet
+    pub party0_indices: OrderSettlementIndices,
+    /// The indices that settlement should modify in the second party's wallet
+    pub party1_indices: OrderSettlementIndices,
+    /// The fee rate owed to the protocol
+    #[serde_as(as = "ScalarFieldDef")]
+    pub protocol_fee: ScalarField,
+}
+
+/// Represents the outputs produced by one of the parties in a match
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct MatchPayload {
+    /// The statement for the party's `VALID_COMMITMENTS` proof
+    pub valid_commitments_statement: ValidCommitmentsStatement,
+    /// The statement for the party's `VALID_REBLIND` proof
+    pub valid_reblind_statement: ValidReblindStatement,
+}
+
+/// The statement type for `VALID MATCH SETTLE ATOMIC`
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ValidMatchSettleAtomicStatement {
+    /// The result of the match
+    pub match_result: ExternalMatchResult,
+    /// The external party's fee obligations as a result of the match
+    pub external_party_fees: FeeTake,
+    /// The modified public shares of the internal party
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub internal_party_modified_shares: Vec<ScalarField>,
+    /// The indices that settlement should modify in the internal party's wallet
+    pub internal_party_indices: OrderSettlementIndices,
+    /// The protocol fee used in the match
+    #[serde_as(as = "ScalarFieldDef")]
+    pub protocol_fee: ScalarField,
+    /// The address at which the relayer wishes to receive their fee due from
+    /// the external party
+    #[serde_as(as = "AddressDef")]
+    pub relayer_fee_address: Address,
+}
+
+/// Statement for the `VALID RELAYER FEE SETTLEMENT` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidRelayerFeeSettlementStatement {
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the sender's wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub sender_root: ScalarField,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the recipient's wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub recipient_root: ScalarField,
+    /// The nullifier of the sender's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub sender_nullifier: ScalarField,
+    /// The nullifier of the recipient's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub recipient_nullifier: ScalarField,
+    /// A commitment to the sender's new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub sender_wallet_commitment: ScalarField,
+    /// A commitment to the recipient's new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub recipient_wallet_commitment: ScalarField,
+    /// The blinded public secret shares of the sender's new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub sender_updated_public_shares: Vec<ScalarField>,
+    /// The blinded public secret shares of the recipient's new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub recipient_updated_public_shares: Vec<ScalarField>,
+    /// The public root key of the recipient, rotated out after this update
+    pub recipient_pk_root: PublicSigningKey,
+}
+
+/// The EC-ElGamal encryption of a fee note
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct NoteCiphertext(
+    pub BabyJubJubPoint,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+    #[serde_as(as = "ScalarFieldDef")] pub ScalarField,
+);
+
+/// Statement for the `VALID OFFLINE FEE SETTLEMENT` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidOfflineFeeSettlementStatement {
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub merkle_root: ScalarField,
+    /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub nullifier: ScalarField,
+    /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub updated_wallet_commitment: ScalarField,
+    /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub updated_wallet_public_shares: Vec<ScalarField>,
+    /// The ciphertext of the fee note
+    pub note_ciphertext: NoteCiphertext,
+    /// The commitment to the note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub note_commitment: ScalarField,
+    /// The protocol's public encryption key
+    pub protocol_key: PublicEncryptionKey,
+    /// Whether the fee is a protocol fee or a relayer fee
+    pub is_protocol_fee: bool,
+}
+
+/// Statement for the `VALID FEE REDEMPTION` circuit
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ValidFeeRedemptionStatement {
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to the old wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub wallet_root: ScalarField,
+    /// A historic merkle root for which we prove inclusion of
+    /// the commitment to note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub note_root: ScalarField,
+    /// The nullifier of the old wallet's secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub nullifier: ScalarField,
+    /// The nullifier of the note
+    #[serde_as(as = "ScalarFieldDef")]
+    pub note_nullifier: ScalarField,
+    /// A commitment to the new wallet's private secret shares
+    #[serde_as(as = "ScalarFieldDef")]
+    pub new_wallet_commitment: ScalarField,
+    /// The blinded public secret shares of the new wallet
+    #[serde_as(as = "Vec<ScalarFieldDef>")]
+    pub new_wallet_public_shares: Vec<ScalarField>,
+    /// The public root key of the old wallet, rotated out after this update
+    pub old_pk_root: PublicSigningKey,
+}

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -32,36 +32,31 @@ use common::types::{
     transfer_auth::TransferAuth,
 };
 use constants::{Scalar, ScalarField};
-use contracts_common::{
-    constants::NUM_SCALARS_PK,
-    custom_serde::scalar_to_u256,
-    types::{
-        BabyJubJubPoint as ContractBabyJubJubPoint,
-        ExternalMatchResult as ContractExternalMatchResult,
-        ExternalTransfer as ContractExternalTransfer, FeeTake as ContractFeeTake,
-        LinkingProof as ContractLinkingProof,
-        MatchAtomicLinkingProofs as ContractMatchAtomicLinkingProofs,
-        MatchAtomicProofs as ContractMatchAtomicProofs,
-        MatchLinkingProofs as ContractMatchLinkingProofs, MatchProofs as ContractMatchProofs,
-        NoteCiphertext as ContractNoteCiphertext,
-        OrderSettlementIndices as ContractOrderSettlementIndices, Proof as ContractProof,
-        PublicEncryptionKey as ContractPublicEncryptionKey,
-        PublicSigningKey as ContractPublicSigningKey, TransferAuxData as ContractTransferAuxData,
-        ValidCommitmentsStatement as ContractValidCommitmentsStatement,
-        ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
-        ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
-        ValidMatchSettleStatement as ContractValidMatchSettleStatement,
-        ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
-        ValidReblindStatement as ContractValidReblindStatement,
-        ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
-        ValidWalletCreateStatement as ContractValidWalletCreateStatement,
-        ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
-    },
-};
 use num_bigint::BigUint;
 use ruint::aliases::{U160, U256};
 use util::hex::biguint_to_hex_string;
 
+use crate::contract_types::{
+    BabyJubJubPoint as ContractBabyJubJubPoint, ExternalMatchResult as ContractExternalMatchResult,
+    ExternalTransfer as ContractExternalTransfer, FeeTake as ContractFeeTake,
+    LinkingProof as ContractLinkingProof,
+    MatchAtomicLinkingProofs as ContractMatchAtomicLinkingProofs,
+    MatchAtomicProofs as ContractMatchAtomicProofs,
+    MatchLinkingProofs as ContractMatchLinkingProofs, MatchProofs as ContractMatchProofs,
+    NoteCiphertext as ContractNoteCiphertext,
+    OrderSettlementIndices as ContractOrderSettlementIndices, Proof as ContractProof,
+    PublicEncryptionKey as ContractPublicEncryptionKey,
+    PublicSigningKey as ContractPublicSigningKey, TransferAuxData as ContractTransferAuxData,
+    ValidCommitmentsStatement as ContractValidCommitmentsStatement,
+    ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+    ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
+    ValidMatchSettleStatement as ContractValidMatchSettleStatement,
+    ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
+    ValidReblindStatement as ContractValidReblindStatement,
+    ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
+    ValidWalletCreateStatement as ContractValidWalletCreateStatement,
+    ValidWalletUpdateStatement as ContractValidWalletUpdateStatement, NUM_SCALARS_PK,
+};
 use crate::errors::ConversionError;
 
 /// Type alias for the affine representation of the
@@ -457,7 +452,7 @@ pub fn to_contract_valid_fee_redemption_statement(
 pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[AlloyU256; NUM_SCALARS_PK], ConversionError> {
     pk.to_scalars()
         .iter()
-        .map(|s| scalar_to_u256(s.inner()))
+        .map(|s| scalar_to_u256(*s))
         .collect::<Vec<_>>()
         .try_into()
         .map_err(|_| ConversionError::InvalidLength)
@@ -476,6 +471,11 @@ pub fn biguint_to_address(biguint: &BigUint) -> Result<Address, ConversionError>
 /// Convert an `Amount` to a `U256`
 pub fn amount_to_u256(amount: Amount) -> Result<U256, ConversionError> {
     amount.try_into().map_err(|_| ConversionError::InvalidUint)
+}
+
+/// Converts a `Scalar` to a `U256`
+pub fn scalar_to_u256(scalar: Scalar) -> U256 {
+    U256::from_be_slice(&scalar.to_bytes_be())
 }
 
 /// Try to extract a fixed-length array of G1Affine points

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -8,15 +8,6 @@ use circuit_types::{
     SizedWalletShare,
 };
 use constants::Scalar;
-use contracts_common::types::{
-    ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
-    ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
-    ValidMatchSettleStatement as ContractValidMatchSettleStatement,
-    ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
-    ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
-    ValidWalletCreateStatement as ContractValidWalletCreateStatement,
-    ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
-};
 use ethers::types::Bytes;
 use serde::{Deserialize, Serialize};
 use util::err_str;
@@ -26,6 +17,15 @@ use crate::{
         newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
         processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,
         updateWalletCall,
+    },
+    contract_types::{
+        ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+        ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
+        ValidMatchSettleStatement as ContractValidMatchSettleStatement,
+        ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
+        ValidRelayerFeeSettlementStatement as ContractValidRelayerFeeSettlementStatement,
+        ValidWalletCreateStatement as ContractValidWalletCreateStatement,
+        ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
     },
     errors::ArbitrumClientError,
 };

--- a/arbitrum-client/src/lib.rs
+++ b/arbitrum-client/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod abi;
 pub mod client;
 pub mod constants;
+pub mod contract_types;
 pub mod conversion;
 pub mod errors;
 pub mod helpers;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -56,9 +56,6 @@ constants = { path = "../constants", default-features = false }
 renegade-crypto = { path = "../renegade-crypto" }
 util = { path = "../util" }
 
-# === Contracts Repo Dependencies === #
-contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-
 # === Misc Dependencies === #
 base64 = { version = "0.22" }
 bimap = "0.6.2"

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -210,7 +210,6 @@ impl TaskDescriptor {
 pub mod mocks {
     use circuit_types::keychain::SecretSigningKey;
     use constants::Scalar;
-    use contracts_common::custom_serde::BytesSerializable;
     use ethers::core::utils::keccak256;
     use ethers::signers::Wallet as EthersWallet;
     use k256::ecdsa::SigningKey as K256SigningKey;
@@ -229,7 +228,9 @@ pub mod mocks {
 
         // Serialize the commitment, uses the contract's serialization here:
         //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-        let comm_bytes = new_wallet_comm.inner().serialize_to_bytes();
+        // The `to_bytes_be` method is used to match the contract's serialization, with
+        // appropriate padding
+        let comm_bytes = new_wallet_comm.to_bytes_be();
         let digest = keccak256(comm_bytes);
 
         // Sign the message

--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -2,7 +2,6 @@
 
 use circuit_types::{keychain::PublicSigningKey, Amount};
 use constants::Scalar;
-use contracts_common::custom_serde::BytesSerializable;
 use ethers::core::types::Signature;
 use ethers::utils::{keccak256, public_key_to_address};
 use k256::ecdsa::VerifyingKey as K256VerifyingKey;
@@ -214,7 +213,9 @@ pub fn verify_wallet_update_signature(
 
     // Serialize the commitment, uses the contract's serialization here:
     //  https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/custom_serde.rs#L82-L87
-    let comm_bytes = new_wallet_comm.inner().serialize_to_bytes();
+    // The `to_bytes_be` method is used to match the contract's serialization, with
+    // appropriate padding
+    let comm_bytes = new_wallet_comm.to_bytes_be();
     let digest = keccak256(comm_bytes);
 
     // Verify the signature


### PR DESCRIPTION
### Purpose
This PR removes the dependency on `contracts-common` from the relayer repo, which previously caused a cyclic dependency. To do so, we directly replicate the functionality from the contracts into the relayer.

### Testing
- [x] All unit tests pass
- [ ] Testing in testnet