### PR TITLE
api-server: http: external-match: Add malleable match endpoint

### DIFF
--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -208,15 +208,21 @@ impl ExternalMatchingEngineOptions {
         self
     }
 
-    /// Set the bundle duration
-    pub fn with_bundle_duration(mut self, duration: Duration) -> Self {
-        self.bundle_duration = duration;
-        self
-    }
-
     /// Set whether to allow shared access to the resulting bundle
     pub fn with_allow_shared(mut self, allow_shared: bool) -> Self {
         self.allow_shared = allow_shared;
+        self
+    }
+
+    /// Set whether to emit a bounded match
+    pub fn with_bounded_match(mut self, bounded_match: bool) -> Self {
+        self.bounded_match = bounded_match;
+        self
+    }
+
+    /// Set the bundle duration
+    pub fn with_bundle_duration(mut self, duration: Duration) -> Self {
+        self.bundle_duration = duration;
         self
     }
 


### PR DESCRIPTION
### Purpose
This PR adds an endpoint for assembling a quote into a malleable match bundle. This largely mimics the regular assemble flow, but creates a `BoundedMatchResult` rather than an `ExternalMatchResult`.

### Todo
- Build malleable match calldata, left for a follow up.

### Testing
- [x] Unit tests pass