### PR TITLE
darkpool-client: base: Add base implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "abi"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#b129fee7c277fa09dea680b4dd437e64176aca02"
+dependencies = [
+ "alloy",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3465,7 @@ dependencies = [
 name = "darkpool-client"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "alloy",
  "alloy-contract",
  "alloy-primitives",
@@ -3474,16 +3483,13 @@ dependencies = [
  "eyre",
  "inventory",
  "itertools 0.12.1",
- "json",
  "lazy_static",
  "mpc-plonk",
- "mpc-relation",
  "num-bigint",
  "num-traits",
  "postcard",
  "rand 0.8.5",
  "renegade-crypto 0.1.0",
- "renegade-metrics",
  "ruint",
  "serde",
  "serde_with",

--- a/darkpool-client/Cargo.toml
+++ b/darkpool-client/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-arbitrum = []
-base = []
+default = []
+arbitrum = ["dep:serde_with", "dep:postcard"]
+base = ["dep:renegade-solidity-abi"]
 integration = [
     "dep:rand",
     "circuit-types/test-helpers",
@@ -22,13 +23,12 @@ required-features = ["integration"]
 
 [dependencies]
 # === Cryptography / Arithmetic === #
-ark-bn254 = "0.4.0"
-ark-ec = "0.4.0"
+ark-bn254 = { version = "0.4.0" }
+ark-ec = { version = "0.4.0" }
 ark-ff = "0.4.0"
 num-bigint = { workspace = true }
 num-traits = "0.2"
 ruint = { version = "1.11.1", features = ["num-bigint"] }
-mpc-relation = { workspace = true }
 
 # === Blockchain === #
 alloy = { workspace = true, features = ["provider-debug-api"] }
@@ -42,19 +42,18 @@ circuit-types = { workspace = true }
 circuits = { workspace = true }
 common = { workspace = true }
 renegade-crypto = { workspace = true }
+renegade-solidity-abi = { package = "abi", git = "https://github.com/renegade-fi/renegade-solidity-contracts", optional = true }
 util = { workspace = true, features = ["telemetry"] }
-renegade-metrics = { workspace = true }
 
 # === Serde === #
 serde = { version = "1.0.197" }
-serde_with = "3.4"
-postcard = { version = "1", features = ["alloc"] }
+serde_with = { version = "3.4", optional = true }
+postcard = { version = "1", features = ["alloc"], optional = true }
 
 # === Misc === #
 async-trait = "0.1"
 itertools = "0.12"
 lazy_static = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
 
@@ -63,7 +62,6 @@ clap = { version = "4.0", features = ["derive"] }
 eyre = { workspace = true }
 test-helpers = { workspace = true }
 util = { workspace = true }
-json = "0.12"
 tokio = { workspace = true }
 colored = "2"
 inventory = "0.3"

--- a/darkpool-client/Cargo.toml
+++ b/darkpool-client/Cargo.toml
@@ -11,6 +11,7 @@ integration = [
     "circuit-types/test-helpers",
     "circuits/test_helpers",
     "common/mocks",
+    "test-helpers/arbitrum",
 ]
 
 [[test]]
@@ -60,7 +61,7 @@ rand = { workspace = true, optional = true }
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
 eyre = { workspace = true }
-test-helpers = { workspace = true, features = ["arbitrum"] }
+test-helpers = { workspace = true }
 util = { workspace = true }
 json = "0.12"
 tokio = { workspace = true }

--- a/darkpool-client/src/base/conversion.rs
+++ b/darkpool-client/src/base/conversion.rs
@@ -1,0 +1,338 @@
+//! Type conversion utilities for the Base darkpool implementation
+
+use alloy::primitives::Bytes;
+use alloy::primitives::U256;
+use ark_ec::AffineRepr;
+use ark_ff::{BigInteger, PrimeField};
+use circuit_types::keychain::PublicSigningKey;
+use circuit_types::r#match::OrderSettlementIndices as CircuitOrderSettlementIndices;
+use circuit_types::traits::BaseType;
+use circuit_types::transfers::ExternalTransfer as CircuitExternalTransfer;
+use circuit_types::transfers::ExternalTransferDirection;
+use circuit_types::PlonkLinkProof as CircuitPlonkLinkProof;
+use circuit_types::PlonkProof as CircuitPlonkProof;
+use circuit_types::PolynomialCommitment;
+use circuits::zk_circuits::valid_commitments::ValidCommitmentsStatement as CircuitValidCommitmentsStatement;
+use circuits::zk_circuits::valid_match_settle::{
+    SizedValidMatchSettleStatement, SizedValidMatchSettleWithCommitmentsStatement,
+};
+use circuits::zk_circuits::valid_reblind::ValidReblindStatement as CircuitValidReblindStatement;
+use circuits::zk_circuits::valid_wallet_create::SizedValidWalletCreateStatement;
+use circuits::zk_circuits::valid_wallet_update::SizedValidWalletUpdateStatement;
+use common::types::proof_bundles::OrderValidityProofBundle;
+use common::types::transfer_auth::TransferAuth as CircuitTransferAuth;
+use constants::Scalar;
+
+use renegade_solidity_abi::IDarkpool::*;
+use renegade_solidity_abi::BN254::G1Point;
+
+use crate::conversion::biguint_to_address;
+use crate::conversion::biguint_to_u256;
+use crate::conversion::scalar_to_u256;
+
+/// A helper method to convert a circuit type into a contract type
+pub(crate) fn to_contract_type<T, C>(t: T) -> C
+where
+    C: From<ConversionWrapper<T>>,
+{
+    C::from(ConversionWrapper(t))
+}
+
+/// A wrapper type that allows us to define conversions between circuit and
+/// contract types outside of the circuit crate
+struct ConversionWrapper<T>(T);
+impl<T> From<T> for ConversionWrapper<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ConversionWrapper<SizedValidWalletCreateStatement>> for ValidWalletCreateStatement {
+    fn from(wrapper: ConversionWrapper<SizedValidWalletCreateStatement>) -> Self {
+        let statement = wrapper.0;
+        Self {
+            walletShareCommitment: scalar_to_u256(statement.wallet_share_commitment),
+            publicShares: statement
+                .public_wallet_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+        }
+    }
+}
+
+/// Convert a relayer [`SizedValidWalletUpdateStatement`] to a contract
+/// [`ValidWalletUpdateStatement`]
+impl From<ConversionWrapper<SizedValidWalletUpdateStatement>> for ValidWalletUpdateStatement {
+    fn from(wrapper: ConversionWrapper<SizedValidWalletUpdateStatement>) -> Self {
+        let statement = wrapper.0;
+        Self {
+            previousNullifier: scalar_to_u256(statement.old_shares_nullifier),
+            newWalletCommitment: scalar_to_u256(statement.new_wallet_commitment),
+            newPublicShares: statement
+                .new_public_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            merkleRoot: scalar_to_u256(statement.merkle_root),
+            externalTransfer: to_contract_type(statement.external_transfer),
+            oldPkRoot: to_contract_type(statement.old_pk_root),
+        }
+    }
+}
+
+impl From<ConversionWrapper<CircuitValidReblindStatement>> for ValidReblindStatement {
+    fn from(wrapper: ConversionWrapper<CircuitValidReblindStatement>) -> Self {
+        let statement = wrapper.0;
+        Self {
+            originalSharesNullifier: scalar_to_u256(statement.original_shares_nullifier),
+            newPrivateShareCommitment: scalar_to_u256(statement.reblinded_private_share_commitment),
+            merkleRoot: scalar_to_u256(statement.merkle_root),
+        }
+    }
+}
+
+impl From<ConversionWrapper<CircuitValidCommitmentsStatement>> for ValidCommitmentsStatement {
+    fn from(wrapper: ConversionWrapper<CircuitValidCommitmentsStatement>) -> Self {
+        let statement = wrapper.0;
+        Self { indices: to_contract_type(statement.indices) }
+    }
+}
+
+impl From<ConversionWrapper<OrderValidityProofBundle>> for PartyMatchPayload {
+    fn from(wrapper: ConversionWrapper<OrderValidityProofBundle>) -> Self {
+        let proof_bundle = wrapper.0;
+        let commitments_statement =
+            to_contract_type(proof_bundle.commitment_proof.statement.clone());
+        let reblind_statement = to_contract_type(proof_bundle.reblind_proof.statement.clone());
+        PartyMatchPayload {
+            validCommitmentsStatement: commitments_statement,
+            validReblindStatement: reblind_statement,
+        }
+    }
+}
+
+impl From<ConversionWrapper<SizedValidMatchSettleStatement>> for ValidMatchSettleStatement {
+    fn from(wrapper: ConversionWrapper<SizedValidMatchSettleStatement>) -> Self {
+        let statement = wrapper.0;
+        Self {
+            firstPartyPublicShares: statement
+                .party0_modified_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            secondPartyPublicShares: statement
+                .party1_modified_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            firstPartySettlementIndices: to_contract_type(statement.party0_indices),
+            secondPartySettlementIndices: to_contract_type(statement.party1_indices),
+            protocolFeeRate: scalar_to_u256(statement.protocol_fee.repr),
+        }
+    }
+}
+
+impl From<ConversionWrapper<SizedValidMatchSettleWithCommitmentsStatement>>
+    for ValidMatchSettleWithCommitmentsStatement
+{
+    fn from(wrapper: ConversionWrapper<SizedValidMatchSettleWithCommitmentsStatement>) -> Self {
+        let statement = wrapper.0;
+        Self {
+            privateShareCommitment0: scalar_to_u256(statement.private_share_commitment0),
+            privateShareCommitment1: scalar_to_u256(statement.private_share_commitment1),
+            newShareCommitment0: scalar_to_u256(statement.new_share_commitment0),
+            newShareCommitment1: scalar_to_u256(statement.new_share_commitment1),
+            firstPartyPublicShares: statement
+                .party0_modified_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            secondPartyPublicShares: statement
+                .party1_modified_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            firstPartySettlementIndices: to_contract_type(statement.party0_indices),
+            secondPartySettlementIndices: to_contract_type(statement.party1_indices),
+            protocolFeeRate: scalar_to_u256(statement.protocol_fee.repr),
+        }
+    }
+}
+
+// ---------------------
+// | Application Types |
+// ---------------------
+
+/// Convert a relayer [`ExternalTransfer`] to a contract [`ExternalTransfer`]
+impl From<ConversionWrapper<CircuitExternalTransfer>> for ExternalTransfer {
+    fn from(wrapper: ConversionWrapper<CircuitExternalTransfer>) -> Self {
+        let transfer = wrapper.0;
+        let transfer_type = match transfer.direction {
+            ExternalTransferDirection::Deposit => 0,
+            ExternalTransferDirection::Withdrawal => 1,
+        };
+
+        ExternalTransfer {
+            account: biguint_to_address(&transfer.account_addr).expect("invalid account"),
+            mint: biguint_to_address(&transfer.mint).expect("invalid mint"),
+            amount: U256::from(transfer.amount),
+            transferType: transfer_type,
+        }
+    }
+}
+
+impl From<ConversionWrapper<CircuitTransferAuth>> for TransferAuthorization {
+    fn from(wrapper: ConversionWrapper<CircuitTransferAuth>) -> Self {
+        let auth = wrapper.0;
+        match auth {
+            CircuitTransferAuth::Deposit(deposit_auth) => {
+                let permit_sig = Bytes::from(deposit_auth.permit_signature);
+                let permit_deadline =
+                    biguint_to_u256(&deposit_auth.permit_deadline).expect("invalid deadline");
+                let permit_nonce =
+                    biguint_to_u256(&deposit_auth.permit_nonce).expect("invalid nonce");
+
+                TransferAuthorization {
+                    permit2Nonce: permit_nonce,
+                    permit2Deadline: permit_deadline,
+                    permit2Signature: permit_sig,
+                    externalTransferSignature: Bytes::default(),
+                }
+            },
+            CircuitTransferAuth::Withdrawal(withdrawal_auth) => TransferAuthorization {
+                permit2Nonce: U256::ZERO,
+                permit2Deadline: U256::ZERO,
+                permit2Signature: Bytes::default(),
+                externalTransferSignature: Bytes::from(withdrawal_auth.external_transfer_signature),
+            },
+        }
+    }
+}
+
+/// Convert a relayer [`PublicSigningKey`] to a contract [`PublicRootKey`]
+impl From<ConversionWrapper<PublicSigningKey>> for PublicRootKey {
+    fn from(wrapper: ConversionWrapper<PublicSigningKey>) -> Self {
+        let key = wrapper.0;
+        let x_words = &key.x.scalar_words;
+        let y_words = &key.y.scalar_words;
+        let x = [scalar_to_u256(x_words[0]), scalar_to_u256(x_words[1])];
+        let y = [scalar_to_u256(y_words[0]), scalar_to_u256(y_words[1])];
+
+        PublicRootKey { x, y }
+    }
+}
+
+/// Convert a relayer [`OrderSettlementIndices`] to a contract
+/// [`OrderSettlementIndices`]
+impl From<ConversionWrapper<CircuitOrderSettlementIndices>> for OrderSettlementIndices {
+    fn from(wrapper: ConversionWrapper<CircuitOrderSettlementIndices>) -> Self {
+        let indices = wrapper.0;
+        Self {
+            balanceSend: U256::from(indices.balance_send),
+            balanceReceive: U256::from(indices.balance_receive),
+            order: U256::from(indices.order),
+        }
+    }
+}
+
+// ----------------------
+// | Proof System Types |
+// ----------------------
+
+/// Convert from a relayer's `PlonkProof` to a contract's `Proof`
+impl From<ConversionWrapper<CircuitPlonkProof>> for PlonkProof {
+    fn from(wrapper: ConversionWrapper<CircuitPlonkProof>) -> Self {
+        let proof = wrapper.0;
+        let evals = proof.poly_evals;
+        Self {
+            wire_comms: size_vec(
+                proof.wires_poly_comms.into_iter().map(convert_jf_commitment).collect(),
+            ),
+            z_comm: convert_jf_commitment(proof.prod_perm_poly_comm),
+            quotient_comms: size_vec(
+                proof.split_quot_poly_comms.into_iter().map(convert_jf_commitment).collect(),
+            ),
+            w_zeta: convert_jf_commitment(proof.opening_proof),
+            w_zeta_omega: convert_jf_commitment(proof.shifted_opening_proof),
+            wire_evals: size_vec(evals.wires_evals.into_iter().map(fr_to_u256).collect()),
+            sigma_evals: size_vec(evals.wire_sigma_evals.into_iter().map(fr_to_u256).collect()),
+            z_bar: fr_to_u256(evals.perm_next_eval),
+        }
+    }
+}
+
+impl From<ConversionWrapper<CircuitPlonkLinkProof>> for LinkingProof {
+    fn from(wrapper: ConversionWrapper<CircuitPlonkLinkProof>) -> Self {
+        let proof = wrapper.0;
+        Self {
+            linking_quotient_poly_comm: convert_jf_commitment(proof.quotient_commitment),
+            linking_poly_opening: convert_g1_point(proof.opening_proof.proof),
+        }
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Size a vector of values to be a known fixed size
+pub fn size_vec<const N: usize, T>(vec: Vec<T>) -> [T; N] {
+    let size = vec.len();
+    if size != N {
+        panic!("vector is not the correct size: expected {N}, got {size}");
+    }
+    vec.try_into().map_err(|_| ()).unwrap()
+}
+
+/// Convert a `Fr` to a `U256`
+///
+/// This is the same field as `Scalar`, but must first be wrapped
+fn fr_to_u256(fr: ark_bn254::Fr) -> U256 {
+    scalar_to_u256(Scalar::new(fr))
+}
+
+/// Convert a point in the BN254 base field to a Uint256
+fn base_field_to_u256(fq: ark_bn254::Fq) -> U256 {
+    let bytes = fq.into_bigint().to_bytes_be();
+    bytes_to_u256(&bytes)
+}
+
+/// Convert a set of big endian bytes to a Uint256
+///
+/// Handles padding as necessary
+fn bytes_to_u256(bytes: &[u8]) -> U256 {
+    let mut buf = [0u8; 32];
+    buf[..bytes.len()].copy_from_slice(bytes);
+    U256::from_be_bytes(buf)
+}
+
+/// Pad big endian bytes to a fixed size
+fn pad_bytes<const N: usize>(bytes: &[u8]) -> [u8; N] {
+    assert!(bytes.len() <= N, "bytes are too long for padding");
+
+    let mut padded = [0u8; N];
+    padded[N - bytes.len()..].copy_from_slice(bytes);
+    padded
+}
+
+// --- Curve Points --- //
+
+/// Convert a point on the BN254 curve to a `G1Point` in the contract's format
+fn convert_g1_point(point: ark_bn254::G1Affine) -> G1Point {
+    let x = point.x().expect("x is zero");
+    let y = point.y().expect("y is zero");
+
+    G1Point { x: base_field_to_u256(*x), y: base_field_to_u256(*y) }
+}
+
+/// Convert a `JfCommitment` to a `G1Point`
+fn convert_jf_commitment(commitment: PolynomialCommitment) -> G1Point {
+    convert_g1_point(commitment.0)
+}

--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -1,0 +1,5 @@
+//! The Base implementation of the darkpool client
+
+/// The Base darkpool implementation
+#[derive(Clone)]
+pub struct BaseDarkpool {}

--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -1,5 +1,330 @@
 //! The Base implementation of the darkpool client
+mod conversion;
+
+use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+use conversion::to_contract_type;
+use renegade_solidity_abi::IDarkpool::{
+    IDarkpoolInstance, MatchLinkingProofs, MatchProofs, MerkleInsertion as AbiMerkleInsertion,
+    MerkleOpeningNode as AbiMerkleOpeningNode, NullifierSpent as AbiNullifierSpent,
+    WalletUpdated as AbiWalletUpdated,
+};
+
+use alloy_primitives::{Address, Bytes, Selector};
+use async_trait::async_trait;
+use circuit_types::{
+    elgamal::EncryptionKey, fixed_point::FixedPoint, merkle::MerkleRoot,
+    r#match::ExternalMatchResult, wallet::Nullifier, SizedWalletShare,
+};
+use common::types::{
+    proof_bundles::{
+        AtomicMatchSettleBundle, MalleableAtomicMatchSettleBundle, MatchBundle,
+        OrderValidityProofBundle, SizedFeeRedemptionBundle, SizedOfflineFeeSettlementBundle,
+        SizedRelayerFeeSettlementBundle, SizedValidWalletCreateBundle,
+        SizedValidWalletUpdateBundle,
+    },
+    transfer_auth::TransferAuth,
+};
+use constants::Scalar;
+
+use crate::{
+    client::RenegadeProvider,
+    conversion::{scalar_to_u256, u256_to_scalar},
+    errors::DarkpoolClientError,
+    traits::{
+        DarkpoolImpl, DarkpoolImplExt, MerkleInsertionEvent, MerkleOpeningNodeEvent,
+        NullifierSpentEvent, WalletUpdatedEvent,
+    },
+};
 
 /// The Base darkpool implementation
 #[derive(Clone)]
-pub struct BaseDarkpool {}
+pub struct BaseDarkpool {
+    /// The darkpool instance
+    darkpool: IDarkpoolInstance<RenegadeProvider>,
+}
+
+impl BaseDarkpool {
+    /// Get a reference to the darkpool instance
+    pub fn darkpool(&self) -> &IDarkpoolInstance<RenegadeProvider> {
+        &self.darkpool
+    }
+}
+
+#[async_trait]
+impl DarkpoolImpl for BaseDarkpool {
+    type MerkleInsertion = AbiMerkleInsertion;
+    type MerkleOpening = AbiMerkleOpeningNode;
+    type NullifierSpent = AbiNullifierSpent;
+    type WalletUpdated = AbiWalletUpdated;
+
+    fn new(darkpool_addr: Address, provider: RenegadeProvider) -> Self {
+        Self { darkpool: IDarkpoolInstance::new(darkpool_addr, provider) }
+    }
+
+    fn address(&self) -> Address {
+        *self.darkpool.address()
+    }
+
+    fn provider(&self) -> &RenegadeProvider {
+        self.darkpool.provider()
+    }
+
+    // -----------
+    // | Getters |
+    // -----------
+
+    async fn get_merkle_root(&self) -> Result<Scalar, DarkpoolClientError> {
+        self.darkpool
+            .getMerkleRoot()
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+            .map(u256_to_scalar)
+    }
+
+    async fn get_protocol_fee(&self) -> Result<FixedPoint, DarkpoolClientError> {
+        self.darkpool
+            .getProtocolFee()
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+            .map(|r| FixedPoint::from_repr(u256_to_scalar(r)))
+    }
+
+    async fn get_external_match_fee(
+        &self,
+        mint: Address,
+    ) -> Result<FixedPoint, DarkpoolClientError> {
+        self.darkpool
+            .getTokenExternalMatchFeeRate(mint)
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+            .map(|r| FixedPoint::from_repr(u256_to_scalar(r)))
+    }
+
+    async fn get_protocol_pubkey(&self) -> Result<EncryptionKey, DarkpoolClientError> {
+        let pubkey = self
+            .darkpool()
+            .getProtocolFeeKey()
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)?;
+
+        let x = u256_to_scalar(pubkey.point.x);
+        let y = u256_to_scalar(pubkey.point.y);
+        Ok(EncryptionKey { x, y })
+    }
+
+    async fn check_merkle_root(&self, root: MerkleRoot) -> Result<bool, DarkpoolClientError> {
+        let root_u256 = scalar_to_u256(root);
+        self.darkpool()
+            .rootInHistory(root_u256)
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+    }
+
+    async fn is_nullifier_spent(&self, nullifier: Nullifier) -> Result<bool, DarkpoolClientError> {
+        let nullifier_u256 = scalar_to_u256(nullifier);
+        self.darkpool()
+            .nullifierSpent(nullifier_u256)
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+    }
+
+    async fn is_blinder_used(&self, blinder: Scalar) -> Result<bool, DarkpoolClientError> {
+        let blinder_u256 = scalar_to_u256(blinder);
+        self.darkpool()
+            .publicBlinderUsed(blinder_u256)
+            .call()
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+    }
+
+    fn is_known_selector(selector: Selector) -> bool {
+        todo!()
+    }
+
+    // -----------
+    // | Setters |
+    // -----------
+
+    async fn new_wallet(
+        &self,
+        valid_wallet_create: &SizedValidWalletCreateBundle,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        let statement = to_contract_type(valid_wallet_create.statement.clone());
+        let proof = to_contract_type(valid_wallet_create.proof.clone());
+        let call = self.darkpool.createWallet(statement, proof);
+        self.send_tx(call).await
+    }
+
+    async fn update_wallet(
+        &self,
+        valid_wallet_update: &SizedValidWalletUpdateBundle,
+        wallet_commitment_signature: Vec<u8>,
+        transfer_auth: Option<TransferAuth>,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        // TODO: re-serialize the signature using the ABI encoding
+        let statement = to_contract_type(valid_wallet_update.statement.clone());
+        let proof = to_contract_type(valid_wallet_update.proof.clone());
+        let transfer_auth = transfer_auth.map(to_contract_type).unwrap_or_default();
+
+        let call = self.darkpool.updateWallet(
+            Bytes::from(wallet_commitment_signature),
+            transfer_auth,
+            statement,
+            proof,
+        );
+
+        self.send_tx(call).await
+    }
+
+    async fn process_match_settle(
+        &self,
+        party0_validity_proofs: &OrderValidityProofBundle,
+        party1_validity_proofs: &OrderValidityProofBundle,
+        match_bundle: &MatchBundle,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        let party0_payload = to_contract_type(party0_validity_proofs.clone());
+        let party1_payload = to_contract_type(party1_validity_proofs.clone());
+        let statement = to_contract_type(match_bundle.match_proof.statement.clone());
+
+        // Build the match proof bundle
+        let commitments0 = to_contract_type(party0_validity_proofs.commitment_proof.proof.clone());
+        let reblind0 = to_contract_type(party0_validity_proofs.reblind_proof.proof.clone());
+        let commitments1 = to_contract_type(party1_validity_proofs.commitment_proof.proof.clone());
+        let reblind1 = to_contract_type(party1_validity_proofs.reblind_proof.proof.clone());
+        let match_proof = to_contract_type(match_bundle.match_proof.proof.clone());
+        let proofs = MatchProofs {
+            validCommitments0: commitments0,
+            validReblind0: reblind0,
+            validCommitments1: commitments1,
+            validReblind1: reblind1,
+            validMatchSettle: match_proof,
+        };
+
+        // Build the link proofs bundle
+        let commitments_reblind0 = to_contract_type(party0_validity_proofs.linking_proof.clone());
+        let commitments_match0 = to_contract_type(match_bundle.commitments_link0.clone());
+        let commitments_reblind1 = to_contract_type(party1_validity_proofs.linking_proof.clone());
+        let commitments_match1 = to_contract_type(match_bundle.commitments_link1.clone());
+        let link_proofs = MatchLinkingProofs {
+            validReblindCommitments0: commitments_reblind0,
+            validCommitmentsMatchSettle0: commitments_match0,
+            validReblindCommitments1: commitments_reblind1,
+            validCommitmentsMatchSettle1: commitments_match1,
+        };
+
+        // Submit the match settle tx
+        let call = self.darkpool.processMatchSettle(
+            party0_payload,
+            party1_payload,
+            statement,
+            proofs,
+            link_proofs,
+        );
+        self.send_tx(call).await
+    }
+
+    async fn settle_online_relayer_fee(
+        &self,
+        valid_relayer_fee_settlement: &SizedRelayerFeeSettlementBundle,
+        relayer_wallet_commitment_signature: Vec<u8>,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        todo!()
+    }
+
+    async fn settle_offline_fee(
+        &self,
+        valid_offline_fee_settlement: &SizedOfflineFeeSettlementBundle,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        todo!()
+    }
+
+    async fn redeem_fee(
+        &self,
+        valid_fee_redemption: &SizedFeeRedemptionBundle,
+        recipient_wallet_commitment_signature: Vec<u8>,
+    ) -> Result<TransactionReceipt, DarkpoolClientError> {
+        todo!()
+    }
+
+    // ----------------
+    // | Calldata Gen |
+    // ----------------
+
+    fn gen_atomic_match_settle_calldata(
+        &self,
+        receiver_address: Option<Address>,
+        internal_party_validity_proofs: &OrderValidityProofBundle,
+        match_atomic_bundle: &AtomicMatchSettleBundle,
+    ) -> Result<TransactionRequest, DarkpoolClientError> {
+        todo!()
+    }
+
+    fn gen_malleable_atomic_match_settle_calldata(
+        &self,
+        receiver_address: Option<Address>,
+        internal_party_validity_proofs: &OrderValidityProofBundle,
+        match_atomic_bundle: &MalleableAtomicMatchSettleBundle,
+    ) -> Result<TransactionRequest, DarkpoolClientError> {
+        todo!()
+    }
+
+    fn parse_shares(
+        selector: Selector,
+        calldata: &[u8],
+        public_blinder_share: Scalar,
+    ) -> Result<SizedWalletShare, DarkpoolClientError> {
+        todo!()
+    }
+
+    fn parse_external_match(
+        calldata: &[u8],
+    ) -> Result<Option<ExternalMatchResult>, DarkpoolClientError> {
+        todo!()
+    }
+}
+
+// ----------
+// | Events |
+// ----------
+
+impl MerkleInsertionEvent for AbiMerkleInsertion {
+    fn index(&self) -> u128 {
+        self.index
+    }
+
+    fn value(&self) -> Scalar {
+        u256_to_scalar(self.value)
+    }
+}
+
+impl MerkleOpeningNodeEvent for AbiMerkleOpeningNode {
+    fn depth(&self) -> u64 {
+        self.depth as u64
+    }
+
+    fn index(&self) -> u64 {
+        self.index as u64
+    }
+
+    fn new_value(&self) -> Scalar {
+        u256_to_scalar(self.new_value)
+    }
+}
+
+impl NullifierSpentEvent for AbiNullifierSpent {
+    fn nullifier(&self) -> Nullifier {
+        u256_to_scalar(self.nullifier)
+    }
+}
+
+impl WalletUpdatedEvent for AbiWalletUpdated {
+    fn blinder_share(&self) -> Scalar {
+        u256_to_scalar(self.wallet_blinder_share)
+    }
+}

--- a/darkpool-client/src/client/event_indexing.rs
+++ b/darkpool-client/src/client/event_indexing.rs
@@ -101,7 +101,7 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
             } else if topic0 == D::MerkleOpening::SIGNATURE_HASH {
                 let event = D::MerkleOpening::decode_log(&log)
                     .map_err(DarkpoolClientError::event_querying)?;
-                all_insertion_events.push((event.height(), event.new_value()));
+                all_insertion_events.push((event.depth(), event.new_value()));
             } else {
                 // Ignore other events and unknown events
                 continue;

--- a/darkpool-client/src/conversion.rs
+++ b/darkpool-client/src/conversion.rs
@@ -2,17 +2,11 @@
 //! proofs, and their analogues as expected by the smart contracts.
 
 use alloy_primitives::{Address, U160, U256};
-use ark_bn254::g1::Config as G1Config;
-use ark_ec::short_weierstrass::Affine;
 use circuit_types::Amount;
 use constants::Scalar;
 use num_bigint::BigUint;
 
 use crate::errors::ConversionError;
-
-/// Type alias for the affine representation of the
-/// system curve's G1 group
-pub type G1Affine = Affine<G1Config>;
 
 // ------------------------
 // | CONVERSION UTILITIES |
@@ -22,6 +16,12 @@ pub type G1Affine = Affine<G1Config>;
 pub fn biguint_to_address(biguint: &BigUint) -> Result<Address, ConversionError> {
     let u160: U160 = biguint.try_into().map_err(|_| ConversionError::InvalidUint)?;
     Ok(Address::from(u160))
+}
+
+/// Convert a `BigUint` to a `U256`
+pub fn biguint_to_u256(biguint: &BigUint) -> Result<U256, ConversionError> {
+    let u256: U256 = biguint.try_into().map_err(|_| ConversionError::InvalidUint)?;
+    Ok(u256)
 }
 
 /// Convert an `Address` to a `BigUint`

--- a/darkpool-client/src/lib.rs
+++ b/darkpool-client/src/lib.rs
@@ -12,6 +12,10 @@
 #![feature(generic_const_exprs)]
 #![feature(let_chains)]
 
+// Make sure we don't enable both features at the same time
+#[cfg(all(feature = "arbitrum", feature = "base"))]
+compile_error!("Only one of features 'arbitrum' or 'base' should be enabled at a time");
+
 pub mod client;
 pub mod constants;
 pub mod conversion;
@@ -28,3 +32,14 @@ pub type DarkpoolClient = client::DarkpoolClientInner<arbitrum::ArbitrumDarkpool
 ///
 /// Exported here to allow lower level access from other workers
 pub type DarkpoolImplementation = arbitrum::ArbitrumDarkpool;
+
+#[cfg(feature = "base")]
+pub mod base;
+#[cfg(feature = "base")]
+/// The darkpool client for the Base chain
+pub type DarkpoolClient = client::DarkpoolClientInner<base::BaseDarkpool>;
+#[cfg(feature = "base")]
+/// The darkpool implementation for the Base chain
+///
+/// Exported here to allow lower level access from other workers
+pub type DarkpoolImplementation = base::BaseDarkpool;

--- a/gossip-api/Cargo.toml
+++ b/gossip-api/Cargo.toml
@@ -11,7 +11,7 @@ sha2 = { version = "0.10", features = ["asm"] }
 # === Workspace Dependencies === #
 circuit-types = { workspace = true }
 common = { workspace = true }
-util = { workspace = true }
+util = { workspace = true, features = ["telemetry"] }
 
 # === Serialization === #
 bincode = "1.3"

--- a/workers/proof-manager/Cargo.toml
+++ b/workers/proof-manager/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-mocks = ["dep:circuit-types", "common/mocks"]
+mocks = ["common/mocks"]
 
 [dependencies]
 # === Cryptography === #
@@ -20,7 +20,7 @@ tokio = { workspace = true }
 
 # === Workspace Dependencies === #
 circuits = { workspace = true }
-circuit-types = { workspace = true, optional = true }
+circuit-types = { workspace = true }
 common = { workspace = true }
 constants = { workspace = true }
 job-types = { workspace = true }


### PR DESCRIPTION
### Purpose
This PR begins the Base implementation of the darkpool client, implementing the first few setter methods.

### Todo
- Implement the rest of the client

### Testing
- [x] Relayer builds with `--features "base"`
- [x] Unit tests pass