### PR TITLE
circuits: zk-circuits: wallet-update: Compute full commitment in circuit

### DIFF
--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -261,9 +261,9 @@ pub struct ValidWalletUpdateStatement {
     /// The nullifier of the old wallet's secret shares
     #[serde_as(as = "ScalarFieldDef")]
     pub old_shares_nullifier: ScalarField,
-    /// A commitment to the new wallet's private secret shares
+    /// A commitment to the new wallet's secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub new_private_shares_commitment: ScalarField,
+    pub new_wallet_commitment: ScalarField,
     /// The blinded public secret shares of the new wallet
     #[serde_as(as = "Vec<ScalarFieldDef>")]
     pub new_public_shares: Vec<ScalarField>,

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -153,7 +153,7 @@ pub fn to_contract_valid_wallet_update_statement(
 
     Ok(ContractValidWalletUpdateStatement {
         old_shares_nullifier: statement.old_shares_nullifier.inner(),
-        new_private_shares_commitment: statement.new_private_shares_commitment.inner(),
+        new_wallet_commitment: statement.new_wallet_commitment.inner(),
         new_public_shares,
         merkle_root: statement.merkle_root.inner(),
         external_transfer,

--- a/workers/task-driver/integration/helpers.rs
+++ b/workers/task-driver/integration/helpers.rs
@@ -165,14 +165,14 @@ pub async fn mock_wallet_update(wallet: &mut Wallet, client: &ArbitrumClient) ->
     wallet.reblind_wallet();
 
     let mut rng = thread_rng();
-    let share_comm = wallet.get_private_share_commitment();
+    let share_comm = wallet.get_wallet_share_commitment();
     let nullifier = Scalar::random(&mut rng);
 
     // Mock a `VALID WALLET UPDATE` proof bundle
     let mut proof = dummy_valid_wallet_update_bundle();
     proof.statement.external_transfer = ExternalTransfer::default();
     proof.statement.old_shares_nullifier = nullifier;
-    proof.statement.new_private_shares_commitment = share_comm;
+    proof.statement.new_wallet_commitment = share_comm;
     proof.statement.new_public_shares = wallet.blinded_public_shares.clone();
 
     client

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -425,13 +425,13 @@ impl UpdateWalletTask {
         // Build the witness and statement
         let old_wallet = &self.old_wallet;
         let new_wallet = &self.new_wallet;
-        let new_private_share_commitment = self.new_wallet.get_private_share_commitment();
+        let new_wallet_commitment = self.new_wallet.get_wallet_share_commitment();
 
         let transfer_index = self.get_transfer_idx()?;
         let transfer = self.transfer.clone().map(|t| t.external_transfer).unwrap_or_default();
         let statement = SizedValidWalletUpdateStatement {
             old_shares_nullifier: old_wallet.get_wallet_nullifier(),
-            new_private_shares_commitment: new_private_share_commitment,
+            new_wallet_commitment,
             new_public_shares: new_wallet.blinded_public_shares.clone(),
             merkle_root,
             external_transfer: transfer,


### PR DESCRIPTION
### Purpose
This PR changes the `VALID WALLET UPDATE` circuit to compute the wallet's full share commitment in circuit, as opposed to just the private share commitment.

### Performance
This PR takes the circuit size to the next power of two which increases prover time from 634ms to 1.24s. This is the same prover time as before the Poseidon arithmetization optimizations in #904, though note that we have a considerably larger margin before the next power of two in gate count.

### Testing
- [x] All tests pass