### PR TITLE
darkpool-client: client: Respect `polling_interval` config param

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -20,11 +20,8 @@ use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::worker::{new_worker_failure_channel, watch_worker, Worker};
 use common::{default_wrapper::default_option, types::new_cancel_channel};
 use constants::{in_bootstrap_mode, VERSION};
-use darkpool_client::{
-    client::DarkpoolClientConfig,
-    constants::{BLOCK_POLLING_INTERVAL_MS, EVENT_FILTER_POLLING_INTERVAL_MS},
-    DarkpoolClient,
-};
+use darkpool_client::constants::{BLOCK_POLLING_INTERVAL, EVENT_FILTER_POLLING_INTERVAL};
+use darkpool_client::{client::DarkpoolClientConfig, DarkpoolClient};
 use event_manager::{manager::EventManager, worker::EventManagerConfig};
 use external_api::bus_message::SystemBusMessage;
 use gossip_server::{server::GossipServer, worker::GossipServerConfig};
@@ -160,7 +157,7 @@ async fn main() -> Result<(), CoordinatorError> {
         chain: args.chain_id,
         rpc_url: args.rpc_url.clone().expect("rpc url not set"),
         private_key: args.private_key.clone(),
-        block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
+        block_polling_interval: BLOCK_POLLING_INTERVAL,
     })
     .map_err(err_str!(CoordinatorError::DarkpoolClient))?;
 
@@ -170,7 +167,7 @@ async fn main() -> Result<(), CoordinatorError> {
         chain: args.chain_id,
         rpc_url: args.rpc_url.unwrap(),
         private_key: args.private_key.clone(),
-        block_polling_interval_ms: EVENT_FILTER_POLLING_INTERVAL_MS,
+        block_polling_interval: EVENT_FILTER_POLLING_INTERVAL,
     })
     .map_err(err_str!(CoordinatorError::DarkpoolClient))?;
 

--- a/darkpool-client/integration/main.rs
+++ b/darkpool-client/integration/main.rs
@@ -15,7 +15,7 @@ mod contract_interaction;
 mod event_indexing;
 mod helpers;
 
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use ::constants::Scalar;
 use alloy::signers::local::PrivateKeySigner;
@@ -114,7 +114,7 @@ impl From<CliArgs> for IntegrationTestArgs {
             darkpool_addr,
             private_key,
             rpc_url: test_args.rpc_url,
-            block_polling_interval_ms: 100,
+            block_polling_interval: Duration::from_millis(100),
         })
         .unwrap();
 

--- a/darkpool-client/src/constants.rs
+++ b/darkpool-client/src/constants.rs
@@ -1,6 +1,6 @@
 //! Constant values referenced by the darkpool client.
 
-use std::{fmt::Display, marker::PhantomData, str::FromStr};
+use std::{fmt::Display, marker::PhantomData, str::FromStr, time::Duration};
 
 use ark_ff::{BigInt, Fp};
 use constants::{Scalar, MERKLE_HEIGHT};
@@ -43,9 +43,9 @@ impl FromStr for Chain {
 }
 
 /// The interval at which to poll for pending transactions
-pub const BLOCK_POLLING_INTERVAL_MS: u64 = 100;
+pub const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 /// The interval at which to poll for event filters
-pub const EVENT_FILTER_POLLING_INTERVAL_MS: u64 = 7000;
+pub const EVENT_FILTER_POLLING_INTERVAL: Duration = Duration::from_secs(7);
 
 lazy_static! {
     // ------------------------

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -19,7 +19,7 @@ use common::{
 };
 use config::RelayerConfig;
 use darkpool_client::{
-    client::DarkpoolClientConfig, constants::BLOCK_POLLING_INTERVAL_MS, DarkpoolClient,
+    client::DarkpoolClientConfig, constants::BLOCK_POLLING_INTERVAL, DarkpoolClient,
 };
 use ed25519_dalek::Keypair;
 use external_api::bus_message::SystemBusMessage;
@@ -254,7 +254,7 @@ impl MockNodeController {
             chain: self.config.chain_id,
             rpc_url: self.config.rpc_url.clone().unwrap(),
             private_key: self.config.relayer_wallet_key().clone(),
-            block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
+            block_polling_interval: BLOCK_POLLING_INTERVAL,
         };
 
         // Expects to be running in a Tokio runtime

--- a/workers/task-driver/integration/main.rs
+++ b/workers/task-driver/integration/main.rs
@@ -10,7 +10,7 @@
 mod helpers;
 mod tests;
 
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::Address;
@@ -197,7 +197,7 @@ fn setup_darkpool_client_mock(test_args: &CliArgs) -> DarkpoolClient {
         darkpool_addr,
         private_key,
         rpc_url: test_args.devnet_url.clone(),
-        block_polling_interval_ms: 100,
+        block_polling_interval: Duration::from_millis(100),
     })
     .unwrap()
 }


### PR DESCRIPTION
### Purpose
This PR makes two changes to the `DarkpoolClient`:
- Use the `SimpleNonceManager` which re-fetches the current nonce on every call. We do this to prevent the nonce getting out of sync. I will follow up with a PR that uses a custom cached nonce manager, the alloy `CachedNonceManager` does not have an invalidation mechanism.
- Set the client's polling interval to the configured value.

### Testing
- [x] Tested in testnet