### PR TITLE
api-server: integration: external-match: Fix basic external match test

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -452,6 +452,7 @@ impl RelayerConfig {
         .map_err(|e| e.to_string())
     }
 }
+
 impl Default for RelayerConfig {
     fn default() -> Self {
         // Parse a dummy set of command line args and convert this to a config

--- a/workers/api-server/integration/ctx/external_match.rs
+++ b/workers/api-server/integration/ctx/external_match.rs
@@ -24,13 +24,13 @@ impl IntegrationTestCtx {
         let path = REQUEST_EXTERNAL_QUOTE_ROUTE;
         let body_bytes = serde_json::to_vec(&req).expect("failed to serialize request");
         add_expiring_auth_to_headers(
-            &path,
+            path,
             &mut headers,
             &body_bytes,
             &self.admin_api_key,
             REQUEST_AUTH_DURATION,
         );
 
-        self.send_req_with_headers(REQUEST_EXTERNAL_QUOTE_ROUTE, Method::POST, headers, req).await
+        self.send_req_raw(path, Method::POST, headers, req).await
     }
 }

--- a/workers/api-server/integration/ctx/mod.rs
+++ b/workers/api-server/integration/ctx/mod.rs
@@ -5,8 +5,10 @@
 
 use std::env::temp_dir;
 
+use alloy::primitives::Address;
 use common::types::{hmac::HmacKey, token::Token};
 use config::RelayerConfig;
+use darkpool_client::conversion::address_to_biguint;
 use eyre::Result;
 use mock_node::MockNodeController;
 use num_bigint::BigUint;
@@ -17,13 +19,16 @@ use state::test_helpers::tmp_db_path;
 mod external_match;
 mod wallet_setup;
 
+/// A dummy RPC url for the integration tests
+const DUMMY_RPC_URL: &str = "https://dummy-rpc-url.com";
+
 /// The arguments used for the integration tests
 #[derive(Clone)]
 pub struct IntegrationTestCtx {
-    /// The mock node controller
-    pub mock_node: MockNodeController,
     /// The admin API key for the integration tests
     pub admin_api_key: HmacKey,
+    /// The mock node controller
+    pub mock_node: MockNodeController,
 }
 
 impl IntegrationTestCtx {
@@ -31,11 +36,15 @@ impl IntegrationTestCtx {
     pub fn relayer_config(admin_key: HmacKey) -> RelayerConfig {
         let raft_snapshot_path = temp_dir().to_str().unwrap().to_string();
         let db_path = tmp_db_path();
+        let external_fee_addr = address_to_biguint(&Address::ZERO).unwrap();
 
         RelayerConfig {
             raft_snapshot_path,
             db_path,
             admin_api_key: Some(admin_key),
+            rpc_url: Some(DUMMY_RPC_URL.to_string()),
+            // External matches are disabled if this value is unset
+            external_fee_addr: Some(external_fee_addr),
             ..Default::default()
         }
     }

--- a/workers/api-server/integration/ctx/wallet_setup.rs
+++ b/workers/api-server/integration/ctx/wallet_setup.rs
@@ -46,7 +46,7 @@ impl IntegrationTestCtx {
             order.base_mint.clone(),
             matching_side,
             order.quote_amount,
-            worst_cast_price,
+            worst_case_price,
             order.min_fill_size,
             true, // allow_external_matches
         )

--- a/workers/api-server/integration/external_match/basic_match.rs
+++ b/workers/api-server/integration/external_match/basic_match.rs
@@ -5,7 +5,7 @@ use common::types::token::Token;
 use external_api::http::external_match::ExternalOrder;
 use eyre::Result;
 use reqwest::StatusCode;
-use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
+use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::ctx::IntegrationTestCtx;
 
@@ -16,21 +16,19 @@ async fn test_basic_external_match__no_quote_found(ctx: IntegrationTestCtx) -> R
     // with an order created by another test
     let base_mint = Token::from_ticker("UNI").get_addr_biguint();
     let quote_mint = Token::from_ticker("USDC").get_addr_biguint();
+    let quote_amount = ctx.quote_token().convert_from_decimal(1000.);
 
     let external_order = ExternalOrder {
         base_mint,
         quote_mint,
         side: OrderSide::Buy,
-        quote_amount: 0,
+        quote_amount,
         ..Default::default()
     };
 
     // Request an external match
     let res = ctx.send_external_quote_req(&external_order).await?;
-    let status = res.status();
-    let body = res.text().await?;
-    println!("\nResponse body: {}", body);
-    assert_eq_result!(status, StatusCode::NO_CONTENT)
+    assert_eq_result!(res.status(), StatusCode::NO_CONTENT)
 }
 integration_test_async!(test_basic_external_match__no_quote_found);
 


### PR DESCRIPTION
### Purpose
This PR finishes the setup for the basic "no quote" external match test. 

### Todo
- Valid external match tests
- Exact amount and min fill tests

### Testing
- [x] All integration tests pass
- [x] All unit tests pass