### PR TITLE
common: tasks: descriptors: Add tracing context to all tasks

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -22,7 +22,7 @@ pub use update_wallet::*;
 use serde::{Deserialize, Serialize};
 use util::{
     get_current_time_millis,
-    telemetry::propagation::{trace_context, TraceContext},
+    telemetry::propagation::{set_parent_span_from_context, trace_context, TraceContext},
 };
 use uuid::Uuid;
 
@@ -63,6 +63,11 @@ impl QueuedTask {
             created_at: get_current_time_millis(),
             trace_context: trace_context(),
         }
+    }
+
+    /// Set the parent span of the caller to that described in the trace context
+    pub fn set_parent_span(&self) {
+        set_parent_span_from_context(&self.trace_context);
     }
 }
 

--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -20,6 +20,10 @@ pub use update_merkle_proof::*;
 pub use update_wallet::*;
 
 use serde::{Deserialize, Serialize};
+use util::{
+    get_current_time_millis,
+    telemetry::propagation::{trace_context, TraceContext},
+};
 use uuid::Uuid;
 
 use crate::types::wallet::WalletIdentifier;
@@ -44,6 +48,22 @@ pub struct QueuedTask {
     pub descriptor: TaskDescriptor,
     /// The time at which the task was created
     pub created_at: u64,
+    /// The tracing context in which the task was created
+    #[serde(default)]
+    pub trace_context: TraceContext,
+}
+
+impl QueuedTask {
+    /// Create a new queued task
+    pub fn new(descriptor: TaskDescriptor) -> Self {
+        Self {
+            id: TaskIdentifier::new_v4(),
+            state: QueuedTaskState::Queued,
+            descriptor,
+            created_at: get_current_time_millis(),
+            trace_context: trace_context(),
+        }
+    }
 }
 
 /// The state of a queued task
@@ -222,7 +242,7 @@ pub mod mocks {
     use constants::Scalar;
     use k256::ecdsa::SigningKey as K256SigningKey;
     use rand::thread_rng;
-    use util::get_current_time_millis;
+    use util::{get_current_time_millis, telemetry::propagation::TraceContext};
 
     use crate::types::{tasks::TaskIdentifier, wallet::Wallet, wallet_mocks::mock_empty_wallet};
 
@@ -256,6 +276,7 @@ pub mod mocks {
             state: QueuedTaskState::Queued,
             descriptor: mock_task_descriptor(queue_key),
             created_at: get_current_time_millis(),
+            trace_context: TraceContext::new(),
         }
     }
 

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -1,11 +1,9 @@
 //! Setup logic for the node
 
-use common::types::tasks::{
-    NodeStartupTaskDescriptor, QueuedTask, QueuedTaskState, TaskDescriptor, TaskIdentifier,
-};
+use common::types::tasks::{NodeStartupTaskDescriptor, QueuedTask, TaskDescriptor};
 use config::RelayerConfig;
 use job_types::task_driver::{TaskDriverJob, TaskDriverQueue};
-use util::{err_str, get_current_time_millis};
+use util::err_str;
 
 use crate::error::CoordinatorError;
 
@@ -26,16 +24,9 @@ pub async fn node_setup(
     )
     .into();
 
-    let tid = TaskIdentifier::new_v4();
-    let queued_task = QueuedTask {
-        id: tid,
-        state: QueuedTaskState::Preemptive,
-        descriptor: desc,
-        created_at: get_current_time_millis(),
-    };
-
     // Send the task to the task driver
-    let (job, rx) = TaskDriverJob::run_with_notification(queued_task);
+    let task = QueuedTask::new(desc);
+    let (job, rx) = TaskDriverJob::run_with_notification(task);
     task_queue.send(job).map_err(|_| CoordinatorError::setup(ERR_SENDING_STARTUP_TASK))?;
 
     // Await the task driver to complete the task

--- a/gossip-api/src/request_response/mod.rs
+++ b/gossip-api/src/request_response/mod.rs
@@ -3,7 +3,7 @@
 use common::types::hmac::HmacKey;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use util::telemetry::propagation::{trace_context_headers, TraceContextHeaders};
+use util::telemetry::propagation::{trace_context, TraceContext};
 
 use crate::{check_hmac, create_hmac, GossipDestination};
 
@@ -62,7 +62,7 @@ impl AuthenticatedGossipRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GossipRequest {
     /// The tracing context
-    pub tracing_context: Option<TraceContextHeaders>,
+    pub tracing_context: Option<TraceContext>,
     /// The type of the request
     pub body: GossipRequestType,
 }
@@ -70,14 +70,14 @@ pub struct GossipRequest {
 impl GossipRequest {
     /// Construct a new request and add the current tracing information
     pub fn new(body: GossipRequestType) -> Self {
-        let tracing_context = Some(trace_context_headers());
+        let tracing_context = Some(trace_context());
         Self { tracing_context, body }
     }
 
     /// Get the tracing headers
     ///
-    /// Returns an empty `TraceContextHeaders` if no tracing context is present
-    pub fn tracing_headers(&self) -> TraceContextHeaders {
+    /// Returns an empty `TraceContext` if no tracing context is present
+    pub fn tracing_headers(&self) -> TraceContext {
         self.tracing_context.clone().unwrap_or_default()
     }
 }
@@ -203,7 +203,7 @@ impl AuthenticatedGossipResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GossipResponse {
     /// The tracing context
-    pub tracing_context: Option<TraceContextHeaders>,
+    pub tracing_context: Option<TraceContext>,
     /// The type of response
     pub body: GossipResponseType,
 }
@@ -211,14 +211,14 @@ pub struct GossipResponse {
 impl GossipResponse {
     /// Construct a new response and add the current tracing information
     pub fn new(body: GossipResponseType) -> Self {
-        let tracing_context = Some(trace_context_headers());
+        let tracing_context = Some(trace_context());
         Self { tracing_context, body }
     }
 
     /// Get the tracing headers
     ///
-    /// Returns an empty `TraceContextHeaders` if no tracing context is present
-    pub fn tracing_headers(&self) -> TraceContextHeaders {
+    /// Returns an empty `TraceContext` if no tracing context is present
+    pub fn tracing_headers(&self) -> TraceContext {
         self.tracing_context.clone().unwrap_or_default()
     }
 }

--- a/state/src/applicator/task_queue.rs
+++ b/state/src/applicator/task_queue.rs
@@ -254,7 +254,6 @@ impl StateApplicator {
     }
 
     /// Start a task if the current peer is the executor
-    #[instrument(skip_all, err, fields(task_id = %task.id, task = %task.descriptor.display_description()))]
     fn maybe_execute_task<T: TransactionKind>(
         &self,
         task: &QueuedTask,

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -23,8 +23,6 @@ use common::types::{
     MatchingPoolName,
 };
 use notifications::ProposalId;
-#[cfg(not(feature = "mocks"))]
-use replication::network::gossip::GossipNetwork;
 use replication::{NodeId, RaftNode};
 use serde::{Deserialize, Serialize};
 

--- a/util/src/channels/traced_channel.rs
+++ b/util/src/channels/traced_channel.rs
@@ -9,15 +9,13 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
 };
 
-use crate::telemetry::propagation::{
-    set_parent_span_from_headers, trace_context_headers, TraceContextHeaders,
-};
+use crate::telemetry::propagation::{set_parent_span_from_context, trace_context, TraceContext};
 
 /// A traced wrapper type that adds tracing information to the channel message
 /// type
 pub struct TracedMessage<T> {
     /// The tracing context
-    pub tracing_context: TraceContextHeaders,
+    pub trace_context: TraceContext,
     /// The message
     pub message: T,
 }
@@ -31,8 +29,8 @@ impl<T: std::fmt::Debug> std::fmt::Debug for TracedMessage<T> {
 impl<T> TracedMessage<T> {
     /// Create a new traced message
     pub fn new(message: T) -> Self {
-        let tracing_context = trace_context_headers();
-        Self { tracing_context, message }
+        let trace_context = trace_context();
+        Self { trace_context, message }
     }
 
     /// Convert the traced message to the original message
@@ -43,7 +41,7 @@ impl<T> TracedMessage<T> {
     /// Consume the traced message, setting the parent span and returning the
     /// original message
     pub fn consume(self) -> T {
-        set_parent_span_from_headers(&self.tracing_context);
+        set_parent_span_from_context(&self.trace_context);
         self.message
     }
 }

--- a/workers/network-manager/src/executor/behavior.rs
+++ b/workers/network-manager/src/executor/behavior.rs
@@ -14,7 +14,7 @@ use tokio::sync::{
     oneshot,
 };
 use tracing::instrument;
-use util::{err_str, telemetry::propagation::set_parent_span_from_headers};
+use util::{err_str, telemetry::propagation::set_parent_span_from_context};
 
 use crate::{composed_protocol::ComposedNetworkBehavior, error::NetworkManagerError};
 
@@ -72,7 +72,7 @@ impl NetworkManagerExecutor {
     ) -> Result<(), NetworkManagerError> {
         match job {
             BehaviorJob::SendReq(peer_id, req, chan) => {
-                set_parent_span_from_headers(&req.inner.tracing_headers());
+                set_parent_span_from_context(&req.inner.tracing_headers());
 
                 let rid = swarm.behaviour_mut().request_response.send_request(&peer_id, req);
                 if let Some(chan) = chan {
@@ -82,7 +82,7 @@ impl NetworkManagerExecutor {
                 Ok(())
             },
             BehaviorJob::SendResp(channel, resp) => {
-                set_parent_span_from_headers(&resp.inner.tracing_headers());
+                set_parent_span_from_context(&resp.inner.tracing_headers());
 
                 swarm
                     .behaviour_mut()

--- a/workers/network-manager/src/executor/request_response.rs
+++ b/workers/network-manager/src/executor/request_response.rs
@@ -15,7 +15,7 @@ use libp2p::request_response::{Message as RequestResponseMessage, ResponseChanne
 use libp2p::PeerId;
 use tracing::{error, instrument, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use util::{err_str, telemetry::propagation::set_parent_span_from_headers};
+use util::{err_str, telemetry::propagation::set_parent_span_from_context};
 
 use crate::error::NetworkManagerError;
 
@@ -43,7 +43,7 @@ impl NetworkManagerExecutor {
             // Handle inbound request from another peer
             RequestResponseMessage::Request { request, channel, .. } => {
                 // Use the request's span if provided
-                set_parent_span_from_headers(&request.inner.tracing_headers());
+                set_parent_span_from_context(&request.inner.tracing_headers());
 
                 // Authenticate the request
                 let pkey = self.cluster_key;
@@ -76,7 +76,7 @@ impl NetworkManagerExecutor {
             // Handle inbound response
             RequestResponseMessage::Response { request_id, response } => {
                 // Use the response's span if provided
-                set_parent_span_from_headers(&response.inner.tracing_headers());
+                set_parent_span_from_context(&response.inner.tracing_headers());
 
                 // Authenticate the response
                 let pkey = self.cluster_key;
@@ -175,7 +175,7 @@ impl NetworkManagerExecutor {
         req: GossipRequest,
         chan: Option<NetworkResponseChannel>,
     ) -> Result<(), NetworkManagerError> {
-        set_parent_span_from_headers(&req.tracing_headers());
+        set_parent_span_from_context(&req.tracing_headers());
 
         // Authenticate the request
         let key = self.cluster_key;
@@ -195,7 +195,7 @@ impl NetworkManagerExecutor {
         resp: GossipResponse,
         chan: ResponseChannel<AuthenticatedGossipResponse>,
     ) -> Result<(), NetworkManagerError> {
-        set_parent_span_from_headers(&resp.tracing_headers());
+        set_parent_span_from_context(&resp.tracing_headers());
 
         // Authenticate the response
         let key = self.cluster_key;

--- a/workers/task-driver/src/driver.rs
+++ b/workers/task-driver/src/driver.rs
@@ -3,7 +3,10 @@
 
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 
-use common::types::{tasks::TaskDescriptor, tasks::TaskIdentifier, wallet::WalletIdentifier};
+use common::types::{
+    tasks::{QueuedTask, TaskDescriptor, TaskIdentifier},
+    wallet::WalletIdentifier,
+};
 use job_types::task_driver::{TaskDriverJob, TaskDriverReceiver, TaskNotificationSender};
 use state::State;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
@@ -163,7 +166,7 @@ impl TaskExecutor {
         match job.consume() {
             TaskDriverJob::Run { task, channel } => {
                 let affected_wallets = task.descriptor.affected_wallets();
-                self.start_task(task.id, task.descriptor, affected_wallets, channel).await
+                self.start_task(task.id, task, affected_wallets, channel).await
             },
             TaskDriverJob::Notify { task_id, channel } => {
                 self.handle_notification_request(task_id, channel).await
@@ -201,16 +204,18 @@ impl TaskExecutor {
     /// Returns the success of the task
     #[instrument(name = "task", skip_all, err, fields(
         task_id = %id,
-        task = %task.display_description(),
-        wallet_ids = ?task.affected_wallets(),
+        task = %task.descriptor.display_description(),
+        wallet_ids = ?affected_wallets,
     ))]
     async fn start_task(
         &self,
         id: TaskIdentifier,
-        task: TaskDescriptor,
+        task: QueuedTask,
         affected_wallets: Vec<WalletIdentifier>,
         channel: Option<TaskNotificationSender>,
     ) -> Result<(), TaskDriverError> {
+        task.set_parent_span();
+
         // Register the notification if one was requested
         if let Some(c) = channel {
             let mut notifications_locked = self.task_notifications.write().expect("poisoned");
@@ -218,7 +223,7 @@ impl TaskExecutor {
         }
 
         // Construct the task from the descriptor
-        let res = match task {
+        let res = match task.descriptor {
             TaskDescriptor::NewWallet(desc) => {
                 self.start_task_helper::<NewWalletTask>(id, desc, affected_wallets).await
             },


### PR DESCRIPTION
### Purpose
This PR adds tracing context to all tasks so that the task driver handlers may open spans in the parent span that created the task; i.e. we retain the OTel context across consensus boundaries. 

This will give a much clearer picture of the e2e latency for API requests which involve a task (e.g. external matches).

### Testing
- [x] Testing in testnet