### PR TITLE
state: storage: task-queuev2: Add write-preference access class logic

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -101,6 +101,9 @@ impl StateApplicator {
                 self.transition_task_state(task_id, state)
             },
             StateTransition::ClearTaskQueue { queue } => self.clear_queue(queue),
+            StateTransition::EnqueuePreemptiveTask { keys, task, executor, serial } => {
+                self.enqueue_preemptive_task(&keys, &task, &executor, serial)
+            },
             StateTransition::PreemptTaskQueues { keys, task, executor } => {
                 self.preempt_task_queues(&keys, &task, &executor)
             },

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -229,6 +229,9 @@ impl StateInner {
     }
 
     /// Resume a task queue
+    ///
+    /// TODO(@joeykraut): Remove this once the migration is complete
+    #[deprecated(note = "Use `pop_task` instead")]
     pub async fn resume_task_queue(
         &self,
         key: &TaskQueueKey,
@@ -238,7 +241,10 @@ impl StateInner {
     }
 
     /// Resume multiple task queues
+    ///
+    /// TODO(@joeykraut): Remove this once the migration is complete
     #[instrument(name = "propose_resume_task_queues", skip_all, err, fields(queue_keys = ?keys))]
+    #[deprecated(note = "Use `pop_task` instead")]
     pub async fn resume_multiple_task_queues(
         &self,
         keys: Vec<TaskQueueKey>,

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -167,8 +167,24 @@ pub enum StateTransition {
     /// Preempt the given task queue
     ///
     /// Returns any running tasks to `Queued` state and pauses the queue
+    /// 
+    /// TODO(@joeykraut): Remove this once the migration is complete
+    #[deprecated(note="Use `EnqueuePreemptiveTask` instead")]
     PreemptTaskQueues { keys: Vec<TaskQueueKey>, task: QueuedTask, executor: WrappedPeerId },
+    /// Enqueue a preemptive task for the given task queues
+    /// 
+    /// Transitions any running tasks to `Queued` state and enqueues the given task
+    /// at the front of each queue
+    /// 
+    /// If `serial` is true, the task is enqueued as a serial task and requires
+    /// exclusive access to the task queue. If false, the task is enqueued as a
+    /// concurrent task and may share the queue with other concurrent, preemptive
+    /// tasks.
+    EnqueuePreemptiveTask { keys: Vec<TaskQueueKey>, task: QueuedTask, executor: WrappedPeerId, serial: bool },
     /// Resume the given task queue
+    /// 
+    /// TODO(@joeykraut): Remove this once the migration is complete
+    #[deprecated(note="Use `PopTask` instead, as in the standard task flow")]
     ResumeTaskQueues { keys: Vec<TaskQueueKey>, success: bool},
     /// Reassign all tasks from one peer to another peer
     ReassignTasks { from: WrappedPeerId, to: WrappedPeerId },


### PR DESCRIPTION
### Purpose
This PR updates the `TaskQueue` to track its preemption state, and enforces valid transitions in the `TaskQueue` update helpers. These transitions enforce the write-preferenced access class logic that the new task queue implements. 

We add the access logic to the `TaskQueue` type so that it remains internally consistent through mutations, rather than encoding the access logic at higher layers (the applicator) which may be prone to bad writes.

### Testing
- [x] Added tests for all access patterns
- [x] All tests pass