### PR TITLE
config: token-remaps: allow merging supported exchanges

### DIFF
--- a/config/src/token_remaps.rs
+++ b/config/src/token_remaps.rs
@@ -91,10 +91,6 @@ impl TokenRemap {
     pub fn set_exchange_support_map(&self) {
         let mut exchange_support_map = write_exchange_support();
 
-        // Clear the existing exchange support map so that it can be completely
-        // overwritten
-        exchange_support_map.clear();
-
         for info in &self.tokens {
             exchange_support_map.insert(info.ticker.clone(), info.supported_exchanges.clone());
         }


### PR DESCRIPTION
### Purpose
This PR allows the supported exchanges global static map to merge values across token remaps. If we're only loading one token remap: no need to clear the exchange support map. If we're loading multiple: we assume supported exchanges are chain-agnostic and we want to merge across remaps.

### Testing
- [x] Tested locally
- [ ] Test in testnet