### PR TITLE
node-support: bootloader: gas_wallet: use old (bkwds-compat) register-gas-wallet route

### DIFF
--- a/node-support/bootloader/src/gas_wallet.rs
+++ b/node-support/bootloader/src/gas_wallet.rs
@@ -78,8 +78,8 @@ pub(crate) async fn setup_gas_wallet(
 
     // Prepare the request
     let client = Client::new();
-    let chain = read_env_var::<String>(ENV_CHAIN)?;
-    let path = format!("/custody/{chain}/gas-wallets/{REGISTER_GAS_WALLET_ROUTE}");
+    let _chain = read_env_var::<String>(ENV_CHAIN)?;
+    let path = format!("/custody/gas-wallets/{REGISTER_GAS_WALLET_ROUTE}");
     let body = RegisterGasWalletRequest { peer_id: peer_id.to_string() };
     let body_json = serde_json::to_vec(&body).unwrap();
 


### PR DESCRIPTION
This PR patches the `bootloader` to invoke the old `/register-gas-wallet` route on the funds manager. The purpose of this is to decouple relayer deployments from funds manager deployments (as the funds manager relies on newer versions of the relayer). This old form of the route is also supported on the pending new version of the funds manager.