### PR TITLE
circuits: zk-circuits: wallet-create: Compute full wallet share comm

### DIFF
--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -1,10 +1,7 @@
 //! Helper functions for Arbitrum client integration tests
 
 use arbitrum_client::client::ArbitrumClient;
-use circuit_types::{
-    native_helpers::compute_wallet_commitment_from_private, traits::BaseType,
-    wallet::WalletShareStateCommitment, SizedWalletShare,
-};
+use circuit_types::{traits::BaseType, wallet::WalletShareStateCommitment, SizedWalletShare};
 use common::types::proof_bundles::mocks::dummy_valid_wallet_create_bundle;
 use constants::Scalar;
 use eyre::{eyre, Result};
@@ -31,14 +28,7 @@ pub async fn deploy_new_wallet(
     let statement = valid_wallet_create_bundle.statement.clone();
 
     client.new_wallet(&valid_wallet_create_bundle).await?;
-
-    // The contract will compute the full commitment and insert it into the Merkle
-    // tree; we repeat the same computation here for consistency
-    let full_commitment = compute_wallet_commitment_from_private(
-        &statement.public_wallet_shares,
-        statement.private_shares_commitment,
-    );
-    Ok((full_commitment, statement.public_wallet_shares))
+    Ok((statement.wallet_share_commitment, statement.public_wallet_shares))
 }
 
 /// Sets up pre-allocated state used by the integration tests

--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -248,7 +248,7 @@ pub type PublicEncryptionKey = BabyJubJubPoint;
 pub struct ValidWalletCreateStatement {
     /// The commitment to the private secret shares of the wallet
     #[serde_as(as = "ScalarFieldDef")]
-    pub private_shares_commitment: ScalarField,
+    pub wallet_share_commitment: ScalarField,
     /// The blinded public secret shares of the wallet
     #[serde_as(as = "Vec<ScalarFieldDef>")]
     pub public_wallet_shares: Vec<ScalarField>,

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -131,7 +131,7 @@ pub fn to_contract_valid_wallet_create_statement(
     let public_wallet_shares = wallet_shares_to_scalar_vec(&statement.public_wallet_shares);
 
     ContractValidWalletCreateStatement {
-        private_shares_commitment: statement.private_shares_commitment.inner(),
+        wallet_share_commitment: statement.wallet_share_commitment.inner(),
         public_wallet_shares,
     }
 }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -125,4 +125,8 @@ rand = "0.8"
 serde_json = "1.0"
 test-helpers = { workspace = true, features = ["mpc-network"] }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
-util = { workspace = true, features = ["mocks", "matching-engine"] }
+util = { workspace = true, features = [
+    "mocks",
+    "matching-engine",
+    "telemetry",
+] }

--- a/circuits/benches/valid_wallet_create.rs
+++ b/circuits/benches/valid_wallet_create.rs
@@ -5,7 +5,7 @@
 
 use circuit_types::elgamal::DecryptionKey;
 use circuit_types::fixed_point::FixedPoint;
-use circuit_types::native_helpers::compute_wallet_private_share_commitment;
+use circuit_types::native_helpers::compute_wallet_share_commitment;
 use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
 use circuit_types::wallet::Wallet;
 use circuit_types::PlonkCircuit;
@@ -52,12 +52,12 @@ where
     let blinder_seed = Scalar::random(&mut rng);
     let (private_shares, public_shares) =
         create_wallet_shares_with_blinder_seed(&mut wallet, blinder_seed);
-    let private_shares_commitment = compute_wallet_private_share_commitment(&private_shares);
+    let share_commitment = compute_wallet_share_commitment(&public_shares, &private_shares);
 
     (
         ValidWalletCreateWitness { private_wallet_share: private_shares, blinder_seed },
         ValidWalletCreateStatement {
-            private_shares_commitment,
+            wallet_share_commitment: share_commitment,
             public_wallet_shares: public_shares,
         },
     )

--- a/test-helpers/src/contract_interaction.rs
+++ b/test-helpers/src/contract_interaction.rs
@@ -39,11 +39,11 @@ pub async fn allocate_wallet_in_darkpool(
     wallet: &mut Wallet,
     client: &ArbitrumClient,
 ) -> Result<()> {
-    let share_comm = wallet.get_private_share_commitment();
+    let share_comm = wallet.get_wallet_share_commitment();
 
     let mut proof = dummy_valid_wallet_create_bundle();
     proof.statement.public_wallet_shares = wallet.blinded_public_shares.clone();
-    proof.statement.private_shares_commitment = share_comm;
+    proof.statement.wallet_share_commitment = share_comm;
 
     client.new_wallet(&proof).await?;
 

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -13,7 +13,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use arbitrum_client::client::ArbitrumClient;
 use async_trait::async_trait;
-use circuit_types::native_helpers::compute_wallet_private_share_commitment;
+use circuit_types::native_helpers::compute_wallet_share_commitment;
 use circuits::zk_circuits::valid_wallet_create::{
     SizedValidWalletCreateStatement, SizedValidWalletCreateWitness, ValidWalletCreateStatement,
     ValidWalletCreateWitness,
@@ -296,8 +296,10 @@ impl NewWalletTask {
     fn get_witness_statement(
         &self,
     ) -> (SizedValidWalletCreateWitness, SizedValidWalletCreateStatement) {
-        let private_shares_commitment =
-            compute_wallet_private_share_commitment(&self.wallet.private_shares);
+        let public_shares = &self.wallet.blinded_public_shares;
+        let private_shares = &self.wallet.private_shares;
+        let wallet_share_commitment =
+            compute_wallet_share_commitment(public_shares, private_shares);
 
         (
             ValidWalletCreateWitness {
@@ -305,7 +307,7 @@ impl NewWalletTask {
                 blinder_seed: self.blinder_seed,
             },
             ValidWalletCreateStatement {
-                private_shares_commitment,
+                wallet_share_commitment,
                 public_wallet_shares: self.wallet.blinded_public_shares.clone(),
             },
         )


### PR DESCRIPTION
### Purpose
This PR changes the `VALID WALLET CREATE` circuit to compute the full wallet commitment in-circuit, as opposed to by the contract. 

### Performance
For `VALID WALLET CREATE` this increases the circuit size to the next power of two, but only implies a minimal impact on prover latency, from ~150ms -> ~324ms

### Testing
- [x] All tests pass