### PR TITLE
common: token: idempotent set default chain

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -354,9 +354,7 @@ pub fn default_chain() -> Chain {
     *chains.keys().next().expect("No chains configured")
 }
 
-/// Set the default chain
+/// Set the default chain in an idempotent manner
 pub fn set_default_chain(chain: Chain) {
-    DEFAULT_CHAIN
-        .set(chain)
-        .expect("DEFAULT_CHAIN should not be initialized before calling set_default_chain()")
+    DEFAULT_CHAIN.get_or_init(|| chain);
 }


### PR DESCRIPTION
### Purpose
This PR ensures the default chain is set in an idempotent way, allowing multiple token remaps to be configured without panicking.

### Testing
- [x] Tested locally using price reporter
- [ ] Test in testnet