### PR TITLE
api-server: external-match: Allow native asset in token validation

### DIFF
--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -258,8 +258,8 @@ impl ExternalMatchProcessor {
         }
 
         // Check that the base token is in the token configuration -- i.e. if it is
-        // named
-        if !base.is_named() {
+        // named or the native asset
+        if !(base.is_named() || base.addr == NATIVE_ASSET_ADDRESS) {
             return Err(bad_request(ERR_UNSUPPORTED_PAIR));
         }
 


### PR DESCRIPTION
### Purpose
This PR updates the token validation logic in the external match API to allow either named tokens or the native token address. Previously we were only checking for named tokens, thereby disallowing native asset requests erroneously.

### Testing
- [x] Unit tests pass
- [x] Testing in testnet