### PR TITLE
external-api: price-report: Add `/v0/token-prices` endpoint

### DIFF
--- a/external-api/src/http/mod.rs
+++ b/external-api/src/http/mod.rs
@@ -2,8 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::ApiToken;
-
 #[cfg(feature = "admin-api")]
 pub mod admin;
 #[cfg(feature = "external-match-api")]
@@ -21,13 +19,6 @@ pub mod task_history;
 #[cfg(feature = "wallet-api")]
 pub mod wallet;
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Returns the supported token list
-pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
-
 // -------------
 // | API Types |
 // -------------
@@ -37,11 +28,4 @@ pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
 pub struct PingResponse {
     /// The timestamp when the response is sent
     pub timestamp: u64,
-}
-
-/// The response type to fetch the supported token list
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetSupportedTokensResponse {
-    /// The supported tokens
-    pub tokens: Vec<ApiToken>,
 }

--- a/external-api/src/http/price_report.rs
+++ b/external-api/src/http/price_report.rs
@@ -1,7 +1,12 @@
 //! Groups price reporting API types
 
-use common::types::{exchange::PriceReporterState, token::Token};
+use common::types::{exchange::PriceReporterState, token::Token, Price};
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    deserialize_price_from_string, deserialize_token_from_hex_string, serialize_price_as_string,
+    serialize_token_as_hex_string, types::ApiToken,
+};
 
 // ---------------
 // | HTTP Routes |
@@ -9,6 +14,10 @@ use serde::{Deserialize, Serialize};
 
 /// Price report route
 pub const PRICE_REPORT_ROUTE: &str = "/v0/price_report";
+/// Returns the supported token list
+pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
+/// Returns the prices for all supported pairs
+pub const GET_TOKEN_PRICES_ROUTE: &str = "/v0/token-prices";
 
 /// A request to get the relayer's price report for a pair
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -24,4 +33,41 @@ pub struct GetPriceReportRequest {
 pub struct GetPriceReportResponse {
     /// The PriceReporterState corresponding to the pair
     pub price_report: PriceReporterState,
+}
+
+/// The response type to fetch the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetSupportedTokensResponse {
+    /// The supported tokens
+    pub tokens: Vec<ApiToken>,
+}
+
+/// A response containing all token prices
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetTokenPricesResponse {
+    /// List of tokens with their price information
+    pub token_prices: Vec<TokenPrice>,
+}
+
+/// Price information for a token
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TokenPrice {
+    /// The base token
+    #[serde(
+        serialize_with = "serialize_token_as_hex_string",
+        deserialize_with = "deserialize_token_from_hex_string"
+    )]
+    pub base_token: Token,
+    /// The quote token
+    #[serde(
+        serialize_with = "serialize_token_as_hex_string",
+        deserialize_with = "deserialize_token_from_hex_string"
+    )]
+    pub quote_token: Token,
+    /// The price data for this token
+    #[serde(
+        serialize_with = "serialize_price_as_string",
+        deserialize_with = "deserialize_price_from_string"
+    )]
+    pub price: Price,
 }

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -38,7 +38,7 @@ use external_api::{
         order_book::{
             GET_EXTERNAL_MATCH_FEE_ROUTE, GET_NETWORK_ORDERS_ROUTE, GET_NETWORK_ORDER_BY_ID_ROUTE,
         },
-        price_report::PRICE_REPORT_ROUTE,
+        price_report::{GET_SUPPORTED_TOKENS_ROUTE, GET_TOKEN_PRICES_ROUTE, PRICE_REPORT_ROUTE},
         task::{GET_TASK_QUEUE_PAUSED_ROUTE, GET_TASK_QUEUE_ROUTE, GET_TASK_STATUS_ROUTE},
         task_history::TASK_HISTORY_ROUTE,
         wallet::{
@@ -48,7 +48,7 @@ use external_api::{
             ORDER_HISTORY_ROUTE, PAY_FEES_ROUTE, REDEEM_NOTE_ROUTE, REFRESH_WALLET_ROUTE,
             UPDATE_ORDER_ROUTE, WALLET_ORDERS_ROUTE, WITHDRAW_BALANCE_ROUTE,
         },
-        PingResponse, GET_SUPPORTED_TOKENS_ROUTE,
+        PingResponse,
     },
     EmptyRequestResponse,
 };
@@ -63,7 +63,8 @@ use hyper::{
 };
 use num_bigint::BigUint;
 use num_traits::Num;
-use order_book::{GetExternalMatchFeesHandler, GetSupportedTokensHandler};
+use order_book::GetExternalMatchFeesHandler;
+use price_report::{GetSupportedTokensHandler, TokenPricesHandler};
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
@@ -471,6 +472,13 @@ impl HttpServer {
             &Method::GET,
             GET_SUPPORTED_TOKENS_ROUTE.to_string(),
             GetSupportedTokensHandler,
+        );
+
+        // The "/token-prices" route
+        router.add_unauthenticated_route(
+            &Method::GET,
+            GET_TOKEN_PRICES_ROUTE.to_string(),
+            TokenPricesHandler::new(config.price_reporter_work_queue.clone()),
         );
 
         // The "/order_book/external-match-fee" route

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -1,16 +1,11 @@
 //! Groups routes and handlers for order book API operations
 
 use async_trait::async_trait;
-use common::types::token::{read_token_remap, USDT_TICKER, USD_TICKER};
 use constants::EXTERNAL_MATCH_RELAYER_FEE;
 use external_api::{
-    http::{
-        order_book::{
-            GetExternalMatchFeeResponse, GetNetworkOrderByIdResponse, GetNetworkOrdersResponse,
-        },
-        GetSupportedTokensResponse,
+    http::order_book::{
+        GetExternalMatchFeeResponse, GetNetworkOrderByIdResponse, GetNetworkOrdersResponse,
     },
-    types::ApiToken,
     EmptyRequestResponse,
 };
 use hyper::HeaderMap;
@@ -24,9 +19,6 @@ use crate::{
 };
 
 use super::{parse_mint_from_params, parse_order_id_from_params};
-
-/// Tokens filtered from the supported token endpoint
-const FILTERED_TOKENS: [&str; 2] = [USD_TICKER, USDT_TICKER];
 
 // ------------------
 // | Error Messages |
@@ -105,33 +97,6 @@ impl TypedHandler for GetNetworkOrderByIdHandler {
         } else {
             Err(not_found(ERR_ORDER_NOT_FOUND.to_string()))
         }
-    }
-}
-
-/// Handler for the GET /supported-tokens route
-#[derive(Clone)]
-pub struct GetSupportedTokensHandler;
-
-#[async_trait]
-impl TypedHandler for GetSupportedTokensHandler {
-    type Request = EmptyRequestResponse;
-    type Response = GetSupportedTokensResponse;
-
-    async fn handle_typed(
-        &self,
-        _headers: HeaderMap,
-        _req: Self::Request,
-        _params: UrlParams,
-        _query_params: QueryParams,
-    ) -> Result<Self::Response, ApiServerError> {
-        let token_map = read_token_remap();
-        let tokens = token_map
-            .iter()
-            .map(|(addr, sym)| ApiToken::new(addr.clone(), sym.clone()))
-            .filter(|token| !FILTERED_TOKENS.contains(&token.symbol.as_str()))
-            .collect_vec();
-
-        Ok(GetSupportedTokensResponse { tokens })
     }
 }
 

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -1,14 +1,30 @@
 //! Groups price reporting API handlers and types
 
 use async_trait::async_trait;
-use external_api::http::price_report::{GetPriceReportRequest, GetPriceReportResponse};
+use common::types::token::{read_token_remap, Token, USDC_TICKER, USDT_TICKER, USD_TICKER};
+use external_api::{
+    http::price_report::{
+        GetPriceReportRequest, GetPriceReportResponse, GetSupportedTokensResponse,
+        GetTokenPricesResponse, TokenPrice,
+    },
+    types::ApiToken,
+    EmptyRequestResponse,
+};
+use futures::{future::join_all, FutureExt};
 use hyper::HeaderMap;
+use itertools::Itertools;
+use job_types::price_reporter::PriceReporterQueue;
 
 use crate::{
     error::{internal_error, ApiServerError},
     router::{QueryParams, TypedHandler, UrlParams},
     worker::ApiServerConfig,
 };
+
+/// Tokens filtered from the supported token endpoint
+const FILTERED_TOKENS: [&str; 2] = [USD_TICKER, USDT_TICKER];
+/// Tokens filtered from the token prices endpoint
+const FILTERED_TOKENS_PRICES: [&str; 3] = [USD_TICKER, USDT_TICKER, USDC_TICKER];
 
 // ------------------
 // | Route Handlers |
@@ -50,4 +66,89 @@ impl TypedHandler for PriceReportHandler {
 
         Ok(GetPriceReportResponse { price_report })
     }
+}
+
+/// Handler for the GET /supported-tokens route
+#[derive(Clone)]
+pub struct GetSupportedTokensHandler;
+
+#[async_trait]
+impl TypedHandler for GetSupportedTokensHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetSupportedTokensResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        _req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        let tokens = get_all_tokens_filtered(&FILTERED_TOKENS)
+            .into_iter()
+            .map(|token| ApiToken::new(token.get_addr(), token.get_ticker().unwrap()))
+            .collect_vec();
+        Ok(GetSupportedTokensResponse { tokens })
+    }
+}
+
+/// Handler for the /v0/token-prices route, returns prices for all supported
+/// pairs
+#[derive(Clone)]
+pub(crate) struct TokenPricesHandler {
+    /// The price reporter work queue
+    price_reporter_work_queue: PriceReporterQueue,
+}
+
+impl TokenPricesHandler {
+    /// Create a new handler for "/v0/token-prices"
+    pub fn new(price_reporter_work_queue: PriceReporterQueue) -> Self {
+        Self { price_reporter_work_queue }
+    }
+}
+
+#[async_trait]
+impl TypedHandler for TokenPricesHandler {
+    type Request = EmptyRequestResponse;
+    type Response = GetTokenPricesResponse;
+
+    async fn handle_typed(
+        &self,
+        _headers: HeaderMap,
+        _req: Self::Request,
+        _params: UrlParams,
+        _query_params: QueryParams,
+    ) -> Result<Self::Response, ApiServerError> {
+        // Fetch all prices concurrently
+        let usdc = Token::usdc();
+        let mut price_futures = Vec::new();
+        for base_token in get_all_tokens_filtered(&FILTERED_TOKENS_PRICES) {
+            let job = self
+                .price_reporter_work_queue
+                .peek_price_usdc(base_token.clone())
+                .map(|p| Ok(TokenPrice { base_token, quote_token: usdc.clone(), price: p?.price }));
+            price_futures.push(job);
+        }
+
+        let token_prices = join_all(price_futures)
+            .await
+            .into_iter()
+            .filter_map(|r: Result<TokenPrice, String>| r.ok())
+            .collect_vec();
+        Ok(GetTokenPricesResponse { token_prices })
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Get all tokens from the token map filtering out given tokens
+fn get_all_tokens_filtered(filtered_tokens: &[&str]) -> Vec<Token> {
+    let token_map = read_token_remap();
+    token_map
+        .iter()
+        .map(|(addr, _)| Token::from_addr(addr))
+        .filter(|token| !filtered_tokens.contains(&token.get_addr().as_str()))
+        .collect_vec()
 }

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -46,6 +46,13 @@ impl PriceReporterQueue {
         report.price()
     }
 
+    /// Peek a timestamped price from the price reporter using usdc as the quote
+    /// token
+    pub async fn peek_price_usdc(&self, base_token: Token) -> Result<TimestampedPrice, String> {
+        let usdc = Token::usdc();
+        self.peek_price(base_token, usdc).await
+    }
+
     /// Peek a full price report from the price reporter
     pub async fn peek_price_report(
         &self,


### PR DESCRIPTION
### Purpose
This PR adds the `v0/token-prices` endpoint, which fetches all token prices for all pairs supported by the relayer.

### Testing
- [x] Tested locally
- [ ] Testing in testnet