### PR TITLE
darkpool-client: arbitrum: Add `quote_amount` to malleable match calls

### DIFF
--- a/darkpool-client/src/arbitrum/abi.rs
+++ b/darkpool-client/src/arbitrum/abi.rs
@@ -2,6 +2,7 @@
 //! data structures used by the darkpool client.
 #![allow(missing_docs)]
 #![allow(unused_doc_comments)]
+#![allow(clippy::too_many_arguments)]
 
 use alloy::consensus::constants::SELECTOR_LEN;
 use alloy_sol_types::{sol, SolCall};
@@ -24,8 +25,8 @@ sol! {
         function processMatchSettle(bytes memory party_0_match_payload, bytes memory party_1_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs,) external;
         function processAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
         function processAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-        function processMalleableAtomicMatchSettle(uint256 base_amount,  bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
-        function processMalleableAtomicMatchSettleWithReceiver(uint256 base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function processMalleableAtomicMatchSettle(uint256 quote_amount, uint256 base_amount, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
+        function processMalleableAtomicMatchSettleWithReceiver(uint256 quote_amount, uint256 base_amount, address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_statement, bytes memory match_proofs, bytes memory match_linking_proofs) external;
         function settleOnlineRelayerFee(bytes memory proof, bytes memory valid_relayer_fee_settlement_statement, bytes memory relayer_wallet_commitment_signature) external;
         function settleOfflineFee(bytes memory proof, bytes memory valid_offline_fee_settlement_statement) external;
         function redeemFee(bytes memory proof, bytes memory valid_fee_redemption_statement, bytes memory recipient_wallet_commitment_signature) external;

--- a/darkpool-client/src/arbitrum/mod.rs
+++ b/darkpool-client/src/arbitrum/mod.rs
@@ -508,7 +508,13 @@ impl DarkpoolImpl for ArbitrumDarkpool {
         // as a placeholder for the calldata base amount
         let base_amount = valid_match_settle_atomic_statement.bounded_match_result.max_base_amount;
         let base_amount_calldata = U256::from(base_amount);
+
+        let price = valid_match_settle_atomic_statement.bounded_match_result.price;
+        let quote_amount_fp = price * Scalar::from(base_amount);
+        let quote_amount_calldata = scalar_to_u256(quote_amount_fp.floor());
+
         Ok(self.build_malleable_atomic_match_from_serialized_data(
+            quote_amount_calldata,
             base_amount_calldata,
             receiver_address,
             internal_party_match_payload_calldata,
@@ -645,8 +651,10 @@ impl ArbitrumDarkpool {
 
     /// Build a `process_malleable_atomic_match_settle` transaction from
     /// calldata serialized values
+    #[allow(clippy::too_many_arguments)]
     fn build_malleable_atomic_match_from_serialized_data(
         &self,
+        quote_amount: U256,
         base_amount: U256,
         receiver: Option<Address>,
         internal_party_match_payload_calldata: Bytes,
@@ -657,6 +665,7 @@ impl ArbitrumDarkpool {
         if let Some(receiver) = receiver {
             self.darkpool()
                 .processMalleableAtomicMatchSettleWithReceiver(
+                    quote_amount,
                     base_amount,
                     receiver,
                     internal_party_match_payload_calldata,
@@ -668,6 +677,7 @@ impl ArbitrumDarkpool {
         } else {
             self.darkpool()
                 .processMalleableAtomicMatchSettle(
+                    quote_amount,
                     base_amount,
                     internal_party_match_payload_calldata,
                     valid_match_settle_atomic_statement_calldata,


### PR DESCRIPTION
### Purpose
This PR adds the `quote_amount` field to malleable match calldata generated by the relayer in the external match API. This value defaults to the maximum tradable quote amount, in line with the base amount default.

### Testing
- [ ] Test in testnet with @akirillo 