### PR TITLE
circuits: zk-gadgets: comparators: Fix `greater_than_eq_zero`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#9808fd9d0d0148ab086865cbbf33821dbbe0f471"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#f18be35c2bb8bd6c95e035e67b6db0aec16c1820"
 dependencies = [
  "alloy",
 ]
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -711,7 +711,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "http 1.3.1",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -874,15 +874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
 ]
 
 [[package]]
@@ -1520,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.83.0"
+version = "1.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51384750334005f40e1a334b0d54eca822a77eacdcf3c50fdf38f583c5eee7a2"
+checksum = "2111975ef21dc06542918479df0df861b273eb8d99e6bb987da469b546dce32c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1555,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c5fb5d108c518c3bfc077d39a3cd5120e0115ac60aba8085dc79e2d08ab6b1"
+checksum = "0e4ebe6d9cfbb2cdb6641ce776ca3bea870c12d5480ffeb6b3c3653bf9c07959"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1578,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efec445fb78df585327094fcef4cad895b154b58711e504db7a93c41aa27151"
+checksum = "858007b14d0f1ade2e0124473c2126b24d334dc9486ad12eb7c0ed14757be464"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1601,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.66.0"
+version = "1.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e49cca619c10e7b002dc8e66928ceed66ab7f56c1a3be86c5437bf2d8d89bba"
+checksum = "b83abf3ae8bd10a014933cc2383964a12ca5a3ebbe1948ad26b1b808e7d0d1f2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1624,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.66.0"
+version = "1.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7420479eac0a53f776cc8f0d493841ffe58ad9d9783f3947be7265784471b47a"
+checksum = "74e8e9ac4a837859c8f1d747054172e1e55933f02ed34728b0b34dea0591ec84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1748,7 +1739,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1759,7 +1750,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -1932,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -2356,11 +2347,10 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
 dependencies = [
- "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -2425,9 +2415,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -2569,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2612,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2681,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2936,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -3081,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3627,17 +3617,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -4490,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -5030,9 +5009,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5285,9 +5264,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -5429,7 +5408,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5466,7 +5445,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -5903,7 +5882,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.0",
+ "hermit-abi 0.5.1",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -5968,7 +5947,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -6012,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -6178,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -6259,9 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmdbx"
@@ -6621,7 +6600,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.11",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -6974,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -7008,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -7858,7 +7837,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.11",
+ "redox_syscall 0.5.12",
  "smallvec 1.15.0",
  "windows-targets 0.52.6",
 ]
@@ -8774,9 +8753,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -8864,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -8918,7 +8897,7 @@ dependencies = [
  "opentelemetry",
  "price-reporter",
  "proof-manager",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "state",
  "system-bus",
  "system-clock",
@@ -8983,7 +8962,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -9277,16 +9256,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.2",
  "subtle",
  "zeroize",
 ]
@@ -9335,9 +9314,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -9351,9 +9333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.14",
@@ -10667,9 +10649,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10745,7 +10727,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -10798,12 +10780,12 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.10",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -11226,7 +11208,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.1",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -11423,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a34b679f401e930370a5b28a7c20c412c8caeae0"
+source = "git+https://github.com/renegade-fi/renegade.git#b813f5eab760d7361f3aacf354499ee8cb40268a"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -11755,9 +11737,18 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12200,9 +12191,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/circuits/src/zk_gadgets/arithmetic.rs
+++ b/circuits/src/zk_gadgets/arithmetic.rs
@@ -67,7 +67,10 @@ where
         a: Variable,
         b: Variable,
         cs: &mut PlonkCircuit,
-    ) -> Result<(Variable, Variable), CircuitError> {
+    ) -> Result<(Variable, Variable), CircuitError>
+    where
+        [(); D + 1]: Sized,
+    {
         assert!(D <= DIVREM_MAX_BITSIZE, "Bitlength of divisor is too large");
 
         let a_bigint = scalar_to_biguint(&a.eval(cs));

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -557,6 +557,7 @@ mod test {
         assert!(res);
     }
 
+    /// Tests the `GreaterThanEqGadget`
     #[test]
     #[rustfmt::skip]
     fn test_geq_gadget() {
@@ -598,6 +599,23 @@ mod test {
         cs.enforce_false(lt3).unwrap();
 
         assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+    }
+
+    /// Tests the `GreaterThanEqGadget` with a value that is out of bit range
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_geq_gadget__out_of_bitrange() {
+        let mut rng = thread_rng();
+
+        const BITS: usize = 10;
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let a_var = Scalar::random(&mut rng).create_witness(&mut cs);
+        let b_var = Scalar::random(&mut rng).create_witness(&mut cs);
+
+        GreaterThanEqGadget::<BITS>::greater_than_eq(a_var, b_var, &mut cs).unwrap();
+
+        // The difference a - b should fail to bit-reconstruct in the gadget
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
     }
 
     #[tokio::test]

--- a/circuits/src/zk_gadgets/comparators.rs
+++ b/circuits/src/zk_gadgets/comparators.rs
@@ -185,17 +185,35 @@ impl NotEqualGadget {
 /// The sizing parameter `D` represents the maximum bitlength of positive
 /// scalars under the caller's representation
 #[derive(Clone, Debug)]
-pub struct GreaterThanEqZeroGadget<const D: usize> {}
+pub struct GreaterThanEqZeroGadget<const D: usize>;
 impl<const D: usize> GreaterThanEqZeroGadget<D> {
     /// Evaluate the condition x >= 0; returns 1 if true, otherwise 0
-    pub fn greater_than_eq_zero(
-        x: Variable,
-        cs: &mut PlonkCircuit,
-    ) -> Result<BoolVar, CircuitError> {
-        // Decompose and reconstruct the value in the given bitlength, if we can do so
-        // then the value is greater than zero
-        let reconstructed = ToBitsGadget::<D>::decompose_and_reconstruct(x, cs)?;
-        EqGadget::eq(&reconstructed, &x, cs)
+    ///
+    /// We check the GEQ gadget following the example in circomlib:
+    ///  https://github.com/iden3/circomlib/blob/35e54ea21da3e8762557234298dbb553c175ea8d/circuits/comparators.circom#L89-L99
+    ///
+    /// That is, we bit decompose and reconstruct the value x + 2^D in D+1 bits.
+    /// This gives two cases:
+    ///  1. If x is negative, then x + 2^D < 2^D so the MSB will be zero.
+    ///  2. If x is positive or zero, then x + 2^D >= 2^D so the MSB will be
+    ///     one.
+    ///
+    /// In either case we have x >= 0 <=> MSB(x + 2^D) == 1
+    ///
+    /// Note: The `to_bits` method will enforce that the decomposed bits recover
+    /// the input value, so for completeness sake we assume x is in the range
+    /// [-2^D, 2^D - 1]
+    pub fn greater_than_eq_zero(x: Variable, cs: &mut PlonkCircuit) -> Result<BoolVar, CircuitError>
+    where
+        [(); D + 1]: Sized,
+    {
+        // Add 2^D to the input
+        let two_to_d = Scalar::from(2u8).pow(D as u64);
+        let x_plus_2_to_d = cs.add_constant(x, &two_to_d.inner())?;
+
+        // Return the MSB
+        let bits = ToBitsGadget::<{ D + 1 }>::to_bits(x_plus_2_to_d, cs)?;
+        Ok(bits[D])
     }
 
     /// Constrain the value to be greater than zero
@@ -212,14 +230,17 @@ impl<const D: usize> GreaterThanEqZeroGadget<D> {
 /// Enforces the constraint a >= b
 ///
 /// `D` is the bitlength of the values being compared
-pub struct GreaterThanEqGadget<const D: usize> {}
+pub struct GreaterThanEqGadget<const D: usize>;
 impl<const D: usize> GreaterThanEqGadget<D> {
     /// Evaluates the comparator a >= b; returns 1 if true, otherwise 0
     pub fn greater_than_eq(
         a: Variable,
         b: Variable,
         cs: &mut PlonkCircuit,
-    ) -> Result<BoolVar, CircuitError> {
+    ) -> Result<BoolVar, CircuitError>
+    where
+        [(); D + 1]: Sized,
+    {
         let a_minus_b = cs.sub(a, b)?;
         GreaterThanEqZeroGadget::<D>::greater_than_eq_zero(a_minus_b, cs)
     }
@@ -239,14 +260,17 @@ impl<const D: usize> GreaterThanEqGadget<D> {
 ///
 /// D is the bitlength of the inputs
 #[derive(Clone, Debug)]
-pub struct LessThanGadget<const D: usize> {}
+pub struct LessThanGadget<const D: usize>;
 impl<const D: usize> LessThanGadget<D> {
     /// Compute the boolean a < b; returns 1 if true, otherwise 0
     pub fn less_than(
         a: Variable,
         b: Variable,
         cs: &mut PlonkCircuit,
-    ) -> Result<BoolVar, CircuitError> {
+    ) -> Result<BoolVar, CircuitError>
+    where
+        [(); D + 1]: Sized,
+    {
         let a_geq_b = GreaterThanEqGadget::<D>::greater_than_eq(a, b, cs)?;
         cs.logic_neg(a_geq_b)
     }
@@ -256,7 +280,10 @@ impl<const D: usize> LessThanGadget<D> {
         a: Variable,
         b: Variable,
         cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
+    ) -> Result<(), CircuitError>
+    where
+        [(); D + 1]: Sized,
+    {
         let lt_result = Self::less_than(a, b, cs)?;
         cs.enforce_true(lt_result)
     }


### PR DESCRIPTION
### Purpose
This PR fixed the `greater_than_eq_zero` gadget in the `comparators` to fix a soundness issue when the gadget returns false. The updated implementation follows the [circomlib implementation](https://github.com/iden3/circomlib/blob/35e54ea21da3e8762557234298dbb553c175ea8d/circuits/comparators.circom#L89-L99) as suggested in the audit.

### Testing
- [x] All unit tests pass