### PR TITLE
api-server: http: Remove spammy error logs

### DIFF
--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -646,11 +646,7 @@ impl HttpServer {
         loop {
             let (stream, _) = listener.accept().await.map_err(ApiServerError::server_failure)?;
             let self_clone = self.clone();
-            tokio::spawn(async move {
-                if let Err(e) = self_clone.handle_stream(stream).await {
-                    error!("Error handling stream: {e}");
-                }
-            });
+            tokio::spawn(async move { self_clone.handle_stream(stream).await });
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR removes a spammy error log that originates when a client hangs up a connection unexpectedly. We don't need to monitor the stream for errors as the internal errors are already captured elsewhere.

### Testing
- [ ] Testing in testnet