### PR TITLE
api-server: integration: external-match: Add full basic match tests

### DIFF
--- a/test-helpers/src/macros.rs
+++ b/test-helpers/src/macros.rs
@@ -70,21 +70,20 @@ macro_rules! integration_test_main {
                 // | Setup |
                 // ---------
 
-                // Call the setup callback if requested
-                $setup(&args);
-
-                // ----------------
-                // | Test Harness |
-                // ----------------
-
                 if print_harness {
                     println!("\n\n{}\n", "Running integration tests...".blue());
                 }
 
                 // Assumed From<$cli_args> is implemented for $test_args
                 let test_args: $test_args = args.clone().into();
-                let mut all_success = true;
+                // Call the setup callback if requested
+                $setup(&test_args);
 
+                // ----------------
+                // | Test Harness |
+                // ----------------
+
+                let mut all_success = true;
                 for test_wrapper in inventory::iter::<TestWrapper>.into_iter() {
                     let test = &test_wrapper.0;
                     if args.borrow().test.is_some()

--- a/workers/api-server/integration/ctx/mod.rs
+++ b/workers/api-server/integration/ctx/mod.rs
@@ -6,12 +6,15 @@
 use std::env::temp_dir;
 
 use alloy::primitives::Address;
-use common::types::{hmac::HmacKey, token::Token};
+use circuit_types::{fixed_point::FixedPoint, Amount};
+use common::types::{hmac::HmacKey, token::Token, TimestampedPrice};
 use config::RelayerConfig;
+use constants::Scalar;
 use darkpool_client::conversion::address_to_biguint;
 use eyre::Result;
 use mock_node::MockNodeController;
 use num_bigint::BigUint;
+use renegade_crypto::fields::scalar_to_u128;
 use reqwest::{header::HeaderMap, Method, Response};
 use serde::{de::DeserializeOwned, Serialize};
 use state::test_helpers::tmp_db_path;
@@ -25,6 +28,8 @@ const DUMMY_RPC_URL: &str = "https://dummy-rpc-url.com";
 /// The arguments used for the integration tests
 #[derive(Clone)]
 pub struct IntegrationTestCtx {
+    /// The mock price used for the integration tests
+    pub mock_price: f64,
     /// The admin API key for the integration tests
     pub admin_api_key: HmacKey,
     /// The mock node controller
@@ -67,6 +72,35 @@ impl IntegrationTestCtx {
     /// Get the quote mint used for testing
     pub fn quote_mint(&self) -> BigUint {
         Token::from_ticker("USDC").get_addr_biguint()
+    }
+
+    /// Get the decimal corrected price for the canonical token pair
+    pub fn decimal_corrected_price(&self) -> FixedPoint {
+        let price = TimestampedPrice::new(self.mock_price);
+        let base_token = self.base_token();
+        let quote_token = self.quote_token();
+        let decimal_corrected = price
+            .get_decimal_corrected_price(&base_token, &quote_token)
+            .expect("error decimal correcting price");
+
+        decimal_corrected.as_fixed_point()
+    }
+
+    /// Get the expected base amount for the given quote amount
+    pub fn expected_base_amount(&self, quote_amount: Amount) -> Amount {
+        // quote_amount / price
+        let price = self.decimal_corrected_price();
+        let quote_scalar = FixedPoint::floor_div_int(quote_amount, price);
+        scalar_to_u128(&quote_scalar)
+    }
+
+    /// Get the expected quote amount for the given base amount
+    pub fn expected_quote_amount(&self, base_amount: Amount) -> Amount {
+        // base_amount * price
+        let price = self.decimal_corrected_price();
+        let base = Scalar::from(base_amount);
+        let quote_scalar = (price * base).floor();
+        scalar_to_u128(&quote_scalar)
     }
 
     // --- HTTP Helpers --- //

--- a/workers/api-server/integration/external_match/basic_match.rs
+++ b/workers/api-server/integration/external_match/basic_match.rs
@@ -9,6 +9,9 @@ use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::{ctx::IntegrationTestCtx, helpers::assert_approx_eq};
 
+/// The tolerance used for approximate equality checks
+const DIFF_TOLERANCE: f64 = 0.000001;
+
 /// Test a basic external match with no quote found
 #[allow(non_snake_case)]
 async fn test_basic_external_match__no_quote_found(ctx: IntegrationTestCtx) -> Result<()> {
@@ -32,7 +35,7 @@ async fn test_basic_external_match__no_quote_found(ctx: IntegrationTestCtx) -> R
 }
 integration_test_async!(test_basic_external_match__no_quote_found);
 
-/// Test a basic external match
+/// Test a basic external match on the buy side with a send amount specified
 #[allow(non_snake_case)]
 async fn test_basic_external_match__buy_side__send_amount_specified(
     ctx: IntegrationTestCtx,
@@ -61,13 +64,13 @@ async fn test_basic_external_match__buy_side__send_amount_specified(
 
     let recv_mint = quote.receive.mint;
     let recv_amount = quote.receive.amount;
+    let total_fees = quote.fees.total();
     let expected_base_amt = ctx.expected_base_amount(quote_amount);
     assert_eq_result!(recv_mint, base_mint)?;
-    assert_approx_eq(recv_amount, expected_base_amt, 0.0005)?;
+    assert_approx_eq(recv_amount + total_fees, expected_base_amt, DIFF_TOLERANCE)?;
 
     // Verify the match result
     let match_res = quote.match_result;
-    let total_fees = quote.fees.total();
     assert_eq_result!(match_res.base_mint, base_mint)?;
     assert_eq_result!(match_res.quote_mint, quote_mint)?;
     assert_eq_result!(match_res.quote_amount, send_amount)?;
@@ -76,7 +79,7 @@ async fn test_basic_external_match__buy_side__send_amount_specified(
 }
 integration_test_async!(test_basic_external_match__buy_side__send_amount_specified);
 
-/// Test a basic external match
+/// Test a basic external match on the sell side with a send amount specified
 #[allow(non_snake_case)]
 async fn test_basic_external_match__sell_side__send_amount_specified(
     ctx: IntegrationTestCtx,
@@ -105,13 +108,13 @@ async fn test_basic_external_match__sell_side__send_amount_specified(
 
     let recv_mint = quote.receive.mint;
     let recv_amount = quote.receive.amount;
+    let total_fees = quote.fees.total();
     let expected_quote_amt = ctx.expected_quote_amount(base_amount);
     assert_eq_result!(recv_mint, quote_mint)?;
-    assert_approx_eq(recv_amount, expected_quote_amt, 0.0005)?;
+    assert_approx_eq(recv_amount + total_fees, expected_quote_amt, DIFF_TOLERANCE)?;
 
     // Verify the match result
     let match_res = quote.match_result;
-    let total_fees = quote.fees.total();
     assert_eq_result!(match_res.base_mint, base_mint)?;
     assert_eq_result!(match_res.quote_mint, quote_mint)?;
     assert_eq_result!(match_res.quote_amount, recv_amount + total_fees)?;
@@ -119,3 +122,92 @@ async fn test_basic_external_match__sell_side__send_amount_specified(
     assert_eq_result!(match_res.direction, OrderSide::Sell)
 }
 integration_test_async!(test_basic_external_match__sell_side__send_amount_specified);
+
+/// Tests a basic external match on the buy side with a receive amount specified
+#[allow(non_snake_case)]
+async fn test_basic_external_match__buy_side__receive_amount_specified(
+    ctx: IntegrationTestCtx,
+) -> Result<()> {
+    let base_amount = ctx.base_token().convert_from_decimal(1.); // 1 WETH
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Buy,
+        base_amount,
+        ..Default::default()
+    };
+
+    // Setup a matching order, then request a quote
+    ctx.setup_wallet_for_order(&external_order).await?;
+    let resp = ctx.request_external_quote(&external_order).await?;
+    let quote = resp.signed_quote.quote;
+
+    // Verify the response contents
+    let base_mint = ctx.base_token().get_addr();
+    let quote_mint = ctx.quote_token().get_addr();
+    let send_mint = quote.send.mint;
+    let send_amount = quote.send.amount;
+    let expected_quote_amt = ctx.expected_quote_amount(base_amount);
+    assert_eq_result!(send_mint, quote_mint)?;
+    assert_approx_eq(send_amount, expected_quote_amt, DIFF_TOLERANCE)?;
+
+    let recv_mint = quote.receive.mint;
+    let recv_amount = quote.receive.amount;
+    let total_fees = quote.fees.total();
+    assert_eq_result!(recv_mint, base_mint)?;
+    assert_eq_result!(recv_amount + total_fees, base_amount)?;
+
+    // Verify the match result
+    let match_res = quote.match_result;
+    assert_eq_result!(match_res.base_mint, base_mint)?;
+    assert_eq_result!(match_res.quote_mint, quote_mint)?;
+    assert_eq_result!(match_res.quote_amount, send_amount)?;
+    assert_eq_result!(match_res.base_amount, recv_amount + total_fees)?;
+    assert_eq_result!(match_res.direction, OrderSide::Buy)
+}
+integration_test_async!(test_basic_external_match__buy_side__receive_amount_specified);
+
+/// Tests a basic external match on the sell side with a receive amount
+/// specified
+#[allow(non_snake_case)]
+async fn test_basic_external_match__sell_side__receive_amount_specified(
+    ctx: IntegrationTestCtx,
+) -> Result<()> {
+    let quote_amount = ctx.quote_token().convert_from_decimal(1000.);
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Sell,
+        quote_amount,
+        ..Default::default()
+    };
+
+    // Setup a matching order, then request a quote
+    ctx.setup_wallet_for_order(&external_order).await?;
+    let resp = ctx.request_external_quote(&external_order).await?;
+    let quote = resp.signed_quote.quote;
+
+    // Verify the response contents
+    let base_mint = ctx.base_token().get_addr();
+    let quote_mint = ctx.quote_token().get_addr();
+    let send_mint = quote.send.mint;
+    let send_amount = quote.send.amount;
+    let expected_base_amt = ctx.expected_base_amount(quote_amount);
+    assert_eq_result!(send_mint, base_mint)?;
+    assert_approx_eq(send_amount, expected_base_amt, DIFF_TOLERANCE)?;
+
+    let recv_mint = quote.receive.mint;
+    let recv_amount = quote.receive.amount;
+    let total_fees = quote.fees.total();
+    assert_eq_result!(recv_mint, quote_mint)?;
+    assert_eq_result!(recv_amount + total_fees, quote_amount)?;
+
+    // Verify the match result
+    let match_res = quote.match_result;
+    assert_eq_result!(match_res.base_mint, base_mint)?;
+    assert_eq_result!(match_res.quote_mint, quote_mint)?;
+    assert_eq_result!(match_res.quote_amount, recv_amount + total_fees)?;
+    assert_eq_result!(match_res.base_amount, send_amount)?;
+    assert_eq_result!(match_res.direction, OrderSide::Sell)
+}
+integration_test_async!(test_basic_external_match__sell_side__receive_amount_specified);

--- a/workers/api-server/integration/helpers.rs
+++ b/workers/api-server/integration/helpers.rs
@@ -1,0 +1,18 @@
+//! Helper methods for the integration tests
+
+use circuit_types::Amount;
+use eyre::Result;
+
+/// Check whether two values are within a given tolerance of one another
+pub fn assert_approx_eq(a: Amount, b: Amount, tolerance: f64) -> Result<()> {
+    let a_f64 = a as f64;
+    let b_f64 = b as f64;
+    let diff = (a_f64 - b_f64).abs();
+    let diff_percent = diff / a_f64;
+
+    if diff_percent > tolerance {
+        eyre::bail!("expected {a} to be within {}% of {b}", tolerance * 100.);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Purpose
This PR adds a full test suite for the basic parameterization of external matches by using only `quote_amount` and `base_amount` to specify size.

### Testing
- [x] All integration tests pass