### PR TITLE
task-driver: running-task: Remove unused immediate field & use `client_ff`

### DIFF
--- a/state/src/interface/error.rs
+++ b/state/src/interface/error.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use system_clock::SystemClockError;
 
 use crate::{
-    applicator::error::StateApplicatorError, replication::error::ReplicationV2Error,
+    applicator::error::StateApplicatorError, replication::error::ReplicationError,
     storage::error::StorageError,
 };
 
@@ -24,7 +24,7 @@ pub enum StateError {
     /// An error sending a proposal to the replication layer
     Proposal(String),
     /// An error in the replication substrate
-    Replication(ReplicationV2Error),
+    Replication(ReplicationError),
     /// An error awaiting a runtime task
     Runtime(String),
     /// An error deserializing a message
@@ -53,8 +53,8 @@ impl From<StateError> for String {
     }
 }
 
-impl From<ReplicationV2Error> for StateError {
-    fn from(e: ReplicationV2Error) -> Self {
+impl From<ReplicationError> for StateError {
+    fn from(e: ReplicationError) -> Self {
         StateError::Replication(e)
     }
 }

--- a/state/src/replication/error.rs
+++ b/state/src/replication/error.rs
@@ -42,7 +42,7 @@ pub fn new_apply_error<T: ToString>(
 
 /// Convert a snapshot error to a raft error
 pub fn new_snapshot_error(
-    err: ReplicationV2Error,
+    err: ReplicationError,
 ) -> RaftStorageError<<TypeConfig as RaftTypeConfig>::NodeId> {
     let io_err = IoError::new(IoErrorKind::Other, Box::new(err));
     RaftStorageError::from_io_error(ErrorSubject::Snapshot(None), ErrorVerb::Write, io_err)
@@ -50,13 +50,13 @@ pub fn new_snapshot_error(
 
 /// Convert a replication error into a networking error
 #[allow(clippy::needless_pass_by_value)]
-pub fn new_network_error(err: ReplicationV2Error) -> RPCError<NodeId, Node, RaftError<NodeId>> {
+pub fn new_network_error(err: ReplicationError) -> RPCError<NodeId, Node, RaftError<NodeId>> {
     RPCError::Network(NetworkError::new(&err))
 }
 
 /// The error type emitted by the replication interface
 #[derive(Debug)]
-pub enum ReplicationV2Error {
+pub enum ReplicationError {
     /// An error deserializing a raft response
     Deserialize(String),
     /// An error proposing a state transition
@@ -73,29 +73,29 @@ pub enum ReplicationV2Error {
     Storage(StorageError),
 }
 
-impl Display for ReplicationV2Error {
+impl Display for ReplicationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ReplicationV2Error::Deserialize(e) => write!(f, "Deserialization error: {e}"),
-            ReplicationV2Error::Proposal(e) => write!(f, "Proposal error: {e}"),
-            ReplicationV2Error::Raft(e) => write!(f, "Raft error: {e}"),
-            ReplicationV2Error::RaftSetup(e) => write!(f, "Raft setup error: {e}"),
-            ReplicationV2Error::RaftTeardown(e) => write!(f, "Raft teardown error: {e}"),
-            ReplicationV2Error::Snapshot(e) => write!(f, "Snapshot error: {e}"),
-            ReplicationV2Error::Storage(e) => write!(f, "Storage error: {e}"),
+            ReplicationError::Deserialize(e) => write!(f, "Deserialization error: {e}"),
+            ReplicationError::Proposal(e) => write!(f, "Proposal error: {e}"),
+            ReplicationError::Raft(e) => write!(f, "Raft error: {e}"),
+            ReplicationError::RaftSetup(e) => write!(f, "Raft setup error: {e}"),
+            ReplicationError::RaftTeardown(e) => write!(f, "Raft teardown error: {e}"),
+            ReplicationError::Snapshot(e) => write!(f, "Snapshot error: {e}"),
+            ReplicationError::Storage(e) => write!(f, "Storage error: {e}"),
         }
     }
 }
-impl Error for ReplicationV2Error {}
+impl Error for ReplicationError {}
 
-impl From<StorageError> for ReplicationV2Error {
+impl From<StorageError> for ReplicationError {
     fn from(value: StorageError) -> Self {
-        ReplicationV2Error::Storage(value)
+        ReplicationError::Storage(value)
     }
 }
 
-impl<E: Debug> From<RaftError<NodeId, E>> for ReplicationV2Error {
+impl<E: Debug> From<RaftError<NodeId, E>> for ReplicationError {
     fn from(value: RaftError<NodeId, E>) -> Self {
-        ReplicationV2Error::Raft(format!("{value:?}"))
+        ReplicationError::Raft(format!("{value:?}"))
     }
 }

--- a/state/src/replication/network/gossip.rs
+++ b/state/src/replication/network/gossip.rs
@@ -11,7 +11,7 @@ use util::err_str;
 use crate::{
     ciborium_serialize,
     replication::{
-        error::{new_network_error, ReplicationV2Error},
+        error::{new_network_error, ReplicationError},
         Node, NodeId,
     },
 };
@@ -44,11 +44,11 @@ impl GossipNetwork {
     }
 
     /// Convert a gossip response into a raft response
-    fn to_raft_response(resp: GossipResponse) -> Result<RaftResponse, ReplicationV2Error> {
+    fn to_raft_response(resp: GossipResponse) -> Result<RaftResponse, ReplicationError> {
         let resp_bytes = match resp.body {
             GossipResponseType::Raft(x) => x,
             _ => {
-                return Err(ReplicationV2Error::Deserialize(ERR_INVALID_RESPONSE.to_string()));
+                return Err(ReplicationError::Deserialize(ERR_INVALID_RESPONSE.to_string()));
             },
         };
 
@@ -57,8 +57,8 @@ impl GossipNetwork {
     }
 
     /// Deserialize a raft response from bytes
-    fn deserialize_raft_response(msg_bytes: &[u8]) -> Result<RaftResponse, ReplicationV2Error> {
-        ciborium::de::from_reader(msg_bytes).map_err(err_str!(ReplicationV2Error::Deserialize))
+    fn deserialize_raft_response(msg_bytes: &[u8]) -> Result<RaftResponse, ReplicationError> {
+        ciborium::de::from_reader(msg_bytes).map_err(err_str!(ReplicationError::Deserialize))
     }
 }
 

--- a/state/src/replication/state_machine/recovery.rs
+++ b/state/src/replication/state_machine/recovery.rs
@@ -5,20 +5,20 @@ use tokio::fs;
 use tracing::info;
 use util::err_str;
 
-use crate::replication::error::ReplicationV2Error;
+use crate::replication::error::ReplicationError;
 
 use super::StateMachine;
 
 impl StateMachine {
     /// Check for a snapshot to recover from
-    pub(crate) async fn maybe_recover_snapshot(&mut self) -> Result<(), ReplicationV2Error> {
+    pub(crate) async fn maybe_recover_snapshot(&mut self) -> Result<(), ReplicationError> {
         let path = self.snapshot_archive_path();
         if !path.exists() {
             return Ok(());
         }
 
         // Check if the file is empty, this may happen if a dummy snapshot was created
-        let metadata = fs::metadata(path).await.map_err(err_str!(ReplicationV2Error::Snapshot))?;
+        let metadata = fs::metadata(path).await.map_err(err_str!(ReplicationError::Snapshot))?;
         if metadata.len() == 0 {
             info!("empty snapshot found, skipping...");
             return Ok(());
@@ -43,7 +43,7 @@ impl StateMachine {
     ///
     /// We do this when recovering to prevent wallets from being blocked on a
     /// task queue that failed
-    fn clear_wallet_task_queues(&self) -> Result<(), ReplicationV2Error> {
+    fn clear_wallet_task_queues(&self) -> Result<(), ReplicationError> {
         let tx = self.db().new_write_tx().unwrap();
         let wallets = tx.get_all_wallets()?;
         for wallet in wallets.into_iter() {

--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -19,8 +19,6 @@ use crate::{
 ///
 /// Used to simplify driver logic
 pub struct RunnableTask<T: Task> {
-    /// Whether or not the task is a preemptive task
-    preemptive: bool,
     /// The id of the underlying task
     task_id: TaskIdentifier,
     /// The underlying task
@@ -31,13 +29,12 @@ pub struct RunnableTask<T: Task> {
 
 impl<T: Task> RunnableTask<T> {
     /// Creates a new running task from the given task and state
-    pub fn new(preemptive: bool, task_id: TaskIdentifier, task: T, state: State) -> Self {
-        Self { preemptive, task_id, task, state }
+    pub fn new(task_id: TaskIdentifier, task: T, state: State) -> Self {
+        Self { task_id, task, state }
     }
 
     /// Create a runnable from the given descriptor and context
     pub async fn from_descriptor(
-        preemptive: bool,
         id: TaskIdentifier,
         descriptor: T::Descriptor,
         ctx: TaskContext,
@@ -45,7 +42,7 @@ impl<T: Task> RunnableTask<T> {
         let state = ctx.state.clone();
         let task = T::new(descriptor, ctx).await?;
 
-        Ok(Self::new(preemptive, id, task, state))
+        Ok(Self::new(id, task, state))
     }
 
     /// The ID of the underlying task
@@ -66,7 +63,7 @@ impl<T: Task> RunnableTask<T> {
     /// `true` if the task does not need to update the task queue during state
     /// transitions or cleanup
     pub fn bypass_task_queue(&self) -> bool {
-        self.task.bypass_task_queue() || self.preemptive
+        self.task.bypass_task_queue()
     }
 
     /// Step the underlying task, returns whether the driver should continue or

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -438,6 +438,7 @@ impl SettleMatchExternalTask {
 
     /// Create link proofs between the proof of `VALID MATCH SETTLE ATOMIC` and
     /// the internal party's proof of `VALID COMMITMENTS`
+    #[instrument(skip_all)]
     fn create_link_proofs(
         &self,
         atomic_match_proof: ProofBundle,


### PR DESCRIPTION
### Purpose
This PR makes a cleanup to remove the unused `immediate` field in the `RunningTask` struct.

### Testing
- [ ] Testing in testnet