### PR TITLE
workers: chain-events: update order metadata on settlement

### DIFF
--- a/workers/chain-events/src/lib.rs
+++ b/workers/chain-events/src/lib.rs
@@ -19,4 +19,5 @@
 
 pub mod error;
 pub mod listener;
+pub mod post_settlement;
 pub mod worker;

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -2,6 +2,8 @@
 
 use std::{thread::JoinHandle, time::Duration};
 
+use super::error::OnChainEventListenerError;
+use crate::post_settlement::PostSettlementCtx;
 use alloy::{
     primitives::TxHash,
     providers::{DynProvider, Provider, ProviderBuilder, WsConnect},
@@ -25,12 +27,6 @@ use rand::{Rng, thread_rng};
 use state::State;
 use tracing::{error, info};
 use util::concurrency::runtime::sleep_forever_async;
-// no longer need fee computation helpers here
-
-// Post-settlement helpers
-use crate::post_settlement::PostSettlementCtx;
-
-use super::error::OnChainEventListenerError;
 
 /// The minimum delay in seconds for wallet refresh
 const MIN_NULLIFIER_REFRESH_DELAY_S: u64 = 20; // 20 seconds
@@ -347,7 +343,7 @@ impl OnChainEventListenerExecutor {
         let external_match = !matches.is_empty();
 
         for external_match_result in matches {
-            let ctx = PostSettlementCtx::new(wallet_id, &external_match_result);
+            let ctx = PostSettlementCtx::new(wallet_id, external_match_result.clone());
             // Record metrics for the match
             self.record_metrics(&ctx);
 

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -8,29 +8,27 @@ use alloy::{
     rpc::types::Filter,
     sol_types::SolEvent,
 };
-use circuit_types::{
-    fees::FeeTake, fixed_point::FixedPoint, r#match::ExternalMatchResult, wallet::Nullifier,
-};
+use circuit_types::r#match::ExternalMatchResult;
+use circuit_types::wallet::Nullifier;
 use common::types::{
     CancelChannel,
-    price::TimestampedPrice,
     wallet::{OrderIdentifier, WalletIdentifier},
 };
-use constants::{EXTERNAL_MATCH_RELAYER_FEE, in_bootstrap_mode};
+use constants::in_bootstrap_mode;
 use darkpool_client::{
     DarkpoolClient, DarkpoolImplementation, conversion::u256_to_scalar, traits::DarkpoolImpl,
 };
 use futures_util::StreamExt;
-use job_types::event_manager::{
-    EventManagerQueue, ExternalFillEvent, RelayerEventType, try_send_event,
-};
+use job_types::event_manager::EventManagerQueue;
 use job_types::handshake_manager::{HandshakeManagerJob, HandshakeManagerQueue};
 use rand::{Rng, thread_rng};
 use state::State;
 use tracing::{error, info};
 use util::concurrency::runtime::sleep_forever_async;
-use util::matching_engine::compute_fee_obligation_with_protocol_fee;
-use util::on_chain::get_external_match_fee;
+// no longer need fee computation helpers here
+
+// Post-settlement helpers
+use crate::post_settlement::PostSettlementCtx;
 
 use super::error::OnChainEventListenerError;
 
@@ -106,7 +104,7 @@ pub struct OnChainEventListener {
 #[derive(Clone)]
 pub struct OnChainEventListenerExecutor {
     /// A copy of the config that the executor maintains
-    config: OnChainEventListenerConfig,
+    pub(crate) config: OnChainEventListenerConfig,
 }
 
 impl OnChainEventListenerExecutor {
@@ -121,7 +119,7 @@ impl OnChainEventListenerExecutor {
     }
 
     /// Shorthand for fetching a reference to the global state
-    fn state(&self) -> &State {
+    pub(crate) fn state(&self) -> &State {
         &self.config.global_state
     }
 
@@ -348,16 +346,17 @@ impl OnChainEventListenerExecutor {
         let matches = self.darkpool_client().find_external_matches_in_tx(tx).await?;
         let external_match = !matches.is_empty();
 
-        // Record metrics for each match
         for external_match_result in matches {
-            let match_result = external_match_result.to_match_result();
-            renegade_metrics::record_match_volume(
-                &match_result,
-                true, // is_external_match
-                &[wallet_id],
-            );
-            // Emit relayer event for the fill
-            self.emit_external_fill(wallet_id, external_match_result.clone()).await?;
+            let ctx = PostSettlementCtx::new(wallet_id, &external_match_result);
+            // Record metrics for the match
+            self.record_metrics(&ctx);
+
+            // Update the wallet state
+            let order_id = self.find_internal_order(wallet_id, &external_match_result).await?;
+            self.record_order_fill(order_id, &ctx).await?;
+
+            // Emit the external fill event to the event manager
+            self.emit_event(order_id, &ctx)?;
         }
 
         Ok(external_match)
@@ -367,27 +366,12 @@ impl OnChainEventListenerExecutor {
     // | Helpers |
     // -----------
 
-    /// Emit an `ExternalFillEvent` to the event manager
-    async fn emit_external_fill(
-        &self,
-        wallet_id: WalletIdentifier,
-        ext_match: ExternalMatchResult,
-    ) -> Result<(), OnChainEventListenerError> {
-        let order_id = self.find_internal_order(wallet_id, &ext_match).await?;
-        let exec_price = self.execution_price(&ext_match);
-        let fee_take = self.internal_fee_take(&ext_match);
-
-        let event = RelayerEventType::ExternalFill(ExternalFillEvent::new(
-            wallet_id, order_id, exec_price, ext_match, fee_take,
-        ));
-        try_send_event(event, &self.config.event_queue)
-            .map_err(|e| OnChainEventListenerError::SendMessage(e.to_string()))
-    }
-
     /// Find the internal order in the given wallet that matches the external
     /// match result
     ///
-    /// This will return the first order that matches the external match result
+    /// This will return the first order that matches the external match result.
+    /// While it is possible for multiple orders to match the same external
+    /// match, this is not expected to happen in practice.
     async fn find_internal_order(
         &self,
         wallet_id: WalletIdentifier,
@@ -408,27 +392,5 @@ impl OnChainEventListenerExecutor {
             }
         }
         Err(OnChainEventListenerError::state("matching order not found"))
-    }
-
-    /// Compute the execution price (quote/base) and return as
-    /// `TimestampedPrice`
-    fn execution_price(&self, ext_match: &ExternalMatchResult) -> TimestampedPrice {
-        let base_amt_f64 = ext_match.base_amount as f64;
-        let quote_amt_f64 = ext_match.quote_amount as f64;
-        let price = quote_amt_f64 / base_amt_f64;
-        TimestampedPrice::new(price)
-    }
-
-    /// Compute the internal party's fee take for the external match
-    fn internal_fee_take(&self, ext_match: &ExternalMatchResult) -> FeeTake {
-        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
-        let protocol_fee = get_external_match_fee(&ext_match.base_mint);
-        let side = ext_match.internal_party_side();
-        compute_fee_obligation_with_protocol_fee(
-            relayer_fee,
-            protocol_fee,
-            side,
-            &ext_match.to_match_result(),
-        )
     }
 }

--- a/workers/chain-events/src/post_settlement.rs
+++ b/workers/chain-events/src/post_settlement.rs
@@ -1,0 +1,127 @@
+//! Post-settlement helpers for external match processing
+//!
+//! This module holds a small immutable context struct (`PostSettlementCtx`) and
+//! a set of methods on `OnChainEventListenerExecutor` that apply
+//! post-settlement side-effects.
+
+use crate::error::OnChainEventListenerError;
+use crate::listener::OnChainEventListenerExecutor;
+use circuit_types::{fees::FeeTake, fixed_point::FixedPoint, r#match::ExternalMatchResult};
+use common::types::{
+    price::TimestampedPrice,
+    wallet::{OrderIdentifier, WalletIdentifier, order_metadata::OrderState},
+};
+use constants::EXTERNAL_MATCH_RELAYER_FEE;
+use renegade_metrics;
+use util::{
+    matching_engine::compute_fee_obligation_with_protocol_fee, on_chain::get_external_match_fee,
+};
+
+/// The error message emitted when metadata for an order cannot be found
+const ERR_NO_ORDER_METADATA: &str = "order metadata not found";
+
+/// Bundle of data shared across post-settlement helpers
+pub(crate) struct PostSettlementCtx<'a> {
+    /// Wallet containing the internal order
+    pub wallet_id: WalletIdentifier,
+    /// The full external match result
+    pub external_match_result: &'a ExternalMatchResult,
+    /// Execution price (quote/base)
+    pub price: TimestampedPrice,
+}
+
+impl<'a> PostSettlementCtx<'a> {
+    /// Build a context from the external match
+    pub fn new(
+        wallet_id: WalletIdentifier,
+        external_match_result: &'a ExternalMatchResult,
+    ) -> Self {
+        let price = execution_price(external_match_result);
+        Self { wallet_id, external_match_result, price }
+    }
+}
+
+// ----------------------------
+// | Post-settlement helpers |
+// ----------------------------
+
+impl OnChainEventListenerExecutor {
+    /// Record volume metrics for the match
+    pub(crate) fn record_metrics(&self, ctx: &PostSettlementCtx<'_>) {
+        let match_result = ctx.external_match_result.to_match_result();
+        renegade_metrics::record_match_volume(
+            &match_result,
+            true, // is_external_match
+            &[ctx.wallet_id],
+        );
+    }
+
+    /// Record the internal fill and update the order metadata
+    pub(crate) async fn record_order_fill(
+        &self,
+        order_id: OrderIdentifier,
+        ctx: &PostSettlementCtx<'_>,
+    ) -> Result<(), OnChainEventListenerError> {
+        let match_result = ctx.external_match_result.to_match_result();
+        // Get the order metadata
+        let mut metadata = self
+            .state()
+            .get_order_metadata(&order_id)
+            .await?
+            .ok_or(OnChainEventListenerError::State(ERR_NO_ORDER_METADATA.to_string()))?;
+
+        // Increment filled amount and transition state if the entire order has matched
+        metadata.record_partial_fill(match_result.base_amount, ctx.price);
+        if metadata.data.amount == metadata.total_filled() {
+            metadata.state = OrderState::Filled;
+        }
+
+        self.state().update_order_metadata(metadata).await?;
+        Ok(())
+    }
+
+    /// Emit `ExternalFill` relayer event
+    pub(crate) fn emit_event(
+        &self,
+        order_id: OrderIdentifier,
+        ctx: &PostSettlementCtx<'_>,
+    ) -> Result<(), OnChainEventListenerError> {
+        use job_types::event_manager::{ExternalFillEvent, RelayerEventType, try_send_event};
+
+        let fee_take = internal_fee_take(ctx.external_match_result);
+        let event = RelayerEventType::ExternalFill(ExternalFillEvent::new(
+            ctx.wallet_id,
+            order_id,
+            ctx.price,
+            ctx.external_match_result.clone(),
+            fee_take,
+        ));
+        let queue = &self.config.event_queue;
+        try_send_event(event, queue)
+            .map_err(|e| OnChainEventListenerError::SendMessage(e.to_string()))
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Compute execution price (quote/base)
+fn execution_price(external_match_result: &ExternalMatchResult) -> TimestampedPrice {
+    let base = external_match_result.base_amount as f64;
+    let quote = external_match_result.quote_amount as f64;
+    TimestampedPrice::new(quote / base)
+}
+
+/// Compute internal party fee take
+fn internal_fee_take(external_match_result: &ExternalMatchResult) -> FeeTake {
+    let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
+    let protocol_fee = get_external_match_fee(&external_match_result.base_mint);
+    let side = external_match_result.internal_party_side();
+    compute_fee_obligation_with_protocol_fee(
+        relayer_fee,
+        protocol_fee,
+        side,
+        &external_match_result.to_match_result(),
+    )
+}


### PR DESCRIPTION
### Purpose
This PR ensures the applicator is made aware of fills on external orders using the same code paths for handling fills on internal orders. Currently, we do not record historical state in the relayer, but we do emit `SystemBusMessage::OrderMetadataUpdated` messages that are propagated to clients listening to the order history topic over socket connections.

### Testing
- [x] Tested in testnet that `OrdermetadataUpdated` events are emitted by the relayer and received by clients over socket