### PR TITLE
handshake-manager: external-engine: Create malleable matches when requested

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -115,6 +115,8 @@ pub enum TaskDescriptor {
     SettleMatch(SettleMatchTaskDescriptor),
     /// The task descriptor for the `SettleExternalMatch` task
     SettleExternalMatch(SettleExternalMatchTaskDescriptor),
+    /// The task descriptor for the `SettleMalleableExternalMatch` task
+    SettleMalleableExternalMatch(SettleMalleableExternalMatchTaskDescriptor),
     /// The task descriptor for the `UpdateMerkleProof` task
     UpdateMerkleProof(UpdateMerkleProofTaskDescriptor),
     /// The task descriptor for the `UpdateWallet` task
@@ -140,6 +142,7 @@ impl TaskDescriptor {
                 unimplemented!("SettleMatchInternal should preempt queue, no key needed")
             },
             TaskDescriptor::SettleExternalMatch(task) => task.internal_wallet_id,
+            TaskDescriptor::SettleMalleableExternalMatch(task) => task.internal_wallet_id,
             TaskDescriptor::UpdateMerkleProof(task) => task.wallet.wallet_id,
             TaskDescriptor::UpdateWallet(task) => task.wallet_id,
             TaskDescriptor::NodeStartup(task) => task.id,
@@ -158,6 +161,7 @@ impl TaskDescriptor {
             TaskDescriptor::SettleMatch(task) => vec![task.wallet_id],
             TaskDescriptor::SettleMatchInternal(task) => vec![task.wallet_id1, task.wallet_id2],
             TaskDescriptor::SettleExternalMatch(task) => vec![task.internal_wallet_id],
+            TaskDescriptor::SettleMalleableExternalMatch(task) => vec![task.internal_wallet_id],
             TaskDescriptor::UpdateMerkleProof(task) => vec![task.wallet.wallet_id],
             TaskDescriptor::UpdateWallet(task) => vec![task.wallet_id],
             TaskDescriptor::NodeStartup(_) => vec![],
@@ -177,6 +181,7 @@ impl TaskDescriptor {
             | TaskDescriptor::SettleMatch(_)
             | TaskDescriptor::SettleMatchInternal(_)
             | TaskDescriptor::SettleExternalMatch(_)
+            | TaskDescriptor::SettleMalleableExternalMatch(_)
             | TaskDescriptor::UpdateMerkleProof(_) => true,
             TaskDescriptor::NodeStartup(_) => false,
         }
@@ -191,7 +196,8 @@ impl TaskDescriptor {
             TaskDescriptor::RefreshWallet(_) => "Refresh Wallet".to_string(),
             TaskDescriptor::SettleMatch(_) => "Settle Match".to_string(),
             TaskDescriptor::SettleMatchInternal(_) => "Settle Match".to_string(),
-            TaskDescriptor::SettleExternalMatch(_) => "Settle Match".to_string(),
+            TaskDescriptor::SettleExternalMatch(_) => "Settle External Match".to_string(),
+            TaskDescriptor::SettleMalleableExternalMatch(_) => "Settle Malleable Match".to_string(),
             TaskDescriptor::OfflineFee(_) => "Pay Fee Offline".to_string(),
             TaskDescriptor::RelayerFee(_) => "Pay Relayer Fee".to_string(),
             TaskDescriptor::RedeemFee(_) => "Redeem Fee".to_string(),

--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -157,6 +157,12 @@ impl SettleMalleableExternalMatchTaskDescriptor {
     }
 }
 
+impl From<SettleMalleableExternalMatchTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: SettleMalleableExternalMatchTaskDescriptor) -> Self {
+        TaskDescriptor::SettleMalleableExternalMatch(descriptor)
+    }
+}
+
 /// The task descriptor containing only the parameterization of the
 /// `SettleMatch` task
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -163,15 +163,24 @@ pub struct ExternalMatchingEngineOptions {
     /// Whether or not to only generate a quote, without proving validity
     /// for the order's match
     pub only_quote: bool,
-    /// The duration for which a match bundle is valid; i.e. for which the task
-    /// driver should lock the matched wallet's queue
-    pub bundle_duration: Duration,
     /// Whether or not to allow shared access to the resulting bundle
     ///
     /// If true, the bundle may be sent to other clients requesting an external
     /// match. If false, the bundle will be exclusively held for
     /// `bundle_duration`
     pub allow_shared: bool,
+    /// Whether or not to emit a bounded match rather than an exact match
+    ///
+    /// A `BoundedMatchResult` is one in which the exact `base_amount` is not
+    /// known at the time the proof is generated. Rather, the submitting
+    /// party will choose a `base_amount` in between the supplied bounds.
+    ///
+    /// The matching engine, then, must find a match but emit a match result
+    /// that has appropriate (and valid) bounds on the `base_amount`.
+    pub bounded_match: bool,
+    /// The duration for which a match bundle is valid; i.e. for which the task
+    /// driver should lock the matched wallet's queue
+    pub bundle_duration: Duration,
     /// The price to use for the external match. If `None`, the price will
     /// be sampled by the engine
     ///

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -17,8 +17,9 @@ use crate::{
         create_new_wallet::NewWalletTask, lookup_wallet::LookupWalletTask,
         node_startup::NodeStartupTask, pay_offline_fee::PayOfflineFeeTask,
         pay_relayer_fee::PayRelayerFeeTask, redeem_fee::RedeemFeeTask,
-        refresh_wallet::RefreshWalletTask, settle_match::SettleMatchTask,
-        settle_match_external::SettleMatchExternalTask,
+        refresh_wallet::RefreshWalletTask,
+        settle_malleable_external_match::SettleMalleableExternalMatchTask,
+        settle_match::SettleMatchTask, settle_match_external::SettleMatchExternalTask,
         settle_match_internal::SettleMatchInternalTask, update_merkle_proof::UpdateMerkleProofTask,
         update_wallet::UpdateWalletTask,
     },
@@ -277,6 +278,15 @@ impl TaskExecutor {
             },
             TaskDescriptor::SettleExternalMatch(desc) => {
                 self.start_task_helper::<SettleMatchExternalTask>(
+                    immediate,
+                    id,
+                    desc,
+                    affected_wallets,
+                )
+                .await
+            },
+            TaskDescriptor::SettleMalleableExternalMatch(desc) => {
+                self.start_task_helper::<SettleMalleableExternalMatchTask>(
                     immediate,
                     id,
                     desc,

--- a/workers/task-driver/src/task_state.rs
+++ b/workers/task-driver/src/task_state.rs
@@ -11,7 +11,7 @@ use crate::{
         node_startup::NodeStartupTaskState, pay_offline_fee::PayOfflineFeeTaskState,
         pay_relayer_fee::PayRelayerFeeTaskState, redeem_fee::RedeemFeeTaskState,
         refresh_wallet::RefreshWalletTaskState,
-        settle_malleable_external_match::SettleMalleableMatchExternalTaskState,
+        settle_malleable_external_match::SettleMalleableExternalMatchTaskState,
         settle_match::SettleMatchTaskState, settle_match_external::SettleMatchExternalTaskState,
         settle_match_internal::SettleMatchInternalTaskState,
         update_merkle_proof::UpdateMerkleProofTaskState, update_wallet::UpdateWalletTaskState,
@@ -47,7 +47,7 @@ pub enum StateWrapper {
     /// The state object for the settle match external task
     SettleMatchExternal(SettleMatchExternalTaskState),
     /// The state object for the settle malleable match external task
-    SettleMalleableMatchExternal(SettleMalleableMatchExternalTaskState),
+    SettleMalleableExternalMatch(SettleMalleableExternalMatchTaskState),
     /// The state object for the update Merkle proof task
     UpdateMerkleProof(UpdateMerkleProofTaskState),
     /// The state object for the update wallet task
@@ -69,7 +69,7 @@ impl StateWrapper {
             StateWrapper::SettleMatch(state) => state.committed(),
             StateWrapper::SettleMatchInternal(state) => state.committed(),
             StateWrapper::SettleMatchExternal(state) => state.committed(),
-            StateWrapper::SettleMalleableMatchExternal(state) => state.committed(),
+            StateWrapper::SettleMalleableExternalMatch(state) => state.committed(),
             StateWrapper::UpdateWallet(state) => state.committed(),
             StateWrapper::UpdateMerkleProof(state) => state.committed(),
             StateWrapper::NodeStartup(state) => state.committed(),
@@ -93,8 +93,8 @@ impl StateWrapper {
             StateWrapper::SettleMatchExternal(state) => {
                 state == &SettleMatchExternalTaskState::commit_point()
             },
-            StateWrapper::SettleMalleableMatchExternal(state) => {
-                state == &SettleMalleableMatchExternalTaskState::commit_point()
+            StateWrapper::SettleMalleableExternalMatch(state) => {
+                state == &SettleMalleableExternalMatchTaskState::commit_point()
             },
             StateWrapper::UpdateWallet(state) => state == &UpdateWalletTaskState::commit_point(),
             StateWrapper::UpdateMerkleProof(state) => {
@@ -116,7 +116,7 @@ impl StateWrapper {
             StateWrapper::SettleMatch(state) => state.completed(),
             StateWrapper::SettleMatchInternal(state) => state.completed(),
             StateWrapper::SettleMatchExternal(state) => state.completed(),
-            StateWrapper::SettleMalleableMatchExternal(state) => state.completed(),
+            StateWrapper::SettleMalleableExternalMatch(state) => state.completed(),
             StateWrapper::UpdateWallet(state) => state.completed(),
             StateWrapper::UpdateMerkleProof(state) => state.completed(),
             StateWrapper::NodeStartup(state) => state.completed(),
@@ -136,7 +136,7 @@ impl Display for StateWrapper {
             StateWrapper::SettleMatch(state) => state.to_string(),
             StateWrapper::SettleMatchInternal(state) => state.to_string(),
             StateWrapper::SettleMatchExternal(state) => state.to_string(),
-            StateWrapper::SettleMalleableMatchExternal(state) => state.to_string(),
+            StateWrapper::SettleMalleableExternalMatch(state) => state.to_string(),
             StateWrapper::UpdateWallet(state) => state.to_string(),
             StateWrapper::UpdateMerkleProof(state) => state.to_string(),
             StateWrapper::NodeStartup(state) => state.to_string(),


### PR DESCRIPTION
### Purpose
This PR updates the external matching engine to create malleable matches when requested. This is specified by the `bounded_match` flag on the `ExternalEngineOptions` type. When set, the matching engine proceeds with the normal match flow, until the point at which a match is found and needs to be settled. The engine will then derive _bounds_ on the match and forward a `SettleMalleableExternalMatchTask` to the driver.

### Testing
- [x] Unit tests pass
- Full testing deferred until this engine config is accessible from the API