### PR TITLE
bin: use chain-aware env in build & deploy scripts

### DIFF
--- a/bin/build_and_push.sh
+++ b/bin/build_and_push.sh
@@ -1,26 +1,26 @@
 #!/bin/sh
 REGION=us-east-2
-DEFAULT_ENVIRONMENT=dev
+DEFAULT_CHAIN=arbitrum-sepolia
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        --env) ENVIRONMENT="$2"; shift ;;
+        --chain) CHAIN="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Use default if not provided
-ENVIRONMENT=${ENVIRONMENT:-$DEFAULT_ENVIRONMENT}
-ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$ENVIRONMENT
+CHAIN=${CHAIN:-$DEFAULT_CHAIN}
+ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$CHAIN
 
 GIT_HASH=$(git rev-parse HEAD)
 
 TAG_1=$ECR_URL\:$GIT_HASH
 TAG_2=$ECR_URL\:latest
 
-echo "Building and pushing relayer image to: $ENVIRONMENT"
+echo "Building and pushing relayer image to: $CHAIN"
 
 docker build -t relayer:latest  -f ./docker/release/Dockerfile .
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_URL

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 REGION=us-east-2
-DEFAULT_ENVIRONMENT=dev
+DEFAULT_CHAIN=arbitrum-sepolia
 
 # Get the current git commit hash (long form)
 DEFAULT_IMAGE_TAG=$(git rev-parse HEAD)
@@ -9,24 +9,24 @@ DEFAULT_IMAGE_TAG=$(git rev-parse HEAD)
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --image-tag) IMAGE_TAG="$2"; shift ;;
-        --env) ENVIRONMENT="$2"; shift ;;
+        --chain) CHAIN="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Use defaults if not provided
-ENVIRONMENT=${ENVIRONMENT:-$DEFAULT_ENVIRONMENT}
+CHAIN=${CHAIN:-$DEFAULT_CHAIN}
 IMAGE_TAG=${IMAGE_TAG:-$DEFAULT_IMAGE_TAG}
 
-CLUSTER_NAME=$ENVIRONMENT-cluster0
-SERVICE_NAME=$ENVIRONMENT-cluster0-service
-TASK_FAMILY=$ENVIRONMENT-cluster0-task-def
-ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$ENVIRONMENT
+CLUSTER_NAME=$CHAIN-relayer
+SERVICE_NAME=$CHAIN-relayer-service
+TASK_FAMILY=$CHAIN-relayer-task-def
+ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$CHAIN
 
 FULL_IMAGE_URI="$ECR_URL:$IMAGE_TAG"
 echo "Using image URI: $FULL_IMAGE_URI"
-echo "Deploying relayer to: $ENVIRONMENT"
+echo "Deploying relayer to: $CHAIN"
 
 # Fetch the existing definition of the task and create a new revision with the updated URI
 TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition $TASK_FAMILY --region $REGION --query 'taskDefinition')


### PR DESCRIPTION
This PR updates the `build_and_push` & `deploy` scripts to expect chain-aware environment names, i.e. `arbitrum-sepolia` and `arbitrum-one` instead of `testnet` and `mainnet`, respectively.

Both of these newly-named ECR repos have already been created, so the scripts should be ready for immediate use.

### Testing
- [x] Build/push/deploy `arbitrum-sepolia` relayer image