### PR TITLE
api-server: http: external-match: Mark direct external matches as shared

### DIFF
--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -320,8 +320,9 @@ impl ExternalMatchProcessor {
         receiver: Option<Address>,
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
-        let opt =
-            ExternalMatchingEngineOptions::new().with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT);
+        let opt = ExternalMatchingEngineOptions::new()
+            .with_allow_shared(true)
+            .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT);
         let resp = self.request_handshake_manager(external_order.clone(), opt).await?;
 
         match resp {


### PR DESCRIPTION
### Purpose
This PR marks all direct external match requests as shared. This parameter will not be configurable for the direct match path.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet