### PR TITLE
darkpool-client: Move arbitrum transfer auth to `DarkpoolClient`

### DIFF
--- a/darkpool-client/Cargo.toml
+++ b/darkpool-client/Cargo.toml
@@ -15,6 +15,7 @@ integration = [
     "common/mocks",
     "test-helpers/arbitrum",
 ]
+transfer-auth = ["dep:rand"]
 
 [[test]]
 name = "integration"

--- a/darkpool-client/src/errors.rs
+++ b/darkpool-client/src/errors.rs
@@ -15,6 +15,8 @@ pub enum DarkpoolClientError {
     DarkpoolSubcallNotFound(String),
     /// Error thrown when serializing/deserializing calldata/retdata
     Serde(String),
+    /// An signing error
+    Signing(String),
     /// Error thrown when converting between relayer & smart contract types
     Conversion(ConversionError),
     /// Error thrown when querying events
@@ -55,6 +57,12 @@ impl DarkpoolClientError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn rpc<T: ToString>(msg: T) -> Self {
         Self::Rpc(msg.to_string())
+    }
+
+    /// Create a new signing error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn signing<T: ToString>(msg: T) -> Self {
+        Self::Signing(msg.to_string())
     }
 
     /// Create a new transaction querying error

--- a/darkpool-client/src/lib.rs
+++ b/darkpool-client/src/lib.rs
@@ -23,6 +23,9 @@ pub mod conversion;
 pub mod errors;
 pub mod traits;
 
+#[cfg(feature = "transfer-auth")]
+pub mod transfer_auth;
+
 #[cfg(feature = "arbitrum")]
 pub mod arbitrum;
 #[cfg(all(feature = "arbitrum", not(feature = "all-chains")))]

--- a/darkpool-client/src/transfer_auth/mod.rs
+++ b/darkpool-client/src/transfer_auth/mod.rs
@@ -1,0 +1,13 @@
+//! Helpers for constructing external transfer auth data which the contracts
+//! will validate
+//!
+//! For deposits this is a Permit2 signature, with the root key used as the
+//! deposit witness.
+//!
+//! For withdrawals, this is just the serialized transfer struct, signed by the
+//! root key.
+
+mod permit2_abi;
+
+#[cfg(feature = "arbitrum")]
+pub mod arbitrum;

--- a/darkpool-client/src/transfer_auth/permit2_abi.rs
+++ b/darkpool-client/src/transfer_auth/permit2_abi.rs
@@ -4,6 +4,9 @@
 
 use alloy_sol_types::sol;
 
+/// The name of the domain separator for Permit2 typed data
+pub(crate) const PERMIT2_EIP712_DOMAIN_NAME: &str = "Permit2";
+
 // Types & methods from the Permit2 `ISignatureTransfer` interface, taken from https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol
 sol! {
     /// The token and amount details for a transfer signed in the permit transfer signature

--- a/test-helpers/src/contract_interaction.rs
+++ b/test-helpers/src/contract_interaction.rs
@@ -12,9 +12,6 @@ use eyre::Result;
 use rand::thread_rng;
 use renegade_crypto::hash::{evaluate_hash_chain, PoseidonCSPRNG};
 
-#[cfg(any(feature = "arbitrum", feature = "base"))]
-pub mod transfer_auth;
-
 // ---------------------
 // | Wallet Allocation |
 // ---------------------


### PR DESCRIPTION
### Purpose
This PR moves the transfer auth helpers from the `test-helpers` crate to the `darkpool-client` crate. 

A follow-up will add helpers for Base transfer auth.

### Testing
- [x] Testing using a version of the CLI pointing to this change