### PR TITLE
api-server: external-match: Validate token pair explicitly

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -90,6 +90,11 @@ impl Display for Token {
 }
 
 impl Token {
+    /// Get the USDC token
+    pub fn usdc() -> Self {
+        Self::from_ticker(USDC_TICKER)
+    }
+
     /// Given an ERC-20 contract address, returns a new Token
     pub fn from_addr(addr: &str) -> Self {
         Self { addr: String::from(addr).to_lowercase() }

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use common::types::{
     exchange::PriceReporterState,
-    token::{read_token_remap, Token, USDC_TICKER},
+    token::{read_token_remap, Token},
     wallet::OrderIdentifier,
     TimestampedPrice,
 };
@@ -33,7 +33,7 @@ const ERR_NO_PRICE_STREAM: &str = "price report not available for token pair";
 pub fn init_price_streams(
     price_reporter_job_queue: PriceReporterQueue,
 ) -> Result<(), HandshakeManagerError> {
-    let quote = Token::from_ticker(USDC_TICKER);
+    let quote = Token::usdc();
 
     for (addr, _) in read_token_remap().iter() {
         let base = Token::from_addr(addr);
@@ -58,7 +58,7 @@ impl HandshakeExecutor {
         // remap across an await point.
         let channels = {
             let token_maps = read_token_remap();
-            let quote = Token::from_ticker(USDC_TICKER);
+            let quote = Token::usdc();
 
             let mut channels = Vec::with_capacity(token_maps.len());
             for (base_addr, _ticker) in token_maps.iter() {


### PR DESCRIPTION
### Purpose
This PR explicitly validates the token pair in an external match. Currently, invalid pairs fail when fetching a price, with an unhelpful error message.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet