### PR TITLE
api-server: external-match: processor: Allow USDT in token validation

### DIFF
--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -377,11 +377,6 @@ impl ExternalMatchProcessor {
             return Err(bad_request(ERR_QUOTE_TOKEN_NOT_USDC));
         }
 
-        // The base token cannot be another stablecoin
-        if base == Token::usdt() {
-            return Err(bad_request(ERR_UNSUPPORTED_PAIR));
-        }
-
         // Check that the base token is in the token configuration -- i.e. if it is
         // named or the native asset
         if !(base.is_named() || base.is_native_asset()) {


### PR DESCRIPTION
### Purpose
This PR allows USDT in external match requests. This represents the changes needed to allow relayer trading on the USDT/USDC pair; internal trading included.

### Testing
- [x] Unit tests pass
- [x] Tested external matches on USDT/USDC
- [x] Tested internal matches on USDT/USDC