### PR TITLE
darkpool-client: event_indexing: skip anon events when finding merkle path

### DIFF
--- a/darkpool-client/src/client/event_indexing.rs
+++ b/darkpool-client/src/client/event_indexing.rs
@@ -91,8 +91,12 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         // Parse the Merkle path from the transaction logs
         let mut all_insertion_events = vec![];
         for log in tx.logs().iter().cloned().map(Log::from) {
+            let topic0 = match log.topics().first() {
+                Some(topic) => *topic,
+                None => continue,
+            };
+
             // Matches cannot depend on associated constants, so we if-else
-            let topic0 = log.topics()[0];
             if topic0 == D::MerkleInsertion::SIGNATURE_HASH {
                 // Track the number of Merkle insertions in the tx, so that we may properly find
                 // our commitment in the log stream


### PR DESCRIPTION
This PR fixes a bug wherein we assume that all logs in a transaction that adds a commitment to the Merkle tree have a 0th topic. This was leading to task driver panics when trying to refresh wallets that were updated in such transactions.

### Testing
- [x] All unit tests pass
- [ ] Test on testnet