### PR TITLE
task-driver: state-migration: remove-old-task-queues: Add state migration

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -75,9 +75,11 @@ pub(crate) const NULLIFIER_TO_WALLET_TABLE: &str = "nullifier-to-wallet";
 pub(crate) const WALLETS_TABLE: &str = "wallet-info";
 
 /// The name of the db table that stores task queues
+///
+/// TODO(@joeykraut): Privatize all tables
 pub const TASK_QUEUE_TABLE: &str = "task-queues";
 /// The name of the db table that maps tasks to their queue keys
-pub(crate) const TASK_TO_KEY_TABLE: &str = "task-to-key";
+pub const TASK_TO_KEY_TABLE: &str = "task-to-key";
 /// The name of the db table that maps nodes to their assigned tasks
 pub(crate) const TASK_ASSIGNMENT_TABLE: &str = "task-assignments";
 /// The name of the db table that stores historical task information

--- a/state/src/storage/db.rs
+++ b/state/src/storage/db.rs
@@ -31,6 +31,8 @@ pub(crate) fn serialize_value<V: Serialize>(value: &V) -> Result<Vec<u8>, Storag
 }
 
 /// Deserialize a value from a `flexbuffers` byte vector
+///
+/// TODO(@joeykraut): Privatize this method
 pub fn deserialize_value<V: for<'de> Deserialize<'de>>(
     value_bytes: &[u8],
 ) -> Result<V, StorageError> {

--- a/state/src/storage/tx/mod.rs
+++ b/state/src/storage/tx/mod.rs
@@ -43,6 +43,8 @@ use super::{
 // --------------------------
 
 /// A read-only transaction in the database
+///
+/// TODO(@joeykraut): Remove this type
 pub type ReadTxn<'db> = StateTxn<'db, RO>;
 
 /// A high level transaction in the database

--- a/workers/task-driver/src/state_migration/mod.rs
+++ b/workers/task-driver/src/state_migration/mod.rs
@@ -5,5 +5,7 @@
 //!
 //! These migrations should be idempotent, and defined as need be
 
+mod remove_old_task_queues;
 mod remove_phantom_orders;
+pub(crate) use remove_old_task_queues::remove_old_queues;
 pub(crate) use remove_phantom_orders::remove_phantom_orders;

--- a/workers/task-driver/src/state_migration/remove_old_task_queues.rs
+++ b/workers/task-driver/src/state_migration/remove_old_task_queues.rs
@@ -1,0 +1,132 @@
+//! Removes old task queues from the state
+
+use std::borrow::Cow;
+
+use state::{
+    error::StateError,
+    storage::{db::deserialize_value, traits::Key, tx::ReadTxn},
+    State, TASK_QUEUE_TABLE, TASK_TO_KEY_TABLE,
+};
+use tracing::info;
+use uuid::Uuid;
+
+/// A type alias used for reading from the database
+type CowBuffer<'a> = Cow<'a, [u8]>;
+
+/// Remove all old task queues from the state
+pub(crate) async fn remove_old_queues(state: &State) -> Result<(), String> {
+    // Old task queues
+    let keys = find_old_task_queues(state).await?;
+    info!("found {} old task queues", keys.len());
+    delete_keys(state, keys, TASK_QUEUE_TABLE).await?;
+    info!("deleted old task queues");
+
+    // Old paused queues
+    let paused_keys = find_old_paused_queues(state).await?;
+    info!("found {} old paused queues", paused_keys.len());
+    delete_keys(state, paused_keys, TASK_QUEUE_TABLE).await?;
+    info!("deleted old paused queues");
+
+    // Old task -> queue mappings
+    let mappings = find_old_task_to_queue_mappings(state).await?;
+    info!("found {} old task -> queue mappings", mappings.len());
+    delete_keys(state, mappings, TASK_TO_KEY_TABLE).await?;
+    info!("deleted old task -> queue mappings");
+
+    Ok(())
+}
+
+// --- Find Queues --- //
+
+/// Find all old task queues
+async fn find_old_task_queues(state: &State) -> Result<Vec<Uuid>, StateError> {
+    state.with_read_tx(find_old_task_queues_with_tx).await
+}
+
+/// Find all old task queue keys with a tx scoped in
+fn find_old_task_queues_with_tx(tx: &ReadTxn) -> Result<Vec<Uuid>, StateError> {
+    let mut cursor = tx.inner().cursor::<CowBuffer, CowBuffer>(TASK_QUEUE_TABLE).unwrap();
+    let mut keys = Vec::new();
+    while !cursor.seek_next_raw()? {
+        let pair = cursor.get_current_raw()?;
+        if pair.is_none() {
+            continue;
+        }
+
+        let (key, _) = pair.unwrap();
+        if let Ok(id) = deserialize_value(&key) {
+            keys.push(id);
+        }
+    }
+
+    Ok(keys)
+}
+
+/// Find all the old paused queue keys in the state
+async fn find_old_paused_queues(state: &State) -> Result<Vec<String>, StateError> {
+    state.with_read_tx(find_old_paused_queues_with_tx).await
+}
+
+/// Find all the old paused queue keys in the state with a tx scoped in
+fn find_old_paused_queues_with_tx(tx: &ReadTxn) -> Result<Vec<String>, StateError> {
+    let mut cursor = tx.inner().cursor::<CowBuffer, CowBuffer>(TASK_QUEUE_TABLE).unwrap();
+    let mut keys = Vec::new();
+    while !cursor.seek_next_raw()? {
+        let pair = cursor.get_current_raw()?;
+        if pair.is_none() {
+            continue;
+        }
+
+        let (key, _) = pair.unwrap();
+        if let Ok(value) = deserialize_value::<String>(&key)
+            && value.ends_with("paused")
+        {
+            keys.push(value);
+        }
+    }
+
+    Ok(keys)
+}
+
+/// Find all old task -> queue mappings
+async fn find_old_task_to_queue_mappings(state: &State) -> Result<Vec<Uuid>, StateError> {
+    state.with_read_tx(find_old_task_to_queue_mappings_with_tx).await
+}
+
+/// Find all old task -> queue mappings with a tx scoped in
+fn find_old_task_to_queue_mappings_with_tx(tx: &ReadTxn) -> Result<Vec<Uuid>, StateError> {
+    let mut cursor = tx.inner().cursor::<CowBuffer, CowBuffer>(TASK_TO_KEY_TABLE).unwrap();
+    let mut keys = Vec::new();
+    while !cursor.seek_next_raw()? {
+        let pair = cursor.get_current_raw()?;
+        if pair.is_none() {
+            continue;
+        }
+
+        let (key, _) = pair.unwrap();
+        if let Ok(value) = deserialize_value::<Uuid>(&key) {
+            keys.push(value);
+        }
+    }
+
+    Ok(keys)
+}
+
+// --- Delete Queues --- //
+
+/// Delete a set of keys from the state
+async fn delete_keys<K: Key + Send + Sync + 'static>(
+    state: &State,
+    keys: Vec<K>,
+    table: &'static str,
+) -> Result<(), String> {
+    state
+        .with_write_tx(move |tx| {
+            for key in keys.iter() {
+                tx.inner().delete(table, key)?;
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -37,7 +37,7 @@ use util::{
 
 use crate::{
     await_task,
-    state_migration::remove_phantom_orders,
+    state_migration::{remove_old_queues, remove_phantom_orders},
     task_state::StateWrapper,
     traits::{Task, TaskContext, TaskError, TaskState},
     utils::ERR_WALLET_NOT_FOUND,
@@ -455,6 +455,17 @@ impl NodeStartupTask {
                 error!("error removing phantom orders: {e}");
             } else {
                 info!("done removing phantom orders");
+            }
+        });
+
+        // Remove old task queues
+        let state = self.state.clone();
+        tokio::task::spawn(async move {
+            info!("removing old task queues...");
+            if let Err(e) = remove_old_queues(&state).await {
+                error!("error removing old task queues: {e}");
+            } else {
+                info!("done removing old task queues");
             }
         });
 


### PR DESCRIPTION
### Purpose
This PR removes all keys for the old task queue implementation from the state using a state migration run during `NodeStartup` task execution.

This will be deleted after it is deployed.

### Testing
- [x] Tested on a local version of the DB
- [x] Testing in testnet