### PR TITLE
api-server: network: Report chain correctly in `/v0/network`

### DIFF
--- a/external-api/src/types/api_network_info.rs
+++ b/external-api/src/types/api_network_info.rs
@@ -1,5 +1,5 @@
 //! API types for network info requests
-use common::types::gossip::PeerInfo as IndexedPeerInfo;
+use common::types::{chain::Chain, gossip::PeerInfo as IndexedPeerInfo};
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -13,19 +13,16 @@ pub struct Network {
     pub clusters: Vec<Cluster>,
 }
 
-/// Cast from a map of cluster ID to peer list to the `Cluster` API type
-impl From<HashMap<String, Vec<Peer>>> for Network {
-    fn from(cluster_membership: HashMap<String, Vec<Peer>>) -> Self {
-        let mut clusters = Vec::with_capacity(cluster_membership.len());
-        for (cluster_id, peers) in cluster_membership.into_iter() {
-            clusters.push(Cluster { id: cluster_id, peers });
+impl Network {
+    /// Create a network from a map of cluster ID to peer IDs
+    pub fn from_cluster_peer_map(chain: Chain, clusters: HashMap<String, Vec<Peer>>) -> Self {
+        let mut network_clusters = Vec::with_capacity(clusters.len());
+        for (cluster_id, peers) in clusters.into_iter() {
+            network_clusters.push(Cluster { id: cluster_id, peers });
         }
 
-        Self {
-            // TODO: Make this not a constant
-            id: "goerli".to_string(),
-            clusters,
-        }
+        let id = chain.to_string();
+        Self { id, clusters: network_clusters }
     }
 }
 

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -523,7 +523,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_NETWORK_TOPOLOGY_ROUTE.to_string(),
-            GetNetworkTopologyHandler::new(state.clone()),
+            GetNetworkTopologyHandler::new(config.chain, state.clone()),
         );
 
         // The "/network/clusters/:id" route

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -3,10 +3,11 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use common::types::chain::Chain;
 use external_api::{
     EmptyRequestResponse,
     http::network::{GetClusterInfoResponse, GetNetworkTopologyResponse, GetPeerInfoResponse},
-    types::{Cluster, Peer},
+    types::{Cluster, Network, Peer},
 };
 use hyper::HeaderMap;
 use itertools::Itertools;
@@ -33,14 +34,16 @@ const ERR_PEER_NOT_FOUND: &str = "could not find peer in index";
 /// Handler for the GET "/network" route
 #[derive(Clone)]
 pub struct GetNetworkTopologyHandler {
+    /// The chain to report topology on
+    chain: Chain,
     /// A copy of the relayer-global state
     state: State,
 }
 
 impl GetNetworkTopologyHandler {
     /// Constructor
-    pub fn new(state: State) -> Self {
-        Self { state }
+    pub fn new(chain: Chain, state: State) -> Self {
+        Self { chain, state }
     }
 }
 
@@ -80,7 +83,8 @@ impl TypedHandler for GetNetworkTopologyHandler {
         }
 
         // Reformat into response
-        Ok(GetNetworkTopologyResponse { local_cluster_id, network: peers_by_cluster.into() })
+        let network = Network::from_cluster_peer_map(self.chain, peers_by_cluster);
+        Ok(GetNetworkTopologyResponse { local_cluster_id, network })
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR correctly reports the network ID as the stringified chain in the `/v0/network` handler.

### Testing
- [x] Tested locally