### PR TITLE
storage: applicator: task-queue: Double write task updates

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2018"
 default-run = "renegade-relayer"
 
 [features]
-dev-metrics = ["task-queue-len", "task-metrics", "proof-metrics"]
+dev-metrics = ["task-metrics", "proof-metrics"]
 metered-channels = ["util/metered-channels"]
-task-queue-len = ["state/task-queue-len"]
 task-metrics = ["task-driver/task-metrics"]
 proof-metrics = ["proof-manager/proof-metrics"]
 tx-metrics = ["arbitrum-client/tx-metrics"]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [features]
 # Used to enable mocks from other crates in tests
 mocks = ["dep:tempfile", "dep:test-helpers"]
-task-queue-len = []
 ci = ["mocks"]
 
 [[bench]]


### PR DESCRIPTION
### Purpose
This PR changes the applicator logic for the task queue to double write between the v1 and v2 implementations of the task queue. This will be deployed independently and subsequently migrated into a version that _reads from_ the v2 task queues and implements their locking semantics. 

I also made a few cleanups for unused helpers in the applicator, and removed the task queue length metrics (also unused).

### Testing
- [x] All unit tests pass 
- [x] Added double write tests  