### PR TITLE
chain-events: listener: Allow `chain-events` worker to use ws connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "const-hex",
  "enr",
  "ethers-core",
+ "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -43,7 +43,7 @@ pub struct Cli {
     pub config_file: Option<String>,
     /// The price reporter from which to stream prices.
     /// If unset, the relayer will connect to exchanges directly.
-    #[clap(long, value_parser, conflicts_with_all = &["coinbase_key_name", "coinbase_key_secret", "eth_websocket_addr"])]
+    #[clap(long, value_parser, conflicts_with_all = &["coinbase_key_name", "coinbase_key_secret"])]
     pub price_reporter_url: Option<String>,
 
     // -----------------------------
@@ -214,7 +214,7 @@ pub struct Cli {
     #[clap(long = "coinbase-key-secret", value_parser)]
     pub coinbase_key_secret: Option<String>,
     /// The Ethereum RPC node websocket address to dial for on-chain data
-    #[clap(long = "eth-websocket", value_parser)]
+    #[clap(long = "eth-websocket-url", value_parser, env = "ETH_WEBSOCKET_URL")]
     pub eth_websocket_addr: Option<String>,
     /// The HTTP addressable Arbitrum JSON-RPC node
     #[clap(long = "rpc-url", value_parser, env = "RPC_URL")]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -301,7 +301,7 @@ async fn main() -> Result<(), CoordinatorError> {
         exchange_conn_config: ExchangeConnectionsConfig {
             coinbase_key_name: args.coinbase_key_name,
             coinbase_key_secret: args.coinbase_key_secret,
-            eth_websocket_addr: args.eth_websocket_addr,
+            eth_websocket_addr: args.eth_websocket_addr.clone(),
         },
         price_reporter_url: args.price_reporter_url,
         disabled: args.disable_price_reporter,
@@ -317,12 +317,10 @@ async fn main() -> Result<(), CoordinatorError> {
     // Start the on-chain event listener
     let (chain_listener_cancel_sender, chain_listener_cancel_receiver) = new_cancel_channel();
     let mut chain_listener = OnChainEventListener::new(OnChainEventListenerConfig {
-        max_root_staleness: args.max_merkle_staleness,
+        websocket_addr: args.eth_websocket_addr,
         arbitrum_client: chain_listener_arbitrum_client,
         global_state: global_state.clone(),
         handshake_manager_job_queue: handshake_worker_sender.clone(),
-        proof_generation_work_queue: proof_generation_worker_sender.clone(),
-        network_sender: network_sender.clone(),
         cancel_channel: chain_listener_cancel_receiver,
     })
     .await

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -457,17 +457,13 @@ impl MockNodeController {
             self.arbitrum_client.clone().expect("Arbitrum client not initialized");
         let global_state = self.state.clone().expect("State not initialized");
         let handshake_manager_job_queue = self.handshake_queue.0.clone();
-        let proof_generation_work_queue = self.proof_queue.0.clone();
-        let network_sender = self.network_queue.0.clone();
         let cancel_channel = mock_cancel();
 
         let conf = OnChainEventListenerConfig {
-            max_root_staleness: config.max_merkle_staleness,
+            websocket_addr: config.eth_websocket_addr.clone(),
             arbitrum_client,
             global_state,
             handshake_manager_job_queue,
-            proof_generation_work_queue,
-            network_sender,
             cancel_channel,
         };
 

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -9,7 +9,7 @@ crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Crypto === #
-ethers = { workspace = true }
+ethers = { workspace = true, features = ["ws"] }
 
 # === Workspace Dependencies === #
 arbitrum-client = { workspace = true }

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -3,6 +3,7 @@
 use std::{error::Error, fmt::Display};
 
 use arbitrum_client::errors::ArbitrumClientError;
+use ethers::providers::Middleware;
 use state::error::StateError;
 
 /// The error type that the event listener emits
@@ -10,7 +11,7 @@ use state::error::StateError;
 pub enum OnChainEventListenerError {
     /// An error executing some method in the Arbitrum client
     Arbitrum(String),
-    /// An RPC error with the StarkNet provider
+    /// An RPC error with the provider
     Rpc(String),
     /// An error sending a message to another worker in the local node
     SendMessage(String),
@@ -47,6 +48,18 @@ impl From<StateError> for OnChainEventListenerError {
 
 impl From<ArbitrumClientError> for OnChainEventListenerError {
     fn from(e: ArbitrumClientError) -> Self {
-        OnChainEventListenerError::Arbitrum(e.to_string())
+        OnChainEventListenerError::arbitrum(e)
+    }
+}
+
+impl From<ethers::providers::WsClientError> for OnChainEventListenerError {
+    fn from(e: ethers::providers::WsClientError) -> Self {
+        OnChainEventListenerError::Rpc(e.to_string())
+    }
+}
+
+impl<M: Middleware> From<ethers::contract::ContractError<M>> for OnChainEventListenerError {
+    fn from(e: ethers::contract::ContractError<M>) -> Self {
+        OnChainEventListenerError::arbitrum(e)
     }
 }


### PR DESCRIPTION
### Purpose
This PR allows the chain events listener to use a websocket connection rather than polling via the HTTP-based arbitrum client. This will allow us to receive nullifier events as fast as possible without spending API compute units polling in a short interval.

### Todo
- Configure the relayer in testnet and mainnet to use a websocket connection

### Testing
- [x] Tested locally with both http and websocket configurations