### PR TITLE
external-api: external-match: Respect all base denominated min fills

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -216,6 +216,16 @@ impl ExternalOrder {
         self.base_mint == native_mint
     }
 
+    /// Returns whether the order size is base denominated
+    pub fn is_base_denominated(&self) -> bool {
+        self.base_amount != 0 || self.exact_base_output != 0
+    }
+
+    /// Returns whether the order size is quote denominated
+    pub fn is_quote_denominated(&self) -> bool {
+        self.quote_amount != 0 || self.exact_quote_output != 0
+    }
+
     /// Convert the external order to the standard `Order` type used throughout
     /// the relayer
     ///
@@ -298,7 +308,7 @@ impl ExternalOrder {
     /// field, we must convert through the price
     fn get_min_fill_in_base(&self, price: FixedPoint) -> Amount {
         let min_fill = self.min_fill_size;
-        if self.base_amount != 0 {
+        if self.is_base_denominated() {
             return min_fill;
         }
 


### PR DESCRIPTION
### Purpose
The min fill size for an external match is specified in the denominating token -- i.e. if the user specifies a quote amount the `min_fill_size` is expected to be in units of the quote token. If the user specifies a base amount the unit is in the base token.

The check for whether an order is base or quote denominated was incomplete in the `get_min_fill_in_base`; not respecting `exact_base_output` parameters. This PR changes that check to use a new `is_base_denominated` method.

### Testing
- [x] Unit tests pass
- [ ] Testing in testnet
