### PR TITLE
price-reporter: Support USDT price streaming

### DIFF
--- a/common/src/types/token.rs
+++ b/common/src/types/token.rs
@@ -230,6 +230,16 @@ impl Token {
         self.get_ticker().is_some_and(|ticker| STABLECOIN_TICKERS.contains(&ticker.as_str()))
     }
 
+    /// Returns true if the Token is tradable on Renegade
+    ///
+    /// Only USDC and USD are not tradable on Renegade
+    pub fn is_tradable(&self) -> bool {
+        let usdc = Token::usdc();
+        let usd = Token::from_ticker(USD_TICKER);
+
+        !(self == &usdc || self == &usd)
+    }
+
     /// Returns the set of Exchanges that support this token.
     pub fn supported_exchanges(&self) -> HashSet<Exchange> {
         if !self.is_named() {
@@ -320,7 +330,7 @@ pub fn get_all_tokens() -> Vec<Token> {
 
 /// Get all base tokens in the remap
 pub fn get_all_base_tokens() -> Vec<Token> {
-    get_all_tokens().into_iter().filter(|t| !t.is_stablecoin()).collect()
+    get_all_tokens().into_iter().filter(|t| t.is_tradable()).collect()
 }
 
 /// Returns a read lock quard to the per-chain decimals map

--- a/external-api/src/http/price_report.rs
+++ b/external-api/src/http/price_report.rs
@@ -13,20 +13,11 @@ use crate::{
 // ---------------
 
 /// Price report route
-pub const PRICE_REPORT_ROUTE: &str = "/v0/price_report";
+pub const PRICE_REPORT_ROUTE: &str = "/v0/price_report/:mint";
 /// Returns the supported token list
 pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
 /// Returns the prices for all supported pairs
 pub const GET_TOKEN_PRICES_ROUTE: &str = "/v0/token-prices";
-
-/// A request to get the relayer's price report for a pair
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetPriceReportRequest {
-    /// The base token
-    pub base_token: Token,
-    /// The quote token
-    pub quote_token: Token,
-}
 
 /// A response containing the relayer's price report for a pair
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -7,8 +7,7 @@ use common::types::token::{Token, get_all_base_tokens};
 use external_api::{
     EmptyRequestResponse,
     http::price_report::{
-        GetPriceReportRequest, GetPriceReportResponse, GetSupportedTokensResponse,
-        GetTokenPricesResponse, TokenPrice,
+        GetPriceReportResponse, GetSupportedTokensResponse, GetTokenPricesResponse, TokenPrice,
     },
     types::ApiToken,
 };
@@ -18,6 +17,7 @@ use price_state::PriceStreamStates;
 
 use crate::{
     error::ApiServerError,
+    http::parse_token_from_params,
     router::{QueryParams, TypedHandler, UrlParams},
 };
 
@@ -42,17 +42,19 @@ impl PriceReportHandler {
 
 #[async_trait]
 impl TypedHandler for PriceReportHandler {
-    type Request = GetPriceReportRequest;
+    type Request = EmptyRequestResponse;
     type Response = GetPriceReportResponse;
 
     async fn handle_typed(
         &self,
         _headers: HeaderMap,
-        req: Self::Request,
-        _params: UrlParams,
+        _req: Self::Request,
+        params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let price_report = self.price_streams.get_state(&req.base_token, &req.quote_token);
+        let base = parse_token_from_params(&params)?;
+        let quote = Token::usdc();
+        let price_report = self.price_streams.get_state(&base, &quote);
         Ok(GetPriceReportResponse { price_report })
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds $USDT to the `get_all_base_tokens` return value by filtering on a new `is_tradable` method which returns true for USDT. 

I also reformatted the request format for the `/v0/price_report` endpoint. This endpoint is only used internally, so changing its interface is fine.

### Testing
- [x] Unit tests pass
- [x] Fetched USDT prices from the relayer