### PR TITLE
state: storage: error: Allow storage layer to reject state transitions

### DIFF
--- a/state/src/applicator/error.rs
+++ b/state/src/applicator/error.rs
@@ -48,6 +48,9 @@ impl Error for StateApplicatorError {}
 
 impl From<StorageError> for StateApplicatorError {
     fn from(value: StorageError) -> Self {
-        Self::Storage(value)
+        match value {
+            StorageError::Rejected(msg) => Self::reject(msg),
+            _ => Self::Storage(value),
+        }
     }
 }

--- a/state/src/applicator/matching_pools.rs
+++ b/state/src/applicator/matching_pools.rs
@@ -2,9 +2,7 @@
 
 use common::types::wallet::OrderIdentifier;
 
-use crate::storage::tx::matching_pools::{
-    MATCHING_POOL_DOES_NOT_EXIST_ERR, MATCHING_POOL_EXISTS_ERR,
-};
+use crate::storage::tx::matching_pools::MATCHING_POOL_DOES_NOT_EXIST_ERR;
 
 use super::{StateApplicator, error::StateApplicatorError, return_type::ApplicatorReturnType};
 
@@ -15,11 +13,6 @@ impl StateApplicator {
         pool_name: &str,
     ) -> Result<ApplicatorReturnType, StateApplicatorError> {
         let tx = self.db().new_write_tx()?;
-
-        if tx.matching_pool_exists(pool_name)? {
-            return Err(StateApplicatorError::reject(MATCHING_POOL_EXISTS_ERR));
-        }
-
         tx.create_matching_pool(pool_name)?;
         tx.commit()?;
 

--- a/state/src/storage/error.rs
+++ b/state/src/storage/error.rs
@@ -17,9 +17,6 @@ pub enum StorageError {
     /// An invalid key was used to access the database
     #[error("invalid key: {0}")]
     InvalidKey(String),
-    /// An invalid storage write was attempted
-    #[error("invalid write: {0}")]
-    InvalidWrite(String),
     /// An entry was not found in the database
     #[error("entry not found: {0}")]
     NotFound(String),
@@ -35,9 +32,12 @@ pub enum StorageError {
     /// relayer is not configured to record historical state.
     #[error("table disabled: {0}")]
     TableDisabled(String),
-    /// An uncategorized error
+    /// An un-categorized error
     #[error("other error: {0}")]
     Other(String),
+    /// The storage layer rejects the operation for validation reasons
+    #[error("Write rejected: {0}")]
+    Rejected(String),
     /// Error serializing a value for storage
     #[error("error serializing value: {0}")]
     Serialization(String),
@@ -50,10 +50,10 @@ pub enum StorageError {
 }
 
 impl StorageError {
-    /// Create a new `InvalidWrite` error
+    /// Create a new `Rejected` error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn invalid_write<T: ToString>(msg: T) -> Self {
-        Self::InvalidWrite(msg.to_string())
+    pub fn reject<T: ToString>(msg: T) -> Self {
+        Self::Rejected(msg.to_string())
     }
 
     /// Create a new `NotFound` error

--- a/state/src/storage/tx/matching_pools.rs
+++ b/state/src/storage/tx/matching_pools.rs
@@ -73,7 +73,7 @@ impl StateTxn<'_, RW> {
     pub fn create_matching_pool(&self, pool_name: &str) -> Result<(), StorageError> {
         // Check that the pool does not already exist
         if self.matching_pool_exists(pool_name)? {
-            return Err(StorageError::Other(MATCHING_POOL_EXISTS_ERR.to_string()));
+            return Err(StorageError::reject(MATCHING_POOL_EXISTS_ERR));
         }
 
         let all_pools_key = all_matching_pools_key();

--- a/state/src/storage/tx/order_history.rs
+++ b/state/src/storage/tx/order_history.rs
@@ -75,7 +75,7 @@ impl StateTxn<'_, RW> {
 
         // Check for a duplicate
         if orders.iter().any(|o| o.id == metadata.id) {
-            return Err(StorageError::Other(ERR_DUPLICATE_ORDER.to_string()));
+            return Err(StorageError::reject(ERR_DUPLICATE_ORDER));
         }
 
         // Push to the front of the list
@@ -92,7 +92,7 @@ impl StateTxn<'_, RW> {
         let mut orders = self.get_order_history(wallet_id)?;
         let index = orders.iter().position(|o| o.id == metadata.id);
         if index.is_none() {
-            return Err(StorageError::Other(ERR_ORDER_NOT_FOUND.to_string()));
+            return Err(StorageError::reject(ERR_ORDER_NOT_FOUND));
         }
 
         orders[index.unwrap()] = metadata;
@@ -108,7 +108,7 @@ impl StateTxn<'_, RW> {
         let mut orders = self.get_order_history(wallet_id)?;
         let index = orders.iter().position(|o| &o.id == order_id);
         if index.is_none() {
-            return Err(StorageError::Other(ERR_ORDER_NOT_FOUND.to_string()));
+            return Err(StorageError::reject(ERR_ORDER_NOT_FOUND));
         }
 
         orders.remove(index.unwrap());


### PR DESCRIPTION
### Purpose
This PR replaces `StorageError::InvalidWrite` with `StorageError::Reject` and converts a storage level rejection into a state applicator rejection. This allows the storage layer to reject a state applicator's state transition directly rather than signalling through a subset of its error types.

### Testing
- [x] All unit tests pass