### PR TITLE
chain-events: listener: Do not panic websocket listener

### DIFF
--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -163,7 +163,9 @@ impl OnChainEventListenerExecutor {
 
             let event = log.log_decode::<NullifierSpentEvent>()?;
             let nullifier = u256_to_scalar(event.data().nullifier);
-            self.handle_nullifier_spent(tx_hash, nullifier).await?;
+            if let Err(e) = self.handle_nullifier_spent(tx_hash, nullifier).await {
+                self.handle_nullifier_spent_error(nullifier, e).await;
+            }
         }
 
         unreachable!()


### PR DESCRIPTION
### Purpose
This PR adds error logging to the websocket chain events listener as is done in the HTTP listener.

### Testing
- [x] Unit tests pass
- [ ] Test in testnet