### PR TITLE
state: storage: task-queue: Expand task queue pause state

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -33,6 +33,23 @@ pub type TaskIdentifier = Uuid;
 /// resource
 pub type TaskQueueKey = Uuid;
 
+/// The pause state of a task queue
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum TaskQueuePauseState {
+    /// The queue is in the active state, running the top task on the queue
+    Active,
+    /// The queue in in the paused state, waiting for a preemptive task to
+    /// complete. Non-preemptive tasks will not run until this state is cleared
+    ///
+    /// In this state, the preemptive task allows other preemptive tasks to
+    /// share the queue; i.e. they can run concurrently.
+    PausedShared,
+    /// The queue is in the paused state, and not shared with other workers
+    ///
+    /// Non-preemptive tasks will not run until this state is cleared
+    Paused,
+}
+
 /// A task in the task queue
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueuedTask {

--- a/workers/job-types/Cargo.toml
+++ b/workers/job-types/Cargo.toml
@@ -18,7 +18,7 @@ common = { workspace = true }
 constants = { workspace = true }
 external-api = { workspace = true }
 gossip-api = { workspace = true }
-util = { workspace = true }
+util = { workspace = true, features = ["metered-channels"] }
 renegade-metrics = { workspace = true }
 
 # === Misc === #


### PR DESCRIPTION
### Purpose
This PR expands the `paused` boolean state to an enum `TaskQueuePauseState` that allows us to express a `PausedShared` state. This state will be used by preemptive tasks that wish to pause the queue from normal operation, but allow _other preemptive tasks_ to run concurrently. This will be used to support multiple external match bundles sharing the same queue.

### Todo
- Use the shared paused state in external matches

### Testing
- [x] Unit tests pass