### PR TITLE
common: token: Add `is_native_asset` method

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -17,6 +17,7 @@
 //! Unnamed Tokens only use Uniswap V3 for the price feed.
 use alloy::primitives::Address;
 use bimap::BiMap;
+use constants::NATIVE_ASSET_ADDRESS;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -100,6 +101,11 @@ impl Token {
     /// Get the USDT token
     pub fn usdt() -> Self {
         Self::from_ticker(USDT_TICKER)
+    }
+
+    /// Return whether the token represents the native asset
+    pub fn is_native_asset(&self) -> bool {
+        self.addr.to_lowercase() == NATIVE_ASSET_ADDRESS.to_lowercase()
     }
 
     /// Given an ERC-20 contract address, returns a new Token

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -307,7 +307,7 @@ impl ExternalMatchProcessor {
 
         // Check that the base token is in the token configuration -- i.e. if it is
         // named or the native asset
-        if !(base.is_named() || base.addr == NATIVE_ASSET_ADDRESS) {
+        if !(base.is_named() || base.is_native_asset()) {
             return Err(bad_request(ERR_UNSUPPORTED_PAIR));
         }
 


### PR DESCRIPTION
### Purpose
This PR adds the `is_native_asset` method to the `Token` struct to encapsulate comparison to the hardcoded "native asset" address representation. This needs to be lower cased, so using this method in the api server fixes a bug validating native asset pairs.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet