### PR TITLE
Update reference to utils in comment to point to new location in mono…

### DIFF
--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -55,9 +55,9 @@ type WsWriteStream = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Messa
 type WsReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 /// A message that is sent by the price reporter to the client indicating
-/// a price udpate for the given topic
+/// a price update for the given topic
 ///
-/// Ported over from https://github.com/renegade-fi/renegade-price-reporter/blob/main/src/utils.rs
+/// Ported over from https://github.com/renegade-fi/renegade/blob/main/util/src/lib.rs
 #[derive(Serialize, Deserialize)]
 pub struct PriceMessage {
     /// The topic for which the price update is being sent


### PR DESCRIPTION
…repo

The old link to `renegade-price-reporter/src/utils.rs` was outdated, as the price reporter utilities have been consolidated into the main Renegade monorepo.  
This comment now references the correct location for shared utility functions:  
https://github.com/renegade-fi/renegade/blob/main/util/src/lib.rs

This ensures future maintainers can easily find the relevant code and context.