### PR TITLE
config: token-remaps: add canonical exchange field

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -6,4 +6,4 @@ mod token_remaps;
 mod validation;
 
 pub use cli::*;
-pub use token_remaps::{fetch_remap_from_repo, setup_token_remaps};
+pub use token_remaps::{fetch_remap_from_repo, parse_remap_from_file, setup_token_remaps};

--- a/config/src/token_remaps.rs
+++ b/config/src/token_remaps.rs
@@ -48,6 +48,8 @@ pub struct TokenInfo {
     /// The exchanges that list the token, along with the ticker that we should
     /// use to fetch the token's price from the exchange
     supported_exchanges: HashMap<Exchange, String>,
+    /// The canonical exchange from which to source the token's price
+    canonical_exchange: Exchange,
 }
 
 impl TokenRemap {
@@ -104,6 +106,11 @@ impl TokenRemap {
                 .collect(),
         );
     }
+
+    /// Get the canonical exchange map from the token remap
+    pub fn get_canonical_exchange_map(&self) -> HashMap<String, Exchange> {
+        self.tokens.iter().map(|t| (t.ticker.clone(), t.canonical_exchange)).collect()
+    }
 }
 
 /// Setup token remaps in the global `OnceCell`
@@ -141,7 +148,7 @@ fn lowercase_addresses(remap: &mut TokenRemap) {
 }
 
 /// Parse a token remap from a JSON file
-fn parse_remap_from_file(file_path: String) -> Result<TokenRemap, String> {
+pub fn parse_remap_from_file(file_path: String) -> Result<TokenRemap, String> {
     // Read the file into a string
     let file = std::fs::read_to_string(file_path)
         .map_err(raw_err_str!("Failed to read remap file: {}"))?;
@@ -161,7 +168,7 @@ pub fn fetch_remap_from_repo(chain: Chain) -> Result<TokenRemap, String> {
 mod test {
     use std::{collections::HashMap, fs::File};
 
-    use common::types::{chain::Chain, token::read_token_remaps};
+    use common::types::{chain::Chain, exchange::Exchange, token::read_token_remaps};
     use tempfile::{tempdir, TempDir};
 
     use crate::token_remaps::parse_remap_from_file;
@@ -194,6 +201,7 @@ mod test {
                 address: "0x1234".to_string(),
                 decimals: 18,
                 supported_exchanges: HashMap::new(),
+                canonical_exchange: Exchange::Renegade,
             }],
         };
 


### PR DESCRIPTION
### Purpose
This PR adds the canonical exchange field to the TokenRemap struct along with a getter method to retrieve the map of Ticker -> Canonical Exchange.

### Testing
- [x] Tested locally
- [ ] Test in testnet