### PR TITLE
darkpool-client: transfer-auth: base: Implement Base transfer auth

### DIFF
--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -1,5 +1,5 @@
 //! The Base implementation of the darkpool client
-mod conversion;
+pub(crate) mod conversion;
 mod helpers;
 
 use alloy::{

--- a/darkpool-client/src/conversion.rs
+++ b/darkpool-client/src/conversion.rs
@@ -24,6 +24,11 @@ pub fn biguint_to_u256(biguint: &BigUint) -> Result<U256, ConversionError> {
     Ok(u256)
 }
 
+/// Convert a `U256` to a `BigUint`
+pub fn u256_to_biguint(u: U256) -> BigUint {
+    BigUint::from_bytes_le(u.as_le_slice())
+}
+
 /// Convert an `Address` to a `BigUint`
 pub fn address_to_biguint(address: &Address) -> Result<BigUint, ConversionError> {
     let bytes = address.0.to_vec();

--- a/darkpool-client/src/transfer_auth/arbitrum.rs
+++ b/darkpool-client/src/transfer_auth/arbitrum.rs
@@ -1,38 +1,24 @@
 //! Arbitrum implementation of transfer auth
 
 use alloy::signers::{local::PrivateKeySigner, SignerSync};
-use alloy_primitives::{keccak256, Address, B256, U256};
-use alloy_sol_types::{
-    eip712_domain,
-    sol_data::{Address as SolAddress, Uint as SolUint},
-    Eip712Domain, SolStruct, SolType,
-};
+use alloy_primitives::{keccak256, Address, B256};
 use circuit_types::{
     keychain::PublicSigningKey,
-    traits::BaseType,
     transfers::{ExternalTransfer, ExternalTransferDirection},
 };
-use common::types::transfer_auth::{DepositAuth, ExternalTransferWithAuth, WithdrawalAuth};
-use num_bigint::BigUint;
-use rand::{thread_rng, RngCore};
+use common::types::transfer_auth::{ExternalTransferWithAuth, WithdrawalAuth};
 
 use crate::{
     arbitrum::{
         contract_types::conversion::to_contract_external_transfer, helpers::serialize_calldata,
     },
-    conversion::scalar_to_u256,
-    errors::{ConversionError, DarkpoolClientError},
+    errors::DarkpoolClientError,
 };
 
-use super::permit2_abi::{
-    DepositWitness, PermitWitnessTransferFrom, TokenPermissions, PERMIT2_EIP712_DOMAIN_NAME,
-};
-
-/// The number of scalars in a secp256k1 public key
-const NUM_SCALARS_PK: usize = 4;
+use super::common::build_deposit_auth;
 
 /// Generates an external transfer augmented with auth data
-pub fn gen_transfer_with_auth(
+pub fn build_transfer_auth(
     wallet: &PrivateKeySigner,
     pk_root: &PublicSigningKey,
     permit2_address: Address,
@@ -41,7 +27,7 @@ pub fn gen_transfer_with_auth(
     transfer: ExternalTransfer,
 ) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
     match transfer.direction {
-        ExternalTransferDirection::Deposit => gen_deposit_with_auth(
+        ExternalTransferDirection::Deposit => build_deposit_auth(
             wallet,
             pk_root,
             transfer,
@@ -49,12 +35,12 @@ pub fn gen_transfer_with_auth(
             darkpool_address,
             chain_id,
         ),
-        ExternalTransferDirection::Withdrawal => gen_withdrawal_with_auth(wallet, transfer),
+        ExternalTransferDirection::Withdrawal => build_withdrawal_auth(wallet, transfer),
     }
 }
 
 /// Generate a withdrawal payload with proper auth data
-pub fn gen_withdrawal_with_auth(
+fn build_withdrawal_auth(
     wallet: &PrivateKeySigner,
     transfer: ExternalTransfer,
 ) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
@@ -70,127 +56,4 @@ pub fn gen_withdrawal_with_auth(
         transfer.amount,
         WithdrawalAuth { external_transfer_signature: sig_bytes },
     ))
-}
-
-/// Generate a deposit payload with proper auth data
-pub fn gen_deposit_with_auth(
-    wallet: &PrivateKeySigner,
-    pk_root: &PublicSigningKey,
-    transfer: ExternalTransfer,
-    permit2_address: Address,
-    darkpool_address: Address,
-    chain_id: u64,
-) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
-    let contract_transfer = to_contract_external_transfer(&transfer)?;
-    let (permit_nonce, permit_deadline, permit_signature) = gen_permit_payload(
-        wallet,
-        contract_transfer.mint,
-        contract_transfer.amount,
-        pk_root,
-        permit2_address,
-        darkpool_address,
-        chain_id,
-    )?;
-
-    let permit_nonce = u256_to_biguint(permit_nonce);
-    let permit_deadline = u256_to_biguint(permit_deadline);
-
-    Ok(ExternalTransferWithAuth::deposit(
-        transfer.account_addr,
-        transfer.mint,
-        transfer.amount,
-        DepositAuth { permit_nonce, permit_deadline, permit_signature },
-    ))
-}
-
-/// Generates a permit payload for the given token and amount
-fn gen_permit_payload(
-    wallet: &PrivateKeySigner,
-    token: Address,
-    amount: U256,
-    pk_root: &PublicSigningKey,
-    permit2_address: Address,
-    darkpool_address: Address,
-    chain_id: u64,
-) -> Result<(U256, U256, Vec<u8>), DarkpoolClientError> {
-    let permitted = TokenPermissions { token, amount };
-
-    // Generate a random nonce
-    let mut nonce_bytes = [0_u8; 32];
-    thread_rng().fill_bytes(&mut nonce_bytes);
-    let nonce = U256::from_be_slice(&nonce_bytes);
-
-    // Set an effectively infinite deadline
-    let deadline = U256::from(u64::MAX);
-    let witness = DepositWitness { pkRoot: pk_to_u256s(pk_root)? };
-    let signable_permit = PermitWitnessTransferFrom {
-        permitted,
-        spender: darkpool_address,
-        nonce,
-        deadline,
-        witness,
-    };
-
-    // Construct the EIP712 domain
-    let permit_domain = eip712_domain!(
-        name: PERMIT2_EIP712_DOMAIN_NAME,
-        chain_id: chain_id,
-        verifying_contract: permit2_address,
-    );
-
-    let msg_hash = permit_signing_hash(&signable_permit, &permit_domain);
-    let signature = wallet.sign_hash_sync(&msg_hash).map_err(DarkpoolClientError::signing)?;
-    let sig_bytes = signature.as_bytes().to_vec();
-    Ok((nonce, deadline, sig_bytes))
-}
-
-/// This is a re-implementation of `eip712_signing_hash` (https://github.com/alloy-rs/core/blob/v0.3.1/crates/sol-types/src/types/struct.rs#L117)
-/// which correctly encodes the data for the nested `TokenPermissions` struct.
-///
-/// We do so by mirroring the functionality implemented in the `sol!` macro (https://github.com/alloy-rs/core/blob/v0.3.1/crates/sol-macro/src/expand/struct.rs#L56)
-/// but avoiding the (unintended) extra hash of the `TokenPermissions` struct's
-/// EIP-712 struct hash.
-///
-/// This is fixed here: https://github.com/alloy-rs/core/pull/258
-/// But the version of `alloy` used by `renegade-contracts` is not updated to
-/// include this fix.
-///
-/// TODO: Remove this function when `renegade-contracts` uses `alloy >= 0.4.0`
-fn permit_signing_hash(permit: &PermitWitnessTransferFrom, domain: &Eip712Domain) -> B256 {
-    let domain_separator = domain.hash_struct();
-
-    let mut type_hash = permit.eip712_type_hash().to_vec();
-    let encoded_data = [
-        permit.permitted.eip712_hash_struct().0,
-        SolAddress::eip712_data_word(&permit.spender).0,
-        SolUint::<256>::eip712_data_word(&permit.nonce).0,
-        SolUint::<256>::eip712_data_word(&permit.deadline).0,
-        permit.witness.eip712_hash_struct().0,
-    ]
-    .concat();
-    type_hash.extend(encoded_data);
-    let struct_hash = keccak256(&type_hash);
-
-    let mut digest_input = [0u8; 2 + 32 + 32];
-    digest_input[0] = 0x19;
-    digest_input[1] = 0x01;
-    digest_input[2..34].copy_from_slice(&domain_separator[..]);
-    digest_input[34..66].copy_from_slice(&struct_hash[..]);
-    keccak256(digest_input)
-}
-
-/// Convert a `U256` to a `BigUint`
-fn u256_to_biguint(u: U256) -> BigUint {
-    BigUint::from_bytes_le(u.as_le_slice())
-}
-
-/// Converts a [`PublicSigningKey`] to a fixed-length array of [`AlloyU256`]
-/// elements
-pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], ConversionError> {
-    pk.to_scalars()
-        .iter()
-        .map(|s| scalar_to_u256(*s))
-        .collect::<Vec<_>>()
-        .try_into()
-        .map_err(|_| ConversionError::InvalidLength)
 }

--- a/darkpool-client/src/transfer_auth/arbitrum.rs
+++ b/darkpool-client/src/transfer_auth/arbitrum.rs
@@ -1,7 +1,7 @@
 //! Arbitrum implementation of transfer auth
 
-use alloy::signers::{local::PrivateKeySigner, SignerSync};
-use alloy_primitives::{keccak256, Address, B256};
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::Address;
 use circuit_types::{
     keychain::PublicSigningKey,
     transfers::{ExternalTransfer, ExternalTransferDirection},
@@ -15,7 +15,9 @@ use crate::{
     errors::DarkpoolClientError,
 };
 
-use super::common::build_deposit_auth;
+// Re-export the deposit auth builder under the `arbitrum` module
+pub use super::common::build_deposit_auth;
+use super::common::sign_bytes;
 
 /// Generates an external transfer augmented with auth data
 pub fn build_transfer_auth(
@@ -40,15 +42,13 @@ pub fn build_transfer_auth(
 }
 
 /// Generate a withdrawal payload with proper auth data
-fn build_withdrawal_auth(
+pub fn build_withdrawal_auth(
     wallet: &PrivateKeySigner,
     transfer: ExternalTransfer,
 ) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
     let contract_transfer = to_contract_external_transfer(&transfer)?;
     let transfer_bytes = serialize_calldata(&contract_transfer)?;
-    let transfer_hash = B256::from_slice(keccak256(&transfer_bytes).as_slice());
-    let signature = wallet.sign_hash_sync(&transfer_hash).map_err(DarkpoolClientError::signing)?;
-    let sig_bytes = signature.as_bytes().to_vec();
+    let sig_bytes = sign_bytes(wallet, &transfer_bytes)?;
 
     Ok(ExternalTransferWithAuth::withdrawal(
         transfer.account_addr,

--- a/darkpool-client/src/transfer_auth/base.rs
+++ b/darkpool-client/src/transfer_auth/base.rs
@@ -1,0 +1,1 @@
+//! Base implementation of transfer auth

--- a/darkpool-client/src/transfer_auth/base.rs
+++ b/darkpool-client/src/transfer_auth/base.rs
@@ -1,1 +1,56 @@
 //! Base implementation of transfer auth
+
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::Address;
+use alloy_sol_types::SolValue;
+use circuit_types::{
+    keychain::PublicSigningKey,
+    transfers::{ExternalTransfer, ExternalTransferDirection},
+};
+use common::types::transfer_auth::{ExternalTransferWithAuth, WithdrawalAuth};
+
+use crate::{base::conversion::ToContractType, errors::DarkpoolClientError};
+
+// Re-export the deposit auth builder under the `base` module
+pub use super::common::build_deposit_auth;
+use super::common::sign_bytes;
+
+/// Generates an external transfer augmented with auth data
+pub fn build_transfer_auth(
+    wallet: &PrivateKeySigner,
+    pk_root: &PublicSigningKey,
+    permit2_address: Address,
+    darkpool_address: Address,
+    chain_id: u64,
+    transfer: ExternalTransfer,
+) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
+    match transfer.direction {
+        ExternalTransferDirection::Deposit => build_deposit_auth(
+            wallet,
+            pk_root,
+            transfer,
+            permit2_address,
+            darkpool_address,
+            chain_id,
+        ),
+        ExternalTransferDirection::Withdrawal => build_withdrawal_auth(wallet, transfer),
+    }
+}
+
+/// Generate a withdrawal payload with proper auth data
+pub fn build_withdrawal_auth(
+    wallet: &PrivateKeySigner,
+    transfer: ExternalTransfer,
+) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
+    // Sign the ABI encoded transfer struct
+    let contract_transfer = transfer.to_contract_type()?;
+    let transfer_bytes = contract_transfer.abi_encode();
+    let sig_bytes = sign_bytes(wallet, &transfer_bytes)?;
+
+    Ok(ExternalTransferWithAuth::withdrawal(
+        transfer.account_addr,
+        transfer.mint,
+        transfer.amount,
+        WithdrawalAuth { external_transfer_signature: sig_bytes },
+    ))
+}

--- a/darkpool-client/src/transfer_auth/common.rs
+++ b/darkpool-client/src/transfer_auth/common.rs
@@ -1,0 +1,108 @@
+//! Common helpers across chains
+
+use alloy::signers::{local::PrivateKeySigner, SignerSync};
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::{eip712_domain, SolStruct};
+use circuit_types::{keychain::PublicSigningKey, traits::BaseType, transfers::ExternalTransfer};
+use common::types::transfer_auth::{DepositAuth, ExternalTransferWithAuth};
+use rand::RngCore;
+
+use crate::{
+    conversion::{amount_to_u256, biguint_to_address, scalar_to_u256, u256_to_biguint},
+    errors::{ConversionError, DarkpoolClientError},
+};
+
+use super::permit2_abi::{
+    DepositWitness, PermitWitnessTransferFrom, TokenPermissions, PERMIT2_EIP712_DOMAIN_NAME,
+};
+
+/// The number of scalars in a secp256k1 public key
+const NUM_SCALARS_PK: usize = 4;
+
+/// Generate a deposit payload with proper auth data
+pub(crate) fn build_deposit_auth(
+    wallet: &PrivateKeySigner,
+    pk_root: &PublicSigningKey,
+    transfer: ExternalTransfer,
+    permit2_address: Address,
+    darkpool_address: Address,
+    chain_id: u64,
+) -> Result<ExternalTransferWithAuth, DarkpoolClientError> {
+    let transfer_mint = biguint_to_address(&transfer.mint)?;
+    let transfer_amount = amount_to_u256(transfer.amount)?;
+    let (permit_nonce, permit_deadline, permit_signature) = gen_permit_payload(
+        wallet,
+        transfer_mint,
+        transfer_amount,
+        pk_root,
+        permit2_address,
+        darkpool_address,
+        chain_id,
+    )?;
+
+    let permit_nonce = u256_to_biguint(permit_nonce);
+    let permit_deadline = u256_to_biguint(permit_deadline);
+
+    Ok(ExternalTransferWithAuth::deposit(
+        transfer.account_addr,
+        transfer.mint,
+        transfer.amount,
+        DepositAuth { permit_nonce, permit_deadline, permit_signature },
+    ))
+}
+
+/// Generates a permit payload for the given token and amount
+fn gen_permit_payload(
+    wallet: &PrivateKeySigner,
+    token: Address,
+    amount: U256,
+    pk_root: &PublicSigningKey,
+    permit2_address: Address,
+    darkpool_address: Address,
+    chain_id: u64,
+) -> Result<(U256, U256, Vec<u8>), DarkpoolClientError> {
+    let permitted = TokenPermissions { token, amount };
+
+    // Set an effectively infinite deadline
+    let nonce = gen_permit_nonce();
+    let deadline = U256::from(u64::MAX);
+    let witness = DepositWitness { pkRoot: pk_to_u256s(pk_root)? };
+    let signable_permit = PermitWitnessTransferFrom {
+        permitted,
+        spender: darkpool_address,
+        nonce,
+        deadline,
+        witness,
+    };
+
+    // Construct the EIP712 domain
+    let permit_domain = eip712_domain!(
+        name: PERMIT2_EIP712_DOMAIN_NAME,
+        chain_id: chain_id,
+        verifying_contract: permit2_address,
+    );
+
+    let msg_hash = signable_permit.eip712_signing_hash(&permit_domain);
+    let signature = wallet.sign_hash_sync(&msg_hash).map_err(DarkpoolClientError::signing)?;
+    let sig_bytes = signature.as_bytes().to_vec();
+    Ok((nonce, deadline, sig_bytes))
+}
+
+/// Generate a permit nonce for a deposit
+fn gen_permit_nonce() -> U256 {
+    let mut rng = rand::thread_rng();
+    let mut nonce_bytes = [0_u8; 32];
+    rng.fill_bytes(&mut nonce_bytes);
+    U256::from_be_slice(&nonce_bytes)
+}
+
+/// Converts a [`PublicSigningKey`] to a fixed-length array of [`AlloyU256`]
+/// elements
+pub fn pk_to_u256s(pk: &PublicSigningKey) -> Result<[U256; NUM_SCALARS_PK], ConversionError> {
+    pk.to_scalars()
+        .iter()
+        .map(|s| scalar_to_u256(*s))
+        .collect::<Vec<_>>()
+        .try_into()
+        .map_err(|_| ConversionError::InvalidLength)
+}

--- a/darkpool-client/src/transfer_auth/mod.rs
+++ b/darkpool-client/src/transfer_auth/mod.rs
@@ -7,7 +7,10 @@
 //! For withdrawals, this is just the serialized transfer struct, signed by the
 //! root key.
 
+mod common;
 mod permit2_abi;
 
 #[cfg(feature = "arbitrum")]
 pub mod arbitrum;
+#[cfg(feature = "base")]
+pub mod base;


### PR DESCRIPTION
### Purpose
This PR adds the Base transfer auth helpers to the darkpool client in the same pattern as is done for the Arbitrum transfer auth helpers. These two implementations differ only in how they serialize withdrawal structs. The Stylus VM uses `postcard` serialization across the board, whereas we use the Solidity ABI encoding to serialize transfer structs in the solidity contracts.

The deposit (permit2) digest is the same on both chains, so I moved that to a common helper.

### Testing
- [x] Tested with Base integration tests