### PR TITLE
darkpool-client: event-indexing: Publish `fetch_tx_darkpool_calls`

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -305,7 +305,7 @@ pub struct RelayerConfig {
     ///     https://github.com/renegade-fi/relayer-extensions/tree/master/compliance/compliance-api
     pub compliance_service_url: Option<String>,
     /// The URL to export relayer events to.
-    /// If ommitted, the event manager is disabled.
+    /// If omitted, the event manager is disabled.
     pub event_export_url: Option<Url>,
 
     // ----------------------------

--- a/darkpool-client/src/client/event_indexing.rs
+++ b/darkpool-client/src/client/event_indexing.rs
@@ -229,7 +229,7 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
     // --- Call Tracing --- //
 
     /// Fetch the darkpool calls from a given transaction
-    async fn fetch_tx_darkpool_calls(
+    pub async fn fetch_tx_darkpool_calls(
         &self,
         tx_hash: TxHash,
     ) -> Result<Vec<CallFrame>, DarkpoolClientError> {


### PR DESCRIPTION
### Purpose
This method publishes the `fetch_tx_darkpool_calls` method. This method is useful to consumers outside the crate, e.g. in the auth server.