### PR TITLE
external-api, handshake-manager: Add matching pool param to external match API

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -17,7 +17,7 @@ use circuit_types::{
     r#match::{BoundedMatchResult, ExternalMatchResult},
     Amount,
 };
-use common::types::price::TimestampedPrice;
+use common::types::{price::TimestampedPrice, MatchingPoolName};
 use constants::{Scalar, NATIVE_ASSET_ADDRESS};
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -96,8 +96,9 @@ pub struct ExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// The matching pool to request a quote from
+    pub matching_pool: Option<MatchingPoolName>,
     /// The receiver address of the match, if not the message sender
-    #[serde(default)]
     pub receiver_address: Option<String>,
     /// The external order
     pub external_order: ExternalOrder,
@@ -120,6 +121,8 @@ pub struct MalleableExternalMatchResponse {
 /// The request type for a quote on an external order
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExternalQuoteRequest {
+    /// The matching pool to request a quote from
+    pub matching_pool: Option<MatchingPoolName>,
     /// The external order
     pub external_order: ExternalOrder,
 }
@@ -144,6 +147,8 @@ pub struct AssembleExternalMatchRequest {
     /// match. If false, the bundle will be exclusively held for some time
     #[serde(default)]
     pub allow_shared: bool,
+    /// The matching pool to request a quote from
+    pub matching_pool: Option<MatchingPoolName>,
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,

--- a/workers/api-server/integration/ctx/external_match.rs
+++ b/workers/api-server/integration/ctx/external_match.rs
@@ -42,6 +42,7 @@ impl IntegrationTestCtx {
             allow_shared: false,
             receiver_address: None,
             updated_order: None,
+            matching_pool: None,
         };
 
         let resp = self.send_admin_req_raw(path, Method::POST, HeaderMap::default(), req).await?;
@@ -57,7 +58,7 @@ impl IntegrationTestCtx {
 
     /// Send an external match request
     pub async fn send_external_quote_req(&self, order: &ExternalOrder) -> Result<Response> {
-        let req = ExternalQuoteRequest { external_order: order.clone() };
+        let req = ExternalQuoteRequest { external_order: order.clone(), matching_pool: None };
 
         // Add admin auth then send the request
         let path = REQUEST_EXTERNAL_QUOTE_ROUTE;

--- a/workers/api-server/integration/external_match/matching_pool.rs
+++ b/workers/api-server/integration/external_match/matching_pool.rs
@@ -1,0 +1,81 @@
+//! Integration tests for external matching in a matching pool
+
+use circuit_types::order::OrderSide;
+use external_api::http::external_match::ExternalOrder;
+use eyre::Result;
+use hyper::StatusCode;
+use state::storage::tx::matching_pools::GLOBAL_MATCHING_POOL;
+use test_helpers::{assert_eq_result, integration_test_async};
+
+use crate::ctx::IntegrationTestCtx;
+
+/// The matching pool to use for testing
+const TEST_POOL: &str = "test-pool";
+
+/// Tests matching against an order in a matching pool when the request
+/// specifies no pool
+#[allow(non_snake_case)]
+async fn test_external_match__matching_pool__no_pool_specified(
+    mut ctx: IntegrationTestCtx,
+) -> Result<()> {
+    ctx.clear_state().await?;
+
+    // Create an order
+    let quote_amount = ctx.quote_token().convert_from_decimal(1000.);
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Buy,
+        quote_amount,
+        min_fill_size: quote_amount,
+        ..Default::default()
+    };
+
+    // Create a counterparty order in a non-global matching pool
+    let wallet = ctx.setup_crossing_wallet(&external_order).await?;
+    let (oid, _) = wallet.orders.first().cloned().unwrap();
+    ctx.move_order_into_pool(oid, TEST_POOL.into()).await?;
+
+    // Request a quote with no pool specified, this should allow all pools, and we
+    // should receive a quote
+    let resp = ctx.request_external_quote(&external_order).await?;
+    let quote = resp.signed_quote.quote;
+    assert_eq_result!(quote.send.mint, ctx.quote_token().get_addr())?;
+    assert_eq_result!(quote.send.amount, quote_amount)
+}
+integration_test_async!(test_external_match__matching_pool__no_pool_specified);
+
+/// Test matching against an order in a matching pool
+#[allow(non_snake_case)]
+async fn test_external_match__matching_pool(mut ctx: IntegrationTestCtx) -> Result<()> {
+    ctx.clear_state().await?;
+
+    // Create an order
+    let quote_amount = ctx.quote_token().convert_from_decimal(1000.);
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Buy,
+        quote_amount,
+        min_fill_size: quote_amount,
+        ..Default::default()
+    };
+
+    // 1. Create a counterparty order and move it into a non-global matching pool
+    let wallet = ctx.setup_crossing_wallet(&external_order).await?;
+    let (oid, _) = wallet.orders.first().cloned().unwrap();
+    ctx.move_order_into_pool(oid, TEST_POOL.into()).await?;
+
+    // 2. Attempt to match against the global pool, no quote should be found
+    let pool = GLOBAL_MATCHING_POOL.to_string();
+    let resp = ctx.send_external_quote_req_in_pool(&external_order, pool).await?;
+    assert_eq_result!(resp.status(), StatusCode::NO_CONTENT)?;
+
+    // 3. Attempt to match against the testing pool, a quote should be found
+    let pool = TEST_POOL.to_string();
+    let resp = ctx.request_external_quote_in_pool(&external_order, pool).await?;
+    let quote = resp.signed_quote.quote;
+    assert_eq_result!(quote.send.mint, ctx.quote_token().get_addr())?;
+    assert_eq_result!(quote.send.amount, quote_amount)
+}
+integration_test_async!(test_external_match__matching_pool);

--- a/workers/api-server/integration/external_match/mod.rs
+++ b/workers/api-server/integration/external_match/mod.rs
@@ -2,4 +2,5 @@
 
 mod basic_match;
 mod exact_amount;
+mod matching_pool;
 mod min_fill_size;

--- a/workers/api-server/src/http/external_match/handlers.rs
+++ b/workers/api-server/src/http/external_match/handlers.rs
@@ -112,7 +112,8 @@ impl TypedHandler for RequestExternalQuoteHandler {
 
         let order = req.external_order;
         order.validate().map_err(bad_request)?;
-        let mut match_res = self.processor.request_external_quote(order.clone()).await?;
+        let mut match_res =
+            self.processor.request_external_quote(order.clone(), req.matching_pool).await?;
 
         if order.trades_native_asset() {
             match_res.base_mint = get_native_asset_address();
@@ -175,6 +176,7 @@ impl TypedHandler for AssembleExternalMatchHandler {
                 req.allow_shared,
                 receiver,
                 price,
+                req.matching_pool,
                 order,
             )
             .await?;
@@ -227,6 +229,7 @@ impl TypedHandler for AssembleMalleableExternalMatchHandler {
                 req.allow_shared,
                 receiver,
                 price,
+                req.matching_pool,
                 order,
             )
             .await?;
@@ -273,8 +276,10 @@ impl TypedHandler for RequestExternalMatchHandler {
         order.validate().map_err(bad_request)?;
 
         let receiver = parse_receiver_address(req.receiver_address)?;
-        let match_bundle =
-            self.processor.request_match_bundle(req.do_gas_estimation, receiver, order).await?;
+        let match_bundle = self
+            .processor
+            .request_match_bundle(req.do_gas_estimation, receiver, req.matching_pool, order)
+            .await?;
         Ok(ExternalMatchResponse { match_bundle })
     }
 }

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -15,6 +15,7 @@ use common::types::{
     },
     token::Token,
     wallet::Order,
+    MatchingPoolName,
 };
 use constants::{EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER};
 use darkpool_client::DarkpoolClient;
@@ -151,8 +152,9 @@ impl ExternalMatchProcessor {
     pub(crate) async fn request_external_quote(
         &self,
         external_order: ExternalOrder,
+        matching_pool: Option<MatchingPoolName>,
     ) -> Result<ExternalMatchResult, ApiServerError> {
-        let opt = ExternalMatchingEngineOptions::only_quote();
+        let opt = ExternalMatchingEngineOptions::only_quote().with_matching_pool(matching_pool);
         let resp = self.request_handshake_manager(external_order, opt).await?;
 
         match resp {
@@ -169,12 +171,14 @@ impl ExternalMatchProcessor {
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
+        matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
-            .with_price(price);
+            .with_price(price)
+            .with_matching_pool(matching_pool);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -200,13 +204,15 @@ impl ExternalMatchProcessor {
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
+        matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
             .with_bounded_match(true)
-            .with_price(price);
+            .with_price(price)
+            .with_matching_pool(matching_pool);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -230,11 +236,13 @@ impl ExternalMatchProcessor {
         &self,
         gas_estimation: bool,
         receiver: Option<Address>,
+        matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_allow_shared(true)
-            .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT);
+            .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
+            .with_matching_pool(matching_pool);
         let resp = self.request_handshake_manager(external_order.clone(), opt).await?;
 
         match resp {

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -8,6 +8,7 @@ use common::types::{
     gossip::WrappedPeerId,
     price::TimestampedPrice,
     wallet::{Order, OrderIdentifier},
+    MatchingPoolName,
 };
 use constants::SystemCurveGroup;
 use external_api::bus_message::gen_atomic_match_response_topic;
@@ -186,6 +187,12 @@ pub struct ExternalMatchingEngineOptions {
     pub exact_quote_amount: Option<Amount>,
     /// The minimum quote amount to use for a full fill
     pub min_quote_amount: Option<Amount>,
+    /// The matching pool to request a quote from
+    ///
+    /// If specified, the matching engine will only consider crossing orders in
+    /// the given pool. If unspecified, all orders are considered candidates for
+    /// a match
+    pub matching_pool: Option<MatchingPoolName>,
 }
 
 impl ExternalMatchingEngineOptions {
@@ -238,6 +245,12 @@ impl ExternalMatchingEngineOptions {
     /// Set the min quote amount
     pub fn with_min_quote_amount(mut self, amount: Amount) -> Self {
         self.min_quote_amount = Some(amount);
+        self
+    }
+
+    /// Set the matching pool
+    pub fn with_matching_pool(mut self, pool: Option<MatchingPoolName>) -> Self {
+        self.matching_pool = pool;
         self
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds a param for the matching pool in all external match requests. If no pool is specified we match against all pools, including the global pool. If a pool is specified we match only against orders in that pool.

I added two integrations tests for:
- No pool specified -> should match against an order allocated in a non-global pool
- Pool specified -> should only match against orders in the given pool

### Testing
- [x] Integration tests pass
- [x] Unit tests pass