### PR TITLE
external-api: external-match: Add options for configuring relayer fee

### DIFF
--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -2,7 +2,10 @@
 
 use std::time::Duration;
 
-use circuit_types::r#match::{BoundedMatchResult, MatchResult};
+use circuit_types::{
+    fixed_point::FixedPoint,
+    r#match::{BoundedMatchResult, MatchResult},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
@@ -81,7 +84,6 @@ impl From<SettleMatchInternalTaskDescriptor> for TaskDescriptor {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettleExternalMatchTaskDescriptor {
     /// The duration for which the external match bundle is valid
-    #[serde(default)]
     pub bundle_duration: Duration,
     /// The ID of the order that the local node matched
     pub internal_order_id: OrderIdentifier,
@@ -89,6 +91,9 @@ pub struct SettleExternalMatchTaskDescriptor {
     pub internal_wallet_id: WalletIdentifier,
     /// The price at which the match was executed
     pub execution_price: TimestampedPriceFp,
+    /// The fee take rate for the relayer in the match
+    #[serde(default)]
+    pub relayer_fee_rate: FixedPoint,
     /// The match result from the external matching engine
     pub match_res: MatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
@@ -102,6 +107,7 @@ impl SettleExternalMatchTaskDescriptor {
         internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
         execution_price: TimestampedPriceFp,
+        relayer_fee_rate: FixedPoint,
         match_res: MatchResult,
         atomic_match_bundle_topic: String,
     ) -> Self {
@@ -111,6 +117,7 @@ impl SettleExternalMatchTaskDescriptor {
             internal_wallet_id,
             atomic_match_bundle_topic,
             execution_price,
+            relayer_fee_rate,
             match_res,
         }
     }
@@ -132,6 +139,9 @@ pub struct SettleMalleableExternalMatchTaskDescriptor {
     pub internal_order_id: OrderIdentifier,
     /// The ID of the wallet that the local node matched an order from
     pub internal_wallet_id: WalletIdentifier,
+    /// The fee take rate for the relayer in the match
+    #[serde(default)]
+    pub relayer_fee_rate: FixedPoint,
     /// The match result from the external matching engine
     pub match_res: BoundedMatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
@@ -144,6 +154,7 @@ impl SettleMalleableExternalMatchTaskDescriptor {
         bundle_duration: Duration,
         internal_order_id: OrderIdentifier,
         internal_wallet_id: WalletIdentifier,
+        relayer_fee_rate: FixedPoint,
         match_res: BoundedMatchResult,
         atomic_match_bundle_topic: String,
     ) -> Self {
@@ -152,6 +163,7 @@ impl SettleMalleableExternalMatchTaskDescriptor {
             internal_order_id,
             internal_wallet_id,
             atomic_match_bundle_topic,
+            relayer_fee_rate,
             match_res,
         }
     }

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -59,10 +59,8 @@ pub const MERKLE_HEIGHT: usize = 32;
 /// The number of historical roots the contract stores as being valid
 pub const MERKLE_ROOT_HISTORY_LENGTH: usize = 30;
 
-/// The external match fee charged by the relayer
-///
-/// TODO: This is currently zero, remove this and add per-asset fees
-pub const EXTERNAL_MATCH_RELAYER_FEE: f64 = 0.;
+/// The default fee take rate for the relayer in the match
+pub const DEFAULT_EXTERNAL_MATCH_RELAYER_FEE: f64 = 0.0;
 
 // ------------------------------------
 // | System Specific Type Definitions |

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -98,6 +98,9 @@ pub struct ExternalMatchRequest {
     pub do_gas_estimation: bool,
     /// The matching pool to request a quote from
     pub matching_pool: Option<MatchingPoolName>,
+    /// The fee take rate for the relayer in the match
+    #[serde(default)]
+    pub relayer_fee_rate: f64,
     /// The receiver address of the match, if not the message sender
     pub receiver_address: Option<String>,
     /// The external order
@@ -123,6 +126,9 @@ pub struct MalleableExternalMatchResponse {
 pub struct ExternalQuoteRequest {
     /// The matching pool to request a quote from
     pub matching_pool: Option<MatchingPoolName>,
+    /// The fee take rate for the relayer in the match
+    #[serde(default)]
+    pub relayer_fee_rate: f64,
     /// The external order
     pub external_order: ExternalOrder,
 }
@@ -149,6 +155,9 @@ pub struct AssembleExternalMatchRequest {
     pub allow_shared: bool,
     /// The matching pool to request a quote from
     pub matching_pool: Option<MatchingPoolName>,
+    /// The fee take rate for the relayer in the match
+    #[serde(default)]
+    pub relayer_fee_rate: f64,
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,

--- a/workers/api-server/integration/ctx/external_match.rs
+++ b/workers/api-server/integration/ctx/external_match.rs
@@ -60,6 +60,7 @@ impl IntegrationTestCtx {
             allow_shared: false,
             receiver_address: None,
             updated_order: None,
+            relayer_fee_rate: 0.0,
             matching_pool: None,
         };
 
@@ -76,7 +77,11 @@ impl IntegrationTestCtx {
 
     /// Send an external match request
     pub async fn send_external_quote_req(&self, order: &ExternalOrder) -> Result<Response> {
-        let req = ExternalQuoteRequest { external_order: order.clone(), matching_pool: None };
+        let req = ExternalQuoteRequest {
+            external_order: order.clone(),
+            relayer_fee_rate: 0.0,
+            matching_pool: None,
+        };
 
         // Add admin auth then send the request
         let path = REQUEST_EXTERNAL_QUOTE_ROUTE;
@@ -91,6 +96,7 @@ impl IntegrationTestCtx {
     ) -> Result<Response> {
         let req = ExternalQuoteRequest {
             external_order: order.clone(),
+            relayer_fee_rate: 0.0,
             matching_pool: Some(pool.clone()),
         };
 

--- a/workers/api-server/src/http/external_match/handlers.rs
+++ b/workers/api-server/src/http/external_match/handlers.rs
@@ -112,8 +112,10 @@ impl TypedHandler for RequestExternalQuoteHandler {
 
         let order = req.external_order;
         order.validate().map_err(bad_request)?;
-        let mut match_res =
-            self.processor.request_external_quote(order.clone(), req.matching_pool).await?;
+        let mut match_res = self
+            .processor
+            .request_external_quote(order.clone(), req.relayer_fee_rate, req.matching_pool)
+            .await?;
 
         if order.trades_native_asset() {
             match_res.base_mint = get_native_asset_address();
@@ -176,6 +178,7 @@ impl TypedHandler for AssembleExternalMatchHandler {
                 req.allow_shared,
                 receiver,
                 price,
+                req.relayer_fee_rate,
                 req.matching_pool,
                 order,
             )
@@ -229,6 +232,7 @@ impl TypedHandler for AssembleMalleableExternalMatchHandler {
                 req.allow_shared,
                 receiver,
                 price,
+                req.relayer_fee_rate,
                 req.matching_pool,
                 order,
             )
@@ -278,7 +282,13 @@ impl TypedHandler for RequestExternalMatchHandler {
         let receiver = parse_receiver_address(req.receiver_address)?;
         let match_bundle = self
             .processor
-            .request_match_bundle(req.do_gas_estimation, receiver, req.matching_pool, order)
+            .request_match_bundle(
+                req.do_gas_estimation,
+                receiver,
+                req.relayer_fee_rate,
+                req.matching_pool,
+                order,
+            )
             .await?;
         Ok(ExternalMatchResponse { match_bundle })
     }

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -152,9 +152,13 @@ impl ExternalMatchProcessor {
     pub(crate) async fn request_external_quote(
         &self,
         external_order: ExternalOrder,
+        relayer_fee_rate: f64,
         matching_pool: Option<MatchingPoolName>,
     ) -> Result<ExternalMatchResult, ApiServerError> {
-        let opt = ExternalMatchingEngineOptions::only_quote().with_matching_pool(matching_pool);
+        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
+        let opt = ExternalMatchingEngineOptions::only_quote()
+            .with_matching_pool(matching_pool)
+            .with_relayer_fee_rate(relayer_fee);
         let resp = self.request_handshake_manager(external_order, opt).await?;
 
         match resp {
@@ -165,20 +169,24 @@ impl ExternalMatchProcessor {
     }
 
     /// Assemble an external match quote into a settlement bundle
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn assemble_external_match(
         &self,
         gas_estimation: bool,
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
+        relayer_fee_rate: f64,
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
+        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
             .with_price(price)
-            .with_matching_pool(matching_pool);
+            .with_matching_pool(matching_pool)
+            .with_relayer_fee_rate(relayer_fee);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -198,21 +206,25 @@ impl ExternalMatchProcessor {
     }
 
     /// Assemble a malleable external match quote into a settlement bundle
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn assemble_malleable_external_match(
         &self,
         gas_estimation: bool,
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
+        relayer_fee_rate: f64,
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
+        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
             .with_bounded_match(true)
             .with_price(price)
-            .with_matching_pool(matching_pool);
+            .with_matching_pool(matching_pool)
+            .with_relayer_fee_rate(relayer_fee);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -236,13 +248,16 @@ impl ExternalMatchProcessor {
         &self,
         gas_estimation: bool,
         receiver: Option<Address>,
+        relayer_fee_rate: f64,
         matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
+        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_allow_shared(true)
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
-            .with_matching_pool(matching_pool);
+            .with_matching_pool(matching_pool)
+            .with_relayer_fee_rate(relayer_fee);
         let resp = self.request_handshake_manager(external_order.clone(), opt).await?;
 
         match resp {

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -17,7 +17,7 @@ use common::types::{
     token::Token,
     wallet::Order,
 };
-use constants::{EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER};
+use constants::{NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER};
 use darkpool_client::DarkpoolClient;
 use external_api::{
     bus_message::SystemBusMessage,
@@ -338,8 +338,7 @@ impl ExternalMatchProcessor {
         let (base, quote) = self.setup_order_tokens(&mut o)?;
         let price = self.get_external_match_price(base, quote).await?;
 
-        // TODO: Currently we set the relayer fee to zero, remove this
-        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
+        let relayer_fee = options.relayer_fee_rate;
         let order = o.to_internal_order(price, relayer_fee);
 
         // Enforce an exact quote amount if specified

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use common::types::{token::Token, wallet::pair_from_mints};
-use constants::EXTERNAL_MATCH_RELAYER_FEE;
+use constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
 use external_api::{
     EmptyRequestResponse,
     http::order_book::{
@@ -127,7 +127,7 @@ impl TypedHandler for GetExternalMatchFeesHandler {
         query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let asset = parse_mint_from_params(&query_params)?;
-        let relayer_fee = EXTERNAL_MATCH_RELAYER_FEE;
+        let relayer_fee = DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
         let protocol_fee = get_external_match_fee(&asset).to_f64();
         Ok(GetExternalMatchFeeResponse {
             protocol_fee: protocol_fee.to_string(),

--- a/workers/chain-events/src/post_settlement.rs
+++ b/workers/chain-events/src/post_settlement.rs
@@ -11,7 +11,7 @@ use common::types::{
     price::TimestampedPrice,
     wallet::{OrderIdentifier, WalletIdentifier, order_metadata::OrderState},
 };
-use constants::EXTERNAL_MATCH_RELAYER_FEE;
+use constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
 use job_types::event_manager::{ExternalFillEvent, RelayerEventType, try_send_event};
 use renegade_metrics;
 use util::{
@@ -119,7 +119,7 @@ fn execution_price(external_match_result: &ExternalMatchResult) -> TimestampedPr
 
 /// Compute internal party fee take
 fn internal_fee_take(external_match_result: &ExternalMatchResult) -> FeeTake {
-    let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
+    let relayer_fee = FixedPoint::from_f64_round_down(DEFAULT_EXTERNAL_MATCH_RELAYER_FEE);
     let protocol_fee = get_external_match_fee(&external_match_result.base_mint);
     let side = external_match_result.internal_party_side();
     compute_fee_obligation_with_protocol_fee(

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -249,6 +249,7 @@ impl HandshakeExecutor {
             internal_order_id,
             wallet_id,
             ts_price,
+            options.relayer_fee_rate,
             match_res,
             response_topic,
         );
@@ -306,6 +307,7 @@ impl HandshakeExecutor {
             options.bundle_duration,
             order_id,
             wallet_id,
+            options.relayer_fee_rate,
             bounded_res,
             response_topic,
         );

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -234,6 +234,12 @@ impl ExternalMatchingEngineOptions {
         self
     }
 
+    /// Set the relayer fee rate
+    pub fn with_relayer_fee_rate(mut self, rate: FixedPoint) -> Self {
+        self.relayer_fee_rate = rate;
+        self
+    }
+
     /// Set the price
     pub fn with_price(mut self, price: TimestampedPrice) -> Self {
         self.price = Some(price);

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use ark_mpc::network::QuicTwoPartyNet;
-use circuit_types::{Amount, wallet::Nullifier};
+use circuit_types::{Amount, fixed_point::FixedPoint, wallet::Nullifier};
 use common::types::{
     MatchingPoolName,
     gossip::WrappedPeerId,
@@ -177,6 +177,10 @@ pub struct ExternalMatchingEngineOptions {
     /// The duration for which a match bundle is valid; i.e. for which the task
     /// driver should lock the matched wallet's queue
     pub bundle_duration: Duration,
+    /// The fee take rate for the relayer in the match
+    ///
+    /// This only applies to the external party
+    pub relayer_fee_rate: FixedPoint,
     /// The price to use for the external match. If `None`, the price will
     /// be sampled by the engine
     ///


### PR DESCRIPTION
### Purpose
This PR adds options for configuring the relayer fee on an external match. This will be set by the auth server on a per-request basis.

### Todo
- A follow up will add an integration test for setting this value

### Testing
- [x] All unit and integration tests pass