### PR TITLE
api-server: http: external-match: Build malleable match calldata for bundle

### DIFF
--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -24,6 +24,8 @@ abigen!(
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processMalleableAtomicMatchSettle(uint256 memory base_amount, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
@@ -57,6 +59,8 @@ abigen!(
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
+        function processMalleableAtomicMatchSettle(uint256 memory base_amount, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -451,7 +451,7 @@ impl HttpServer {
         router.add_admin_authenticated_route(
             &Method::POST,
             ASSEMBLE_MALLEABLE_EXTERNAL_MATCH_ROUTE.to_string(),
-            AssembleMalleableExternalMatchHandler::new(processor.clone(), state.clone()),
+            AssembleMalleableExternalMatchHandler::new(processor.clone()),
         );
 
         // The "/external-match/request" route

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -91,7 +91,7 @@ impl Display for SettleMalleableExternalMatchTaskState {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::Pending => write!(f, "Pending"),
-            Self::ProvingAtomicMatchSettle => write!(f, "Proving Atomic Match Settle"),
+            Self::ProvingAtomicMatchSettle => write!(f, "Proving Malleable Atomic Match Settle"),
             Self::ForwardingAtomicMatchBundle => write!(f, "Forwarding Atomic Match Bundle"),
             Self::AwaitingSettlement => write!(f, "Awaiting Settlement"),
             Self::Completed => write!(f, "Completed"),


### PR DESCRIPTION
### Purpose
This PR builds the calldata for a `processMalleableAtomicMatchSettle` call in assembling a malleable bundle.

### Testing
- [x] Unit tests pass
- [x] Testing locally 