### PR TITLE
arbitrum-client: event-indexing: Recover shares from malleable matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
 name = "arbitrum-client"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
  "ark-bn254",

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -30,9 +30,10 @@ ruint = { version = "1.11.1", features = ["num-bigint"] }
 mpc-relation = { workspace = true }
 
 # === Networking / Blockchain === #
-ethers = { workspace = true }
+alloy = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
+ethers = { workspace = true }
 
 # === Workspace Dependencies === #
 constants = { workspace = true }

--- a/arbitrum-client/src/client/event_indexing.rs
+++ b/arbitrum-client/src/client/event_indexing.rs
@@ -42,7 +42,10 @@ use crate::contract_types::{
 use crate::conversion::{
     alloy_u256_to_ethers_u256, scalar_to_u256 as scalar_to_alloy_u256, to_circuit_fixed_point,
 };
-use crate::helpers::deserialize_calldata;
+use crate::helpers::{
+    deserialize_calldata, parse_shares_from_process_malleable_atomic_match_settle,
+    parse_shares_from_process_malleable_atomic_match_settle_with_receiver,
+};
 use crate::{
     abi::{
         newWalletCall, processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall,
@@ -323,6 +326,12 @@ impl ArbitrumClient {
             },
             <processAtomicMatchSettleWithReceiverCall as SolCall>::SELECTOR => {
                 parse_shares_from_process_atomic_match_settle_with_receiver(calldata)
+            },
+            <processMalleableAtomicMatchSettleCall as SolCall>::SELECTOR => {
+                parse_shares_from_process_malleable_atomic_match_settle(calldata)
+            },
+            <processMalleableAtomicMatchSettleWithReceiverCall as SolCall>::SELECTOR => {
+                parse_shares_from_process_malleable_atomic_match_settle_with_receiver(calldata)
             },
             <settleOnlineRelayerFeeCall as SolCall>::SELECTOR => {
                 parse_shares_from_settle_online_relayer_fee(calldata, public_blinder_share)

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -228,6 +228,18 @@ pub fn to_contract_order_settlement_indices(
     }
 }
 
+/// Convert a contract [`OrderSettlementIndices`] to a
+/// [`OrderSettlementIndices`]
+pub fn to_circuit_order_settlement_indices(
+    indices: &ContractOrderSettlementIndices,
+) -> OrderSettlementIndices {
+    OrderSettlementIndices {
+        balance_send: indices.balance_send as usize,
+        balance_receive: indices.balance_receive as usize,
+        order: indices.order as usize,
+    }
+}
+
 /// Convert a [`SizedValidMatchSettleStatement`] to its corresponding smart
 /// contract type
 pub fn to_contract_valid_match_settle_statement(
@@ -284,6 +296,26 @@ pub fn to_contract_bounded_match_result(
     })
 }
 
+/// Convert a contract [`BoundedMatchResult`] to a [`BoundedMatchResult`]
+pub fn to_circuit_bounded_match_result(
+    match_result: &ContractBoundedMatchResult,
+) -> Result<BoundedMatchResult, ConversionError> {
+    let quote_mint = address_to_biguint(&match_result.quote_mint)?;
+    let base_mint = address_to_biguint(&match_result.base_mint)?;
+    let price = to_circuit_fixed_point(&match_result.price);
+    let min_base_amount = u256_to_amount(match_result.min_base_amount)?;
+    let max_base_amount = u256_to_amount(match_result.max_base_amount)?;
+
+    Ok(BoundedMatchResult {
+        quote_mint,
+        base_mint,
+        price,
+        min_base_amount,
+        max_base_amount,
+        direction: match_result.direction,
+    })
+}
+
 /// Convert a [`FeeTake`] to its corresponding smart contract type
 pub fn to_contract_fee_take(fee_take: &FeeTake) -> Result<ContractFeeTake, ConversionError> {
     Ok(ContractFeeTake {
@@ -297,6 +329,14 @@ pub fn to_contract_fee_rates(fee_rates: &FeeTakeRate) -> Result<ContractFeeRates
     Ok(ContractFeeRates {
         relayer_fee_rate: to_contract_fixed_point(&fee_rates.relayer_fee_rate),
         protocol_fee_rate: to_contract_fixed_point(&fee_rates.protocol_fee_rate),
+    })
+}
+
+/// Convert a contract [`FeeRates`] to a [`FeeRates`]
+pub fn to_circuit_fee_rates(fee_rates: &ContractFeeRates) -> Result<FeeTakeRate, ConversionError> {
+    Ok(FeeTakeRate {
+        relayer_fee_rate: to_circuit_fixed_point(&fee_rates.relayer_fee_rate),
+        protocol_fee_rate: to_circuit_fixed_point(&fee_rates.protocol_fee_rate),
     })
 }
 

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -1,24 +1,29 @@
 //! Various helpers for Arbitrum client execution
 
+use alloy::primitives::U256;
 use alloy_sol_types::SolCall;
 use circuit_types::{
     elgamal::{BabyJubJubPoint, ElGamalCiphertext},
     note::NOTE_CIPHERTEXT_SIZE,
+    r#match::OrderSettlementIndices,
     traits::BaseType,
-    SizedWalletShare,
+    Amount, SizedWalletShare,
 };
 use constants::Scalar;
 use ethers::types::Bytes;
 use serde::{Deserialize, Serialize};
+use util::matching_engine::apply_match_to_shares;
 
 use crate::{
     abi::{
         newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+        processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
         processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,
         updateWalletCall,
     },
     contract_types::{
-        ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+        MatchPayload, ValidFeeRedemptionStatement as ContractValidFeeRedemptionStatement,
+        ValidMalleableMatchSettleAtomicStatement as ContractValidMalleableMatchSettleAtomicStatement,
         ValidMatchSettleAtomicStatement as ContractValidMatchSettleAtomicStatement,
         ValidMatchSettleStatement as ContractValidMatchSettleStatement,
         ValidOfflineFeeSettlementStatement as ContractValidOfflineFeeSettlementStatement,
@@ -26,8 +31,15 @@ use crate::{
         ValidWalletCreateStatement as ContractValidWalletCreateStatement,
         ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
     },
+    conversion::{
+        to_circuit_bounded_match_result, to_circuit_fee_rates, to_circuit_order_settlement_indices,
+    },
     errors::ArbitrumClientError,
 };
+
+// ---------------------
+// | (De)serialization |
+// ---------------------
 
 /// Serializes a calldata element for a contract call
 pub fn serialize_calldata<T: Serialize>(data: &T) -> Result<Bytes, ArbitrumClientError> {
@@ -42,6 +54,10 @@ pub fn deserialize_calldata<'de, T: Deserialize<'de>>(
 ) -> Result<T, ArbitrumClientError> {
     postcard::from_bytes(calldata).map_err(|e| ArbitrumClientError::Serde(e.to_string()))
 }
+
+// ----------------
+// | Parse Shares |
+// ----------------
 
 /// Parses wallet shares from the calldata of a `newWallet` call
 pub fn parse_shares_from_new_wallet(
@@ -124,13 +140,66 @@ pub fn parse_shares_from_process_atomic_match_settle_with_receiver(
     calldata: &[u8],
 ) -> Result<SizedWalletShare, ArbitrumClientError> {
     let call = processAtomicMatchSettleWithReceiverCall::abi_decode(calldata)?;
-
     let statement = deserialize_calldata::<ContractValidMatchSettleAtomicStatement>(
         &call.valid_match_settle_atomic_statement,
     )?;
 
     let mut shares = statement.internal_party_modified_shares.into_iter().map(Scalar::new);
     Ok(SizedWalletShare::from_scalars(&mut shares))
+}
+
+/// Parses wallet shares from the calldata of a
+/// `processMalleableAtomicMatchSettle` call
+pub fn parse_shares_from_process_malleable_atomic_match_settle(
+    calldata: &[u8],
+) -> Result<SizedWalletShare, ArbitrumClientError> {
+    // Parse the pre-update shares from the calldata
+    let call = processMalleableAtomicMatchSettleCall::abi_decode(calldata)?;
+    let statement = deserialize_calldata::<ContractValidMalleableMatchSettleAtomicStatement>(
+        &call.valid_match_settle_statement,
+    )?;
+    let mut shares = statement.internal_party_public_shares.clone().into_iter().map(Scalar::new);
+    let mut wallet_share = SizedWalletShare::from_scalars(&mut shares);
+
+    // Update the shares with the match result
+    let validity_proofs = deserialize_calldata::<MatchPayload>(&call.internal_party_match_payload)?;
+    let indices =
+        to_circuit_order_settlement_indices(&validity_proofs.valid_commitments_statement.indices);
+    apply_malleable_match_result_to_wallet_share(
+        &mut wallet_share,
+        call.baseAmount,
+        indices,
+        &statement,
+    )?;
+
+    Ok(wallet_share)
+}
+
+/// Parses wallet shares from the calldata of a
+/// `processMalleableAtomicMatchSettleWithReceiver` call
+pub fn parse_shares_from_process_malleable_atomic_match_settle_with_receiver(
+    calldata: &[u8],
+) -> Result<SizedWalletShare, ArbitrumClientError> {
+    let call = processMalleableAtomicMatchSettleWithReceiverCall::abi_decode(calldata)?;
+    let statement = deserialize_calldata::<ContractValidMalleableMatchSettleAtomicStatement>(
+        &call.valid_match_settle_statement,
+    )?;
+
+    let mut shares = statement.internal_party_public_shares.clone().into_iter().map(Scalar::new);
+    let mut wallet_share = SizedWalletShare::from_scalars(&mut shares);
+
+    // Update the shares with the match result
+    let validity_proofs = deserialize_calldata::<MatchPayload>(&call.internal_party_match_payload)?;
+    let indices =
+        to_circuit_order_settlement_indices(&validity_proofs.valid_commitments_statement.indices);
+    apply_malleable_match_result_to_wallet_share(
+        &mut wallet_share,
+        call.baseAmount,
+        indices,
+        &statement,
+    )?;
+
+    Ok(wallet_share)
 }
 
 /// Parses wallet shares from the calldata of a `settleOnlineRelayerFee` call
@@ -211,4 +280,36 @@ pub fn parse_note_ciphertext_from_settle_offline_fee(
         [Scalar::new(cipher.1), Scalar::new(cipher.2), Scalar::new(cipher.3)];
 
     Ok(ElGamalCiphertext { ephemeral_key: key_encryption, ciphertext: symmetric_ciphertext })
+}
+
+// ---------------------
+// | Malleable Matches |
+// ---------------------
+
+/// Apply a malleable match result to a wallet share
+///
+/// We replicate this logic in the relayer for simplicity, though we could
+/// conceivably log these updated shares in the contract as well
+pub fn apply_malleable_match_result_to_wallet_share(
+    wallet_share: &mut SizedWalletShare,
+    base_amount: U256,
+    indices: OrderSettlementIndices,
+    statement: &ContractValidMalleableMatchSettleAtomicStatement,
+) -> Result<(), ArbitrumClientError> {
+    let base_amt: Amount = base_amount.try_into().expect("base amount too large");
+
+    // Compute the amounts traded
+    let bounded_match = to_circuit_bounded_match_result(&statement.match_result)?;
+    let external_match_res = bounded_match.to_external_match_result(base_amt);
+    let match_res = external_match_res.to_match_result();
+
+    // Compute the fees due by the internal party
+    let (_, recv_amount) = external_match_res.external_party_send();
+    let fees = to_circuit_fee_rates(&statement.internal_fee_rates)?;
+    let fee_take = fees.compute_fee_take(recv_amount);
+
+    // Apply the match to the wallet share
+    let side = external_match_res.internal_party_side();
+    apply_match_to_shares(wallet_share, &indices, fee_take, &match_res, side);
+    Ok(())
 }

--- a/circuit-types/src/fees.rs
+++ b/circuit-types/src/fees.rs
@@ -1,6 +1,7 @@
 //! Fee types for circuits in the Renegade system
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
+use renegade_crypto::fields::scalar_to_u128;
 use serde::{Deserialize, Serialize};
 
 use crate::{fixed_point::FixedPoint, Amount};
@@ -44,6 +45,17 @@ impl FeeTakeRate {
     /// Get the total fee rate
     pub fn total(&self) -> FixedPoint {
         self.relayer_fee_rate + self.protocol_fee_rate
+    }
+
+    /// Get a fee take given an amount received
+    pub fn compute_fee_take(&self, amount: Amount) -> FeeTake {
+        let amt_scalar = Scalar::from(amount);
+        let relayer_fee_scalar = (self.relayer_fee_rate * amt_scalar).floor();
+        let protocol_fee_scalar = (self.protocol_fee_rate * amt_scalar).floor();
+        let relayer_fee = scalar_to_u128(&relayer_fee_scalar);
+        let protocol_fee = scalar_to_u128(&protocol_fee_scalar);
+
+        FeeTake { relayer_fee, protocol_fee }
     }
 }
 

--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -149,6 +149,34 @@ impl ExternalMatchResult {
             (self.base_mint.clone(), self.base_amount)
         }
     }
+
+    /// Get the `OrderSide` for the internal party
+    pub fn internal_party_side(&self) -> OrderSide {
+        if self.direction {
+            OrderSide::Sell
+        } else {
+            OrderSide::Buy
+        }
+    }
+
+    /// Get a mock `MatchResult` type from an `ExternalMatchResult`
+    ///
+    /// Though an `ExternalMatchResult` doesn't exactly represent the same
+    /// application level idea that a `MatchResult` does, it is useful to
+    /// convert types to use common helpers
+    ///
+    /// Here we make the choice that the internal party acts as "party 0" in the
+    /// `MatchResult` language, and the external party acts as "party 1".
+    pub fn to_match_result(&self) -> MatchResult {
+        MatchResult {
+            quote_mint: self.quote_mint.clone(),
+            base_mint: self.base_mint.clone(),
+            quote_amount: self.quote_amount,
+            base_amount: self.base_amount,
+            direction: self.direction,
+            min_amount_order_index: false, // unused for external matches
+        }
+    }
 }
 
 impl From<MatchResult> for ExternalMatchResult {
@@ -222,6 +250,17 @@ impl BoundedMatchResult {
             (self.quote_mint.clone(), self.quote_amount(base_amount))
         } else {
             (self.base_mint.clone(), base_amount)
+        }
+    }
+
+    /// Get an external match result given a base amount swapped
+    pub fn to_external_match_result(&self, base_amount: Amount) -> ExternalMatchResult {
+        ExternalMatchResult {
+            quote_mint: self.quote_mint.clone(),
+            base_mint: self.base_mint.clone(),
+            quote_amount: self.quote_amount(base_amount),
+            base_amount,
+            direction: self.direction,
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds share recovery helpers to the arbitrum client that recover a wallet's shares from a malleable match transaction. We reconstruct the wallet share updates locally, as opposed to emitting an event on-chain, for simplicity.

### Testing
- [x] Unit tests pass
- [x] Tested locally, generated and submitted a malleable match on-chain, verified that the relayer correctly recovered my wallet.