### PR TITLE
circuits: zk-circuits: valid-offline-fee: Compute full wallet commitment

### DIFF
--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -420,9 +420,9 @@ pub struct ValidOfflineFeeSettlementStatement {
     /// The nullifier of the old wallet's secret shares
     #[serde_as(as = "ScalarFieldDef")]
     pub nullifier: ScalarField,
-    /// A commitment to the new wallet's private secret shares
+    /// A commitment to the new wallet's updated secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub updated_wallet_commitment: ScalarField,
+    pub new_wallet_commitment: ScalarField,
     /// The blinded public secret shares of the new wallet
     #[serde_as(as = "Vec<ScalarFieldDef>")]
     pub updated_wallet_public_shares: Vec<ScalarField>,

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -412,7 +412,7 @@ pub fn to_contract_valid_offline_fee_settlement_statement(
     ContractValidOfflineFeeSettlementStatement {
         merkle_root: statement.merkle_root.inner(),
         nullifier: statement.nullifier.inner(),
-        updated_wallet_commitment: statement.updated_wallet_commitment.inner(),
+        new_wallet_commitment: statement.new_wallet_commitment.inner(),
         updated_wallet_public_shares: statement
             .updated_wallet_public_shares
             .to_scalars()

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -365,7 +365,7 @@ impl PayOfflineFeeTask {
 
         // Generate new wallet shares
         let new_wallet = &self.new_wallet;
-        let updated_wallet_commitment = new_wallet.get_private_share_commitment();
+        let new_wallet_commitment = new_wallet.get_wallet_share_commitment();
         let updated_wallet_public_shares = new_wallet.blinded_public_shares.clone();
         let updated_wallet_private_shares = new_wallet.private_shares.clone();
 
@@ -373,7 +373,7 @@ impl PayOfflineFeeTask {
         let statement = SizedValidOfflineFeeSettlementStatement {
             merkle_root: opening.compute_root(),
             nullifier,
-            updated_wallet_commitment,
+            new_wallet_commitment,
             updated_wallet_public_shares,
             note_ciphertext,
             note_commitment,


### PR DESCRIPTION
### Purpose
This PR computes the full wallet commitment in the `VALID OFFLINE FEE SETTLEMENT` circuit, rather than computing only the private share commitment. This removes the need to do so in the contract handler.

### Testing
- [x] All unit tests pass