### PR TITLE
workers: settlement: record wallet_ids of match

### DIFF
--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -1,14 +1,17 @@
 //! Helpers for calculating and recording metrics
 
 use circuit_types::{r#match::MatchResult, transfers::ExternalTransferDirection};
-use common::types::{token::Token, transfer_auth::ExternalTransferWithAuth};
+use common::types::{
+    token::Token, transfer_auth::ExternalTransferWithAuth, wallet::WalletIdentifier,
+};
 use num_bigint::BigUint;
 use util::hex::biguint_to_hex_addr;
 
 use crate::labels::{
     ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, EXTERNAL_MATCH_METRIC_TAG, FEES_COLLECTED_METRIC,
     MATCH_BASE_VOLUME_METRIC, MATCH_QUOTE_VOLUME_METRIC, NUM_DEPOSITS_METRICS,
-    NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
+    NUM_WITHDRAWALS_METRICS, WALLET_ID1_METRIC_TAG, WALLET_ID2_METRIC_TAG,
+    WITHDRAWAL_VOLUME_METRIC,
 };
 
 /// Get the human-readable asset and volume of
@@ -68,13 +71,24 @@ pub fn maybe_record_transfer_metrics(transfer: &Option<ExternalTransferWithAuth>
 }
 
 /// Record the volume of base/quote assets moved in a match
-pub fn record_match_volume(res: &MatchResult, is_external_match: bool) {
+pub fn record_match_volume(
+    res: &MatchResult,
+    is_external_match: bool,
+    wallet_id1: Option<WalletIdentifier>,
+    wallet_id2: Option<WalletIdentifier>,
+) {
+    let mut labels = vec![];
     // Label the match as external in the metric
-    let labels = if is_external_match {
-        vec![(EXTERNAL_MATCH_METRIC_TAG.to_string(), "true".to_string())]
-    } else {
-        vec![]
-    };
+    if is_external_match {
+        labels.push((EXTERNAL_MATCH_METRIC_TAG.to_string(), "true".to_string()));
+    }
+    // Add wallet ID tags if provided
+    if let Some(wallet_id) = wallet_id1 {
+        labels.push((WALLET_ID1_METRIC_TAG.to_string(), wallet_id.to_string()));
+    }
+    if let Some(wallet_id) = wallet_id2 {
+        labels.push((WALLET_ID2_METRIC_TAG.to_string(), wallet_id.to_string()));
+    }
 
     record_volume_with_tags(&res.base_mint, res.base_amount, MATCH_BASE_VOLUME_METRIC, &labels);
     record_volume_with_tags(&res.quote_mint, res.quote_amount, MATCH_QUOTE_VOLUME_METRIC, &labels);

--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -56,3 +56,7 @@ pub const NUM_EVENT_EXPORT_FAILURES_METRIC: &str = "num_event_export_failures";
 pub const ASSET_METRIC_TAG: &str = "asset";
 /// Metric tag for whether a match is external
 pub const EXTERNAL_MATCH_METRIC_TAG: &str = "is_external_match";
+/// Metric tag for the wallet ID of the first wallet in a match
+pub const WALLET_ID1_METRIC_TAG: &str = "wallet_id1";
+/// Metric tag for the wallet ID of the second wallet in a match
+pub const WALLET_ID2_METRIC_TAG: &str = "wallet_id2";

--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -56,7 +56,7 @@ pub const NUM_EVENT_EXPORT_FAILURES_METRIC: &str = "num_event_export_failures";
 pub const ASSET_METRIC_TAG: &str = "asset";
 /// Metric tag for whether a match is external
 pub const EXTERNAL_MATCH_METRIC_TAG: &str = "is_external_match";
-/// Metric tag for the wallet ID of the first wallet in a match
-pub const WALLET_ID1_METRIC_TAG: &str = "wallet_id1";
-/// Metric tag for the wallet ID of the second wallet in a match
-pub const WALLET_ID2_METRIC_TAG: &str = "wallet_id2";
+/// Helper to generate wallet ID tag names
+pub fn wallet_id_tag(n: usize) -> String {
+    format!("wallet_id{}", n)
+}

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -333,6 +333,7 @@ impl OnChainEventListenerExecutor {
     ) -> Result<bool, OnChainEventListenerError> {
         let matches = self.darkpool_client().find_external_matches_in_tx(tx).await?;
         let external_match = !matches.is_empty();
+        let wallet_ids = wallet_id.into_iter().collect::<Vec<_>>();
 
         // Record metrics for each match
         // TODO: Record a fill on the internal order. We don't do this for now to keep
@@ -344,8 +345,7 @@ impl OnChainEventListenerExecutor {
             renegade_metrics::record_match_volume(
                 &match_result,
                 true, // is_external_match
-                wallet_id,
-                None, // wallet_id2
+                &wallet_ids,
             );
         }
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -421,7 +421,12 @@ impl HandshakeExecutor {
         self.publish_completion_messages(state.local_order_id, state.peer_order_id).await?;
 
         // Record the volume of the match
-        record_match_volume(match_result, false /* is_external_match */);
+        record_match_volume(
+            match_result,
+            false, // is_external_match
+            None,  // wallet_id1
+            None,  // wallet_id2
+        );
         Ok(())
     }
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -424,7 +424,7 @@ impl HandshakeExecutor {
         record_match_volume(
             match_result,
             false, // is_external_match
-            &[],
+            &[],   // wallet_ids
         );
         Ok(())
     }

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -424,8 +424,7 @@ impl HandshakeExecutor {
         record_match_volume(
             match_result,
             false, // is_external_match
-            None,  // wallet_id1
-            None,  // wallet_id2
+            &[],
         );
         Ok(())
     }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -272,7 +272,12 @@ impl Task for SettleMatchInternalTask {
             SettleMatchInternalTaskState::UpdatingValidityProofs => {
                 self.update_proofs().await?;
                 self.emit_events()?;
-                record_match_volume(&self.match_result, false /* is_external_match */);
+                record_match_volume(
+                    &self.match_result,
+                    false, // is_external_match
+                    Some(self.wallet_id1),
+                    Some(self.wallet_id2),
+                );
 
                 self.task_state = SettleMatchInternalTaskState::Completed;
             },

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -275,8 +275,7 @@ impl Task for SettleMatchInternalTask {
                 record_match_volume(
                     &self.match_result,
                     false, // is_external_match
-                    Some(self.wallet_id1),
-                    Some(self.wallet_id2),
+                    &[self.wallet_id1, self.wallet_id2],
                 );
 
                 self.task_state = SettleMatchInternalTaskState::Completed;


### PR DESCRIPTION
### Purpose
This PR ensures the `match_quote_volume` metric is tagged with associated wallet ids. This enables us to accurately track natural crosses by filtering out matches associated with any of the quoters' wallet ids.

### Testing
- [x] Testing in testnet