### PR TITLE
common: token: Default `chain` in deserialization

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -102,6 +102,7 @@ pub struct Token {
     #[serde(deserialize_with = "deserialize_str_lower", serialize_with = "serialize_str_lower")]
     pub addr: String,
     /// The chain the token is on.
+    #[serde(default = "default_chain")]
     pub chain: Chain,
 }
 


### PR DESCRIPTION
### Purpose
This PR defaults the `chain` field on the `Token` struct when not present during deserialization. This allows for API backwards compatibility for endpoints expecting a token.

### Testing
- [x] Tested locally
- [ ] Testing in testnet