### PR TITLE
state, task-driver: use FindingWallet as refresh commit point, remove nullified orders from cache

### DIFF
--- a/state/src/storage/tx/order_book.rs
+++ b/state/src/storage/tx/order_book.rs
@@ -225,16 +225,22 @@ impl StateTxn<'_, RW> {
         Ok(())
     }
 
-    /// Nullify the orders indexed by the given nullifier
-    pub fn nullify_orders(&self, nullifier: Nullifier) -> Result<(), StorageError> {
+    /// Nullify the orders indexed by the given nullifier.
+    /// Returns the IDs of the deleted orders.
+    pub fn nullify_orders(
+        &self,
+        nullifier: Nullifier,
+    ) -> Result<Vec<OrderIdentifier>, StorageError> {
         // Delete all orders
         let orders = self.get_orders_by_nullifier(nullifier)?;
-        for order_id in orders {
-            self.delete_order(&order_id)?;
+        for order_id in &orders {
+            self.delete_order(order_id)?;
         }
 
         // Delete the index for the nullifier
-        self.inner().delete(ORDERS_TABLE, &nullifier_key(nullifier)).map(|_| ())
+        self.inner().delete(ORDERS_TABLE, &nullifier_key(nullifier))?;
+
+        Ok(orders)
     }
 
     /// Update the nullifier sets after a (potential) nullifier change

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -53,7 +53,11 @@ pub enum RefreshWalletTaskState {
 
 impl TaskState for RefreshWalletTaskState {
     fn commit_point() -> Self {
-        RefreshWalletTaskState::CreatingValidityProofs
+        // We use `FindingWallet` as the commit point.
+        // Otherwise, if this task were to be preempted during `FindingWallet`,
+        // it's possible that we'd leave freshly-indexed orders without validity proofs
+        // in the state.
+        RefreshWalletTaskState::FindingWallet
     }
 
     fn completed(&self) -> bool {


### PR DESCRIPTION
This PR makes a couple tweaks to smooth out a potential race condition between wallet refreshes and external matches. Concretely, the race occurs when a refresh task is enqueued and begins executing in the time between an external match request finding a matchable order on the wallet being refreshed, and when the external match task actually preempts the queue.

We make the following changes:
1. We move the commit point of the `RefreshWallet` task to `FindingWallet`, effectively making it non-preemptable. This ensures that even in this race condition, we can't preempt a `RefreshWallet` task during the `FindingWallet` step, before it gets the chance to update validity proofs for the wallet orders. In other tasks which update the wallet & proofs, these actions occur after the commit point, as well.
2. When nullifying a wallet's orders, we remove them from the order cache. This keeps the cache in closer sync with the orders table, from which nullified orders are deleted. If the orders are still present in the new wallet, they will be re-added to the cache when their newly-computed validity proofs are attached. This helps in mitigating a particularly insidious form of the race condition described above, wherein the preempting external match task fails due to not finding the order. This failure causes the preempted refresh task to be cleared from the queue, and as such validity proofs are never computed for the wallet's orders.

### Testing
- [x] All unit tests pass
- [x] Test in testnet w/ large orders requiring multiple fills (ensuring they are re-added to the cache in between nullifications)
- [ ] Test in testnet w/ high load of internal matches 