### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/arbitrum-client/src/client/mod.rs
+++ b/arbitrum-client/src/client/mod.rs
@@ -138,7 +138,7 @@ impl ArbitrumClient {
             // We generally always want to select a Darkpool contract client randomly, but
             // the contracts repo also imports the `arbitrum_client` crate, and
             // it must compile to WASM. The `rand` crate does not compile to
-            // WASM, but the contracts repo only uses the conversion utilites
+            // WASM, but the contracts repo only uses the conversion utilities
             // defined in this crate, so we make this no-op fallback to prevent compilation
             // errors in the contracts repo.
             unimplemented!()

--- a/util/src/telemetry/mod.rs
+++ b/util/src/telemetry/mod.rs
@@ -20,7 +20,7 @@ pub enum TelemetrySetupError {
     EnvVarMissing,
     /// Error emitted when setting up the OTLP tracer
     Tracer(String),
-    /// Error emitted when the OTLP deployment environemt
+    /// Error emitted when the OTLP deployment environment
     /// is not provided
     DeploymentEnvUnset,
     /// Error emitted when the OTLP collector endpoint is not provided

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -52,7 +52,7 @@ type WsWriteStream = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Messa
 type WsReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// A message that is sent by the price reporter to the client indicating
-/// a price udpate for the given topic
+/// a price update for the given topic
 ///
 /// Ported over from https://github.com/renegade-fi/renegade-price-reporter/blob/main/src/utils.rs
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
This PR fixes several typos in comments and documentation across multiple files:

- arbitrum-client/src/client/mod.rs: Fix typo in "utilities" comment
- util/src/telemetry/mod.rs: Fix typo in "environment" comment
- workers/price-reporter/src/manager/external_executor.rs: Fix typo in "update" comment

These changes are purely cosmetic and do not affect any functionality.