### PR TITLE
workers: price-reporter: coinbase: check for rate limiting and add key format comment

### DIFF
--- a/workers/price-reporter/src/errors.rs
+++ b/workers/price-reporter/src/errors.rs
@@ -41,6 +41,9 @@ pub enum ExchangeConnectionError {
     /// Tried to initialize an ExchangeConnection that was already initialized
     #[error("tried to initialize an ExchangeConnection that was already initialized: {0}")]
     AlreadyInitialized(Exchange, Token, Token),
+    /// Rate limit exceeded
+    #[error("rate limit exceeded: {0}")]
+    RateLimit(String),
 }
 
 /// The core error type thrown by the PriceReporter worker.


### PR DESCRIPTION
### Purpose
This PR handles errors due to ratel limiting when using the Coinbase API to query whether a given pair is supported or not. Since rate limiting is not indicative of support/non-support, we propagate it for the consumer to handle appropriately.

Also adds a comment about private key format incompatibilities for future reference.

### Testing
- [ ] Tested locally
- [ ] Test in testnet