### PR TITLE
api-server: integration: relayer-fee: Add tests for non-zero relayer fee

### DIFF
--- a/workers/api-server/integration/external_match/matching_pool.rs
+++ b/workers/api-server/integration/external_match/matching_pool.rs
@@ -68,7 +68,8 @@ async fn test_external_match__matching_pool(mut ctx: IntegrationTestCtx) -> Resu
 
     // 2. Attempt to match against the global pool, no quote should be found
     let pool = GLOBAL_MATCHING_POOL.to_string();
-    let resp = ctx.send_external_quote_req_in_pool(&external_order, pool).await?;
+    let relayer_fee_rate = 0.0;
+    let resp = ctx.send_external_quote_req_in_pool(&external_order, pool, relayer_fee_rate).await?;
     assert_eq_result!(resp.status(), StatusCode::NO_CONTENT)?;
 
     // 3. Attempt to match against the testing pool, a quote should be found

--- a/workers/api-server/integration/external_match/mod.rs
+++ b/workers/api-server/integration/external_match/mod.rs
@@ -4,3 +4,4 @@ mod basic_match;
 mod exact_amount;
 mod matching_pool;
 mod min_fill_size;
+mod relayer_fee;

--- a/workers/api-server/integration/external_match/relayer_fee.rs
+++ b/workers/api-server/integration/external_match/relayer_fee.rs
@@ -1,0 +1,82 @@
+//! Integration tests setting relayer fee rates
+
+use circuit_types::order::OrderSide;
+use external_api::http::external_match::ExternalOrder;
+use eyre::Result;
+use rand::{Rng, thread_rng};
+use test_helpers::{assert_eq_result, assert_true_result, integration_test_async};
+
+use crate::{ctx::IntegrationTestCtx, helpers::assert_approx_eq};
+
+/// The tolerance in which to assert relayer fee equality
+const RELAYER_FEE_TOLERANCE: f64 = 0.000001;
+
+/// Test requesting an external match with a non-zero relayer fee rate
+#[allow(non_snake_case)]
+async fn test_relayer_fee_rate__non_zero(mut ctx: IntegrationTestCtx) -> Result<()> {
+    // Clear the state
+    ctx.clear_state().await?;
+
+    let mut rng = thread_rng();
+    let relayer_fee_rate: f64 = rng.gen_range(0.0..0.01);
+
+    // Create an external order
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Buy,
+        quote_amount: ctx.quote_token().convert_from_decimal(1000.),
+        ..Default::default()
+    };
+
+    // Setup a matching order
+    ctx.setup_crossing_wallet(&external_order).await?;
+
+    // Request an external quote
+    let resp =
+        ctx.request_external_quote_with_relayer_fee(&external_order, relayer_fee_rate).await?;
+    let quote_receive_amt = resp.signed_quote.receive_amount().amount;
+    let buy_amount = resp.signed_quote.match_result().base_amount;
+
+    // Compute expected fees and verify the fee take
+    let fee_take = resp.signed_quote.fees();
+    let relayer_fee = fee_take.relayer_fee;
+    let total_fee = fee_take.total();
+    let expected_relayer_fee = (buy_amount as f64 * relayer_fee_rate).floor() as u128;
+    assert_approx_eq(relayer_fee, expected_relayer_fee, RELAYER_FEE_TOLERANCE)?;
+    assert_approx_eq(buy_amount - quote_receive_amt, total_fee, RELAYER_FEE_TOLERANCE)?;
+
+    // Assemble the quote into an external match, the fee should be reflected
+    let assemble_resp =
+        ctx.request_assemble_quote_with_relayer_fee(&resp.signed_quote, relayer_fee_rate).await?;
+    let bundle = assemble_resp.match_bundle;
+    let fees = bundle.fees;
+    let expected_relayer_fee = (buy_amount as f64 * relayer_fee_rate).floor() as u128;
+    assert_approx_eq(fees.relayer_fee, expected_relayer_fee, RELAYER_FEE_TOLERANCE)?;
+    assert_eq_result!(bundle.receive.amount, quote_receive_amt)
+}
+integration_test_async!(test_relayer_fee_rate__non_zero);
+
+/// Test requesting an external match with a relayer fee rate that is too high
+#[allow(non_snake_case)]
+async fn test_relayer_fee_rate__too_high(mut ctx: IntegrationTestCtx) -> Result<()> {
+    // Clear the state
+    ctx.clear_state().await?;
+    let relayer_fee_rate = 0.011; // 1.1%
+
+    // Build an order
+    let external_order = ExternalOrder {
+        base_mint: ctx.base_mint(),
+        quote_mint: ctx.quote_mint(),
+        side: OrderSide::Buy,
+        quote_amount: ctx.quote_token().convert_from_decimal(1000.),
+        ..Default::default()
+    };
+
+    // Request an external quote
+    let resp = ctx.request_external_quote_with_relayer_fee(&external_order, relayer_fee_rate).await;
+    assert_true_result!(resp.is_err())?;
+    let err = resp.err().unwrap().to_string();
+    assert_true_result!(err.contains("relayer fee rate must be between 0 and 1%"))
+}
+integration_test_async!(test_relayer_fee_rate__too_high);

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -152,13 +152,12 @@ impl ExternalMatchProcessor {
     pub(crate) async fn request_external_quote(
         &self,
         external_order: ExternalOrder,
-        relayer_fee_rate: f64,
+        relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
     ) -> Result<ExternalMatchResult, ApiServerError> {
-        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::only_quote()
             .with_matching_pool(matching_pool)
-            .with_relayer_fee_rate(relayer_fee);
+            .with_relayer_fee_rate(relayer_fee_rate);
         let resp = self.request_handshake_manager(external_order, opt).await?;
 
         match resp {
@@ -176,17 +175,16 @@ impl ExternalMatchProcessor {
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
-        relayer_fee_rate: f64,
+        relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
-        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
             .with_price(price)
             .with_matching_pool(matching_pool)
-            .with_relayer_fee_rate(relayer_fee);
+            .with_relayer_fee_rate(relayer_fee_rate);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -213,18 +211,17 @@ impl ExternalMatchProcessor {
         allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
-        relayer_fee_rate: f64,
+        relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
-        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_allow_shared(allow_shared)
             .with_bounded_match(true)
             .with_price(price)
             .with_matching_pool(matching_pool)
-            .with_relayer_fee_rate(relayer_fee);
+            .with_relayer_fee_rate(relayer_fee_rate);
         let resp = self.request_handshake_manager(order.clone(), opt).await?;
 
         match resp {
@@ -248,16 +245,15 @@ impl ExternalMatchProcessor {
         &self,
         gas_estimation: bool,
         receiver: Option<Address>,
-        relayer_fee_rate: f64,
+        relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
-        let relayer_fee = FixedPoint::from_f64_round_down(relayer_fee_rate);
         let opt = ExternalMatchingEngineOptions::new()
             .with_allow_shared(true)
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
             .with_matching_pool(matching_pool)
-            .with_relayer_fee_rate(relayer_fee);
+            .with_relayer_fee_rate(relayer_fee_rate);
         let resp = self.request_handshake_manager(external_order.clone(), opt).await?;
 
         match resp {


### PR DESCRIPTION
### Purpose
This PR adds two tests for setting the `relayer_fee_rate` value in the external match API:
1. A test which sets the relayer fee rate to a random value between 0% and 1%.
2. A test which sets the relayer fee rate to an invalid value (> 1%) which the API rejects.

### Testing
- [x] All unit and integration tests pass