### PR TITLE
metrics: tag volume metric with base asset for group by

### DIFF
--- a/renegade-metrics/src/helpers.rs
+++ b/renegade-metrics/src/helpers.rs
@@ -8,9 +8,10 @@ use num_bigint::BigUint;
 use util::hex::biguint_to_hex_addr;
 
 use crate::labels::{
-    wallet_id_tag, ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC, EXTERNAL_MATCH_METRIC_TAG,
-    FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC, MATCH_QUOTE_VOLUME_METRIC,
-    NUM_DEPOSITS_METRICS, NUM_WITHDRAWALS_METRICS, WITHDRAWAL_VOLUME_METRIC,
+    wallet_id_tag, ASSET_METRIC_TAG, BASE_ASSET_METRIC_TAG, DEPOSIT_VOLUME_METRIC,
+    EXTERNAL_MATCH_METRIC_TAG, FEES_COLLECTED_METRIC, MATCH_BASE_VOLUME_METRIC,
+    MATCH_QUOTE_VOLUME_METRIC, NUM_DEPOSITS_METRICS, NUM_WITHDRAWALS_METRICS,
+    WITHDRAWAL_VOLUME_METRIC,
 };
 
 /// Get the human-readable asset and volume of
@@ -88,6 +89,10 @@ pub fn record_match_volume(
     }
 
     record_volume_with_tags(&res.base_mint, res.base_amount, MATCH_BASE_VOLUME_METRIC, &labels);
+
+    // Tag the base asset of the match
+    let (base_asset, _) = get_asset_and_volume(&res.base_mint, res.base_amount);
+    labels.push((BASE_ASSET_METRIC_TAG.to_string(), base_asset));
     record_volume_with_tags(&res.quote_mint, res.quote_amount, MATCH_QUOTE_VOLUME_METRIC, &labels);
 }
 

--- a/renegade-metrics/src/labels.rs
+++ b/renegade-metrics/src/labels.rs
@@ -54,6 +54,8 @@ pub const NUM_EVENT_EXPORT_FAILURES_METRIC: &str = "num_event_export_failures";
 
 /// Metric tag for the asset of a deposit/withdrawal
 pub const ASSET_METRIC_TAG: &str = "asset";
+/// Metric tag for the base asset of a match
+pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";
 /// Metric tag for whether a match is external
 pub const EXTERNAL_MATCH_METRIC_TAG: &str = "is_external_match";
 /// Helper to generate wallet ID tag names


### PR DESCRIPTION
### Purpose
This PR tags match quote volume metric with the `base_asset` so that we can group by base asset in DD.

For example, to add a pie chart widget that displays internally settled quote volume by asset, we need to be able to group `match_quoter_volume` metric by `base_asset`.