### PR TITLE
handshake-manager: matching: Hold prices as fixed point values

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,8 +1,5 @@
 //! Defines common types that many crates can depend on
 
-use circuit_types::fixed_point::FixedPoint;
-use serde::{Deserialize, Serialize};
-
 // --- Internal Types --- //
 #[cfg(feature = "internal-types")]
 pub mod gossip;
@@ -24,12 +21,11 @@ pub mod exchange;
 pub mod hmac;
 #[cfg(feature = "wallet")]
 pub mod merkle;
+pub mod price;
 pub mod token;
 #[cfg(feature = "wallet")]
 pub mod wallet;
 
-use token::Token;
-use util::get_current_time_millis;
 // Re-export the mock types
 #[cfg(feature = "mocks")]
 pub use wallet::mocks as wallet_mocks;
@@ -38,65 +34,11 @@ use tokio::sync::watch::{
     channel as watch_channel, Receiver as WatchReceiver, Sender as WatchSender,
 };
 
-use self::exchange::PriceReport;
-
 /// A type alias for an empty channel used to signal cancellation to workers
 pub type CancelChannel = WatchReceiver<()>;
 /// Create a new cancel channel
 pub fn new_cancel_channel() -> (WatchSender<()>, CancelChannel) {
     watch_channel(())
-}
-
-/// An alias for the price of an asset pair that abstracts away its
-/// representation
-pub type Price = f64;
-
-/// A price along with the time it was sampled
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct TimestampedPrice {
-    /// The price
-    pub price: Price,
-    /// The time the price was sampled, in milliseconds since the epoch
-    pub timestamp: u64,
-}
-
-impl TimestampedPrice {
-    /// Create a new timestamped price
-    pub fn new(price: Price) -> Self {
-        let timestamp = get_current_time_millis();
-        Self { price, timestamp }
-    }
-
-    /// Get the price as a fixed point number
-    pub fn as_fixed_point(&self) -> FixedPoint {
-        FixedPoint::from_f64_round_down(self.price)
-    }
-
-    /// Get the decimal-corrected version of this price for a given token pair
-    pub fn get_decimal_corrected_price(
-        self,
-        base_token: &Token,
-        quote_token: &Token,
-    ) -> Result<TimestampedPrice, String> {
-        let base_decimals = base_token
-            .get_decimals()
-            .ok_or(format!("No decimals for {}", base_token.get_addr()))?;
-        let quote_decimals = quote_token
-            .get_decimals()
-            .ok_or(format!("No decimals for {}", quote_token.get_addr()))?;
-
-        let TimestampedPrice { price: original_price, timestamp } = self;
-        let decimal_diff = quote_decimals as i32 - base_decimals as i32;
-        let corrected_price = original_price * 10f64.powi(decimal_diff);
-
-        Ok(TimestampedPrice { price: corrected_price, timestamp })
-    }
-}
-
-impl From<&PriceReport> for TimestampedPrice {
-    fn from(value: &PriceReport) -> Self {
-        Self { price: value.price, timestamp: value.local_timestamp }
-    }
 }
 
 /// A type alias for matching pool names

--- a/common/src/types/exchange.rs
+++ b/common/src/types/exchange.rs
@@ -7,7 +7,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{token::Token, Price, TimestampedPrice};
+use super::token::Token;
+use crate::types::price::{Price, TimestampedPrice};
 
 /// The identifier of an exchange
 #[allow(clippy::missing_docs_in_private_items, missing_docs)]

--- a/common/src/types/handshake.rs
+++ b/common/src/types/handshake.rs
@@ -5,7 +5,9 @@ use crossbeam::channel::Sender;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::{wallet::OrderIdentifier, TimestampedPrice};
+use crate::types::price::TimestampedPrice;
+
+use super::wallet::OrderIdentifier;
 
 /// The role in an MPC network setup; either Dialer or Listener depending on
 /// which node initiates the connection
@@ -137,7 +139,7 @@ pub mod mocks {
     use rand::thread_rng;
     use uuid::Uuid;
 
-    use crate::types::TimestampedPrice;
+    use crate::types::price::TimestampedPrice;
 
     use super::{ConnectionRole, HandshakeState, State};
 

--- a/common/src/types/price.rs
+++ b/common/src/types/price.rs
@@ -1,0 +1,100 @@
+//! Types for prices and price timestamps
+
+use circuit_types::fixed_point::FixedPoint;
+use serde::{Deserialize, Serialize};
+use util::get_current_time_millis;
+
+use crate::types::{exchange::PriceReport, token::Token};
+
+/// An alias for the price of an asset pair that abstracts away its
+/// representation
+pub type Price = f64;
+
+/// A price along with the time it was sampled
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TimestampedPrice {
+    /// The price
+    pub price: Price,
+    /// The time the price was sampled, in milliseconds since the epoch
+    pub timestamp: u64,
+}
+
+impl TimestampedPrice {
+    /// Create a new timestamped price
+    pub fn new(price: Price) -> Self {
+        let timestamp = get_current_time_millis();
+        Self { price, timestamp }
+    }
+
+    /// Get the price as a fixed point number
+    pub fn as_fixed_point(&self) -> FixedPoint {
+        FixedPoint::from_f64_round_down(self.price)
+    }
+
+    /// Get the decimal-corrected version of this price for a given token pair
+    pub fn get_decimal_corrected_price(
+        self,
+        base_token: &Token,
+        quote_token: &Token,
+    ) -> Result<TimestampedPrice, String> {
+        let base_decimals = base_token
+            .get_decimals()
+            .ok_or(format!("No decimals for {}", base_token.get_addr()))?;
+        let quote_decimals = quote_token
+            .get_decimals()
+            .ok_or(format!("No decimals for {}", quote_token.get_addr()))?;
+
+        let TimestampedPrice { price: original_price, timestamp } = self;
+        let decimal_diff = quote_decimals as i32 - base_decimals as i32;
+        let corrected_price = original_price * 10f64.powi(decimal_diff);
+
+        Ok(TimestampedPrice { price: corrected_price, timestamp })
+    }
+}
+
+impl From<&PriceReport> for TimestampedPrice {
+    fn from(value: &PriceReport) -> Self {
+        Self { price: value.price, timestamp: value.local_timestamp }
+    }
+}
+
+/// A timestamped price that holds the price in fixed point representation
+///
+/// This allows the matching engine to retain exact precision for prices which
+/// were computed in fixed point
+///
+/// We also allow conversion to the more readable `TimestampedPrice` type used
+/// throughout the relayer
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TimestampedPriceFp {
+    /// The price
+    pub price: FixedPoint,
+    /// The time the price was sampled, in milliseconds since the epoch
+    pub timestamp: u64,
+}
+
+impl TimestampedPriceFp {
+    /// Create a new timestamped fixed point price
+    pub fn new(price: FixedPoint) -> Self {
+        let timestamp = get_current_time_millis();
+        Self { price, timestamp }
+    }
+
+    /// Get the underlying price as a fixed point number
+    pub fn price(&self) -> FixedPoint {
+        self.price
+    }
+}
+
+impl From<TimestampedPrice> for TimestampedPriceFp {
+    fn from(ts_price: TimestampedPrice) -> Self {
+        let price_fp = FixedPoint::from_f64_round_down(ts_price.price);
+        Self { price: price_fp, timestamp: ts_price.timestamp }
+    }
+}
+
+impl From<TimestampedPriceFp> for TimestampedPrice {
+    fn from(ts_price: TimestampedPriceFp) -> Self {
+        Self { price: ts_price.price.to_f64(), timestamp: ts_price.timestamp }
+    }
+}

--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     handshake::HandshakeState,
+    price::TimestampedPriceFp,
     proof_bundles::{MatchBundle, OrderValidityProofBundle, OrderValidityWitnessBundle},
     wallet::{OrderIdentifier, WalletIdentifier},
-    TimestampedPrice,
 };
 
 use super::TaskDescriptor;
@@ -19,7 +19,7 @@ use super::TaskDescriptor;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettleMatchInternalTaskDescriptor {
     /// The price at which the match was executed
-    pub execution_price: TimestampedPrice,
+    pub execution_price: TimestampedPriceFp,
     /// The identifier of the first order
     pub order_id1: OrderIdentifier,
     /// The identifier of the second order
@@ -44,7 +44,7 @@ impl SettleMatchInternalTaskDescriptor {
     /// Constructor
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        execution_price: TimestampedPrice,
+        execution_price: TimestampedPriceFp,
         order_id1: OrderIdentifier,
         order_id2: OrderIdentifier,
         wallet_id1: WalletIdentifier,
@@ -88,7 +88,7 @@ pub struct SettleExternalMatchTaskDescriptor {
     /// The ID of the wallet that the local node matched an order from
     pub internal_wallet_id: WalletIdentifier,
     /// The price at which the match was executed
-    pub execution_price: TimestampedPrice,
+    pub execution_price: TimestampedPriceFp,
     /// The match result from the external matching engine
     pub match_res: MatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
@@ -101,7 +101,7 @@ impl SettleExternalMatchTaskDescriptor {
         bundle_duration: Duration,
         internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
-        execution_price: TimestampedPrice,
+        execution_price: TimestampedPriceFp,
         match_res: MatchResult,
         atomic_match_bundle_topic: String,
     ) -> Self {

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -4,7 +4,7 @@ use circuit_types::Amount;
 use serde::{Deserialize, Serialize};
 use util::get_current_time_millis;
 
-use crate::types::TimestampedPrice;
+use crate::types::price::TimestampedPrice;
 
 use super::{Order, OrderIdentifier};
 

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -17,7 +17,7 @@ use circuit_types::{
     r#match::{BoundedMatchResult, ExternalMatchResult},
     Amount,
 };
-use common::types::TimestampedPrice;
+use common::types::price::TimestampedPrice;
 use constants::{Scalar, NATIVE_ASSET_ADDRESS};
 use num_bigint::BigUint;
 use num_traits::Zero;

--- a/external-api/src/http/order_book.rs
+++ b/external-api/src/http/order_book.rs
@@ -1,6 +1,6 @@
 //! Groups API types for order book API operations
 
-use common::types::Price;
+use common::types::price::Price;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{ApiNetworkOrder, DepthSide};

--- a/external-api/src/http/price_report.rs
+++ b/external-api/src/http/price_report.rs
@@ -1,6 +1,6 @@
 //! Groups price reporting API types
 
-use common::types::{exchange::PriceReporterState, token::Token, Price};
+use common::types::{exchange::PriceReporterState, price::Price, token::Token};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
-use common::types::{token::Token, Price};
+use common::types::{price::Price, token::Token};
 use num_bigint::BigUint;
 use serde::{
     de::{self, Error as DeserializeError, SeqAccess, Visitor},

--- a/external-api/src/types/admin.rs
+++ b/external-api/src/types/admin.rs
@@ -2,8 +2,8 @@
 
 use circuit_types::Amount;
 use common::types::{
+    price::Price,
     wallet::{order_metadata::OrderMetadata, WalletIdentifier},
-    Price,
 };
 use serde::{Deserialize, Serialize};
 

--- a/gossip-api/src/request_response/handshake.rs
+++ b/gossip-api/src/request_response/handshake.rs
@@ -1,6 +1,6 @@
 //! Groups API definitions for handshake request response
 use common::types::{
-    gossip::WrappedPeerId, token::Token, wallet::OrderIdentifier, TimestampedPrice,
+    gossip::WrappedPeerId, price::TimestampedPrice, token::Token, wallet::OrderIdentifier,
 };
 use std::collections::HashMap;
 use uuid::Uuid;

--- a/metrics-sampler/src/churn_metrics_sampler.rs
+++ b/metrics-sampler/src/churn_metrics_sampler.rs
@@ -3,8 +3,8 @@
 use std::time::Duration;
 
 use common::types::{
-    exchange::PriceReporterState, network_order::NetworkOrderState, token::Token,
-    wallet::order_metadata::OrderMetadata, Price,
+    exchange::PriceReporterState, network_order::NetworkOrderState, price::Price, token::Token,
+    wallet::order_metadata::OrderMetadata,
 };
 use futures::future::join_all;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -14,7 +14,7 @@ use api_server::worker::{ApiServer, ApiServerConfig};
 use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::{
     default_wrapper::{default_option, DefaultOption},
-    types::Price,
+    types::price::Price,
     worker::{new_worker_failure_channel, Worker},
 };
 use config::RelayerConfig;

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -73,7 +73,7 @@ impl StateApplicator {
 #[cfg(test)]
 mod tests {
     use common::types::{
-        wallet::order_metadata::OrderState, wallet_mocks::mock_order, TimestampedPrice,
+        price::TimestampedPrice, wallet::order_metadata::OrderState, wallet_mocks::mock_order,
     };
     use uuid::Uuid;
 

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -64,7 +64,7 @@ pub mod test {
     use std::cmp::Reverse;
 
     use common::types::{
-        wallet::order_metadata::OrderState, wallet_mocks::mock_order, TimestampedPrice,
+        price::TimestampedPrice, wallet::order_metadata::OrderState, wallet_mocks::mock_order,
     };
     use itertools::Itertools;
     use rand::{seq::IteratorRandom, thread_rng, RngCore};

--- a/state/src/interface/wallet_index.rs
+++ b/state/src/interface/wallet_index.rs
@@ -162,12 +162,12 @@ mod test {
 
     use circuit_types::balance::Balance;
     use common::types::{
+        price::TimestampedPrice,
         wallet::{
             order_metadata::{OrderMetadata, OrderState, PartialOrderFill},
             OrderIdentifier, WalletIdentifier,
         },
         wallet_mocks::{mock_empty_wallet, mock_order},
-        TimestampedPrice,
     };
     use itertools::Itertools;
     use num_bigint::BigUint;

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -140,9 +140,9 @@ mod tests {
     use std::cmp::Reverse;
 
     use common::types::{
+        price::TimestampedPrice,
         wallet::order_metadata::{OrderMetadata, OrderState},
         wallet_mocks::mock_order,
-        TimestampedPrice,
     };
     use itertools::Itertools;
     use rand::{thread_rng, Rng, RngCore};

--- a/workers/api-server/integration/ctx/mod.rs
+++ b/workers/api-server/integration/ctx/mod.rs
@@ -5,7 +5,7 @@
 
 use alloy::primitives::Address;
 use circuit_types::{fixed_point::FixedPoint, Amount};
-use common::types::{hmac::HmacKey, token::Token, TimestampedPrice};
+use common::types::{hmac::HmacKey, price::TimestampedPrice, token::Token};
 use config::RelayerConfig;
 use constants::Scalar;
 use darkpool_client::conversion::address_to_biguint;

--- a/workers/api-server/integration/external_match/min_fill_size.rs
+++ b/workers/api-server/integration/external_match/min_fill_size.rs
@@ -254,7 +254,7 @@ async fn test_min_fill_size__quote_denominated__equal_to_quote_amount(
     };
 
     // Setup an order to match against, then fetch a quote
-    let order = ctx.build_matching_order_with_amount(&external_order, base_amount)?;
+    let order = ctx.build_matching_order_with_amount(&external_order, base_amount + 1)?;
     ctx.setup_wallet_with_order(order).await?;
     let resp = ctx.request_external_quote(&external_order).await?;
 

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -10,10 +10,10 @@ use async_trait::async_trait;
 use circuit_types::{fixed_point::FixedPoint, Amount};
 use common::types::{
     chain::Chain,
+    price::Price,
     tasks::UpdateWalletTaskDescriptor,
     token::{get_all_tokens, Token},
     wallet::{order_metadata::OrderMetadata, Order, WalletIdentifier},
-    Price,
 };
 use config::setup_token_remaps;
 use constants::NATIVE_ASSET_ADDRESS;

--- a/workers/api-server/src/http/external_match/handlers.rs
+++ b/workers/api-server/src/http/external_match/handlers.rs
@@ -11,7 +11,7 @@
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use circuit_types::{fees::FeeTake, r#match::ExternalMatchResult};
-use common::types::{hmac::HmacKey, TimestampedPrice};
+use common::types::{hmac::HmacKey, price::TimestampedPrice};
 use constants::Scalar;
 use external_api::http::external_match::{
     ApiExternalQuote, AssembleExternalMatchRequest, ExternalMatchRequest, ExternalMatchResponse,

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -9,12 +9,12 @@ use alloy::{
 use circuit_types::{fixed_point::FixedPoint, r#match::ExternalMatchResult};
 use common::types::{
     hmac::HmacKey,
+    price::TimestampedPrice,
     proof_bundles::{
         AtomicMatchSettleBundle, MalleableAtomicMatchSettleBundle, OrderValidityProofBundle,
     },
     token::Token,
     wallet::Order,
-    TimestampedPrice,
 };
 use constants::{EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER};
 use darkpool_client::DarkpoolClient;

--- a/workers/handshake-manager/src/manager/matching/match_helpers.rs
+++ b/workers/handshake-manager/src/manager/matching/match_helpers.rs
@@ -3,9 +3,9 @@
 use circuit_types::{balance::Balance, fixed_point::FixedPoint, r#match::MatchResult, Amount};
 use common::types::{
     exchange::PriceReporterState,
+    price::{TimestampedPrice, TimestampedPriceFp},
     token::Token,
     wallet::{Order, OrderIdentifier},
-    TimestampedPrice,
 };
 use util::{err_str, matching_engine::match_orders_with_min_base_amount};
 
@@ -91,7 +91,7 @@ impl HandshakeExecutor {
     pub(crate) async fn get_execution_price_for_order(
         &self,
         order: &OrderIdentifier,
-    ) -> Result<TimestampedPrice, HandshakeManagerError> {
+    ) -> Result<TimestampedPriceFp, HandshakeManagerError> {
         let (base, quote) = self.token_pair_for_order(order).await?;
         self.get_execution_price(&base, &quote).await
     }
@@ -101,7 +101,7 @@ impl HandshakeExecutor {
         &self,
         base: &Token,
         quote: &Token,
-    ) -> Result<TimestampedPrice, HandshakeManagerError> {
+    ) -> Result<TimestampedPriceFp, HandshakeManagerError> {
         let base_addr = base.get_addr().to_string();
         let quote_addr = quote.get_addr().to_string();
         let price_recv = self.request_price(base.clone(), quote.clone())?;
@@ -120,7 +120,6 @@ impl HandshakeExecutor {
         let corrected_price = price
             .get_decimal_corrected_price(base, quote)
             .map_err(err_str!(HandshakeManagerError::NoPriceData))?;
-
-        Ok(corrected_price)
+        Ok(corrected_price.into())
     }
 }

--- a/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/workers/handshake-manager/src/manager/price_agreement.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use common::types::{
     exchange::PriceReporterState,
+    price::TimestampedPrice,
     token::{get_all_tokens, Token},
     wallet::OrderIdentifier,
-    TimestampedPrice,
 };
 use gossip_api::request_response::handshake::PriceVector;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterQueue};

--- a/workers/handshake-manager/src/state.rs
+++ b/workers/handshake-manager/src/state.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use super::error::HandshakeManagerError;
 use common::types::{
     handshake::{ConnectionRole, HandshakeState},
+    price::TimestampedPrice,
     wallet::OrderIdentifier,
-    TimestampedPrice,
 };
 use constants::Scalar;
 use crossbeam::channel::Sender;

--- a/workers/job-types/src/event_manager.rs
+++ b/workers/job-types/src/event_manager.rs
@@ -11,9 +11,10 @@ use circuit_types::{
 };
 use common::types::{
     chain::Chain,
+    price::TimestampedPrice,
     tasks::{HistoricalTask, TaskQueueKey},
     wallet::{Order, OrderIdentifier, WalletIdentifier},
-    MatchingPoolName, TimestampedPrice,
+    MatchingPoolName,
 };
 use renegade_metrics::labels::NUM_EVENT_SEND_FAILURES_METRIC;
 use serde::{Deserialize, Serialize};

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -6,8 +6,8 @@ use ark_mpc::network::QuicTwoPartyNet;
 use circuit_types::{wallet::Nullifier, Amount};
 use common::types::{
     gossip::WrappedPeerId,
+    price::TimestampedPrice,
     wallet::{Order, OrderIdentifier},
-    TimestampedPrice,
 };
 use constants::SystemCurveGroup;
 use external_api::bus_message::gen_atomic_match_response_topic;

--- a/workers/job-types/src/price_reporter.rs
+++ b/workers/job-types/src/price_reporter.rs
@@ -1,5 +1,5 @@
 //! Defines all possible jobs for the PriceReporter.
-use common::types::TimestampedPrice;
+use common::types::price::TimestampedPrice;
 use common::types::{exchange::PriceReporterState, token::Token};
 use tokio::sync::oneshot::{self, Receiver as TokioReceiver, Sender as TokioSender};
 use util::channels::{new_traced_tokio_channel, TracedTokioReceiver, TracedTokioSender};

--- a/workers/price-reporter/src/exchange.rs
+++ b/workers/price-reporter/src/exchange.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use atomic_float::AtomicF64;
-use common::types::{exchange::Exchange, token::Token, Price};
+use common::types::{exchange::Exchange, price::Price, token::Token};
 pub use connection::ExchangeConnection;
 
 use futures_util::Stream;

--- a/workers/price-reporter/src/exchange/binance.rs
+++ b/workers/price-reporter/src/exchange/binance.rs
@@ -8,8 +8,8 @@ use std::{
 use async_trait::async_trait;
 use common::types::{
     exchange::{Exchange, PriceReport},
+    price::Price,
     token::Token,
-    Price,
 };
 use futures_util::{Sink, Stream, StreamExt};
 use serde_json::Value;

--- a/workers/price-reporter/src/exchange/coinbase.rs
+++ b/workers/price-reporter/src/exchange/coinbase.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common::types::{token::Token, Price};
+use common::types::{price::Price, token::Token};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use jsonwebtoken::{encode, Algorithm, EncodingKey as JwtEncodingKey, Header as JwtHeader};
 use reqwest::{

--- a/workers/price-reporter/src/exchange/connection.rs
+++ b/workers/price-reporter/src/exchange/connection.rs
@@ -1,7 +1,7 @@
 //! Defines abstract connection interfaces that can be streamed from
 
 use async_trait::async_trait;
-use common::types::{exchange::Exchange, token::Token, Price};
+use common::types::{exchange::Exchange, price::Price, token::Token};
 use futures::stream::StreamExt;
 use futures_util::{
     stream::{SplitSink, SplitStream},

--- a/workers/price-reporter/src/exchange/kraken.rs
+++ b/workers/price-reporter/src/exchange/kraken.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common::types::{exchange::Exchange, token::Token, Price};
+use common::types::{exchange::Exchange, price::Price, token::Token};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use lazy_static::lazy_static;
 use serde_json::{json, Value};

--- a/workers/price-reporter/src/exchange/okx.rs
+++ b/workers/price-reporter/src/exchange/okx.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common::types::{token::Token, Price};
+use common::types::{price::Price, token::Token};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use serde_json::{json, Value};
 use tracing::error;

--- a/workers/price-reporter/src/exchange/uni_v3.rs
+++ b/workers/price-reporter/src/exchange/uni_v3.rs
@@ -1,7 +1,7 @@
 //! Defines logic for streaming from decentralized exchanges
 
 use async_trait::async_trait;
-use common::types::{token::Token, Price};
+use common::types::{price::Price, token::Token};
 use core::time::Duration;
 use futures::StreamExt;
 use futures_util::Stream;

--- a/workers/price-reporter/src/manager.rs
+++ b/workers/price-reporter/src/manager.rs
@@ -10,8 +10,8 @@ use std::{
 use atomic_float::AtomicF64;
 use common::types::{
     exchange::{Exchange, PriceReport, PriceReporterState},
+    price::Price,
     token::{default_exchange_stable, is_pair_named, Token},
-    Price,
 };
 use external_api::bus_message::{price_report_topic, SystemBusMessage};
 use itertools::Itertools;

--- a/workers/price-reporter/src/manager/external_executor.rs
+++ b/workers/price-reporter/src/manager/external_executor.rs
@@ -11,8 +11,9 @@ use common::{
     default_wrapper::DefaultOption,
     types::{
         exchange::{Exchange, PriceReporterState},
+        price::Price,
         token::Token,
-        CancelChannel, Price,
+        CancelChannel,
     },
 };
 use constants::in_bootstrap_mode;

--- a/workers/price-reporter/src/mock.rs
+++ b/workers/price-reporter/src/mock.rs
@@ -4,10 +4,10 @@ use std::thread;
 
 use common::types::chain::Chain;
 use common::types::exchange::{PriceReport, PriceReporterState};
+use common::types::price::Price;
 use common::types::token::{
     set_default_chain, write_token_remaps, Token, USDC_TICKER, USDT_TICKER, USD_TICKER,
 };
-use common::types::Price;
 use job_types::price_reporter::{PriceReporterJob, PriceReporterReceiver};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::oneshot::Sender as OneshotSender;

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -15,13 +15,13 @@ use circuits::zk_circuits::proof_linking::link_sized_commitments_atomic_match_se
 use circuits::zk_circuits::valid_match_settle_atomic::{
     SizedValidMatchSettleAtomicStatement, SizedValidMatchSettleAtomicWitness,
 };
+use common::types::price::TimestampedPriceFp;
 use common::types::proof_bundles::{
     AtomicMatchSettleBundle, OrderValidityProofBundle, OrderValidityWitnessBundle, ProofBundle,
     ValidMatchSettleAtomicBundle,
 };
 use common::types::tasks::SettleExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
-use common::types::TimestampedPrice;
 use constants::EXTERNAL_MATCH_RELAYER_FEE;
 use darkpool_client::errors::DarkpoolClientError;
 use external_api::bus_message::SystemBusMessage;
@@ -184,7 +184,7 @@ pub struct SettleMatchExternalTask {
     /// The ID of the wallet that the local node matched an order from
     internal_wallet_id: WalletIdentifier,
     /// The price at which the match was executed
-    execution_price: TimestampedPrice,
+    execution_price: TimestampedPriceFp,
     /// The match result from the external matching engine
     match_res: MatchResult,
     /// The duration for which the external match bundle is valid
@@ -429,7 +429,7 @@ impl SettleMatchExternalTask {
             internal_party_receive_balance,
             relayer_fee,
             internal_party_fees,
-            price: self.execution_price.as_fixed_point(),
+            price: self.execution_price.price(),
             internal_party_public_shares,
         };
 

--- a/workers/task-driver/src/utils/order_states.rs
+++ b/workers/task-driver/src/utils/order_states.rs
@@ -2,8 +2,8 @@
 
 use circuit_types::r#match::MatchResult;
 use common::types::{
+    price::TimestampedPrice,
     wallet::{order_metadata::OrderState, OrderIdentifier},
-    TimestampedPrice,
 };
 use state::State;
 


### PR DESCRIPTION
### Purpose
The conversion to and from `f64` sometimes causes prices to violate min fill size constraints when rounding down. To solve this, we hold all prices as `FixedPoint` values throughout matching and only convert to `f64` for display or metrics.

### Testing
- [x] All integration and unit tests pass
- [ ] Testing prover errors in testnet 