### PR TITLE
arbitrum-client: event-indexing: Parse external match from malleable

### DIFF
--- a/arbitrum-client/integration/event_indexing.rs
+++ b/arbitrum-client/integration/event_indexing.rs
@@ -9,25 +9,6 @@ use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{helpers::setup_pre_allocated_state, IntegrationTestArgs};
 
-/// Tests finding a pre-allocated commitment in the Merkle state
-async fn test_find_commitment(test_args: IntegrationTestArgs) -> Result<()> {
-    let mut client = test_args.client;
-    let state = setup_pre_allocated_state(&mut client).await?;
-
-    for (index, commitment) in
-        [state.index0_commitment, state.index1_commitment, state.index2_commitment]
-            .into_iter()
-            .enumerate()
-    {
-        // Test the commitment
-        let commitment_index = client.find_commitment_in_state(commitment).await?;
-        assert_eq_result!(commitment_index, index as u128)?;
-    }
-
-    Ok(())
-}
-integration_test_async!(test_find_commitment);
-
 /// Tests finding a Merkle authentication path for a pre-allocated commitment
 async fn test_find_merkle_path(test_args: IntegrationTestArgs) -> Result<()> {
     let mut client = test_args.client;

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -81,6 +81,8 @@ sol! {
     function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
     function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processMalleableAtomicMatchSettle(uint256 baseAmount,  bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+    function processMalleableAtomicMatchSettleWithReceiver(uint256 baseAmount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
     function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
     function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
     function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::abi::{
     newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+    processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
     processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,
     updateWalletCall,
 };
@@ -77,6 +78,12 @@ pub const PROCESS_ATOMIC_MATCH_SETTLE_SELECTOR: [u8; SELECTOR_LEN] =
 /// Selector for `processAtomicMatchSettleWithReceiver`
 pub const PROCESS_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR: [u8; SELECTOR_LEN] =
     processAtomicMatchSettleWithReceiverCall::SELECTOR;
+/// Selector for `processMalleableAtomicMatchSettleWithReceiver`
+pub const PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR: [u8; SELECTOR_LEN] =
+    processMalleableAtomicMatchSettleWithReceiverCall::SELECTOR;
+/// Selector for `processMalleableAtomicMatchSettle`
+pub const PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_SELECTOR: [u8; SELECTOR_LEN] =
+    processMalleableAtomicMatchSettleCall::SELECTOR;
 /// Selector for `settleOnlineRelayerFee`
 pub const SETTLE_ONLINE_RELAYER_FEE_SELECTOR: [u8; SELECTOR_LEN] =
     settleOnlineRelayerFeeCall::SELECTOR;


### PR DESCRIPTION
### Purpose
This PR adds handlers for `processMalleableAtomicMatchSettle` and `processMalleableAtomicMatchSettleWithReceiver` in the logic used to parse `ExternalMatchResults` from a nullifier transaction.

### Testing
- [x] Unit tests pass
- [ ] Testing locally 