### PR TITLE
arbitrum-cilent: contract-interaction: Set `PendingTransaction` retries

### DIFF
--- a/arbitrum-client/src/client/contract_interaction.rs
+++ b/arbitrum-client/src/client/contract_interaction.rs
@@ -48,6 +48,11 @@ use crate::{
 
 use super::{ArbitrumClient, MiddlewareStack};
 
+/// The number of retries to attempt when polling a pending transaction for
+/// a receipt. The polling interval on a pending transaction is exactly the
+/// interval specified in the `ArbitrumClientConfig`
+const TX_RECEIPT_POLL_RETRIES: usize = 20;
+
 impl ArbitrumClient {
     // -----------
     // | GETTERS |
@@ -555,6 +560,7 @@ impl ArbitrumClient {
             .send()
             .await
             .map_err(|e| ArbitrumClientError::ContractInteraction(e.to_string()))?
+            .retries(TX_RECEIPT_POLL_RETRIES)
             .await
             .map_err(|e| ArbitrumClientError::ContractInteraction(e.to_string()))?
             .ok_or(ArbitrumClientError::TxDropped)?;


### PR DESCRIPTION
### Purpose
This PR sets the number of retries on the `PendingTransaction` to 20 (default is 3). This will allow the client to poll for longer and avoid unnecessary `TxDropped` errors. 

The `PendingTransaction` is polled on the same interval passed into the `ArbitrumClientConfig` -- currently 100ms. So this change will take the total poll length from 300ms -> 2s

### Testing
- [x] Unit tests pass
- [x] Testing in testnet