### PR TITLE
arbitrum-client: event-indexing: Do not log error waiting for nullifier

### DIFF
--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -201,7 +201,7 @@ impl ArbitrumClient {
     }
 
     /// Await a nullifier spent event on a given nullifier
-    #[instrument(skip_all, err, fields(nullifier = %nullifier))]
+    #[instrument(skip_all, fields(nullifier = %nullifier))]
     pub async fn await_nullifier_spent_from_selectors(
         &self,
         nullifier: Nullifier,


### PR DESCRIPTION
### Purpose
This PR removes the error log emitted by awaiting nullifier spent. This would log an error even in the case that a nullifier cannot be found. We defer to higher level callers to determine if this is an error, and log as appropriate.