### PR TITLE
common: types: exchange, token: Add helpers for `Renegade` exchange

### DIFF
--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -18,6 +18,7 @@ pub enum Exchange {
     Kraken,
     Okx,
     UniswapV3,
+    Renegade,
 }
 
 impl Display for Exchange {
@@ -28,6 +29,7 @@ impl Display for Exchange {
             Exchange::Kraken => String::from("kraken"),
             Exchange::Okx => String::from("okx"),
             Exchange::UniswapV3 => String::from("uniswapv3"),
+            Exchange::Renegade => String::from("renegade"),
         };
         write!(f, "{}", fmt_str)
     }
@@ -43,6 +45,7 @@ impl FromStr for Exchange {
             "kraken" => Ok(Exchange::Kraken),
             "okx" => Ok(Exchange::Okx),
             "uniswapv3" | "uniswap" => Ok(Exchange::UniswapV3),
+            "renegade" => Ok(Exchange::Renegade),
             _ => Err(format!("Unknown exchange: {s}")),
         }
     }

--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -97,6 +97,11 @@ impl Token {
         Self::from_ticker(USDC_TICKER)
     }
 
+    /// Get the USDT token
+    pub fn usdt() -> Self {
+        Self::from_ticker(USDT_TICKER)
+    }
+
     /// Given an ERC-20 contract address, returns a new Token
     pub fn from_addr(addr: &str) -> Self {
         Self { addr: String::from(addr).to_lowercase() }

--- a/workers/price-reporter/src/exchange.rs
+++ b/workers/price-reporter/src/exchange.rs
@@ -51,6 +51,9 @@ pub async fn connect_exchange(
         Exchange::UniswapV3 => {
             Box::new(UniswapV3Connection::connect(base_token, quote_token, config).await?)
         },
+        Exchange::Renegade => {
+            todo!("implement renegade connection")
+        },
     })
 }
 
@@ -66,6 +69,7 @@ pub async fn supports_pair(
         Exchange::Kraken => KrakenConnection::supports_pair(base_token, quote_token).await?,
         Exchange::Okx => OkxConnection::supports_pair(base_token, quote_token).await?,
         Exchange::UniswapV3 => UniswapV3Connection::supports_pair(base_token, quote_token).await?,
+        Exchange::Renegade => BinanceConnection::supports_pair(base_token, quote_token).await?,
     })
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a `Renegade` variant to the `Exchange` enum. This will be used by the price reporter to support "renegade midpoint" and automatic quote translation.

### Testing
- [x] Unit tests pass