### PR TITLE
common, darkpool-client: granular chain enum & all-chains feature

### DIFF
--- a/common/src/types/chain.rs
+++ b/common/src/types/chain.rs
@@ -7,19 +7,25 @@ use serde::{Deserialize, Serialize};
 /// The chain environment
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Chain {
-    /// Mainnet chain
-    Mainnet,
-    /// Testnet chain
-    Testnet,
-    /// Devnet chain
+    /// The Arbitrum Sepolia chain
+    ArbitrumSepolia,
+    /// The Arbitrum One chain
+    ArbitrumOne,
+    /// The Base Sepolia chain
+    BaseSepolia,
+    /// The Base Mainnet chain
+    BaseMainnet,
+    /// Any local devnet chain
     Devnet,
 }
 
 impl Display for Chain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Chain::Mainnet => write!(f, "mainnet"),
-            Chain::Testnet => write!(f, "testnet"),
+            Chain::ArbitrumSepolia => write!(f, "arbitrum-sepolia"),
+            Chain::ArbitrumOne => write!(f, "arbitrum-one"),
+            Chain::BaseSepolia => write!(f, "base-sepolia"),
+            Chain::BaseMainnet => write!(f, "base-mainnet"),
             Chain::Devnet => write!(f, "devnet"),
         }
     }
@@ -30,8 +36,10 @@ impl FromStr for Chain {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "mainnet" => Ok(Chain::Mainnet),
-            "testnet" => Ok(Chain::Testnet),
+            "arbitrum-sepolia" => Ok(Chain::ArbitrumSepolia),
+            "arbitrum-one" => Ok(Chain::ArbitrumOne),
+            "base-sepolia" => Ok(Chain::BaseSepolia),
+            "base-mainnet" => Ok(Chain::BaseMainnet),
             "devnet" => Ok(Chain::Devnet),
             _ => Err(format!("Invalid chain: {s}")),
         }

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -80,7 +80,7 @@ pub struct Cli {
     // -----------------------
 
     /// The chain that the relayer settles to
-    #[clap(long, value_parser, default_value = "testnet", env = "CHAIN")]
+    #[clap(long, value_parser, default_value = "arbitrum-sepolia", env = "CHAIN")]
     pub chain_id: Chain,
     /// The address of the darkpool contract, defaults to the internal testnet deployment
     #[clap(long, value_parser, env = "DARKPOOL_ADDRESS", default_value = "0x2f88458fc25591f1de247dd3297f039eecfcd534")]

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -117,11 +117,19 @@ pub type AuthenticatedScalar = AuthenticatedScalarResult<SystemCurveGroup>;
 /// The block number at which the darkpool was deployed on devnet
 pub const DEVNET_DEPLOY_BLOCK: u64 = 0;
 
-/// The block number at which the darkpool was deployed on testnet
-pub const TESTNET_DEPLOY_BLOCK: u64 = 55713322;
+/// The block number at which the darkpool was deployed on Arbitrum Sepolia
+pub const ARBITRUM_SEPOLIA_DEPLOY_BLOCK: u64 = 55713322;
 
-/// The block number at which the darkpool was deployed on mainnet
-pub const MAINNET_DEPLOY_BLOCK: u64 = 249416532;
+/// The block number at which the darkpool was deployed on Arbitrum One
+pub const ARBITRUM_ONE_DEPLOY_BLOCK: u64 = 249416532;
+
+/// The block number at which the darkpool was deployed on Base Sepolia
+// TODO: Fill in w/ correct value once deployed
+pub const BASE_SEPOLIA_DEPLOY_BLOCK: u64 = 0; // Placeholder
+
+/// The block number at which the darkpool was deployed on Base Mainnet
+// TODO: Fill in w/ correct value once deployed
+pub const BASE_MAINNET_DEPLOY_BLOCK: u64 = 0; // Placeholder
 
 /// The number of bytes in an Arbitrum address
 pub const ADDRESS_BYTE_LENGTH: usize = 20;

--- a/darkpool-client/Cargo.toml
+++ b/darkpool-client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = []
 arbitrum = ["dep:serde_with", "dep:postcard"]
 base = ["dep:renegade-solidity-abi"]
+all-chains = ["arbitrum", "base"]
 integration = [
     "dep:rand",
     "circuit-types/test-helpers",

--- a/darkpool-client/src/client/mod.rs
+++ b/darkpool-client/src/client/mod.rs
@@ -15,7 +15,10 @@ use alloy_contract::{CallBuilder, Event};
 use alloy_primitives::{Address, BlockNumber, ChainId};
 use alloy_sol_types::SolEvent;
 use common::types::chain::Chain;
-use constants::{DEVNET_DEPLOY_BLOCK, MAINNET_DEPLOY_BLOCK, TESTNET_DEPLOY_BLOCK};
+use constants::{
+    ARBITRUM_ONE_DEPLOY_BLOCK, ARBITRUM_SEPOLIA_DEPLOY_BLOCK, BASE_MAINNET_DEPLOY_BLOCK,
+    BASE_SEPOLIA_DEPLOY_BLOCK, DEVNET_DEPLOY_BLOCK,
+};
 use util::err_str;
 
 use crate::{
@@ -42,7 +45,7 @@ pub struct DarkpoolClientConfig {
     /// This is the main entrypoint to interaction with the darkpool.
     pub darkpool_addr: String,
     /// Which chain the client should interact with,
-    /// e.g. mainnet, testnet, or devnet
+    /// e.g. arbitrum-sepolia, base-mainnet, etc.
     pub chain: Chain,
     /// HTTP-addressable RPC endpoint for the client to connect to
     pub rpc_url: String,
@@ -56,8 +59,10 @@ impl DarkpoolClientConfig {
     /// Gets the block number at which the darkpool was deployed
     fn get_deploy_block(&self) -> BlockNumber {
         match self.chain {
-            Chain::Mainnet => MAINNET_DEPLOY_BLOCK,
-            Chain::Testnet => TESTNET_DEPLOY_BLOCK,
+            Chain::ArbitrumSepolia => ARBITRUM_SEPOLIA_DEPLOY_BLOCK,
+            Chain::ArbitrumOne => ARBITRUM_ONE_DEPLOY_BLOCK,
+            Chain::BaseSepolia => BASE_SEPOLIA_DEPLOY_BLOCK,
+            Chain::BaseMainnet => BASE_MAINNET_DEPLOY_BLOCK,
             Chain::Devnet => DEVNET_DEPLOY_BLOCK,
         }
     }

--- a/darkpool-client/src/lib.rs
+++ b/darkpool-client/src/lib.rs
@@ -14,7 +14,7 @@
 #![feature(iterator_try_collect)]
 
 // Make sure we don't enable both features at the same time
-#[cfg(all(feature = "arbitrum", feature = "base"))]
+#[cfg(all(feature = "arbitrum", feature = "base", not(feature = "all-chains")))]
 compile_error!("Only one of features 'arbitrum' or 'base' should be enabled at a time");
 
 pub mod client;
@@ -25,10 +25,10 @@ pub mod traits;
 
 #[cfg(feature = "arbitrum")]
 pub mod arbitrum;
-#[cfg(feature = "arbitrum")]
+#[cfg(all(feature = "arbitrum", not(feature = "all-chains")))]
 /// The darkpool client for the Arbitrum chain
 pub type DarkpoolClient = client::DarkpoolClientInner<arbitrum::ArbitrumDarkpool>;
-#[cfg(feature = "arbitrum")]
+#[cfg(all(feature = "arbitrum", not(feature = "all-chains")))]
 /// The darkpool implementation for the Arbitrum chain
 ///
 /// Exported here to allow lower level access from other workers
@@ -36,10 +36,10 @@ pub type DarkpoolImplementation = arbitrum::ArbitrumDarkpool;
 
 #[cfg(feature = "base")]
 pub mod base;
-#[cfg(feature = "base")]
+#[cfg(all(feature = "base", not(feature = "all-chains")))]
 /// The darkpool client for the Base chain
 pub type DarkpoolClient = client::DarkpoolClientInner<base::BaseDarkpool>;
-#[cfg(feature = "base")]
+#[cfg(all(feature = "base", not(feature = "all-chains")))]
 /// The darkpool implementation for the Base chain
 ///
 /// Exported here to allow lower level access from other workers

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -44,18 +44,17 @@ const MOCK_TICKER_NAMES: &[&str] = &[
 #[allow(unused_must_use)]
 pub fn setup_mock_token_remap() {
     // Setup the mock token map
-    let mut remaps = write_token_remaps();
-    let chain = Chain::Mainnet;
-    let token_map = remaps.entry(chain).or_default();
-
-    // Set the default chain
-    set_default_chain(chain);
-
+    let mut all_maps = write_token_remaps();
+    let chain = Chain::ArbitrumOne;
+    let token_map = all_maps.entry(chain).or_default();
+    token_map.clear();
     for (i, &ticker) in MOCK_TICKER_NAMES.iter().enumerate() {
         let addr = format!("{i:x}");
 
         token_map.insert(addr, ticker.to_string());
     }
+
+    set_default_chain(chain);
 }
 
 /// The mock price reporter, reports a constant price


### PR DESCRIPTION
This PR updates the `Chain` enum to cover our chain options more granularly, and includes a new `all-chains` Cargo feature to the `darkpool-client` crate. Together, these changes allow external crates to construct either `DarkpoolClient` based on the `Chain`.

### Testing
- [x] All unit tests pass