### PR TITLE
state: storage: task-queuev2: Allow task to preempt multiple queues

### DIFF
--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -285,7 +285,7 @@ impl StateApplicator {
         tx.add_assigned_task(executor, &task.id)?;
         // TODO(@joeykraut): Remove the v1 implementation once we migrate
         tx.add_task_front(&key, task)?;
-        double_write_helper(tx.preempt_queue_with_serial(&key, task));
+        double_write_helper(tx.preempt_queue_with_serial(&[key], task));
         self.publish_task_updates(key, task);
 
         Ok(ApplicatorReturnType::None)

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -76,7 +76,7 @@ pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
 /// The name of the db table that stores task queues
 pub(crate) const TASK_QUEUE_TABLE: &str = "task-queues";
-/// The name of the db table that maps tasks to their queue key
+/// The name of the db table that maps tasks to their queue keys
 pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
 /// The name of the db table that maps nodes to their assigned tasks
 pub(crate) const TASK_ASSIGNMENT_TABLE: &str = "task-assignments";


### PR DESCRIPTION
### Purpose
This PR allows a task to preempt multiple queues by changing the task to queue key mapping from `id -> id` to `id -> vec<id>`. 

### Testing
- [x] Unit tests pass
- [x] Added tests for behavior with multiple queues