### PR TITLE
state, common: bound fills array growth if historical state disabled

### DIFF
--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -8,6 +8,9 @@ use crate::types::price::TimestampedPrice;
 
 use super::{Order, OrderIdentifier};
 
+/// The maximum number of recent fills to retain for an order
+const MAX_RECENT_FILLS: usize = 2; // 1 aggregate + 1 most-recent fill kept
+
 /// The state of an order in the wallet
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum OrderState {
@@ -62,6 +65,37 @@ impl OrderMetadata {
     pub fn record_partial_fill(&mut self, amount: Amount, price: TimestampedPrice) {
         let fill = PartialOrderFill::new(amount, price);
         self.fills.push(fill);
+    }
+
+    /// Roll up older fills into a single aggregate fill so that the number of
+    /// retained fill entries never exceeds `MAX_RECENT_FILLS`.
+    ///
+    /// This is a lossy compression that preserves the *total* filled amount
+    /// while bounding per-order storage growth. The newest fill (or newest
+    /// `MAX_RECENT_FILLS - 1` fills) is always preserved verbatim so that
+    /// downstream consumers can detect the latest execution.
+    pub fn roll_up_fills(&mut self) {
+        // Only run if the vector exceeds the cap
+        if self.fills.len() <= MAX_RECENT_FILLS {
+            return;
+        }
+
+        // Keep the newest `MAX_RECENT_FILLS - 1` fills
+        let keep = MAX_RECENT_FILLS - 1;
+        let newest: Vec<_> = self.fills.split_off(self.fills.len() - keep);
+
+        // Aggregate the amounts of all older fills
+        let rolled_amount: Amount = self.fills.iter().map(|f| f.amount).sum();
+
+        // Use the price of the newest fill being aggregated as the representative price
+        // for the aggregate entry. Downstream consumers generally ignore this
+        // price for aggregates, but we must supply *some* value.
+        let representative_price = self.fills.last().unwrap().price;
+        let aggregate_fill = PartialOrderFill::new(rolled_amount, representative_price);
+
+        // Rebuild the fills vector: [aggregate, newest...]
+        self.fills = vec![aggregate_fill];
+        self.fills.extend(newest);
     }
 }
 

--- a/common/src/types/wallet/order_metadata.rs
+++ b/common/src/types/wallet/order_metadata.rs
@@ -94,8 +94,7 @@ impl OrderMetadata {
         let aggregate_fill = PartialOrderFill::new(rolled_amount, representative_price);
 
         // Rebuild the fills vector: [aggregate, newest...]
-        self.fills = vec![aggregate_fill];
-        self.fills.extend(newest);
+        self.fills = iter::once(aggregate_fill).chain(newest).collect();
     }
 }
 

--- a/workers/chain-events/src/post_settlement.rs
+++ b/workers/chain-events/src/post_settlement.rs
@@ -74,6 +74,14 @@ impl OnChainEventListenerExecutor {
             metadata.state = OrderState::Filled;
         }
 
+        // Roll up older fills when historical state recording is disabled to
+        // bound storage growth. We only do this for external matches handled
+        // by this executor.
+        let history_enabled = self.state().historical_state_enabled().await?;
+        if !history_enabled {
+            metadata.roll_up_fills();
+        }
+
         self.state().update_order_metadata(metadata).await?;
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR adds a roll-up helper on OrderMetadata that collapses all but the most recent fill into a single aggregate entry, ensuring that fill arrays are bounded while
- `total_filled()` callsites receive correct data
- newest fill is still delivered to subscribers (frontends and other clients).

This is currently invoked in the external match flow iff historical state is disabled.

### Testing
- [x] Test in testnet