### PR TITLE
state: applicator: task-queue: Implement `EnqueuePreemptiveTask`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10001,6 +10001,7 @@ dependencies = [
  "crossbeam",
  "crossterm 0.27.0",
  "external-api 0.1.0",
+ "eyre",
  "flate2",
  "futures",
  "fxhash",

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -76,6 +76,7 @@ metrics = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
+eyre = "0.6"
 multiaddr = "0.17"
 num-bigint = "0.4"
 num-traits = "0.2"


### PR DESCRIPTION
### Purpose
This PR adds the implementation of `EnqueuePreemptiveTask`. This state transition merely calls out to the preemption helpers in the storage layer and handles task assignment. For the migration, we also double write to the old task queue implementation.

The version in this PR will be deployed ahead of a version which switches over to using the new task queue for all preemptive tasks.

### Todo
In a follow up, deployed separately:
- Change the pop and transition task helpers to use the new task queue
- Further tests with these new implementations

### Testing
- [x] All unit tests pass
- [x] Added basic tests for `EnqueuePreemptiveTask`