### PR TITLE
node-support: bootloader: Use chain-dependent gas wallet URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,11 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "abi"
 version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#0c97508e81a6c3896ec9cf4ebe096827139a4225"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
 ]
 
 [[package]]
@@ -43,17 +33,6 @@ checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array 0.14.7",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher",
- "cpufeatures",
 ]
 
 [[package]]
@@ -84,47 +63,25 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f245ea9ef9be909776941c6c0ce829fb6b79cd6bfafa43762af7a702c4eb8ee4"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-contract 0.14.0",
- "alloy-core",
- "alloy-eips 0.14.0",
- "alloy-genesis 0.14.0",
- "alloy-network 0.14.0",
- "alloy-provider 0.14.0",
- "alloy-rpc-client 0.14.0",
- "alloy-rpc-types 0.14.0",
- "alloy-serde 0.14.0",
- "alloy-signer 0.14.0",
- "alloy-signer-local 0.14.0",
- "alloy-transport 0.14.0",
- "alloy-transport-http 0.14.0",
-]
-
-[[package]]
-name = "alloy"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c47941be7b270d671841b0cf5e94e05fc358e0b79c88e68bc1ad08dc066be3f"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-contract 1.0.1",
+ "alloy-consensus",
+ "alloy-contract",
  "alloy-core",
- "alloy-eips 1.0.1",
- "alloy-genesis 1.0.1",
- "alloy-network 1.0.1",
- "alloy-provider 1.0.1",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-client 1.0.1",
- "alloy-rpc-types 1.0.1",
- "alloy-serde 1.0.1",
- "alloy-signer 1.0.1",
- "alloy-signer-local 1.0.1",
- "alloy-transport 1.0.1",
- "alloy-transport-http 1.0.1",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ws",
 ]
 
@@ -136,30 +93,7 @@ checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.1",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
-dependencies = [
- "alloy-eips 0.14.0",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.14.0",
- "alloy-trie",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "thiserror 2.0.12",
+ "strum",
 ]
 
 [[package]]
@@ -168,10 +102,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af9455152b18b9efc329120c85006705862a21786449e425eb714d0c04bbfda"
 dependencies = [
- "alloy-eips 1.0.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -188,51 +122,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.14.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9256691696deb28fd71ca6b698d958e80abe5dd0ed95f8e96ac55076b4a70e95"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-eips 1.0.1",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-contract"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5084cf42388dff75b255308194f9d3e67ae2a93ce7e24262a512cc4043ac1838"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network 0.14.0",
- "alloy-network-primitives 0.14.0",
- "alloy-primitives",
- "alloy-provider 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-sol-types",
- "alloy-transport 0.14.0",
- "futures",
- "futures-util",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -241,17 +140,17 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6fec63b92c6cd0410450d38c671cc52f1c1eed6327ce6ba42e965c00b53bf3"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-provider 1.0.1",
+ "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
- "alloy-transport 1.0.1",
+ "alloy-transport",
  "futures",
  "futures-util",
  "thiserror 2.0.12",
@@ -325,26 +224,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.14.0",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "serde",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "alloy-eips"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3ecb56e34e1c3dca4aa06b653c96f0f381a67e0d353271949c683fba5ecbd4"
@@ -354,7 +233,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
@@ -365,26 +244,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
-dependencies = [
- "alloy-eips 0.14.0",
- "alloy-primitives",
- "alloy-serde 0.14.0",
- "alloy-trie",
- "serde",
-]
-
-[[package]]
-name = "alloy-genesis"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664371ee21be794e77a1be0e1ea989fd66a43a3539532361f007935f20cc8ece"
 dependencies = [
- "alloy-eips 1.0.1",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "alloy-trie",
  "serde",
 ]
@@ -403,20 +269,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b22b5e5872d5ece9df2411a65637af3bfc5ce868ddf392cb91ce9a0c7cb1b30"
@@ -431,46 +283,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-consensus-any 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-json-rpc 0.14.0",
- "alloy-network-primitives 0.14.0",
- "alloy-primitives",
- "alloy-rpc-types-any 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-serde 0.14.0",
- "alloy-signer 0.14.0",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more 2.0.1",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8a707ccae2aaca8fb64cec54904c1fdce6be5c5d5be24a7ae04e6a393cb62e"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-consensus-any 1.0.1",
- "alloy-eips 1.0.1",
- "alloy-json-rpc 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 1.0.1",
- "alloy-rpc-types-eth 1.0.1",
- "alloy-serde 1.0.1",
- "alloy-signer 1.0.1",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -479,19 +305,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-primitives",
- "alloy-serde 0.14.0",
- "serde",
 ]
 
 [[package]]
@@ -500,10 +313,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d27be7a0d29a77b2568c105e5418736da5555026a4b054ea2e3b549a0a9645b"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-eips 1.0.1",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "serde",
 ]
 
@@ -536,65 +349,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-json-rpc 0.14.0",
- "alloy-network 0.14.0",
- "alloy-network-primitives 0.14.0",
- "alloy-primitives",
- "alloy-rpc-client 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-signer 0.14.0",
- "alloy-sol-types",
- "alloy-transport 0.14.0",
- "alloy-transport-http 0.14.0",
- "async-stream",
- "async-trait",
- "auto_impl",
- "dashmap",
- "either",
- "futures",
- "futures-utils-wasm",
- "lru 0.13.0",
- "parking_lot 0.12.3",
- "pin-project",
- "reqwest 0.12.15",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-provider"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064d72578caba01fc1d04e8119dbfac36f7cc3b0b9c65804f2282482d55c4904"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.1",
- "alloy-eips 1.0.1",
- "alloy-json-rpc 1.0.1",
- "alloy-network 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-rpc-client 1.0.1",
+ "alloy-rpc-client",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
- "alloy-signer 1.0.1",
+ "alloy-signer",
  "alloy-sol-types",
- "alloy-transport 1.0.1",
- "alloy-transport-http 1.0.1",
+ "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -622,9 +396,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071721a7fbe5fa0b7e0391c4ff8b5919a9f9866944cd8608dcb893d846e7087d"
 dependencies = [
- "alloy-json-rpc 1.0.1",
+ "alloy-json-rpc",
  "alloy-primitives",
- "alloy-transport 1.0.1",
+ "alloy-transport",
  "bimap",
  "futures",
  "parking_lot 0.12.3",
@@ -661,40 +435,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
-dependencies = [
- "alloy-json-rpc 0.14.0",
- "alloy-primitives",
- "alloy-transport 0.14.0",
- "alloy-transport-http 0.14.0",
- "async-stream",
- "futures",
- "pin-project",
- "reqwest 0.12.15",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tracing",
- "tracing-futures",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-rpc-client"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb00c4260ca83980422fc4a44658aafe50ad7b7ad43fb21523bd53453cfd202"
 dependencies = [
- "alloy-json-rpc 1.0.1",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport 1.0.1",
- "alloy-transport-http 1.0.1",
+ "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ws",
  "async-stream",
  "futures",
@@ -713,38 +462,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-serde 0.14.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac9e3abe5083df822304ac63664873c988e427a27215b2ce328ee5a2a51bfbd"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
-dependencies = [
- "alloy-consensus-any 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-serde 0.14.0",
 ]
 
 [[package]]
@@ -753,9 +479,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8740d1e374cf177f5e94ee694cbbca5d0435c3e8a6d4e908841e9cfc5247e2"
 dependencies = [
- "alloy-consensus-any 1.0.1",
- "alloy-rpc-types-eth 1.0.1",
- "alloy-serde 1.0.1",
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
 ]
 
 [[package]]
@@ -770,37 +496,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-consensus-any 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-network-primitives 0.14.0",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.14.0",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc2bbc0385aac988551f747c050d5bd1b2b9dd59eabaebf063edbb6a41b2ccb"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-consensus-any 1.0.1",
- "alloy-eips 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.1",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -815,22 +521,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1029148c57853ec9a69e0a5b1f041253a9b3ff0ee7a8c006f243bfc1dc1671"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.1",
- "alloy-serde 1.0.1",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -842,21 +537,6 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
-dependencies = [
- "alloy-primitives",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve 0.13.8",
- "k256",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -876,30 +556,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
-dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-network 0.14.0",
- "alloy-primitives",
- "alloy-signer 0.14.0",
- "async-trait",
- "k256",
- "rand 0.8.5",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-signer-local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98de10c8697f338c6a545a0fc6cd7cd2b250f62797479f7f30eac63765c78ff"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-network 1.0.1",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 1.0.1",
+ "alloy-signer",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -982,33 +646,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
-dependencies = [
- "alloy-json-rpc 0.14.0",
- "base64 0.22.1",
- "derive_more 2.0.1",
- "futures",
- "futures-utils-wasm",
- "parking_lot 0.12.3",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tower 0.5.2",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-transport"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f5564661f166792da89d9a6785ff815e44853436637842c59ab48393c4c2fad"
 dependencies = [
- "alloy-json-rpc 1.0.1",
+ "alloy-json-rpc",
  "alloy-primitives",
  "base64 0.22.1",
  "derive_more 2.0.1",
@@ -1027,27 +669,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
-dependencies = [
- "alloy-json-rpc 0.14.0",
- "alloy-transport 0.14.0",
- "reqwest 0.12.15",
- "serde_json",
- "tower 0.5.2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "alloy-transport-http"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c2bba49856a38b54b9134f1fc218fc67d1b1313c16a310514f3b10110559fc"
 dependencies = [
- "alloy-json-rpc 1.0.1",
- "alloy-transport 1.0.1",
+ "alloy-json-rpc",
+ "alloy-transport",
  "reqwest 0.12.15",
  "serde_json",
  "tower 0.5.2",
@@ -1062,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802de53990270861acf00044837794ea2450ccc3d9795e824a5d865633241a23"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport 1.0.1",
+ "alloy-transport",
  "futures",
  "http 1.3.1",
  "rustls 0.23.27",
@@ -1179,18 +806,18 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 name = "api-server"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "async-trait",
  "base64 0.21.7",
- "circuit-types 0.1.0",
- "common 0.1.0",
+ "circuit-types",
+ "common",
  "compliance-api",
  "config",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "ecdsa 0.16.9",
- "external-api 0.1.0",
+ "external-api",
  "futures",
  "futures-util",
  "gossip-api",
@@ -1204,7 +831,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "ratelimit_meter",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
@@ -1217,8 +844,8 @@ dependencies = [
  "tokio-tungstenite 0.18.0",
  "tracing",
  "tungstenite 0.18.0",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -1584,15 +1211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "asn1-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,7 +1478,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2343,12 +1961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,27 +2031,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2516,7 +2113,7 @@ checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -2597,16 +2194,18 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "base64 0.22.1",
+ "common",
  "config",
- "funds-manager-api",
+ "external-api",
  "hex 0.4.3",
  "libp2p",
  "reqwest 0.11.27",
+ "serde",
  "serde_json",
  "tokio",
  "toml 0.8.22",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2614,16 +2213,6 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2 0.10.9",
- "tinyvec",
-]
 
 [[package]]
 name = "bumpalo"
@@ -2696,26 +2285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "c-kzg"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,38 +2306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
 dependencies = [
  "crossbeam-channel",
-]
-
-[[package]]
-name = "camino"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2843,11 +2380,11 @@ dependencies = [
 name = "chain-events"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "async-trait",
- "circuit-types 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "common",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "futures-util",
@@ -2855,12 +2392,12 @@ dependencies = [
  "job-types",
  "lazy_static",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "state",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2927,17 +2464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "circuit-macros"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "circuit-types"
 version = "0.1.0"
 dependencies = [
@@ -2949,8 +2475,8 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "byteorder",
- "circuit-macros 0.1.0",
- "constants 0.1.0",
+ "circuit-macros",
+ "constants",
  "futures",
  "hex 0.4.3",
  "itertools 0.10.5",
@@ -2962,42 +2488,11 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "test-helpers",
  "tokio",
-]
-
-[[package]]
-name = "circuit-types"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "ark-serialize 0.4.2",
- "async-trait",
- "bigdecimal",
- "byteorder",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "futures",
- "hex 0.4.3",
- "itertools 0.10.5",
- "jf-primitives",
- "k256",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3010,11 +2505,11 @@ dependencies = [
  "ark-mpc",
  "bigdecimal",
  "bitvec 1.0.1",
- "circuit-macros 0.1.0",
- "circuit-types 0.1.0",
+ "circuit-macros",
+ "circuit-types",
  "clap 4.5.38",
  "colored",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "ctor",
  "dns-lookup",
@@ -3030,41 +2525,12 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "test-helpers",
  "tokio",
- "util 0.1.0",
-]
-
-[[package]]
-name = "circuits"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "ark-crypto-primitives",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal",
- "bitvec 1.0.1",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "futures",
- "itertools 0.10.5",
- "jf-primitives",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
@@ -3182,58 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "coins-bip32"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
-dependencies = [
- "bs58 0.5.1",
- "coins-core",
- "digest 0.10.7",
- "hmac",
- "k256",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-bip39"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
-dependencies = [
- "bitvec 1.0.1",
- "coins-bip32",
- "hmac",
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-core"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bs58 0.5.1",
- "digest 0.10.7",
- "generic-array 0.14.7",
- "hex 0.4.3",
- "ripemd",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,16 +2667,16 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "ark-ec",
  "ark-mpc",
  "ark-poly",
  "async-trait",
  "base64 0.22.1",
  "bimap",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "circuits",
+ "constants",
  "crossbeam",
  "derivative",
  "ecdsa 0.16.9",
@@ -3282,53 +2696,15 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rand_core 0.5.1",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "signature 2.2.0",
  "tokio",
  "tracing",
- "util 0.1.0",
- "uuid 1.16.0",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "alloy 0.14.0",
- "ark-mpc",
- "async-trait",
- "base64 0.22.1",
- "bimap",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "crossbeam",
- "derivative",
- "ed25519-dalek 1.0.1",
- "hmac",
- "indexmap 2.9.0",
- "itertools 0.10.5",
- "k256",
- "lazy_static",
- "libp2p",
- "libp2p-identity",
- "metrics",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "signature 2.2.0",
- "tokio",
- "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -3353,14 +2729,14 @@ dependencies = [
 name = "config"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "base64 0.13.1",
  "bimap",
- "circuit-types 0.1.0",
+ "circuit-types",
  "clap 4.5.38",
  "colored",
- "common 0.1.0",
- "constants 0.1.0",
+ "common",
+ "constants",
  "darkpool-client",
  "ed25519-dalek 1.0.1",
  "json",
@@ -3374,7 +2750,7 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "url",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -3418,12 +2794,6 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
@@ -3431,17 +2801,6 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "constants"
 version = "0.1.0"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ed-on-bn254",
- "ark-mpc",
-]
-
-[[package]]
-name = "constants"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3773,15 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,20 +3176,20 @@ name = "darkpool-client"
 version = "0.1.0"
 dependencies = [
  "abi",
- "alloy 1.0.1",
- "alloy-contract 1.0.1",
+ "alloy",
+ "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.38",
  "colored",
- "common 0.1.0",
- "constants 0.1.0",
+ "common",
+ "constants",
  "eyre",
  "inventory",
  "itertools 0.12.1",
@@ -3849,14 +3199,14 @@ dependencies = [
  "num-traits",
  "postcard",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "ruint",
  "serde",
  "serde_with",
  "test-helpers",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -4004,31 +3354,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -4071,48 +3401,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -4307,15 +3595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,24 +3608,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enr"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "hex 0.4.3",
- "k256",
- "log",
- "rand 0.8.5",
- "rlp",
- "serde",
- "sha3 0.10.8",
- "zeroize",
-]
 
 [[package]]
 name = "enum-as-inner"
@@ -4382,55 +3643,16 @@ version = "0.4.0"
 source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4.0#5abd890f79014a86db31286e1f3a529f161e69de"
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest 0.10.7",
- "hex 0.4.3",
- "hmac",
- "pbkdf2 0.11.0",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "thiserror 1.0.69",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "ethabi"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
 dependencies = [
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex 0.4.3",
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types 0.14.1",
- "hex 0.4.3",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
  "thiserror 1.0.69",
  "uint",
 ]
@@ -4444,22 +3666,7 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
+ "impl-serde",
  "tiny-keccak",
 ]
 
@@ -4469,276 +3676,12 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom 0.11.1",
+ "ethbloom",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde 0.3.2",
+ "impl-serde",
  "primitive-types 0.10.1",
  "uint",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core",
- "ethers-etherscan",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "syn 2.0.101",
- "toml 0.8.22",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve 0.13.8",
- "ethabi 18.0.0",
- "generic-array 0.14.7",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "syn 2.0.101",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest 0.11.27",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http 0.2.12",
- "instant",
- "jsonwebtoken 8.3.0",
- "once_cell",
- "pin-project",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.20.1",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve 0.13.8",
- "eth-keystore",
- "ethers-core",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
-dependencies = [
- "cfg-if 1.0.0",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
 ]
 
 [[package]]
@@ -4787,9 +3730,9 @@ name = "event-manager"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "circuit-types 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "common",
+ "constants",
  "futures",
  "job-types",
  "metrics",
@@ -4800,7 +3743,7 @@ dependencies = [
  "tokio-util 0.7.15",
  "tracing",
  "url",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -4817,46 +3760,23 @@ dependencies = [
 name = "external-api"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "base64 0.22.1",
- "circuit-types 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "common",
+ "constants",
  "hex 0.4.3",
  "http 0.2.12",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "util 0.1.0",
- "uuid 1.16.0",
-]
-
-[[package]]
-name = "external-api"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "alloy 0.14.0",
- "base64 0.22.1",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "hex 0.4.3",
- "http 0.2.12",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -4962,12 +3882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5014,16 +3928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5036,23 +3940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "funds-manager-api"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/relayer-extensions.git?rev=25bfcce#25bfcce6830898887e3b173197f8858150e7e51f"
-dependencies = [
- "ethers",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "hex 0.4.3",
- "hmac",
- "http 0.2.12",
- "itertools 0.13.0",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "uuid 1.16.0",
 ]
 
 [[package]]
@@ -5127,16 +4014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,10 +4052,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -5282,24 +4155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gossip-api"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "circuit-types 0.1.0",
- "common 0.1.0",
+ "circuit-types",
+ "common",
  "hmac",
  "libp2p",
  "openraft",
@@ -5307,8 +4168,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tracing",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -5316,10 +4177,10 @@ name = "gossip-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
  "darkpool-client",
  "futures",
  "gossip-api",
@@ -5332,7 +4193,7 @@ dependencies = [
  "state",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -5436,15 +4297,15 @@ dependencies = [
  "ark-mpc",
  "ark-serialize 0.4.2",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.38",
  "colored",
- "common 0.1.0",
- "constants 0.1.0",
+ "common",
+ "constants",
  "crossbeam",
  "darkpool-client",
- "external-api 0.1.0",
+ "external-api",
  "eyre",
  "futures",
  "gossip-api",
@@ -5459,7 +4320,7 @@ dependencies = [
  "portpicker",
  "proof-manager",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "serde",
  "state",
@@ -5467,8 +4328,8 @@ dependencies = [
  "test-helpers",
  "tokio",
  "tracing",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -5521,15 +4382,6 @@ dependencies = [
  "equivalent",
  "foldhash",
  "serde",
-]
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
 ]
 
 [[package]]
@@ -6082,15 +4934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6240,15 +5083,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -6327,12 +5161,12 @@ name = "job-types"
 version = "0.1.0"
 dependencies = [
  "ark-mpc",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
  "crossbeam",
- "external-api 0.1.0",
+ "external-api",
  "gossip-api",
  "lazy_static",
  "libp2p",
@@ -6341,8 +5175,8 @@ dependencies = [
  "renegade-metrics",
  "serde",
  "tokio",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -6384,20 +5218,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -6491,36 +5311,6 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax 0.8.5",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -6731,7 +5521,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
- "bs58 0.4.0",
+ "bs58",
  "ed25519-dalek 2.1.1",
  "log",
  "multiaddr",
@@ -7145,14 +5935,14 @@ dependencies = [
 name = "metrics-sampler"
 version = "0.1.0"
 dependencies = [
- "common 0.1.0",
+ "common",
  "futures",
  "job-types",
  "metrics",
  "num-bigint",
  "state",
  "system-clock",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7239,15 +6029,15 @@ dependencies = [
 name = "mock-node"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "api-server",
  "chain-events",
- "circuit-types 0.1.0",
- "common 0.1.0",
+ "circuit-types",
+ "common",
  "config",
  "darkpool-client",
  "ed25519-dalek 1.0.1",
- "external-api 0.1.0",
+ "external-api",
  "futures",
  "gossip-api",
  "gossip-server",
@@ -7266,7 +6056,7 @@ dependencies = [
  "task-driver",
  "test-helpers",
  "tokio",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7515,9 +6305,9 @@ version = "0.1.0"
 dependencies = [
  "ark-mpc",
  "async-trait",
- "common 0.1.0",
+ "common",
  "ed25519-dalek 1.0.1",
- "external-api 0.1.0",
+ "external-api",
  "futures",
  "gossip-api",
  "itertools 0.11.0",
@@ -7532,15 +6322,9 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nibble_vec"
@@ -7699,7 +6483,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7759,31 +6542,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types 0.14.1",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openraft"
@@ -7975,12 +6733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8162,17 +6914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8207,34 +6948,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "peeking_take_while"
@@ -8279,16 +6992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.9.0",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8296,48 +6999,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -8505,12 +7166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8527,16 +7182,16 @@ dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
  "bimap",
- "common 0.1.0",
- "constants 0.1.0",
+ "common",
+ "constants",
  "create2",
- "external-api 0.1.0",
+ "external-api",
  "futures",
  "futures-util",
  "hex 0.3.2",
  "itertools 0.11.0",
  "job-types",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "lazy_static",
  "reqwest 0.11.27",
  "serde",
@@ -8550,7 +7205,7 @@ dependencies = [
  "tracing",
  "tungstenite 0.18.0",
  "url",
- "util 0.1.0",
+ "util",
  "web3",
 ]
 
@@ -8563,7 +7218,7 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
  "impl-rlp",
- "impl-serde 0.3.2",
+ "impl-serde",
  "uint",
 ]
 
@@ -8575,9 +7230,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
  "uint",
 ]
 
@@ -8684,10 +7336,10 @@ version = "0.1.0"
 dependencies = [
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
  "crossbeam",
  "job-types",
  "mpc-plonk",
@@ -8696,7 +7348,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -8705,8 +7357,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -9089,17 +7741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9157,7 +7798,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "itertools 0.10.5",
  "lazy_static",
@@ -9169,35 +7810,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "renegade-crypto"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "itertools 0.10.5",
- "lazy_static",
- "num-bigint",
- "rand 0.8.5",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "renegade-metrics"
 version = "0.1.0"
 dependencies = [
  "atomic_float 1.1.0",
- "circuit-types 0.1.0",
- "common 0.1.0",
+ "circuit-types",
+ "common",
  "lazy_static",
  "metrics",
  "num-bigint",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -9206,15 +7829,15 @@ version = "0.1.0"
 dependencies = [
  "api-server",
  "chain-events",
- "circuit-types 0.1.0",
+ "circuit-types",
  "clap 3.2.25",
- "common 0.1.0",
+ "common",
  "config",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "event-manager",
- "external-api 0.1.0",
+ "external-api",
  "gossip-api",
  "gossip-server",
  "handshake-manager",
@@ -9232,7 +7855,7 @@ dependencies = [
  "task-driver",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -9250,7 +7873,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -9260,7 +7882,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -9269,13 +7890,11 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -9380,34 +7999,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9716,45 +8314,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if 1.0.0",
- "derive_more 1.0.0",
- "parity-scale-codec 3.7.4",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -9771,18 +8336,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2 0.11.0",
- "salsa20",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "sct"
@@ -9921,9 +8474,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "semver-parser"
@@ -9939,12 +8489,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -10248,12 +8792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10323,12 +8861,12 @@ dependencies = [
  "aws-sdk-s3",
  "clap 3.2.25",
  "config",
- "external-api 0.1.0",
+ "external-api",
  "notify",
  "reqwest 0.12.15",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -10364,20 +8902,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha-1",
-]
-
-[[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf",
- "thiserror 1.0.69",
- "unicode-xid",
 ]
 
 [[package]]
@@ -10428,14 +8952,14 @@ dependencies = [
  "async-trait",
  "bincode",
  "ciborium",
- "circuit-types 0.1.0",
- "common 0.1.0",
+ "circuit-types",
+ "common",
  "config",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "crossbeam",
  "crossterm 0.27.0",
- "external-api 0.1.0",
+ "external-api",
  "eyre",
  "flate2",
  "futures",
@@ -10468,8 +8992,8 @@ dependencies = [
  "tracing-slog",
  "tui",
  "tui-logger",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -10492,18 +9016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot 0.12.3",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10517,33 +9029,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "strum_macros",
 ]
 
 [[package]]
@@ -10564,26 +9054,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs",
- "fs2",
- "hex 0.4.3",
- "once_cell",
- "reqwest 0.11.27",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
- "zip",
-]
 
 [[package]]
 name = "syn"
@@ -10662,7 +9132,7 @@ name = "system-bus"
 version = "0.1.0"
 dependencies = [
  "bus",
- "common 0.1.0",
+ "common",
  "futures",
  "rand 0.8.5",
  "serde",
@@ -10676,7 +9146,7 @@ dependencies = [
  "tokio",
  "tokio-cron-scheduler",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -10757,19 +9227,19 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "task-driver"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "alloy-primitives",
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.38",
  "colored",
- "common 0.1.0",
- "constants 0.1.0",
+ "common",
+ "constants",
  "crossbeam",
  "darkpool-client",
- "external-api 0.1.0",
+ "external-api",
  "eyre",
  "futures",
  "gossip-api",
@@ -10782,7 +9252,7 @@ dependencies = [
  "num-traits",
  "proof-manager",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "serde",
  "serde_json",
@@ -10791,8 +9261,8 @@ dependencies = [
  "test-helpers",
  "tokio",
  "tracing",
- "util 0.1.0",
- "uuid 1.16.0",
+ "util",
+ "uuid",
 ]
 
 [[package]]
@@ -10809,17 +9279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10832,14 +9291,14 @@ dependencies = [
 name = "test-helpers"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "alloy-primitives",
  "alloy-sol-types",
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
- "common 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "common",
+ "constants",
  "darkpool-client",
  "dns-lookup",
  "eyre",
@@ -10848,12 +9307,12 @@ dependencies = [
  "k256",
  "num-bigint",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -11026,7 +9485,7 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -11104,21 +9563,6 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tungstenite 0.18.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.1",
- "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -11527,26 +9971,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls 0.21.12",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -11710,12 +10134,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "util"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.1",
+ "alloy",
  "ark-ec",
  "ark-serialize 0.4.2",
  "chrono",
- "circuit-types 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "constants",
  "crossbeam",
  "eyre",
  "futures",
@@ -11735,7 +10159,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tokio",
@@ -11743,55 +10167,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-serde 0.1.3",
  "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "util"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#04c4011d55d814825c80c0ffd214b2b097bc18fb"
-dependencies = [
- "alloy 0.14.0",
- "ark-ec",
- "ark-serialize 0.4.2",
- "chrono",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "crossbeam",
- "eyre",
- "futures",
- "hex 0.4.3",
- "json",
- "libp2p",
- "metrics",
- "metrics-exporter-statsd",
- "metrics-tracing-context",
- "metrics-util",
- "num-bigint",
- "num-traits",
- "opentelemetry",
- "opentelemetry-datadog",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-serde 0.1.3",
- "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.16",
- "serde",
 ]
 
 [[package]]
@@ -12024,8 +10399,8 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "derive_more 0.99.20",
- "ethabi 16.0.0",
- "ethereum-types 0.12.1",
+ "ethabi",
+ "ethereum-types",
  "futures",
  "futures-timer",
  "headers",
@@ -12071,12 +10446,6 @@ dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -12578,7 +10947,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -12623,12 +10992,6 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"
@@ -12778,26 +11141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq 0.1.5",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
 name = "zkhash"
 version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2.git#055bde3f4782731ba5f5ce5888a440a94327eaf3"
@@ -12821,35 +11164,6 @@ dependencies = [
  "sha2 0.10.9",
  "sha3 0.10.8",
  "subtle",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[patch.unused]]

--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -427,6 +427,11 @@ impl DarkpoolImpl for BaseDarkpool {
 
         Ok(Some(match_res))
     }
+
+    #[cfg(feature = "integration")]
+    async fn clear_merkle_tree(&self) -> Result<TransactionReceipt, DarkpoolClientError> {
+        unimplemented!("We don't currently integration test the Base client")
+    }
 }
 
 // ----------

--- a/node-support/bootloader/Cargo.toml
+++ b/node-support/bootloader/Cargo.toml
@@ -14,7 +14,8 @@ tokio = { workspace = true, features = ["full"] }
 
 # === Workspace Dependencies === #
 config = { workspace = true }
-funds-manager-api = { git = "https://github.com/renegade-fi/relayer-extensions.git", rev = "25bfcce" }
+common = { workspace = true, features = ["hmac"] }
+external-api = { workspace = true, features = ["auth"] }
 util = { workspace = true }
 
 # === Misc Dependencies === #
@@ -22,6 +23,7 @@ base64 = "0.22"
 hex = "0.4"
 libp2p = { workspace = true }
 reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = { workspace = true }
 toml = "0.8"

--- a/node-support/bootloader/src/config.rs
+++ b/node-support/bootloader/src/config.rs
@@ -1,0 +1,147 @@
+//! Helpers for downloading and modifying the relayer config
+
+use std::collections::HashMap;
+
+use aws_sdk_s3::Client as S3Client;
+use base64::{prelude::BASE64_STANDARD, Engine};
+use libp2p::{identity::Keypair, PeerId};
+use tokio::fs;
+use toml::Value;
+use util::raw_err_str;
+
+use crate::{download_s3_file, is_env_var_set, read_env_var, setup_gas_wallet};
+
+// --- Env Vars --- //
+
+/// The bucket in which the relayer config files are stored
+pub(crate) const ENV_CONFIG_BUCKET: &str = "CONFIG_BUCKET";
+/// The path in the config bucket
+pub(crate) const ENV_CONFIG_FILE: &str = "CONFIG_FILE";
+/// The path at which the relayer expects its config
+pub(crate) const CONFIG_PATH: &str = "./config.toml";
+/// The HTTP port to listen on
+const ENV_HTTP_PORT: &str = "HTTP_PORT";
+/// The websocket port to listen on
+const ENV_WS_PORT: &str = "WEBSOCKET_PORT";
+/// The P2P port to listen on
+const ENV_P2P_PORT: &str = "P2P_PORT";
+/// The public IP of the node (optional)
+const ENV_PUBLIC_IP: &str = "PUBLIC_IP";
+/// The symmetric key used to authenticate admin API requests (optional)
+const ENV_ADMIN_KEY: &str = "ADMIN_API_KEY";
+/// The SQS queue URL
+pub(crate) const ENV_SQS_QUEUE_URL: &str = "SQS_QUEUE_URL";
+
+// --- Constants --- //
+
+/// The http port key name in the relayer config
+const CONFIG_HTTP_PORT: &str = "http-port";
+/// The websocket port key name in the relayer config
+const CONFIG_WS_PORT: &str = "websocket-port";
+/// The P2P port key name in the relayer config
+const CONFIG_P2P_PORT: &str = "p2p-port";
+/// The public IP key name in the relayer config
+const CONFIG_PUBLIC_IP: &str = "public-ip";
+/// The admin API key name in the relayer config
+const CONFIG_ADMIN_KEY: &str = "admin-api-key";
+/// The p2p key name in the relayer config
+const CONFIG_P2P_KEY: &str = "p2p-key";
+
+/// A type alias for the parsed config
+///
+/// Mapping from key to toml value
+pub(crate) type ConfigContents = HashMap<String, Value>;
+
+// ---------------------
+// | Config Operations |
+// ---------------------
+
+/// Fetch the relayer's config from s3
+pub(crate) async fn fetch_config(s3: &S3Client) -> Result<(), String> {
+    // Read in the fetch info from environment variables
+    let bucket = read_env_var::<String>(ENV_CONFIG_BUCKET)?;
+    let file = read_env_var::<String>(ENV_CONFIG_FILE)?;
+    download_s3_file(&bucket, &file, CONFIG_PATH, s3).await
+}
+
+/// Modify the config using environment variables set at runtime
+///
+/// Returns the modified config's contents
+pub(crate) async fn modify_config() -> Result<ConfigContents, String> {
+    // Read the config file
+    let config_content = fs::read_to_string(CONFIG_PATH)
+        .await
+        .map_err(raw_err_str!("Failed to read config file: {}"))?;
+    let mut config: ConfigContents =
+        toml::from_str(&config_content).map_err(raw_err_str!("Failed to parse config: {}"))?;
+
+    // Setup the peer id and register a gas wallet under this peer id
+    let peer_id = set_p2p_key(&mut config)?;
+    setup_gas_wallet(peer_id, &mut config).await?;
+
+    // Add values from the environment variables
+    let http_port = Value::String(read_env_var(ENV_HTTP_PORT)?);
+    let ws_port = Value::String(read_env_var(ENV_WS_PORT)?);
+    let p2p_port = Value::String(read_env_var(ENV_P2P_PORT)?);
+    config.insert(CONFIG_HTTP_PORT.to_string(), http_port);
+    config.insert(CONFIG_WS_PORT.to_string(), ws_port);
+    config.insert(CONFIG_P2P_PORT.to_string(), p2p_port);
+
+    if is_env_var_set(ENV_PUBLIC_IP) {
+        let public_ip = Value::String(read_env_var(ENV_PUBLIC_IP)?);
+        config.insert(CONFIG_PUBLIC_IP.to_string(), public_ip);
+    }
+
+    if is_env_var_set(ENV_ADMIN_KEY) {
+        let admin_key = Value::String(read_env_var(ENV_ADMIN_KEY)?);
+        config.insert(CONFIG_ADMIN_KEY.to_string(), admin_key);
+    }
+
+    // Write the modified config back to the original file
+    let new_config_content =
+        toml::to_string(&config).map_err(raw_err_str!("Failed to serialize config: {}"))?;
+    fs::write(CONFIG_PATH, new_config_content)
+        .await
+        .map_err(raw_err_str!("Failed to write config file: {}"))?;
+
+    Ok(config)
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Get the p2p key from the relayer config
+fn get_p2p_key(config: &HashMap<String, Value>) -> Result<Option<PeerId>, String> {
+    config
+        .get(CONFIG_P2P_KEY)
+        .map(|val| {
+            let key_base64 = val.as_str().ok_or("P2P key is not a string".to_string())?;
+            let key_bytes = BASE64_STANDARD
+                .decode(key_base64)
+                .map_err(raw_err_str!("Failed to decode p2p key from base64: {}"))?;
+
+            let keypair = Keypair::from_protobuf_encoding(&key_bytes)
+                .map_err(raw_err_str!("Failed to decode p2p key from protobuf encoding: {}"))?;
+
+            Ok(keypair.public().to_peer_id())
+        })
+        .transpose()
+}
+
+/// Set the p2p key in the relayer config and return the associated peer id
+fn set_p2p_key(config: &mut HashMap<String, Value>) -> Result<PeerId, String> {
+    if let Some(peer_id) = get_p2p_key(config)? {
+        return Ok(peer_id);
+    }
+
+    let keypair = Keypair::generate_ed25519();
+    let peer_id = keypair.public().to_peer_id();
+
+    let key_bytes =
+        keypair.to_protobuf_encoding().map_err(raw_err_str!("Failed to encode p2p key: {}"))?;
+    let encoded = BASE64_STANDARD.encode(key_bytes);
+    config.insert(CONFIG_P2P_KEY.to_string(), Value::String(encoded));
+
+    Ok(peer_id)
+}

--- a/node-support/bootloader/src/gas_wallet.rs
+++ b/node-support/bootloader/src/gas_wallet.rs
@@ -1,0 +1,119 @@
+//! Helpers for setting up a gas wallet for the relayer
+
+use common::types::hmac::HmacKey;
+use external_api::auth::add_expiring_auth_to_headers;
+use reqwest::{
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    Client,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, time::Duration};
+
+use libp2p::PeerId;
+use toml::Value;
+use tracing::{info, warn};
+
+use crate::helpers::read_env_var;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The chain env environment variable
+///
+/// This is a value like `arbitrum-sepolia`
+const ENV_CHAIN: &str = "CHAIN";
+/// The funds manager api URL
+const ENV_FUNDS_MANAGER_URL: &str = "FUNDS_MANAGER_URL";
+/// The funds manager api key
+const ENV_FUNDS_MANAGER_KEY: &str = "FUNDS_MANAGER_KEY";
+
+/// The gas wallet in the relayer config
+const CONFIG_GAS_WALLET: &str = "private-key";
+/// The route to register a gas wallet for a peer
+pub const REGISTER_GAS_WALLET_ROUTE: &str = "register-gas-wallet";
+
+/// The signature duration on requests to the funds manager
+const SIGNATURE_DURATION: Duration = Duration::from_secs(10);
+
+// ---------------------------
+// | Funds Manager API Types |
+// ---------------------------
+
+/// A request to allocate a gas wallet for a peer
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegisterGasWalletRequest {
+    /// The peer ID of the peer to allocate a gas wallet for
+    pub peer_id: String,
+}
+
+/// The response containing an newly active gas wallet's key
+///
+/// Clients will hit the corresponding endpoint to register a gas wallet with
+/// the funds manager when they spin up
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterGasWalletResponse {
+    /// The key of the active gas wallet
+    pub key: String,
+}
+
+// -----------------------
+// | Register Gas Wallet |
+// -----------------------
+
+/// Setup the relayer's gas wallet using the funds manager api
+pub(crate) async fn setup_gas_wallet(
+    peer_id: PeerId,
+    config: &mut HashMap<String, Value>,
+) -> Result<(), String> {
+    info!("registering gas wallet for relayer...");
+    let url = match read_env_var::<String>(ENV_FUNDS_MANAGER_URL) {
+        Ok(url) => url,
+        Err(_) => {
+            warn!("funds manager url not set, skipping gas wallet registration...");
+            return Ok(());
+        },
+    };
+    let key = read_funds_manager_key()?;
+
+    // Prepare the request
+    let client = Client::new();
+    let chain = read_env_var::<String>(ENV_CHAIN)?;
+    let path = format!("/custody/{chain}/gas-wallets/{REGISTER_GAS_WALLET_ROUTE}");
+    let body = RegisterGasWalletRequest { peer_id: peer_id.to_string() };
+    let body_json = serde_json::to_vec(&body).unwrap();
+
+    // Prepare headers
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    add_expiring_auth_to_headers(&path, &mut headers, &body_json, &key, SIGNATURE_DURATION);
+
+    // Send request
+    let url = format!("{}{}", url, path);
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .body(body_json)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send request: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Request failed with status: {}", response.status()));
+    }
+
+    let resp = response
+        .json::<RegisterGasWalletResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    let key = Value::String(resp.key);
+    config.insert(CONFIG_GAS_WALLET.to_string(), Value::Array(vec![key]));
+
+    Ok(())
+}
+
+/// Read in the funds manager HMAC key from environment variables
+fn read_funds_manager_key() -> Result<HmacKey, String> {
+    let key_str = read_env_var::<String>(ENV_FUNDS_MANAGER_KEY)?;
+    HmacKey::from_hex_string(&key_str).map_err(|e| format!("Invalid HMAC key: {}", e))
+}

--- a/node-support/bootloader/src/helpers.rs
+++ b/node-support/bootloader/src/helpers.rs
@@ -1,0 +1,82 @@
+//! Helpers for the bootloader
+
+use std::{fmt::Debug, path::Path, str::FromStr};
+
+use aws_config::Region;
+use aws_sdk_s3::Client as S3Client;
+use tokio::{fs, io::AsyncWriteExt};
+use util::raw_err_str;
+
+use crate::config::ConfigContents;
+
+// --- Environment Variables --- //
+
+/// The bootstrap mode flag in the relayer config
+const CONFIG_BOOTSTRAP_MODE: &str = "bootstrap-mode";
+/// The default AWS region to build an s3 client
+pub(crate) const DEFAULT_AWS_REGION: &str = "us-east-2";
+
+/// Check whether the given environment variable is set
+pub(crate) fn is_env_var_set(var_name: &str) -> bool {
+    std::env::var(var_name).is_ok()
+}
+
+/// Read an environment variable
+pub(crate) fn read_env_var<T: FromStr>(var_name: &str) -> Result<T, String>
+where
+    <T as FromStr>::Err: Debug,
+{
+    std::env::var(var_name)
+        .map_err(raw_err_str!("{var_name} not set: {}"))?
+        .parse::<T>()
+        .map_err(|e| format!("Failed to read env var {}: {:?}", var_name, e))
+}
+
+/// Return whether the relayer is in bootstrap mode
+pub(crate) fn in_bootstrap_mode(config: &ConfigContents) -> bool {
+    config.get(CONFIG_BOOTSTRAP_MODE).map(|val| val.as_bool().unwrap_or(false)).unwrap_or(false)
+}
+
+// --- S3 --- //
+
+/// Build an s3 client
+pub(crate) async fn build_s3_client() -> S3Client {
+    let region = Region::new(DEFAULT_AWS_REGION);
+    let config = aws_config::from_env().region(region).load().await;
+    aws_sdk_s3::Client::new(&config)
+}
+
+/// Download an s3 file to the given location
+pub(crate) async fn download_s3_file(
+    bucket: &str,
+    key: &str,
+    destination: &str,
+    s3_client: &S3Client,
+) -> Result<(), String> {
+    // Get the object from S3
+    let resp = s3_client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .map_err(raw_err_str!("Failed to get object from S3: {}"))?;
+    let body = resp.body.collect().await.map_err(raw_err_str!("Failed to read object body: {}"))?;
+
+    // Create the directory if it doesn't exist
+    if let Some(parent) = Path::new(destination).parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(raw_err_str!("Failed to create destination directory: {}"))?;
+    }
+
+    // Write the body to the destination file
+    let mut file = fs::File::create(destination)
+        .await
+        .map_err(raw_err_str!("Failed to create destination file: {}"))?;
+    file.write_all(&body.into_bytes())
+        .await
+        .map_err(raw_err_str!("Failed to write to destination file: {}"))?;
+
+    Ok(())
+}

--- a/node-support/bootloader/src/main.rs
+++ b/node-support/bootloader/src/main.rs
@@ -6,84 +6,21 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![allow(incomplete_features)]
 
-use funds_manager_api::{
-    auth::{compute_hmac, X_SIGNATURE_HEADER},
-    gas::{RegisterGasWalletRequest, RegisterGasWalletResponse, REGISTER_GAS_WALLET_ROUTE},
+use config::{fetch_config, modify_config, CONFIG_PATH, ENV_SQS_QUEUE_URL};
+use gas_wallet::setup_gas_wallet;
+use helpers::{
+    build_s3_client, download_s3_file, in_bootstrap_mode, is_env_var_set, read_env_var,
+    DEFAULT_AWS_REGION,
 };
-use reqwest::{
-    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
-    Client,
-};
-use std::{collections::HashMap, fmt::Debug, path::Path, str::FromStr};
+use snapshot::{download_snapshot, ENV_SNAP_BUCKET};
+use tokio::process::Command;
+use tracing::error;
+use util::telemetry::{setup_system_logger, LevelFilter};
 
-use aws_config::Region;
-use aws_sdk_s3::{error::SdkError, Client as S3Client};
-use base64::prelude::*;
-use config::parsing::parse_config_from_file;
-use libp2p::{identity::Keypair, PeerId};
-use tokio::{fs, io::AsyncWriteExt, process::Command};
-use toml::Value;
-use tracing::{error, info, warn};
-use util::{
-    raw_err_str,
-    telemetry::{setup_system_logger, LevelFilter},
-};
-
-// --- Env Vars --- //
-
-/// The snapshot bucket environment variable
-const ENV_SNAP_BUCKET: &str = "SNAPSHOT_BUCKET";
-/// The bucket in which the relayer config files are stored
-const ENV_CONFIG_BUCKET: &str = "CONFIG_BUCKET";
-/// The path in the config bucket
-const ENV_CONFIG_FILE: &str = "CONFIG_FILE";
-/// The HTTP port to listen on
-const ENV_HTTP_PORT: &str = "HTTP_PORT";
-/// The websocket port to listen on
-const ENV_WS_PORT: &str = "WEBSOCKET_PORT";
-/// The P2P port to listen on
-const ENV_P2P_PORT: &str = "P2P_PORT";
-/// The public IP of the node (optional)
-const ENV_PUBLIC_IP: &str = "PUBLIC_IP";
-/// The symmetric key used to authenticate admin API requests (optional)
-const ENV_ADMIN_KEY: &str = "ADMIN_API_KEY";
-/// The funds manager api URL
-const ENV_FUNDS_MANAGER_URL: &str = "FUNDS_MANAGER_URL";
-/// The funds manager api key
-const ENV_FUNDS_MANAGER_KEY: &str = "FUNDS_MANAGER_KEY";
-/// The SQS queue URL
-const ENV_SQS_QUEUE_URL: &str = "SQS_QUEUE_URL";
-
-// --- Constants --- //
-
-/// The path at which the relayer expects its config
-const CONFIG_PATH: &str = "./config.toml";
-/// The http port key name in the relayer config
-const CONFIG_HTTP_PORT: &str = "http-port";
-/// The websocket port key name in the relayer config
-const CONFIG_WS_PORT: &str = "websocket-port";
-/// The P2P port key name in the relayer config
-const CONFIG_P2P_PORT: &str = "p2p-port";
-/// The public IP key name in the relayer config
-const CONFIG_PUBLIC_IP: &str = "public-ip";
-/// The admin API key name in the relayer config
-const CONFIG_ADMIN_KEY: &str = "admin-api-key";
-/// The fee whitelist key name in the relayer config
-const CONFIG_FEE_WHITELIST: &str = "relayer-fee-whitelist";
-/// The p2p key name in the relayer config
-const CONFIG_P2P_KEY: &str = "p2p-key";
-/// The gas wallet in the relayer config
-const CONFIG_GAS_WALLET: &str = "private-key";
-/// The bootstrap mode flag in the relayer config
-const CONFIG_BOOTSTRAP_MODE: &str = "bootstrap-mode";
-
-/// The name of the file in the s3 bucket
-const WHITELIST_FILE_NAME: &str = "fee-whitelist.json";
-/// The path at which the relayer expects the whitelist
-const WHITELIST_PATH: &str = "/whitelist.json";
-
-/// The default AWS region to build an s3 client
-const DEFAULT_AWS_REGION: &str = "us-east-2";
+mod config;
+mod gas_wallet;
+mod helpers;
+mod snapshot;
 
 /// The location of the snapshot sidecar binary
 const SNAPSHOT_SIDECAR_BIN: &str = "/bin/snapshot-sidecar";
@@ -91,11 +28,6 @@ const SNAPSHOT_SIDECAR_BIN: &str = "/bin/snapshot-sidecar";
 const EVENT_EXPORT_SIDECAR_BIN: &str = "/bin/event-export-sidecar";
 /// The location of the relayer binary
 const RELAYER_BIN: &str = "/bin/renegade-relayer";
-
-/// A type alias for the parsed config
-///
-/// Mapping from key to toml value
-type ConfigContents = HashMap<String, Value>;
 
 // --- Main --- //
 
@@ -107,9 +39,8 @@ async fn main() -> Result<(), String> {
     let s3_client = build_s3_client().await;
 
     // Fetch the config, modify it, and download the most recent snapshot
-    let whitelist = fetch_fee_whitelist(&s3_client).await?;
     fetch_config(&s3_client).await?;
-    let cfg = modify_config(whitelist).await?;
+    let cfg = modify_config().await?;
     download_snapshot(&s3_client, &cfg).await?;
 
     // Start the snapshot sidecar, event export sidecar, and the relayer
@@ -151,286 +82,4 @@ async fn main() -> Result<(), String> {
     Ok(())
 }
 
-/// Fetch the relayer's config from s3
-async fn fetch_config(s3: &S3Client) -> Result<(), String> {
-    // Read in the fetch info from environment variables
-    let bucket = read_env_var::<String>(ENV_CONFIG_BUCKET)?;
-    let file = read_env_var::<String>(ENV_CONFIG_FILE)?;
-    download_s3_file(&bucket, &file, CONFIG_PATH, s3).await
-}
-
-/// Modify the config using environment variables set at runtime
-///
-/// Returns the modified config's contents
-async fn modify_config(whitelist_path: Option<String>) -> Result<ConfigContents, String> {
-    // Read the config file
-    let config_content = fs::read_to_string(CONFIG_PATH)
-        .await
-        .map_err(raw_err_str!("Failed to read config file: {}"))?;
-    let mut config: ConfigContents =
-        toml::from_str(&config_content).map_err(raw_err_str!("Failed to parse config: {}"))?;
-
-    // Setup the peer id and register a gas wallet under this peer id
-    let peer_id = set_p2p_key(&mut config)?;
-    setup_gas_wallet(peer_id, &mut config).await?;
-
-    // Add values from the environment variables
-    let http_port = Value::String(read_env_var(ENV_HTTP_PORT)?);
-    let ws_port = Value::String(read_env_var(ENV_WS_PORT)?);
-    let p2p_port = Value::String(read_env_var(ENV_P2P_PORT)?);
-    config.insert(CONFIG_HTTP_PORT.to_string(), http_port);
-    config.insert(CONFIG_WS_PORT.to_string(), ws_port);
-    config.insert(CONFIG_P2P_PORT.to_string(), p2p_port);
-
-    if is_env_var_set(ENV_PUBLIC_IP) {
-        let public_ip = Value::String(read_env_var(ENV_PUBLIC_IP)?);
-        config.insert(CONFIG_PUBLIC_IP.to_string(), public_ip);
-    }
-
-    if is_env_var_set(ENV_ADMIN_KEY) {
-        let admin_key = Value::String(read_env_var(ENV_ADMIN_KEY)?);
-        config.insert(CONFIG_ADMIN_KEY.to_string(), admin_key);
-    }
-
-    if let Some(path) = whitelist_path {
-        let val = Value::String(path);
-        config.insert(CONFIG_FEE_WHITELIST.to_string(), val);
-    }
-
-    // Write the modified config back to the original file
-    let new_config_content =
-        toml::to_string(&config).map_err(raw_err_str!("Failed to serialize config: {}"))?;
-    fs::write(CONFIG_PATH, new_config_content)
-        .await
-        .map_err(raw_err_str!("Failed to write config file: {}"))?;
-
-    Ok(config)
-}
-
-/// Fetch the fee whitelist file from s3
-///
-/// Returns the path at which the whitelist was downloaded, or None if it
-/// doesn't exist
-async fn fetch_fee_whitelist(s3: &S3Client) -> Result<Option<String>, String> {
-    let bucket = read_env_var::<String>(ENV_CONFIG_BUCKET)?;
-
-    // Check if a whitelist file exists
-    match s3.head_object().bucket(bucket.clone()).key(WHITELIST_FILE_NAME).send().await {
-        Ok(_) => {},
-        Err(SdkError::ServiceError(e)) if e.err().is_not_found() => return Ok(None),
-        Err(e) => return Err(e.to_string()),
-    };
-
-    download_s3_file(&bucket, WHITELIST_FILE_NAME, WHITELIST_PATH, s3).await?;
-    Ok(Some(WHITELIST_PATH.to_string()))
-}
-
-/// Download the most recent snapshot
-async fn download_snapshot(s3_client: &S3Client, cfg: &ConfigContents) -> Result<(), String> {
-    if in_bootstrap_mode(cfg) {
-        info!("skipping snapshot download in bootstrap mode");
-        return Ok(());
-    }
-
-    info!("downloading latest snapshot...");
-    let bucket = read_env_var::<String>(ENV_SNAP_BUCKET)?;
-
-    // Parse the relayer's config
-    let relayer_config =
-        parse_config_from_file(CONFIG_PATH).expect("could not parse relayer config");
-    let snap_path = format!("cluster-{}", relayer_config.cluster_id);
-
-    // Get the latest snapshot
-    let snaps = s3_client
-        .list_objects_v2()
-        .bucket(&bucket)
-        .prefix(&snap_path)
-        .send()
-        .await
-        .map_err(raw_err_str!("Failed to list objects in S3: {}"))?
-        .contents
-        .unwrap_or_default();
-    if snaps.is_empty() {
-        info!("no snapshots found in s3");
-        return Ok(());
-    }
-
-    let latest = snaps.iter().max_by_key(|obj| obj.last_modified.as_ref().unwrap()).unwrap();
-    let latest_key = latest.key.as_ref().unwrap();
-
-    // Download the snapshot into the snapshot directory
-    let path = format!("{}/snapshot.gz", relayer_config.raft_snapshot_path);
-    download_s3_file(&bucket, latest_key, &path, s3_client).await
-}
-
 // --- Helpers --- //
-
-/// Check whether the given environment variable is set
-fn is_env_var_set(var_name: &str) -> bool {
-    std::env::var(var_name).is_ok()
-}
-
-/// Read an environment variable
-fn read_env_var<T: FromStr>(var_name: &str) -> Result<T, String>
-where
-    <T as FromStr>::Err: Debug,
-{
-    std::env::var(var_name)
-        .map_err(raw_err_str!("{var_name} not set: {}"))?
-        .parse::<T>()
-        .map_err(|e| format!("Failed to read env var {}: {:?}", var_name, e))
-}
-
-/// Return whether the relayer is in bootstrap mode
-fn in_bootstrap_mode(config: &ConfigContents) -> bool {
-    config.get(CONFIG_BOOTSTRAP_MODE).map(|val| val.as_bool().unwrap_or(false)).unwrap_or(false)
-}
-
-/// Get the p2p key from the relayer config
-fn get_p2p_key(config: &HashMap<String, Value>) -> Result<Option<PeerId>, String> {
-    config
-        .get(CONFIG_P2P_KEY)
-        .map(|val| {
-            let key_base64 = val.as_str().ok_or("P2P key is not a string".to_string())?;
-            let key_bytes = BASE64_STANDARD
-                .decode(key_base64)
-                .map_err(raw_err_str!("Failed to decode p2p key from base64: {}"))?;
-
-            let keypair = Keypair::from_protobuf_encoding(&key_bytes)
-                .map_err(raw_err_str!("Failed to decode p2p key from protobuf encoding: {}"))?;
-
-            Ok(keypair.public().to_peer_id())
-        })
-        .transpose()
-}
-
-/// Set the p2p key in the relayer config and return the associated peer id
-fn set_p2p_key(config: &mut HashMap<String, Value>) -> Result<PeerId, String> {
-    if let Some(peer_id) = get_p2p_key(config)? {
-        return Ok(peer_id);
-    }
-
-    let keypair = Keypair::generate_ed25519();
-    let peer_id = keypair.public().to_peer_id();
-
-    let key_bytes =
-        keypair.to_protobuf_encoding().map_err(raw_err_str!("Failed to encode p2p key: {}"))?;
-    let encoded = BASE64_STANDARD.encode(key_bytes);
-    config.insert(CONFIG_P2P_KEY.to_string(), Value::String(encoded));
-
-    Ok(peer_id)
-}
-
-/// Build an s3 client
-async fn build_s3_client() -> S3Client {
-    let region = Region::new(DEFAULT_AWS_REGION);
-    let config = aws_config::from_env().region(region).load().await;
-    aws_sdk_s3::Client::new(&config)
-}
-
-/// Download an s3 file to the given location
-async fn download_s3_file(
-    bucket: &str,
-    key: &str,
-    destination: &str,
-    s3_client: &S3Client,
-) -> Result<(), String> {
-    // Get the object from S3
-    let resp = s3_client
-        .get_object()
-        .bucket(bucket)
-        .key(key)
-        .send()
-        .await
-        .map_err(raw_err_str!("Failed to get object from S3: {}"))?;
-    let body = resp.body.collect().await.map_err(raw_err_str!("Failed to read object body: {}"))?;
-
-    // Create the directory if it doesn't exist
-    if let Some(parent) = Path::new(destination).parent() {
-        fs::create_dir_all(parent)
-            .await
-            .map_err(raw_err_str!("Failed to create destination directory: {}"))?;
-    }
-
-    // Write the body to the destination file
-    let mut file = fs::File::create(destination)
-        .await
-        .map_err(raw_err_str!("Failed to create destination file: {}"))?;
-    file.write_all(&body.into_bytes())
-        .await
-        .map_err(raw_err_str!("Failed to write to destination file: {}"))?;
-
-    Ok(())
-}
-
-/// Setup the relayer's gas wallet using the funds manager api
-async fn setup_gas_wallet(
-    peer_id: PeerId,
-    config: &mut HashMap<String, Value>,
-) -> Result<(), String> {
-    info!("registering gas wallet for relayer...");
-    let url = match read_env_var::<String>(ENV_FUNDS_MANAGER_URL) {
-        Ok(url) => url,
-        Err(_) => {
-            warn!("funds manager url not set, skipping gas wallet registration...");
-            return Ok(());
-        },
-    };
-
-    let key = read_funds_manager_key()?;
-
-    // Prepare the request
-    let client = Client::new();
-    let path = format!("/custody/gas-wallets/{REGISTER_GAS_WALLET_ROUTE}");
-    let method = "POST";
-    let body = RegisterGasWalletRequest { peer_id: peer_id.to_string() };
-    let body_json = serde_json::to_vec(&body).unwrap();
-
-    // Prepare headers
-    let mut headers = HeaderMap::new();
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
-    // Compute HMAC
-    let hmac = compute_hmac(&key, method, &path, &headers, &body_json);
-    let hmac_value =
-        HeaderValue::from_str(&hex::encode(hmac)).expect("Failed to create header value");
-    headers.insert(X_SIGNATURE_HEADER, hmac_value);
-
-    // Send request
-    let url = format!("{}{}", url, path);
-    let response = client
-        .post(&url)
-        .headers(headers)
-        .body(body_json)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to send request: {e}"))?;
-    if !response.status().is_success() {
-        return Err(format!("Request failed with status: {}", response.status()));
-    }
-
-    let resp = response
-        .json::<RegisterGasWalletResponse>()
-        .await
-        .map_err(|e| format!("Failed to parse response: {}", e))?;
-
-    let key = Value::String(resp.key);
-    config.insert(CONFIG_GAS_WALLET.to_string(), Value::Array(vec![key]));
-
-    Ok(())
-}
-
-/// Read in the funds manager HMAC key from environment variables
-fn read_funds_manager_key() -> Result<[u8; 32], String> {
-    let key_str = read_env_var::<String>(ENV_FUNDS_MANAGER_KEY)?;
-    let key_str = key_str.trim_start_matches("0x");
-
-    let decoded = hex::decode(key_str).expect("Invalid HMAC key");
-    if decoded.len() != 32 {
-        panic!("HMAC key must be 32 bytes long");
-    }
-
-    let mut array = [0u8; 32];
-    array.copy_from_slice(&decoded);
-    Ok(array)
-}

--- a/node-support/bootloader/src/snapshot.rs
+++ b/node-support/bootloader/src/snapshot.rs
@@ -1,0 +1,54 @@
+//! Helpers for downloading the latest relayer snapshot
+
+use aws_sdk_s3::Client as S3Client;
+use config::parsing::parse_config_from_file;
+use tracing::info;
+use util::raw_err_str;
+
+use crate::{
+    config::ConfigContents, download_s3_file, in_bootstrap_mode, read_env_var, CONFIG_PATH,
+};
+
+/// The snapshot bucket environment variable
+pub(crate) const ENV_SNAP_BUCKET: &str = "SNAPSHOT_BUCKET";
+
+/// Download the most recent snapshot
+pub(crate) async fn download_snapshot(
+    s3_client: &S3Client,
+    cfg: &ConfigContents,
+) -> Result<(), String> {
+    if in_bootstrap_mode(cfg) {
+        info!("skipping snapshot download in bootstrap mode");
+        return Ok(());
+    }
+
+    info!("downloading latest snapshot...");
+    let bucket = read_env_var::<String>(ENV_SNAP_BUCKET)?;
+
+    // Parse the relayer's config
+    let relayer_config =
+        parse_config_from_file(CONFIG_PATH).expect("could not parse relayer config");
+    let snap_path = format!("cluster-{}", relayer_config.cluster_id);
+
+    // Get the latest snapshot
+    let snaps = s3_client
+        .list_objects_v2()
+        .bucket(&bucket)
+        .prefix(&snap_path)
+        .send()
+        .await
+        .map_err(raw_err_str!("Failed to list objects in S3: {}"))?
+        .contents
+        .unwrap_or_default();
+    if snaps.is_empty() {
+        info!("no snapshots found in s3");
+        return Ok(());
+    }
+
+    let latest = snaps.iter().max_by_key(|obj| obj.last_modified.as_ref().unwrap()).unwrap();
+    let latest_key = latest.key.as_ref().unwrap();
+
+    // Download the snapshot into the snapshot directory
+    let path = format!("{}/snapshot.gz", relayer_config.raft_snapshot_path);
+    download_s3_file(&bucket, latest_key, &path, s3_client).await
+}


### PR DESCRIPTION
### Purpose
This PR makes a number of changes to the relayer's bootloader:
1. Use the chain-dependent funds manager URL for registering a gas wallet
2. Internalize the funds manager API types, to prevent a cyclic dependency with `funds-manager-api`
3. Remove fee whitelisting -- not currently used
4. Refactor individual components of the bootloader into their own files

### Testing
- [x] Deployed to `base-sepolia-relayer`