### PR TITLE
chain-events: listener: Record external match metrics from spent nullifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "renegade-crypto 0.1.0",
+ "renegade-metrics",
  "state",
  "tokio",
  "tracing",

--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -3,8 +3,13 @@
 use alloy_primitives::{Address, U256};
 use ark_bn254::{g1::Config as G1Config, g2::Config as G2Config, Fq, Fq2, Fr};
 use ark_ec::short_weierstrass::Affine;
+use circuit_types::r#match::MatchResult as CircuitMatchResult;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+
+use crate::conversion::address_to_biguint;
+use crate::conversion::u256_to_amount;
+use crate::errors::ConversionError;
 
 use super::serde_def_types::*;
 
@@ -190,6 +195,21 @@ pub struct ExternalMatchResult {
     /// `false` (0) corresponds to the internal party buying the base
     /// `true` (1) corresponds to the internal party selling the base
     pub direction: bool,
+}
+
+impl TryFrom<ExternalMatchResult> for CircuitMatchResult {
+    type Error = ConversionError;
+
+    fn try_from(value: ExternalMatchResult) -> Result<Self, Self::Error> {
+        Ok(CircuitMatchResult {
+            base_mint: address_to_biguint(&value.base_mint)?,
+            quote_mint: address_to_biguint(&value.quote_mint)?,
+            base_amount: u256_to_amount(value.base_amount)?,
+            quote_amount: u256_to_amount(value.quote_amount)?,
+            direction: value.direction,
+            min_amount_order_index: false, // unused for external matches
+        })
+    }
 }
 
 /// Represents the affine coordinates of a secp256k1 ECDSA public key.

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -481,9 +481,10 @@ pub fn amount_to_u256(amount: Amount) -> Result<U256, ConversionError> {
 
 /// Convert a `U256` to an `Amount`
 pub fn u256_to_amount(u256: U256) -> Result<Amount, ConversionError> {
-    let bytes: [u8; 16] =
-        u256.to_be_bytes_vec().try_into().map_err(|_| ConversionError::InvalidUint)?;
-    let amount = Amount::from_be_bytes(bytes);
+    // Take the LSBs of the `U256`
+    let le_bytes = u256.to_le_bytes_vec();
+    let trimmed: [u8; 16] = le_bytes[..16].try_into().unwrap();
+    let amount = Amount::from_le_bytes(trimmed);
     Ok(amount)
 }
 

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -468,9 +468,23 @@ pub fn biguint_to_address(biguint: &BigUint) -> Result<Address, ConversionError>
     Ok(Address::from(u160))
 }
 
+/// Convert an `Address` to a `BigUint`
+pub fn address_to_biguint(address: &Address) -> Result<BigUint, ConversionError> {
+    let bytes = address.0.to_vec();
+    Ok(BigUint::from_bytes_be(&bytes))
+}
+
 /// Convert an `Amount` to a `U256`
 pub fn amount_to_u256(amount: Amount) -> Result<U256, ConversionError> {
     amount.try_into().map_err(|_| ConversionError::InvalidUint)
+}
+
+/// Convert a `U256` to an `Amount`
+pub fn u256_to_amount(u256: U256) -> Result<Amount, ConversionError> {
+    let bytes: [u8; 16] =
+        u256.to_be_bytes_vec().try_into().map_err(|_| ConversionError::InvalidUint)?;
+    let amount = Amount::from_be_bytes(bytes);
+    Ok(amount)
 }
 
 /// Converts a `Scalar` to a `U256`

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -2,6 +2,8 @@
 
 use std::{error::Error, fmt::Display};
 
+use alloy_sol_types::Error as SolError;
+
 /// The error type returned by the Arbitrum client interface
 #[derive(Clone, Debug)]
 pub enum ArbitrumClientError {
@@ -93,5 +95,11 @@ impl Error for ConversionError {}
 impl From<ConversionError> for ArbitrumClientError {
     fn from(e: ConversionError) -> Self {
         Self::Conversion(e)
+    }
+}
+
+impl From<SolError> for ArbitrumClientError {
+    fn from(e: SolError) -> Self {
+        Self::ContractInteraction(e.to_string())
     }
 }

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -17,6 +17,7 @@ circuit-types = { workspace = true }
 common = { workspace = true }
 constants = { workspace = true }
 renegade-crypto = { workspace = true }
+renegade-metrics = { workspace = true }
 gossip-api = { workspace = true }
 job-types = { workspace = true }
 state = { workspace = true }

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::{error::Error, fmt::Display};
 
+use arbitrum_client::errors::ArbitrumClientError;
 use state::error::StateError;
 
 /// The error type that the event listener emits
@@ -23,6 +24,14 @@ pub enum OnChainEventListenerError {
     TaskStartup(String),
 }
 
+impl OnChainEventListenerError {
+    /// Create a new arbitrum error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn arbitrum<T: ToString>(e: T) -> Self {
+        OnChainEventListenerError::Arbitrum(e.to_string())
+    }
+}
+
 impl Display for OnChainEventListenerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
@@ -33,5 +42,11 @@ impl Error for OnChainEventListenerError {}
 impl From<StateError> for OnChainEventListenerError {
     fn from(e: StateError) -> Self {
         OnChainEventListenerError::State(e.to_string())
+    }
+}
+
+impl From<ArbitrumClientError> for OnChainEventListenerError {
+    fn from(e: ArbitrumClientError) -> Self {
+        OnChainEventListenerError::Arbitrum(e.to_string())
     }
 }


### PR DESCRIPTION
### Purpose
This PR removes the nullifier watch loop from the settlement task. This is necessary as we now emit the same bundle to multiple clients who mark their requests with `allow_shared`. The existing logic in the settlement task would then double count each settlement for which it emits multiple bundles.

Instead, we move the metrics and wallet refresh logic to the `chain-events` worker, which will see each nullifier exactly once.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet