### PR TITLE
Cargo.toml: Disable `constants` default features at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ ethers = "2"
 arbitrum-client = { path = "arbitrum-client" }
 api-server = { path = "workers/api-server" }
 chain-events = { path = "workers/chain-events" }
-constants = { path = "constants" }
+constants = { path = "constants", default-features = false }
 circuits = { path = "circuits" }
 circuit-macros = { path = "circuit-macros" }
 circuit-types = { path = "circuit-types" }


### PR DESCRIPTION
### Purpose
This PR disables default features for the `constants` crate at the workspace level. Without this, workspace crates referring to `constants` via the workspace will turn on default features. The default `constants` features are not wasm compatible, so external crates that need wasm builds were failing.

### Testing
- [x] Built an external crate targetting `wasm32-unknown-unknown`
- [x] All tests pass