### PR TITLE
chain-events: listener: Use `subscribe_logs` for websocket client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
@@ -94,6 +95,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
 ]
 
 [[package]]
@@ -157,6 +159,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives 1.0.0",
  "alloy-provider",
+ "alloy-pubsub",
  "alloy-rpc-types-eth",
  "alloy-sol-types 1.0.0",
  "alloy-transport",
@@ -385,12 +388,14 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives 1.0.0",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types 1.0.0",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -408,6 +413,27 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04135d2fd7fa1fba3afe9f79ec2967259dbc0948e02fa0cd0e33a4a812e2cb0a"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives 1.0.0",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "parking_lot 0.12.3",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
  "wasmtimer",
 ]
 
@@ -441,8 +467,10 @@ checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.0.0",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "futures",
  "pin-project",
@@ -710,6 +738,24 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdde5b241745076bcbf2fcad818f2c42203bd2c5f4b50ea43b628ccbd2147ad6"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http 1.3.1",
+ "rustls 0.23.25",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -2504,6 +2550,7 @@ dependencies = [
 name = "chain-events"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "arbitrum-client",
  "async-trait",
  "circuit-types 0.1.0",
@@ -2511,6 +2558,7 @@ dependencies = [
  "constants 0.1.0",
  "crossbeam",
  "ethers",
+ "futures-util",
  "gossip-api",
  "job-types",
  "lazy_static",
@@ -4314,7 +4362,6 @@ dependencies = [
  "const-hex",
  "enr",
  "ethers-core",
- "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -8924,6 +8971,7 @@ dependencies = [
  "opentelemetry",
  "price-reporter",
  "proof-manager",
+ "rustls 0.23.25",
  "state",
  "system-bus",
  "system-clock",
@@ -8973,7 +9021,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -9290,7 +9338,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.0",
  "subtle",
@@ -10806,7 +10856,23 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
- "webpki-roots",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.25",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -11207,6 +11273,25 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "rustls 0.23.25",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -11729,6 +11814,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -80,4 +80,6 @@ sol! {
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
+
+    event NullifierSpent(uint256 indexed nullifier);
 }

--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -3,7 +3,7 @@
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
-use alloy_primitives::ChainId;
+use alloy_primitives::{Address as AlloyAddress, ChainId};
 use constants::{DEVNET_DEPLOY_BLOCK, MAINNET_DEPLOY_BLOCK, TESTNET_DEPLOY_BLOCK};
 use ethers::{
     core::k256::ecdsa::SigningKey,
@@ -143,6 +143,15 @@ impl ArbitrumClient {
             // errors in the contracts repo.
             unimplemented!()
         }
+    }
+
+    /// Get an alloy address for the darkpool contract
+    ///
+    /// TODO: Delete this after we've migrated to alloy entirely
+    pub fn darkpool_alloy_addr(&self) -> AlloyAddress {
+        let client = self.get_darkpool_client();
+        let ethers_addr: ethers::types::Address = client.address();
+        AlloyAddress::from(ethers_addr.as_fixed_bytes())
     }
 
     /// Get a reference to some underlying RPC client

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -493,6 +493,12 @@ pub fn scalar_to_u256(scalar: Scalar) -> U256 {
     U256::from_be_slice(&scalar.to_bytes_be())
 }
 
+/// Converts an alloy `U256` to a `Scalar`
+pub fn alloy_u256_to_scalar(u256: AlloyU256) -> Scalar {
+    let bytes = u256.to_be_bytes_vec();
+    Scalar::from_be_bytes_mod_order(&bytes)
+}
+
 /// Try to extract a fixed-length array of G1Affine points
 /// from a slice of proof system commitments
 pub fn try_unwrap_commitments<const N: usize>(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,6 +43,7 @@ metrics-sampler = { workspace = true }
 clap = { version = "3.2.8", features = ["derive"] }
 ethers = { workspace = true }
 lazy_static = { workspace = true }
+rustls = "0.23"
 tracing = { workspace = true }
 opentelemetry = { version = "0.21", default-features = false, features = [
     "trace",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -74,6 +74,12 @@ const TERMINATION_TIMEOUT_MS: u64 = 10_000; // 10 seconds
 ///     4. Allocate a thread to monitor the worker for faults
 #[tokio::main]
 async fn main() -> Result<(), CoordinatorError> {
+    // Set the default crypto provider for the process, this will be used by
+    // websocket listeners
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     // ---------------------
     // | Environment Setup |
     // ---------------------

--- a/workers/chain-events/Cargo.toml
+++ b/workers/chain-events/Cargo.toml
@@ -9,7 +9,8 @@ crossbeam = { workspace = true }
 tokio = { workspace = true }
 
 # === Crypto === #
-ethers = { workspace = true, features = ["ws"] }
+ethers = { workspace = true }
+alloy = { workspace = true, features = ["provider-ws"] }
 
 # === Workspace Dependencies === #
 arbitrum-client = { workspace = true }
@@ -24,7 +25,8 @@ state = { workspace = true }
 util = { workspace = true }
 
 # === Misc Dependencies === #
-lazy_static = { workspace = true }
 async-trait = { workspace = true }
+futures-util = "0.3.31"
+lazy_static = { workspace = true }
 rand = { workspace = true }
 tracing = { workspace = true }

--- a/workers/chain-events/src/error.rs
+++ b/workers/chain-events/src/error.rs
@@ -3,7 +3,6 @@
 use std::{error::Error, fmt::Display};
 
 use arbitrum_client::errors::ArbitrumClientError;
-use ethers::providers::Middleware;
 use state::error::StateError;
 
 /// The error type that the event listener emits
@@ -52,14 +51,14 @@ impl From<ArbitrumClientError> for OnChainEventListenerError {
     }
 }
 
-impl From<ethers::providers::WsClientError> for OnChainEventListenerError {
-    fn from(e: ethers::providers::WsClientError) -> Self {
+impl<E: Display> From<alloy::transports::RpcError<E>> for OnChainEventListenerError {
+    fn from(e: alloy::transports::RpcError<E>) -> Self {
         OnChainEventListenerError::Rpc(e.to_string())
     }
 }
 
-impl<M: Middleware> From<ethers::contract::ContractError<M>> for OnChainEventListenerError {
-    fn from(e: ethers::contract::ContractError<M>) -> Self {
-        OnChainEventListenerError::arbitrum(e)
+impl From<alloy::sol_types::Error> for OnChainEventListenerError {
+    fn from(e: alloy::sol_types::Error) -> Self {
+        OnChainEventListenerError::Rpc(e.to_string())
     }
 }


### PR DESCRIPTION
### Purpose
This PR fixes the chain events listener's websocket implementation by using the `subscribe_logs` method directly rather than sending `eth_getFilterChanges` through the websocket as ethers will do by default. In the process, I also migrated this crate to use alloy.

### Testing
- [x] Tested locally
- [x] Testing in testnet