### PR TITLE
price-reporter: use Renegade exchange when peeking price

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -235,6 +235,7 @@ impl Token {
             .map(|exchanges| exchanges.keys().copied().collect())
             .unwrap_or_default();
         supported_exchanges.insert(Exchange::UniswapV3);
+        supported_exchanges.insert(Exchange::Renegade);
 
         supported_exchanges
     }
@@ -337,6 +338,7 @@ pub fn default_exchange_stable(exchange: &Exchange) -> Token {
         Exchange::Coinbase => Token::from_ticker(USD_TICKER),
         Exchange::Kraken => Token::from_ticker(USD_TICKER),
         Exchange::Okx => Token::from_ticker(USDT_TICKER),
+        Exchange::Renegade => Token::from_ticker(USDC_TICKER),
         _ => panic!("No default stable quote asset for exchange: {:?}", exchange),
     }
 }

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -182,8 +182,8 @@ impl SharedPriceStreamStates {
             return PriceReporterState::UnsupportedPair(base_token, quote_token);
         }
 
-        // Fetch the most recent Binance price
-        match self.get_latest_price(Exchange::Binance, &base_token, &quote_token).await {
+        // Fetch the most recent price from the canonical exchange
+        match self.get_latest_price(Exchange::Renegade, &base_token, &quote_token).await {
             None => PriceReporterState::NotEnoughDataReported(0),
             Some((price, ts)) => {
                 // Fetch the most recent prices from all other exchanges


### PR DESCRIPTION
### Purpose
This PR ensures prices are fetched from the canonical exchange by adding `Exchange::Renegade` to the list of supported exchanges so that it is subscribed to on `StreamPrice`, and read from the Renegade topic on `PeekPrice`. 

`NativeExecutor` does not require changes since it is not used to establish connections, we would see a `todo!("implement renegade connection")` if this code path was used.

### Testing
- [x] Tested locally that we subscribe to renegade price topics and can fetch prices using `/price_report`
- [x] Test in testnet
    - [x] external buy/sell
    - [x] internal buy/sell