### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -6,7 +6,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected