### PR TITLE
arbitrum-client: Transition from `ethers` to `alloy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,9 @@ dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-signer",
  "alloy-sol-types 1.0.0",
  "alloy-transport",
@@ -494,6 +496,7 @@ checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
 dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-serde",
  "serde",
 ]
@@ -507,6 +510,16 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05525519bd7f37f98875354f0b3693d3ad3c7a7f067e3b8946777920be15cb5b"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -524,6 +537,20 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types 1.0.0",
  "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bccbe4594eaa2d69d21fa0b558c44e36202e599eb209da70b405415cb37a354"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -929,6 +956,7 @@ name = "arbitrum-client"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-contract",
  "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
  "ark-bn254",
@@ -940,7 +968,6 @@ dependencies = [
  "colored",
  "common 0.1.0",
  "constants 0.1.0",
- "ethers",
  "eyre",
  "inventory",
  "itertools 0.12.1",

--- a/arbitrum-client/Cargo.toml
+++ b/arbitrum-client/Cargo.toml
@@ -11,7 +11,6 @@ integration = [
     "common/mocks",
 ]
 rand = ["dep:rand"]
-tx-metrics = ["renegade-metrics/tx-metrics"]
 
 [[test]]
 name = "integration"
@@ -30,10 +29,10 @@ ruint = { version = "1.11.1", features = ["num-bigint"] }
 mpc-relation = { workspace = true }
 
 # === Networking / Blockchain === #
-alloy = { workspace = true }
+alloy = { workspace = true, features = ["provider-debug-api"] }
+alloy-contract = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
-ethers = { workspace = true }
 
 # === Workspace Dependencies === #
 constants = { workspace = true }

--- a/arbitrum-client/integration/helpers.rs
+++ b/arbitrum-client/integration/helpers.rs
@@ -69,7 +69,7 @@ pub async fn setup_pre_allocated_state(client: &mut ArbitrumClient) -> Result<Pr
 pub async fn clear_merkle(client: &ArbitrumClient) -> Result<()> {
     warn!("Clearing Merkle contract state");
     client
-        .send_tx(client.get_darkpool_client().clear_merkle())
+        .send_tx(client.darkpool_client().clearMerkle())
         .await
         .map(|_| ())
         .map_err(|e| eyre!(e.to_string()))

--- a/arbitrum-client/integration/main.rs
+++ b/arbitrum-client/integration/main.rs
@@ -18,13 +18,13 @@ mod helpers;
 use std::str::FromStr;
 
 use ::constants::Scalar;
+use alloy::signers::local::PrivateKeySigner;
 use arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
     constants::Chain,
 };
 use circuit_types::SizedWalletShare;
 use clap::Parser;
-use ethers::signers::LocalWallet;
 use test_helpers::{
     arbitrum::{DEFAULT_DEVNET_HOSTPORT, DEFAULT_DEVNET_PKEY},
     integration_test_main,
@@ -112,11 +112,11 @@ impl From<CliArgs> for IntegrationTestArgs {
         // We block on the client creation so that we can match the (synchronous)
         // function signature of `From`, which is assumed to be implemented in
         // the integration test harness
-        let arb_priv_key = LocalWallet::from_str(&test_args.private_key).unwrap();
+        let private_key = PrivateKeySigner::from_str(&test_args.private_key).unwrap();
         let client = block_current(ArbitrumClient::new(ArbitrumClientConfig {
             chain: Chain::Devnet,
             darkpool_addr,
-            arb_priv_keys: vec![arb_priv_key],
+            private_key,
             rpc_url: test_args.rpc_url,
             block_polling_interval_ms: 100,
         }))

--- a/arbitrum-client/src/abi.rs
+++ b/arbitrum-client/src/abi.rs
@@ -4,88 +4,37 @@
 #![allow(unused_doc_comments)]
 
 use alloy_sol_types::sol;
-use ethers::contract::abigen;
-
-#[cfg(not(feature = "integration"))]
-abigen!(
-    DarkpoolContract,
-    r#"[
-        function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
-        function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool)
-        function getRoot() external view returns (uint256)
-        function getFee() external view returns (uint256)
-        function getExternalMatchFeeForAsset(address memory asset) external view returns (uint256)
-        function getPubkey() external view returns (uint256[2])
-        function getProtocolExternalFeeCollectionAddress() external view returns (address)
-        function rootInHistory(uint256 memory root) external view returns (bool)
-
-        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processMalleableAtomicMatchSettle(uint256 memory base_amount, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
-        function processMalleableAtomicMatchSettleWithReceiver(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
-        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
-        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
-        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
-
-        event WalletUpdated(uint256 indexed wallet_blinder_share)
-        event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
-        event MerkleInsertion(uint128 indexed index, uint256 indexed value)
-        event NullifierSpent(uint256 indexed nullifier)
-        event NotePosted(uint256 indexed note_commitment)
-    ]"#
-);
-
-/// This ABI represents the Darkpool testing contract,
-/// which contains all the same methods as the Darkpool (from which it
-/// inherits), but also exposes some additional methods for testing purposes.
-#[cfg(feature = "integration")]
-abigen!(
-    DarkpoolContract,
-    r#"[
-        function isNullifierSpent(uint256 memory nullifier) external view returns (bool)
-        function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool)
-        function getRoot() external view returns (uint256)
-        function getFee() external view returns (uint256)
-        function getExternalMatchFeeForAsset(address memory asset) external view returns (uint256)
-        function getPubkey() external view returns (uint256[2])
-        function getProtocolExternalFeeCollectionAddress() external view returns (address)
-        function rootInHistory(uint256 memory root) external view returns (bool)
-
-        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external
-        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external
-        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external
-        function processMalleableAtomicMatchSettle(uint256 memory base_amount, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
-        function processMalleableAtomicMatchSettleWithReceiver(uint256 memory base_amount, address receiver, bytes memory internal_party_payload, bytes memory malleable_match_settle_atomic_statement, bytes memory proofs, bytes memory linking_proofs) external payable
-        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external
-        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external
-        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external
-
-        event WalletUpdated(uint256 indexed wallet_blinder_share)
-        event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value)
-        event MerkleInsertion(uint128 indexed index, uint256 indexed value)
-        event NullifierSpent(uint256 indexed nullifier)
-        event NotePosted(uint256 indexed note_commitment)
-
-        function clearMerkle() external
-    ]"#
-);
 
 sol! {
-    function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
-    function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
-    function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
-    function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processMalleableAtomicMatchSettle(uint256 base_amount,  bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function processMalleableAtomicMatchSettleWithReceiver(uint256 base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-    function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
-    function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
-    function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
+    #[sol(rpc)]
+    contract Darkpool {
+        function isNullifierSpent(uint256 memory nullifier) external view returns (bool);
+        function isPublicBlinderUsed(uint256 memory blinder) external view returns (bool);
+        function getRoot() external view returns (uint256);
+        function getFee() external view returns (uint256);
+        function getExternalMatchFeeForAsset(address memory asset) external view returns (uint256);
+        function getPubkey() external view returns (uint256[2]);
+        function getProtocolExternalFeeCollectionAddress() external view returns (address);
+        function rootInHistory(uint256 memory root) external view returns (bool);
 
-    event NullifierSpent(uint256 indexed nullifier);
+        function newWallet(bytes memory proof, bytes memory valid_wallet_create_statement_bytes) external;
+        function updateWallet(bytes memory proof, bytes memory valid_wallet_update_statement_bytes, bytes memory wallet_commitment_signature, bytes memory transfer_aux_data) external;
+        function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
+        function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function processMalleableAtomicMatchSettle(uint256 base_amount,  bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
+        function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
+        function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;
+
+        event NullifierSpent(uint256 indexed nullifier);
+        event WalletUpdated(uint256 indexed wallet_blinder_share);
+        event MerkleOpeningNode(uint8 indexed height, uint128 indexed index, uint256 indexed new_value);
+        event MerkleInsertion(uint128 indexed index, uint256 indexed value);
+        event NotePosted(uint256 indexed note_commitment);
+
+        // Only available in the integration testing contract
+        function clearMerkle() external;
+    }
 }

--- a/arbitrum-client/src/constants.rs
+++ b/arbitrum-client/src/constants.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use renegade_crypto::hash::compute_poseidon_hash;
 use serde::{Deserialize, Serialize};
 
-use crate::abi::{
+use crate::abi::Darkpool::{
     newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
     processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
     processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,

--- a/arbitrum-client/src/conversion.rs
+++ b/arbitrum-client/src/conversion.rs
@@ -34,7 +34,6 @@ use common::types::{
     transfer_auth::TransferAuth,
 };
 use constants::{Scalar, ScalarField};
-use ethers::types::U256 as EthersU256;
 use num_bigint::BigUint;
 use util::hex::biguint_to_hex_string;
 
@@ -581,23 +580,9 @@ pub fn scalar_to_u256(scalar: Scalar) -> U256 {
 }
 
 /// Converts an alloy `U256` to a `Scalar`
-pub fn alloy_u256_to_scalar(u256: U256) -> Scalar {
+pub fn u256_to_scalar(u256: U256) -> Scalar {
     let bytes = u256.to_be_bytes_vec();
     Scalar::from_be_bytes_mod_order(&bytes)
-}
-
-/// Convert an ethers `U256` to an alloy `U256`
-///
-/// TODO: Remove this when we transition to alloy entirely
-pub fn ethers_u256_to_alloy_u256(u256: EthersU256) -> U256 {
-    U256::from_limbs(u256.0)
-}
-
-/// Convert an alloy `U256` to an ethers `U256`
-///
-/// TODO: Remove this when we transition to alloy entirely
-pub fn alloy_u256_to_ethers_u256(u256: U256) -> EthersU256 {
-    EthersU256(u256.into_limbs())
 }
 
 /// Convert a [`FixedPoint`] to its corresponding smart contract type

--- a/arbitrum-client/src/errors.rs
+++ b/arbitrum-client/src/errors.rs
@@ -39,10 +39,28 @@ pub enum ArbitrumClientError {
 }
 
 impl ArbitrumClientError {
+    /// Create a new contract interaction error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn contract_interaction<T: ToString>(msg: T) -> Self {
+        Self::ContractInteraction(msg.to_string())
+    }
+
     /// Create a new event querying error
     #[allow(clippy::needless_pass_by_value)]
     pub fn event_querying<T: ToString>(msg: T) -> Self {
         Self::EventQuerying(msg.to_string())
+    }
+
+    /// Create a new RPC error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn rpc<T: ToString>(msg: T) -> Self {
+        Self::Rpc(msg.to_string())
+    }
+
+    /// Create a new transaction querying error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn tx_querying<T: ToString>(msg: T) -> Self {
+        Self::TxQuerying(msg.to_string())
     }
 }
 

--- a/arbitrum-client/src/helpers.rs
+++ b/arbitrum-client/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Various helpers for Arbitrum client execution
 
-use alloy::primitives::U256;
+use alloy::primitives::{Bytes, U256};
 use alloy_sol_types::SolCall;
 use circuit_types::{
     elgamal::{BabyJubJubPoint, ElGamalCiphertext},
@@ -10,12 +10,11 @@ use circuit_types::{
     Amount, SizedWalletShare,
 };
 use constants::Scalar;
-use ethers::types::Bytes;
 use serde::{Deserialize, Serialize};
 use util::matching_engine::apply_match_to_shares;
 
 use crate::{
-    abi::{
+    abi::Darkpool::{
         newWalletCall, processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
         processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
         processMatchSettleCall, redeemFeeCall, settleOfflineFeeCall, settleOnlineRelayerFeeCall,

--- a/arbitrum-client/src/lib.rs
+++ b/arbitrum-client/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::missing_docs_in_private_items)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
+#![feature(let_chains)]
 
 pub mod abi;
 pub mod client;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,6 @@ default-run = "renegade-relayer"
 dev-metrics = ["proof-metrics"]
 metered-channels = ["util/metered-channels"]
 proof-metrics = ["proof-manager/proof-metrics"]
-tx-metrics = ["arbitrum-client/tx-metrics"]
 
 [dependencies]
 # === Runtime + Async === #

--- a/renegade-metrics/Cargo.toml
+++ b/renegade-metrics/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [features]
 proof-metrics = []
-tx-metrics = []
 
 [dependencies]
 # === Telemetry === #

--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -11,11 +11,6 @@ use crate::labels::{
     NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
 };
 
-#[cfg(feature = "tx-metrics")]
-use crate::global_metrics::IN_FLIGHT_ARBITRUM_TXS;
-#[cfg(feature = "proof-metrics")]
-use crate::global_metrics::IN_FLIGHT_PROOFS;
-
 /// Get the human-readable asset and volume of
 /// the given mint and amount.
 /// The asset is the token ticker, if it is found, otherwise
@@ -88,28 +83,4 @@ pub fn record_match_volume(res: &MatchResult, is_external_match: bool) {
 /// Record the volume of a fee settlement into the relayer's wallet
 pub fn record_relayer_fee_settlement(mint: &BigUint, amount: u128) {
     record_volume(mint, amount, FEES_COLLECTED_METRIC);
-}
-
-/// Increment the number of in-flight proofs by 1
-#[cfg(feature = "proof-metrics")]
-pub fn incr_inflight_proofs() {
-    IN_FLIGHT_PROOFS.increment(1.0);
-}
-
-/// Decrement the number of in-flight proofs by 1
-#[cfg(feature = "proof-metrics")]
-pub fn decr_inflight_proofs() {
-    IN_FLIGHT_PROOFS.decrement(1.0);
-}
-
-/// Increment the number of in-flight transactions by 1
-#[cfg(feature = "tx-metrics")]
-pub fn incr_inflight_txs() {
-    IN_FLIGHT_ARBITRUM_TXS.increment(1.0);
-}
-
-/// Decrement the number of in-flight transactions by 1
-#[cfg(feature = "tx-metrics")]
-pub fn decr_inflight_txs() {
-    IN_FLIGHT_ARBITRUM_TXS.decrement(1.0);
 }


### PR DESCRIPTION
### Purpose
This PR transitions the `arbitrum-client` from using `ethers` to `alloy` and makes the appropriate simplifications. This will be followed up with a PR that removes `ethers` entirely from the relayer. 

### Todo
- Generalize the `arbitrum-client` to support multiple chains (Base)

### Testing
- [x] `arbitrum-client` builds
- Other testing deferred until repo builds, i.e. after `ethers` is removed entirely