### PR TITLE
api-server: external-match: Disallow USDT based pairs

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -190,6 +190,7 @@ pub struct ExternalOrder {
 
 impl ExternalOrder {
     /// Validate the external order
+    #[cfg(feature = "full-api")]
     pub fn validate(&self) -> Result<(), &'static str> {
         // Only one of the order sizing options can be set
         let base_zero = self.base_amount.is_zero();

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -300,6 +300,11 @@ impl ExternalMatchProcessor {
             return Err(bad_request(ERR_QUOTE_TOKEN_NOT_USDC));
         }
 
+        // The base token cannot be another stablecoin
+        if base == Token::usdt() {
+            return Err(bad_request(ERR_UNSUPPORTED_PAIR));
+        }
+
         // Check that the base token is in the token configuration -- i.e. if it is
         // named or the native asset
         if !(base.is_named() || base.addr == NATIVE_ASSET_ADDRESS) {

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -149,6 +149,6 @@ fn get_all_tokens_filtered(filtered_tokens: &[&str]) -> Vec<Token> {
     token_map
         .iter()
         .map(|(addr, _)| Token::from_addr(addr))
-        .filter(|token| !filtered_tokens.contains(&token.get_addr().as_str()))
+        .filter(|t| !filtered_tokens.contains(&t.get_ticker().unwrap().as_str()))
         .collect_vec()
 }


### PR DESCRIPTION
### Purpose
This PR fixes two issues with the supported tokens logic:
1. We need to explicitly disallow pairs with USDT as the base mint
2. We need to remove USDT from the supported tokens response

### Testing
- [x] Tested both fixes locally