### PR TITLE
api-server: external-match: Allow shared bundles on API

### DIFF
--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -19,7 +19,6 @@ pub async fn node_setup(
 ) -> Result<(), CoordinatorError> {
     // Start the node setup task and await its completion
     let needs_relayer_wallet = config.needs_relayer_wallet();
-    println!("needs_relayer_wallet: {needs_relayer_wallet}");
     let desc: TaskDescriptor = NodeStartupTaskDescriptor::new(
         config.gossip_warmup,
         config.relayer_arbitrum_key(),

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -95,6 +95,12 @@ pub struct AssembleExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for some time
+    #[serde(default)]
+    pub allow_shared: bool,
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -286,12 +286,14 @@ impl ExternalMatchProcessor {
     async fn assemble_external_match(
         &self,
         gas_estimation: bool,
+        allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
+            .with_allow_shared(allow_shared)
             .with_price(price);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
@@ -573,7 +575,13 @@ impl TypedHandler for AssembleExternalMatchHandler {
         let price = TimestampedPrice::from(req.signed_quote.quote.price);
         let match_bundle = self
             .processor
-            .assemble_external_match(req.do_gas_estimation, receiver, price, order)
+            .assemble_external_match(
+                req.do_gas_estimation,
+                req.allow_shared,
+                receiver,
+                price,
+                order,
+            )
             .await?;
         Ok(ExternalMatchResponse { match_bundle })
     }

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -15,7 +15,7 @@ use circuit_types::{
     r#match::{ExternalMatchResult, MatchResult},
 };
 use common::types::{
-    tasks::SettleExternalMatchTaskDescriptor,
+    tasks::{SettleExternalMatchTaskDescriptor, TaskDescriptor},
     token::Token,
     wallet::{Order, OrderIdentifier},
     TimestampedPrice,
@@ -229,7 +229,12 @@ impl HandshakeExecutor {
             response_topic,
         );
 
-        self.enqueue_serial_task_await_completion(task.into()).await
+        let descriptor = TaskDescriptor::from(task);
+        if options.allow_shared {
+            self.enqueue_concurrent_task_await_completion(descriptor).await
+        } else {
+            self.enqueue_serial_task_await_completion(descriptor).await
+        }
     }
 
     /// Forward a quote to the client

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -166,6 +166,12 @@ pub struct ExternalMatchingEngineOptions {
     /// The duration for which a match bundle is valid; i.e. for which the task
     /// driver should lock the matched wallet's queue
     pub bundle_duration: Duration,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for
+    /// `bundle_duration`
+    pub allow_shared: bool,
     /// The price to use for the external match. If `None`, the price will
     /// be sampled by the engine
     ///
@@ -196,6 +202,12 @@ impl ExternalMatchingEngineOptions {
     /// Set the bundle duration
     pub fn with_bundle_duration(mut self, duration: Duration) -> Self {
         self.bundle_duration = duration;
+        self
+    }
+
+    /// Set whether to allow shared access to the resulting bundle
+    pub fn with_allow_shared(mut self, allow_shared: bool) -> Self {
+        self.allow_shared = allow_shared;
         self
     }
 


### PR DESCRIPTION
### Purpose
This PR adds an API option to allow a bundle to be shared with other clients. This will be exposed behind a higher rate limit on the auth server that sits in front of the relayer.

### Testing
- [x] Unit tests pass
- [x] Tested with many concurrent requests, verified that they all got bundles back.