### PR TITLE
circuits: zk-circuit: valid-fee-redemption: Compute full wallet comm

### DIFF
--- a/arbitrum-client/src/contract_types/types.rs
+++ b/arbitrum-client/src/contract_types/types.rs
@@ -457,7 +457,7 @@ pub struct ValidFeeRedemptionStatement {
     pub note_nullifier: ScalarField,
     /// A commitment to the new wallet's private secret shares
     #[serde_as(as = "ScalarFieldDef")]
-    pub new_wallet_commitment: ScalarField,
+    pub new_shares_commitment: ScalarField,
     /// The blinded public secret shares of the new wallet
     #[serde_as(as = "Vec<ScalarFieldDef>")]
     pub new_wallet_public_shares: Vec<ScalarField>,

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -436,7 +436,7 @@ pub fn to_contract_valid_fee_redemption_statement(
         note_root: statement.note_root.inner(),
         nullifier: statement.wallet_nullifier.inner(),
         note_nullifier: statement.note_nullifier.inner(),
-        new_wallet_commitment: statement.new_wallet_commitment.inner(),
+        new_shares_commitment: statement.new_shares_commitment.inner(),
         new_wallet_public_shares: statement
             .new_wallet_public_shares
             .to_scalars()

--- a/workers/task-driver/src/tasks/redeem_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_fee.rs
@@ -337,7 +337,7 @@ impl RedeemFeeTask {
             note_root: note_opening.compute_root(),
             wallet_nullifier: self.old_wallet.get_wallet_nullifier(),
             note_nullifier: self.note.nullifier(),
-            new_wallet_commitment: self.new_wallet.get_private_share_commitment(),
+            new_shares_commitment: self.new_wallet.get_wallet_share_commitment(),
             new_wallet_public_shares,
             recipient_root_key: self.old_wallet.key_chain.public_keys.pk_root.clone(),
         };


### PR DESCRIPTION
### Purpose
This PR computes the full wallet commitment in the `VALID FEE REDEMPTION` circuit, rather than only computing the private commitment and deferring the full commitment to the contracts.

### Testing
- [x] Unit tests pass