### PR TITLE
workers: handshake-manager: Add min_quote_amount to external engine

### DIFF
--- a/state/src/replication/mod.rs
+++ b/state/src/replication/mod.rs
@@ -359,6 +359,7 @@ mod test {
         let client = node.get_client(0).await;
         let update = Proposal::from(StateTransition::AddWallet { wallet });
         client.propose_transition(update).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         let db = node.get_db(0).await;
         let tx = db.new_read_tx().unwrap();

--- a/workers/api-server/src/http/external_match.rs
+++ b/workers/api-server/src/http/external_match.rs
@@ -252,10 +252,10 @@ impl ExternalMatchProcessor {
 
         // If the order is quote denominated and a min fill size is specified, we should
         // require the matching engine match at least this amount
-        if o.is_quote_denominated() && o.min_fill_size > 0 {
-            options = options.with_min_quote_amount(o.min_fill_size);
-        }
+        let min_fill_quote = o.get_min_fill_quote();
+        options = options.with_min_quote_amount(min_fill_quote);
 
+        // Check that the order size is at least the min fill size
         self.check_external_order_size(&order).await?;
         Ok((order, options))
     }

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -64,7 +64,7 @@ impl HandshakeExecutor {
             self.get_internal_match_candidates(order_id, &my_order, &wallet).await?;
         while !match_candidates.is_empty() {
             let (other_order_id, match_res) = match self
-                .find_match(&my_order, &my_balance, price, match_candidates.clone())
+                .find_match(&my_order, &my_balance, price, match_candidates.iter())
                 .await?
             {
                 Some(match_res) => match_res,

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -184,6 +184,8 @@ pub struct ExternalMatchingEngineOptions {
     pub price: Option<TimestampedPrice>,
     /// The exact quote amount to use for a full fill
     pub exact_quote_amount: Option<Amount>,
+    /// The minimum quote amount to use for a full fill
+    pub min_quote_amount: Option<Amount>,
 }
 
 impl ExternalMatchingEngineOptions {

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -234,4 +234,10 @@ impl ExternalMatchingEngineOptions {
         self.exact_quote_amount = Some(amount);
         self
     }
+
+    /// Set the min quote amount
+    pub fn with_min_quote_amount(mut self, amount: Amount) -> Self {
+        self.min_quote_amount = Some(amount);
+        self
+    }
 }


### PR DESCRIPTION
### Purpose
This PR:
1. Adds a `min_quote_amount` field to the `ExternalMatchingEngineOptions` struct, which will control the minimum matchable quote amount using existing paths.
2. When an external user passes a quote-denominated order to the API server, the API server will respect `min_fill_size` by forwarding this value to the external matching engine.
3. This PR also cleans up some of the logic for setting the `ExternalMatchingEngineOptions` in the api server, specifically I factored out the large conversion method into smaller helpers.
4. Removed an extra clone in the matching engine, by allowing callers to pass iterators of orders rather than objects which implement `IntoIterator<Item = OrderIdentifier>`.

### Testing
- [x] Testing locally
- [x] Testing in testnet
- [x] Unit tests pass