### PR TITLE
bin: set cargo features in build script

### DIFF
--- a/bin/build_and_push.sh
+++ b/bin/build_and_push.sh
@@ -11,6 +11,15 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+# If chain contains "arbitrum", define the "arbitrum" cargo feature
+if [[ "$CHAIN" == *"arbitrum"* ]]; then
+    CARGO_FEATURES="default,arbitrum"
+elif [[ "$CHAIN" == *"base"* ]]; then
+    CARGO_FEATURES="default,base"
+else
+    CARGO_FEATURES="default"
+fi
+
 # Use default if not provided
 CHAIN=${CHAIN:-$DEFAULT_CHAIN}
 ECR_URL=377928551571.dkr.ecr.us-east-2.amazonaws.com/relayer-$CHAIN
@@ -22,7 +31,7 @@ TAG_2=$ECR_URL\:latest
 
 echo "Building and pushing relayer image to: $CHAIN"
 
-docker build -t relayer:latest  -f ./docker/release/Dockerfile .
+docker build -t relayer:latest  -f ./docker/release/Dockerfile . --build-arg CARGO_FEATURES=$CARGO_FEATURES
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_URL
 
 docker tag relayer:latest $TAG_1

--- a/common/src/types/chain.rs
+++ b/common/src/types/chain.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// The chain environment
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
 pub enum Chain {
     /// The Arbitrum Sepolia chain
     ArbitrumSepolia,


### PR DESCRIPTION
This PR tweaks the `build_and_push` script to set the `CARGO_FEATURES` build arg appropriately based on the passed-in `--chain` flag.

This was used to build the `arbitrum-sepolia` relayer