### PR TITLE
state, workers: fix depth units

### DIFF
--- a/state/src/caching/matchable_amount.rs
+++ b/state/src/caching/matchable_amount.rs
@@ -36,7 +36,8 @@ impl MatchableAmountMap {
 
     /// Get the matchable amount for both sides of a pair
     ///
-    /// Returns (buy_amount, sell_amount)
+    /// Returns (buy_amount, sell_amount) where buy amount is denominated in the
+    /// quote token, sell amount is denominated in the base token
     pub async fn get(&self, pair: &Pair) -> (Amount, Amount) {
         let matchable_amount_map = self.matchable_amount_map.read().await;
         let buy_amount =

--- a/state/src/caching/order_cache.rs
+++ b/state/src/caching/order_cache.rs
@@ -84,7 +84,8 @@ impl OrderBookCache {
 
     /// Get the matchable amount for both sides of a pair
     ///
-    /// Returns (buy_amount, sell_amount)
+    /// Returns (buy_amount, sell_amount) where buy amount is denominated in the
+    /// quote token, sell amount is denominated in the base token
     pub async fn get_matchable_amount(&self, pair: &Pair) -> (Amount, Amount) {
         self.matchable_amount_map.get(pair).await
     }

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -150,7 +150,8 @@ impl StateInner {
 
     /// Get the matchable amount for both sides of a pair
     ///
-    /// Returns (buy_amount, sell_amount)
+    /// Returns (buy_amount, sell_amount) where buy amount is denominated in the
+    /// quote token, sell amount is denominated in the base token
     pub async fn get_liquidity_for_pair(&self, pair: &Pair) -> (Amount, Amount) {
         self.order_cache.get_matchable_amount(pair).await
     }

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -14,6 +14,7 @@ use external_api::{
 use hyper::HeaderMap;
 use itertools::Itertools;
 use job_types::price_reporter::PriceReporterQueue;
+use num_traits::ToPrimitive;
 use state::State;
 use util::on_chain::get_external_match_fee;
 
@@ -171,11 +172,19 @@ impl TypedHandler for GetDepthByMintHandler {
 
         // Get the matchable amount
         let pair = pair_from_mints(mint, quote_token.get_addr_biguint());
-        let (buy_liquidity, sell_liquidity) = self.state.get_liquidity_for_pair(&pair).await;
-        let buy_usd = base_token.convert_to_decimal(buy_liquidity) * ts_price.price;
+        let (buy_liquidity_quote, sell_liquidity) = self.state.get_liquidity_for_pair(&pair).await;
+
+        let buy_usd = quote_token.convert_to_decimal(buy_liquidity_quote);
         let sell_usd = base_token.convert_to_decimal(sell_liquidity) * ts_price.price;
 
-        let buy = DepthSide { total_quantity: buy_liquidity, total_quantity_usd: buy_usd };
+        // Convert buy_liquidity (in terms of quote token) to be in terms of the
+        // base token
+        let base_decimals = base_token.get_decimals().unwrap();
+        let buy_liquidity_base_decimal = buy_usd / ts_price.price;
+        let buy_liquidity_base = buy_liquidity_base_decimal * 10f64.powi(base_decimals as i32);
+        let buy_liquidity_base: u128 = buy_liquidity_base.to_u128().unwrap();
+
+        let buy = DepthSide { total_quantity: buy_liquidity_base, total_quantity_usd: buy_usd };
         let sell = DepthSide { total_quantity: sell_liquidity, total_quantity_usd: sell_usd };
 
         Ok(GetDepthByMintResponse {


### PR DESCRIPTION
### Purpose
This PR ensures `GetDepthByMintResponse` returns raw token values denominated in the base token. Previously, we were not considering the fact that `wallet.get_matchable_amount_for_order()` returns the matchable amount for a given order in terms of the order's sell asset.

### Testing
- [x] Tested locally
- [ ] Test in testnet