### PR TITLE
common: types: token: (De)serialize token addresses as lowercase str

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -54,7 +54,7 @@ circuits = { workspace = true, optional = true }
 circuit-types = { workspace = true, default-features = false }
 constants = { workspace = true, default-features = false }
 renegade-crypto = { workspace = true }
-util = { workspace = true }
+util = { workspace = true, features = ["serde"] }
 
 # === Misc Dependencies === #
 base64 = { version = "0.22" }

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -27,6 +27,7 @@ use std::{
 use util::{
     concurrency::RwStatic,
     hex::{biguint_from_hex_string, biguint_to_hex_addr},
+    serde::{deserialize_str_lower, serialize_str_lower},
 };
 
 use super::exchange::Exchange;
@@ -80,6 +81,7 @@ pub static EXCHANGE_SUPPORT_MAP: RwStatic<HashMap<String, ExchangeSupport>> =
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Token {
     /// The ERC-20 address of the Token.
+    #[serde(deserialize_with = "deserialize_str_lower", serialize_with = "serialize_str_lower")]
     pub addr: String,
 }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -13,6 +13,7 @@ matching-engine = ["blockchain"]
 mocks = []
 metered-channels = []
 networking = []
+serde = []
 telemetry = []
 
 [dependencies]

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -22,6 +22,8 @@ pub mod metered_channels;
 pub mod networking;
 #[cfg(feature = "blockchain")]
 pub mod on_chain;
+#[cfg(feature = "serde")]
+pub mod serde;
 #[cfg(feature = "telemetry")]
 pub mod telemetry;
 

--- a/util/src/serde.rs
+++ b/util/src/serde.rs
@@ -1,0 +1,19 @@
+//! Serialization and deserialization utilities
+
+use serde::Deserialize;
+
+/// Deserialize a string into lowercase
+pub fn deserialize_str_lower<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(|s| s.to_lowercase())
+}
+
+/// Serialize a string as lowercase
+pub fn serialize_str_lower<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_lowercase())
+}


### PR DESCRIPTION
### Purpose
This PR changes the (de)serialization of the `Token` type to always lowercase strings. This provides a more sensible API for, among other things, fetching prices -- in which the request should not be case sensitive.

### Testing
- [x] All unit tests pass
- [x] Tested price API locally
- [ ] Testing in testnet