### PR TITLE
external-api: external_match: fix bug in get_quote_amount

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -245,7 +245,8 @@ impl ExternalOrder {
             return self.exact_quote_output;
         }
 
-        let base_amount_scalar = Scalar::from(self.base_amount);
+        let base_amount = self.get_base_amount(price, relayer_fee);
+        let base_amount_scalar = Scalar::from(base_amount);
         let implied_quote_amount = price * base_amount_scalar;
         scalar_to_u128(&implied_quote_amount.floor())
     }


### PR DESCRIPTION
### Purpose

This PR fixes a bug where `requested_quote_amount` was incorrectly calculated as 0 for orders with `exact_base_output` set but `base_amount` unset.

The issue occurred because `get_quote_amount()` was directly using `self.base_amount` (which was 0) rather than the effective base amount calculated by `get_base_amount()`. This resulted in `get_quote_amount()` incorrectly returning 0. This only affected logging / metrics.

The fix modifies `get_quote_amount()` to use the effective base amount from `get_base_amount()` when neither `quote_amount` nor `exact_quote_output` is set. Circular dependencies should be impossible since `validate()` ensures exactly one of the sizing constraints is set, preventing recursive calls between the two methods.

### Testing
- [x] Test in testnet
  - retrieved quotes using each type of amount specifier, verified bundle logged as expected