### PR TITLE
circuits: benches: match-settle-commitments: Add benchmarks

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -51,6 +51,11 @@ harness = false
 required-features = ["test_helpers"]
 
 [[bench]]
+name = "valid_match_settle_with_commitments"
+harness = false
+required-features = ["test_helpers"]
+
+[[bench]]
 name = "valid_match_settle_atomic"
 harness = false
 required-features = ["test_helpers"]

--- a/circuits/benches/valid_match_settle_with_commitments.rs
+++ b/circuits/benches/valid_match_settle_with_commitments.rs
@@ -1,0 +1,114 @@
+//! Benchmarks the `VALID MATCH SETTLE WITH COMMITMENTS` circuit
+#![allow(incomplete_features)]
+#![allow(missing_docs)]
+#![feature(generic_const_exprs)]
+
+use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
+use circuit_types::PlonkCircuit;
+use circuits::zk_circuits::valid_match_settle::test_helpers::dummy_witness_and_statement_with_commitments;
+use circuits::zk_circuits::valid_match_settle::{
+    ValidMatchSettle, ValidMatchSettleWithCommitments,
+};
+use circuits::{singleprover_prove, verify_singleprover_proof};
+use constants::{MAX_BALANCES, MAX_ORDERS};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use mpc_relation::proof_linking::LinkableCircuit;
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Tests the time taken to apply the constraints of `VALID MATCH SETTLE WITH
+/// COMMITMENTS` circuit
+pub fn bench_apply_constraints(c: &mut Criterion) {
+    let mut group = c.benchmark_group("valid_match_settle_with_commitments");
+    let benchmark_id =
+        BenchmarkId::new("constraint-generation", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            dummy_witness_and_statement_with_commitments::<MAX_BALANCES, MAX_ORDERS>();
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+
+        // Add proof linking groups to the circuit
+        let layout = ValidMatchSettle::<MAX_BALANCES, MAX_ORDERS>::get_circuit_layout().unwrap();
+        for (id, layout) in layout.group_layouts.into_iter() {
+            cs.create_link_group(id, Some(layout));
+        }
+
+        let witness_var = witness.create_witness(&mut cs);
+        let statement_var = statement.create_public_var(&mut cs);
+
+        b.iter(|| {
+            ValidMatchSettleWithCommitments::apply_constraints(
+                witness_var.clone(),
+                statement_var.clone(),
+                &mut cs,
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Tests the time taken to prove `VALID MATCH SETTLE WITH COMMITMENTS`
+pub fn bench_prover(c: &mut Criterion) {
+    let mut group = c.benchmark_group("valid_match_settle_with_commitments");
+    let benchmark_id = BenchmarkId::new("prover", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // Build a witness and statement
+        let (witness, statement) =
+            dummy_witness_and_statement_with_commitments::<MAX_BALANCES, MAX_ORDERS>();
+
+        b.iter(|| {
+            singleprover_prove::<ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>>(
+                witness.clone(),
+                statement.clone(),
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Tests the time taken to verify `VALID MATCH SETTLE WITH COMMITMENTS`
+pub fn bench_verifier(c: &mut Criterion) {
+    let mut group = c.benchmark_group("valid_match_settle_with_commitments");
+    let benchmark_id = BenchmarkId::new("verifier", format!("({MAX_BALANCES}, {MAX_ORDERS})"));
+
+    group.bench_function(benchmark_id, |b| {
+        // First generate a proof that will be verified multiple times
+        let (witness, statement) =
+            dummy_witness_and_statement_with_commitments::<MAX_BALANCES, MAX_ORDERS>();
+
+        let proof =
+            singleprover_prove::<ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>>(
+                witness,
+                statement.clone(),
+            )
+            .unwrap();
+
+        b.iter(|| {
+            verify_singleprover_proof::<ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>>(
+                statement.clone(),
+                &proof,
+            )
+            .unwrap();
+        });
+    });
+}
+
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+criterion_group! {
+    name = valid_match_settle_with_commitments;
+    config = Criterion::default().sample_size(10);
+    targets =
+        bench_apply_constraints,
+        bench_prover,
+        bench_verifier,
+}
+
+criterion_main!(valid_match_settle_with_commitments);

--- a/circuits/src/zk_circuits/valid_match_settle/mod.rs
+++ b/circuits/src/zk_circuits/valid_match_settle/mod.rs
@@ -90,10 +90,10 @@ where
 /// commitment in a multiprover circuit outweighs the gains from removing this
 /// computation in the contract
 #[derive(Clone, Debug)]
-pub struct ValidMatchSettleWithCommitment<const MAX_BALANCES: usize, const MAX_ORDERS: usize>;
+pub struct ValidMatchSettleWithCommitments<const MAX_BALANCES: usize, const MAX_ORDERS: usize>;
 
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize>
-    ValidMatchSettleWithCommitment<MAX_BALANCES, MAX_ORDERS>
+    ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>
 where
     [(); MAX_BALANCES + MAX_ORDERS]: Sized,
 {
@@ -338,7 +338,7 @@ where
 }
 
 impl<const MAX_BALANCES: usize, const MAX_ORDERS: usize> SingleProverCircuit
-    for ValidMatchSettleWithCommitment<MAX_BALANCES, MAX_ORDERS>
+    for ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>
 where
     [(); MAX_BALANCES + MAX_ORDERS]: Sized,
 {
@@ -359,7 +359,7 @@ where
         statement: ValidMatchSettleWithCommitmentStatementVar<MAX_BALANCES, MAX_ORDERS>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), PlonkError> {
-        ValidMatchSettleWithCommitment::singleprover_circuit(&statement, &witness, cs)
+        ValidMatchSettleWithCommitments::singleprover_circuit(&statement, &witness, cs)
             .map_err(PlonkError::CircuitError)
     }
 }
@@ -609,7 +609,7 @@ mod tests {
             test_helpers::{MAX_BALANCES, MAX_ORDERS},
             valid_match_settle::{
                 test_helpers::{dummy_witness_and_statement, SizedValidMatchSettle},
-                ValidMatchSettle, ValidMatchSettleWithCommitment,
+                ValidMatchSettle, ValidMatchSettleWithCommitments,
             },
         },
     };
@@ -636,7 +636,7 @@ mod tests {
     /// A `VALID MATCH SETTLE WITH COMMITMENTS` circuit with test sizing
     /// parameters attached
     type TestValidMatchSettleWithCommitment =
-        ValidMatchSettleWithCommitment<MAX_BALANCES, MAX_ORDERS>;
+        ValidMatchSettleWithCommitments<MAX_BALANCES, MAX_ORDERS>;
     /// A `VALID MATCH SETTLE` circuit with test sizing parameters attached
     type TestValidMatchSettle = ValidMatchSettle<MAX_BALANCES, MAX_ORDERS>;
 
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_n_constraints_with_commitments() {
-        let layout = ValidMatchSettleWithCommitment::<
+        let layout = ValidMatchSettleWithCommitments::<
             { constants::MAX_BALANCES },
             { constants::MAX_ORDERS },
         >::get_circuit_layout()


### PR DESCRIPTION
### Purpose
This PR adds a benchmark suite for the new `VALID MATCH SETTLE WITH COMMITMENTS` circuit.

### Testing
- Benchmarks run