### PR TITLE
darkpool-client: base: Implement external match parse method

### DIFF
--- a/darkpool-client/src/base/conversion.rs
+++ b/darkpool-client/src/base/conversion.rs
@@ -385,6 +385,20 @@ impl ToContractType for CircuitExternalMatchResult {
     }
 }
 
+impl ToCircuitType for ExternalMatchResult {
+    type CircuitType = CircuitExternalMatchResult;
+
+    fn to_circuit_type(&self) -> Result<Self::CircuitType, DarkpoolClientError> {
+        Ok(Self::CircuitType {
+            quote_mint: address_to_biguint(&self.quoteMint)?,
+            base_mint: address_to_biguint(&self.baseMint)?,
+            quote_amount: u256_to_amount(self.quoteAmount)?,
+            base_amount: u256_to_amount(self.baseAmount)?,
+            direction: self.direction == 1, // cast from u8 to bool
+        })
+    }
+}
+
 impl ToContractType for CircuitBoundedMatchResult {
     type ContractType = BoundedMatchResult;
 


### PR DESCRIPTION
### Purpose
This PR implements the helper to parse external matches from a transaction, completing the Base implementation of the `DarkpoolImpl` trait.

### Todo
- Further testing against real contracts

### Testing
- [x] Unit tests pass
- [x] Relayer builds and runs with both `--features "arbitrum"` and `--features "base"`