### PR TITLE
state: interface: Use blocking DB operations in short txns

### DIFF
--- a/metrics-sampler/src/lib.rs
+++ b/metrics-sampler/src/lib.rs
@@ -29,7 +29,7 @@ pub async fn setup_metrics_samplers(
     price_streams: PriceStreamStates,
 ) -> Result<(), SystemClockError> {
     RaftMetricsSampler::new(state.clone()).register(system_clock).await?;
-    if state.historical_state_enabled().await.map_err(err_str!(SystemClockError))? {
+    if state.historical_state_enabled().map_err(err_str!(SystemClockError))? {
         OnboardingMetricsSampler::new(state.clone()).register(system_clock).await?;
         CancellationMetricsSampler::new(state, price_streams).register(system_clock).await?;
     }

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -427,7 +427,7 @@ impl MockNodeController {
     pub fn with_gossip_server(mut self) -> Self {
         let config = &self.config;
         let state = self.state.clone().expect("State not initialized");
-        let local_peer_id = run_fut(state.get_peer_id()).expect("Failed to get peer id");
+        let local_peer_id = state.get_peer_id().expect("Failed to get peer id");
         let darkpool_client =
             self.darkpool_client.clone().expect("Darkpool client not initialized");
 

--- a/state/src/interface/node_metadata.rs
+++ b/state/src/interface/node_metadata.rs
@@ -18,73 +18,72 @@ impl StateInner {
     // -----------
 
     /// Get the peer ID of the local node
-    pub async fn get_peer_id(&self) -> Result<WrappedPeerId, StateError> {
-        self.with_read_tx(|tx| tx.get_peer_id().map_err(StateError::Db)).await
+    pub fn get_peer_id(&self) -> Result<WrappedPeerId, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_peer_id().map_err(StateError::Db))
     }
 
     /// Get the cluster ID of the local node
-    pub async fn get_cluster_id(&self) -> Result<ClusterId, StateError> {
-        self.with_read_tx(|tx| tx.get_cluster_id().map_err(StateError::Db)).await
+    pub fn get_cluster_id(&self) -> Result<ClusterId, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_cluster_id().map_err(StateError::Db))
     }
 
     /// Get the libp2p keypair of the local node
-    pub async fn get_node_keypair(&self) -> Result<Keypair, StateError> {
-        self.with_read_tx(|tx| tx.get_node_keypair().map_err(StateError::Db)).await
+    pub fn get_node_keypair(&self) -> Result<Keypair, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_node_keypair().map_err(StateError::Db))
     }
 
     /// Get the wallet ID that the local relayer owns
-    pub async fn get_relayer_wallet_id(&self) -> Result<Option<WalletIdentifier>, StateError> {
-        self.with_read_tx(|tx| tx.get_local_node_wallet().map_err(StateError::Db)).await
+    pub fn get_relayer_wallet_id(&self) -> Result<Option<WalletIdentifier>, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_local_node_wallet().map_err(StateError::Db))
     }
 
     /// Get the wallet owned by the local relayer
-    pub async fn get_local_relayer_wallet(&self) -> Result<Option<Wallet>, StateError> {
-        self.with_read_tx(|tx| {
+    pub fn get_local_relayer_wallet(&self) -> Result<Option<Wallet>, StateError> {
+        self.with_blocking_read_tx(|tx| {
             let wallet_id = res_some!(tx.get_local_node_wallet()?);
             let wallet = res_some!(tx.get_wallet(&wallet_id)?);
             Ok(Some(wallet))
         })
-        .await
     }
 
     /// Get the decryption key used to settle managed match fees
-    pub async fn get_fee_key(&self) -> Result<RelayerFeeKey, StateError> {
-        self.with_read_tx(|tx| tx.get_fee_key().map_err(StateError::Db)).await
+    pub fn get_fee_key(&self) -> Result<RelayerFeeKey, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_fee_key().map_err(StateError::Db))
     }
 
     /// Get the local relayer's match take rate
-    pub async fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
-        self.with_read_tx(|tx| tx.get_relayer_take_rate().map_err(StateError::Db)).await
+    pub fn get_relayer_take_rate(&self) -> Result<FixedPoint, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_relayer_take_rate().map_err(StateError::Db))
     }
 
     /// Whether atomic matches are supported
-    pub async fn get_atomic_matches_enabled(&self) -> Result<bool, StateError> {
-        let maybe_addr = self.get_external_fee_addr().await?;
+    pub fn get_atomic_matches_enabled(&self) -> Result<bool, StateError> {
+        let maybe_addr = self.get_external_fee_addr()?;
         Ok(maybe_addr.is_some())
     }
 
     /// Get the local relayer's external fee address
-    pub async fn get_external_fee_addr(&self) -> Result<Option<Address>, StateError> {
-        self.with_read_tx(|tx| tx.get_external_fee_addr().map_err(StateError::Db)).await
+    pub fn get_external_fee_addr(&self) -> Result<Option<Address>, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_external_fee_addr().map_err(StateError::Db))
     }
 
     /// Get the relayer fee for a given wallet
-    pub async fn get_relayer_fee_for_wallet(
+    pub fn get_relayer_fee_for_wallet(
         &self,
         wallet_id: &WalletIdentifier,
     ) -> Result<FixedPoint, StateError> {
         let wid = *wallet_id;
-        self.with_read_tx(move |tx| tx.get_relayer_fee(&wid).map_err(StateError::Db)).await
+        self.with_blocking_read_tx(move |tx| tx.get_relayer_fee(&wid).map_err(StateError::Db))
     }
 
     /// Get the local relayer's auto-redeem fees flag
-    pub async fn get_auto_redeem_fees(&self) -> Result<bool, StateError> {
-        self.with_read_tx(|tx| tx.get_auto_redeem_fees().map_err(StateError::Db)).await
+    pub fn get_auto_redeem_fees(&self) -> Result<bool, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_auto_redeem_fees().map_err(StateError::Db))
     }
 
     /// Get the local relayer's historical state enabled flag
-    pub async fn historical_state_enabled(&self) -> Result<bool, StateError> {
-        self.with_read_tx(|tx| tx.get_historical_state_enabled().map_err(StateError::Db)).await
+    pub fn historical_state_enabled(&self) -> Result<bool, StateError> {
+        self.with_blocking_read_tx(|tx| tx.get_historical_state_enabled().map_err(StateError::Db))
     }
 
     // -----------
@@ -190,13 +189,13 @@ mod test {
         let state = mock_state_with_config(&config).await;
 
         // Check the metadata fields
-        let peer_id = state.get_peer_id().await.unwrap();
+        let peer_id = state.get_peer_id().unwrap();
         assert_eq!(peer_id.0, config.p2p_key.public().to_peer_id());
 
-        let cluster_id = state.get_cluster_id().await.unwrap();
+        let cluster_id = state.get_cluster_id().unwrap();
         assert_eq!(cluster_id, config.cluster_id);
 
-        let keypair = state.get_node_keypair().await.unwrap();
+        let keypair = state.get_node_keypair().unwrap();
         // Compare bytes
         assert_eq!(
             keypair.to_protobuf_encoding().unwrap(),

--- a/state/src/interface/task_queue.rs
+++ b/state/src/interface/task_queue.rs
@@ -147,7 +147,7 @@ impl StateInner {
         backfill_trace_field("task_id", tid.to_string());
 
         // Propose the task to the task queue
-        let executor = self.get_peer_id().await?;
+        let executor = self.get_peer_id()?;
         let proposal = StateTransition::AppendTask { task, executor };
         let waiter = self.send_proposal(proposal).await?;
         Ok((tid, waiter))
@@ -203,7 +203,7 @@ impl StateInner {
         backfill_trace_field("task_id", tid.to_string());
 
         // Propose the task to the task queue, with the local peer as the executor
-        let executor = self.get_peer_id().await?;
+        let executor = self.get_peer_id()?;
         let transition = StateTransition::EnqueuePreemptiveTask { keys, task, executor, serial };
         let waiter = self.send_proposal(transition).await?;
         Ok((tid, waiter))
@@ -214,7 +214,7 @@ impl StateInner {
         &self,
         failed_peer: &WrappedPeerId,
     ) -> Result<ProposalWaiter, StateError> {
-        let local_peer = self.get_peer_id().await?;
+        let local_peer = self.get_peer_id()?;
         let proposal = StateTransition::ReassignTasks { from: *failed_peer, to: local_peer };
         self.send_proposal(proposal).await
     }

--- a/state/src/tui.rs
+++ b/state/src/tui.rs
@@ -316,8 +316,8 @@ impl StateTuiApp {
     /// Create a metadata pane
     fn create_metadata_pane(&self) -> List {
         // Fetch the relevant state
-        let peer_id = block_current(self.global_state.get_peer_id()).unwrap();
-        let cluster_id = block_current(self.global_state.get_cluster_id()).unwrap();
+        let peer_id = self.global_state.get_peer_id().unwrap();
+        let cluster_id = self.global_state.get_cluster_id().unwrap();
         let local_addr = block_current(self.global_state.get_peer_info(&peer_id))
             .unwrap()
             .unwrap_or_default()
@@ -380,7 +380,7 @@ impl StateTuiApp {
     /// Create a cluster metadata pane    
     fn create_cluster_metadata_pane(&self) -> List {
         // Read the relevant state
-        let cluster_id = block_current(self.global_state.get_cluster_id()).unwrap();
+        let cluster_id = self.global_state.get_cluster_id().unwrap();
         let cluster_peers =
             block_current(self.global_state.get_cluster_peers(&cluster_id)).unwrap();
 
@@ -404,7 +404,7 @@ impl StateTuiApp {
     /// Create a peer index pane    
     fn create_peer_index_pane(&self) -> Table {
         // Read the necessary state
-        let local_peer_id = block_current(self.global_state.get_peer_id()).unwrap();
+        let local_peer_id = self.global_state.get_peer_id().unwrap();
         let peer_info = block_current(self.global_state.get_peer_info_map()).unwrap();
 
         // Sort the keys so that the table does not re-arrange every frame

--- a/workers/api-server/benches/api-server-bench-util/src/lib.rs
+++ b/workers/api-server/benches/api-server-bench-util/src/lib.rs
@@ -194,7 +194,7 @@ fn setup_node_controller() -> (RelayerConfig, MockNodeController) {
 /// Setup the state for the mock node
 async fn setup_state(mock_node: &MockNodeController) -> Result<()> {
     let state = mock_node.state();
-    let this_peer = state.get_peer_id().await?;
+    let this_peer = state.get_peer_id()?;
     state.initialize_raft(vec![this_peer] /* this_peer */).await?;
     Ok(())
 }

--- a/workers/api-server/integration/ctx/node_state.rs
+++ b/workers/api-server/integration/ctx/node_state.rs
@@ -27,7 +27,7 @@ impl IntegrationTestCtx {
     /// Setup the state of the mock node
     pub async fn setup_state(&mut self) -> Result<()> {
         let state = self.state();
-        let this_peer = state.get_peer_id().await?;
+        let this_peer = state.get_peer_id()?;
         state.initialize_raft(vec![this_peer] /* this_peer */).await?;
         Ok(())
     }

--- a/workers/api-server/src/http/external_match/handlers.rs
+++ b/workers/api-server/src/http/external_match/handlers.rs
@@ -130,7 +130,7 @@ impl TypedHandler for RequestExternalQuoteHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Check that atomic matches are enabled
-        let enabled = self.state.get_atomic_matches_enabled().await?;
+        let enabled = self.state.get_atomic_matches_enabled()?;
         if !enabled {
             return Err(bad_request(ERR_ATOMIC_MATCHES_DISABLED));
         }
@@ -183,7 +183,7 @@ impl TypedHandler for AssembleExternalMatchHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Check that atomic matches are enabled
-        let enabled = self.state.get_atomic_matches_enabled().await?;
+        let enabled = self.state.get_atomic_matches_enabled()?;
         if !enabled {
             return Err(bad_request(ERR_ATOMIC_MATCHES_DISABLED));
         }
@@ -308,7 +308,7 @@ impl TypedHandler for RequestExternalMatchHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Check that atomic matches are enabled
-        let enabled = self.state.get_atomic_matches_enabled().await?;
+        let enabled = self.state.get_atomic_matches_enabled()?;
         if !enabled {
             return Err(bad_request(ERR_ATOMIC_MATCHES_DISABLED));
         }

--- a/workers/api-server/src/http/network.rs
+++ b/workers/api-server/src/http/network.rs
@@ -60,7 +60,7 @@ impl TypedHandler for GetNetworkTopologyHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Fetch all peer info
-        let local_cluster_id = self.state.get_cluster_id().await?.to_string();
+        let local_cluster_id = self.state.get_cluster_id()?.to_string();
         let peers = self.state.get_peer_info_map().await?;
 
         // Gather by cluster

--- a/workers/api-server/src/http/task.rs
+++ b/workers/api-server/src/http/task.rs
@@ -176,7 +176,7 @@ impl TypedHandler for GetTaskHistoryHandler {
         params: UrlParams,
         mut query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        if !self.state.historical_state_enabled().await? {
+        if !self.state.historical_state_enabled()? {
             return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
         }
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -265,8 +265,8 @@ impl TypedHandler for CreateWalletHandler {
         }
 
         // Overwrite the managing cluster and the match fee with the configured values
-        let relayer_key = self.state.get_fee_key().await?.public_key();
-        let relayer_take_rate = self.state.get_relayer_fee_for_wallet(&wallet_id).await?;
+        let relayer_key = self.state.get_fee_key()?.public_key();
+        let relayer_take_rate = self.state.get_relayer_fee_for_wallet(&wallet_id)?;
         req.wallet.managing_cluster = jubjub_to_hex_string(&relayer_key);
         req.wallet.match_fee = relayer_take_rate;
 
@@ -1062,7 +1062,7 @@ impl TypedHandler for GetOrderHistoryHandler {
         params: UrlParams,
         mut query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        if !self.state.historical_state_enabled().await? {
+        if !self.state.historical_state_enabled()? {
             return Err(bad_request(ERR_HISTORICAL_STATE_DISABLED));
         }
 

--- a/workers/chain-events/src/listener.rs
+++ b/workers/chain-events/src/listener.rs
@@ -293,8 +293,8 @@ impl OnChainEventListenerExecutor {
     ) -> Result<bool, OnChainEventListenerError> {
         // Fetch cluster state
         let state = self.state();
-        let my_id = state.get_peer_id().await?;
-        let cluster_id = state.get_cluster_id().await?;
+        let my_id = state.get_peer_id()?;
+        let cluster_id = state.get_cluster_id()?;
         let mut peers = state.get_cluster_peers(&cluster_id).await?;
         peers.sort();
 

--- a/workers/chain-events/src/post_settlement.rs
+++ b/workers/chain-events/src/post_settlement.rs
@@ -77,7 +77,7 @@ impl OnChainEventListenerExecutor {
         // Roll up older fills when historical state recording is disabled to
         // bound storage growth. We only do this for external matches handled
         // by this executor.
-        let history_enabled = self.state().historical_state_enabled().await?;
+        let history_enabled = self.state().historical_state_enabled()?;
         if !history_enabled {
             metadata.roll_up_fills();
         }

--- a/workers/gossip-server/src/orderbook.rs
+++ b/workers/gossip-server/src/orderbook.rs
@@ -60,7 +60,7 @@ impl GossipProtocolExecutor {
 
             // Skip local orders, their state is added on wallet update through raft
             // consensus
-            let is_local = order.cluster == self.state.get_cluster_id().await?;
+            let is_local = order.cluster == self.state.get_cluster_id()?;
             if is_local {
                 debug!("skipping local order {order_id}");
                 continue;
@@ -122,7 +122,7 @@ impl GossipProtocolExecutor {
         cluster: ClusterId,
     ) -> Result<(), GossipError> {
         // Skip local orders, their state is added on wallet update through raft
-        let is_local = cluster == self.state.get_cluster_id().await?;
+        let is_local = cluster == self.state.get_cluster_id()?;
         if is_local {
             return Ok(());
         }
@@ -144,7 +144,7 @@ impl GossipProtocolExecutor {
         proof_bundle: OrderValidityProofBundle,
     ) -> Result<(), GossipError> {
         // Skip local orders, their state is added on wallet update through raft
-        let is_local = cluster == self.state.get_cluster_id().await?;
+        let is_local = cluster == self.state.get_cluster_id()?;
         if is_local {
             return Ok(());
         }

--- a/workers/gossip-server/src/peer_discovery/heartbeat.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat.rs
@@ -84,7 +84,7 @@ impl GossipProtocolExecutor {
         if self.expiry_buffer.is_expiry_candidate(peer).await {
             self.expiry_buffer.remove_expiry_candidate(*peer).await;
             if let Some(peer_info) = self.state.get_peer_info(peer).await? {
-                self.send_expiry_rejection(*peer, peer_info.last_heartbeat).await?;
+                self.send_expiry_rejection(*peer, peer_info.last_heartbeat)?;
             }
         }
 
@@ -166,12 +166,12 @@ impl GossipProtocolExecutor {
         };
 
         // Check whether the expiry window has elapsed
-        if !self.should_expire_peer(&peer_info).await? {
+        if !self.should_expire_peer(&peer_info)? {
             return Ok(());
         }
 
         // If the node is outside the cluster expire it immediately
-        let cluster_id = self.state.get_cluster_id().await?;
+        let cluster_id = self.state.get_cluster_id()?;
         let same_cluster = peer_info.get_cluster_id() == cluster_id;
         if !same_cluster {
             return self.expire_peer(peer_id).await;
@@ -192,9 +192,9 @@ impl GossipProtocolExecutor {
     }
 
     /// Check whether the expiry window for a peer has elapsed
-    async fn should_expire_peer(&self, peer_info: &PeerInfo) -> Result<bool, GossipError> {
+    fn should_expire_peer(&self, peer_info: &PeerInfo) -> Result<bool, GossipError> {
         // Expire cluster peers sooner than non-cluster peers
-        let cluster_id = self.state.get_cluster_id().await?;
+        let cluster_id = self.state.get_cluster_id()?;
         let same_cluster = peer_info.get_cluster_id() == cluster_id;
 
         let now = get_current_time_millis();

--- a/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
+++ b/workers/gossip-server/src/peer_discovery/heartbeat_timer.rs
@@ -78,8 +78,8 @@ impl HeartbeatTimer {
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("failed to build tokio runtime");
-        let local_peer_id = rt.block_on(global_state.get_peer_id())?;
-        let cluster_id = rt.block_on(global_state.get_cluster_id())?;
+        let local_peer_id = global_state.get_peer_id()?;
+        let cluster_id = global_state.get_cluster_id()?;
 
         loop {
             // Get all peers in the local peer's cluster

--- a/workers/gossip-server/src/peer_discovery/peer_metrics.rs
+++ b/workers/gossip-server/src/peer_discovery/peer_metrics.rs
@@ -6,7 +6,7 @@ use tracing::error;
 
 /// Get the number of local and remote peers the cluster is connected to
 async fn get_num_peers(state: &State) -> Result<(usize, usize), StateError> {
-    let cluster_id = state.get_cluster_id().await?;
+    let cluster_id = state.get_cluster_id()?;
     let num_local_peers = state.get_cluster_peers(&cluster_id).await?.len();
     let num_remote_peers = state.get_non_cluster_peers(&cluster_id).await?.len();
 

--- a/workers/gossip-server/src/peer_discovery/peers.rs
+++ b/workers/gossip-server/src/peer_discovery/peers.rs
@@ -81,7 +81,7 @@ impl GossipProtocolExecutor {
                 "rejecting expiry of {peer_id} from {sender}, last heartbeat was {time_since_last_heartbeat}ms ago"
             );
 
-            self.send_expiry_rejection(peer_id, info.last_heartbeat).await?;
+            self.send_expiry_rejection(peer_id, info.last_heartbeat)?;
         } else {
             // If we do not reject the expiry, begin expiring on the local node
             info!("received expiry request, marking {peer_id} as expiry candidate");
@@ -190,12 +190,12 @@ impl GossipProtocolExecutor {
     }
 
     /// Send a rejection for a proposed expiry
-    pub(crate) async fn send_expiry_rejection(
+    pub(crate) fn send_expiry_rejection(
         &self,
         peer_id: WrappedPeerId,
         last_heartbeat: u64,
     ) -> Result<(), GossipError> {
-        let cluster_id = self.state.get_cluster_id().await?;
+        let cluster_id = self.state.get_cluster_id()?;
         let topic = cluster_id.get_management_topic();
         let message_type = ClusterManagementMessageType::RejectExpiry { peer_id, last_heartbeat };
 

--- a/workers/handshake-manager/src/manager.rs
+++ b/workers/handshake-manager/src/manager.rs
@@ -416,7 +416,7 @@ impl HandshakeExecutor {
 
         // Update the state of the handshake in the completed state
         self.handshake_state_index.completed(&request_id).await;
-        self.publish_completion_messages(state.local_order_id, state.peer_order_id).await?;
+        self.publish_completion_messages(state.local_order_id, state.peer_order_id)?;
 
         // Record the volume of the match
         record_match_volume(
@@ -429,7 +429,7 @@ impl HandshakeExecutor {
 
     /// Publish a cache sync message to the cluster and a local event indicating
     /// that a handshake has completed
-    async fn publish_completion_messages(
+    fn publish_completion_messages(
         &self,
         local_order_id: OrderIdentifier,
         peer_order_id: OrderIdentifier,
@@ -437,7 +437,7 @@ impl HandshakeExecutor {
         // Send a message to cluster peers indicating that the local peer has completed
         // a match. Cluster peers should cache the matched order pair as
         // completed and not initiate matches on this pair going forward
-        let cluster_id = self.state.get_cluster_id().await.unwrap();
+        let cluster_id = self.state.get_cluster_id().unwrap();
         let topic = cluster_id.get_management_topic();
         let message = PubsubMessage::Cluster(ClusterManagementMessage {
             cluster_id,

--- a/workers/network-manager/src/worker.rs
+++ b/workers/network-manager/src/worker.rs
@@ -151,8 +151,8 @@ impl Worker for NetworkManager {
     type Error = NetworkManagerError;
 
     async fn new(config: Self::WorkerConfig) -> Result<Self, Self::Error> {
-        let local_peer_id = config.global_state.get_peer_id().await?;
-        let local_keypair = config.global_state.get_node_keypair().await?;
+        let local_peer_id = config.global_state.get_peer_id()?;
+        let local_keypair = config.global_state.get_node_keypair()?;
 
         // If the local node is given a known dialable addr for itself at startup,
         // construct the local addr directly, otherwise set it to the canonical

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -337,7 +337,7 @@ impl NodeStartupTask {
     /// Initialize a new raft cluster
     async fn initialize_raft(&mut self) -> Result<(), NodeStartupTaskError> {
         // Get the list of other peers in the cluster
-        let my_cluster = self.state.get_cluster_id().await?;
+        let my_cluster = self.state.get_cluster_id()?;
         let peers = self.state.get_cluster_peers(&my_cluster).await?;
 
         info!("initializing raft with {} peers", peers.len());
@@ -350,7 +350,7 @@ impl NodeStartupTask {
         let leader = self.state.get_leader().unwrap();
         info!("leader elected: {}", leader);
 
-        let my_peer_id = self.state.get_peer_id().await?;
+        let my_peer_id = self.state.get_peer_id()?;
         if leader != my_peer_id {
             info!("elected leader is a cluster peer");
             self.task_state = NodeStartupTaskState::JoinRaft;

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -298,8 +298,8 @@ impl PayOfflineFeeTask {
 
         // If this was a relayer fee payment and auto-redeem is enabled, enqueue a job
         // for the relayer to redeem the fee
-        let auto_redeem = self.state.get_auto_redeem_fees().await?;
-        let decryption_key = self.state.get_fee_key().await?.secret_key();
+        let auto_redeem = self.state.get_auto_redeem_fees()?;
+        let decryption_key = self.state.get_fee_key()?.secret_key();
         if !self.is_protocol_fee && auto_redeem && decryption_key.is_some() {
             enqueue_relayer_redeem_job(self.note.clone(), &self.state)
                 .await

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -224,7 +224,7 @@ impl Task for SettleMalleableExternalMatchTask {
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self> {
         // Check that atomic matches are enabled
-        let enabled = ctx.state.get_atomic_matches_enabled().await?;
+        let enabled = ctx.state.get_atomic_matches_enabled()?;
         if !enabled {
             return Err(SettleMalleableExternalMatchTaskError::state(ERR_ATOMIC_MATCHES_DISABLED));
         }
@@ -316,7 +316,7 @@ impl SettleMalleableExternalMatchTask {
 
     /// Prove the atomic match settlement
     async fn prove_atomic_match_settle(&mut self) -> Result<()> {
-        let (statement, witness) = self.get_witness_statement().await?;
+        let (statement, witness) = self.get_witness_statement()?;
 
         // Enqueue a job with the proof generation module
         let job = ProofJob::ValidMalleableMatchSettleAtomic { witness, statement };
@@ -379,7 +379,7 @@ impl SettleMalleableExternalMatchTask {
 
     /// Get the witness and statement for the atomic match settle proof
     /// `VALID ATOMIC MATCH SETTLE` for an exact match
-    async fn get_witness_statement(
+    fn get_witness_statement(
         &self,
     ) -> Result<(
         SizedValidMalleableMatchSettleAtomicStatement,
@@ -387,7 +387,7 @@ impl SettleMalleableExternalMatchTask {
     )> {
         let match_res = &self.match_res;
         let commitments_witness = &self.internal_order_validity_witness.commitment_witness;
-        let relayer_fee_address = self.state.get_external_fee_addr().await?.unwrap();
+        let relayer_fee_address = self.state.get_external_fee_addr()?.unwrap();
 
         // Copy values from the witnesses and statements of the order validity proofs
         let internal_party_order = commitments_witness.order.clone();

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -218,7 +218,7 @@ impl Task for SettleMatchExternalTask {
 
     async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self, Self::Error> {
         // Check that atomic matches are enabled
-        let enabled = ctx.state.get_atomic_matches_enabled().await?;
+        let enabled = ctx.state.get_atomic_matches_enabled()?;
         if !enabled {
             return Err(SettleMatchExternalTaskError::state(ERR_ATOMIC_MATCHES_DISABLED));
         }
@@ -312,7 +312,7 @@ impl SettleMatchExternalTask {
 
     /// Prove the atomic match settlement
     async fn prove_atomic_match_settle(&mut self) -> Result<(), SettleMatchExternalTaskError> {
-        let (statement, witness) = self.get_witness_statement().await?;
+        let (statement, witness) = self.get_witness_statement()?;
 
         // Enqueue a job with the proof generation module
         let job = ProofJob::ValidMatchSettleAtomic { witness, statement };
@@ -375,7 +375,7 @@ impl SettleMatchExternalTask {
     }
 
     /// Get the witness and statement for the atomic match settle proof
-    async fn get_witness_statement(
+    fn get_witness_statement(
         &self,
     ) -> Result<
         (SizedValidMatchSettleAtomicStatement, SizedValidMatchSettleAtomicWitness),
@@ -410,7 +410,7 @@ impl SettleMatchExternalTask {
         );
 
         // Compute the fees due by the external party in the match
-        let relayer_fee_address = self.state.get_external_fee_addr().await?.unwrap();
+        let relayer_fee_address = self.state.get_external_fee_addr()?.unwrap();
         let external_party_relayer_fee = self.relayer_fee_rate;
         let external_party_fees = compute_fee_obligation_with_protocol_fee(
             external_party_relayer_fee,

--- a/workers/task-driver/src/utils/validity_proofs.rs
+++ b/workers/task-driver/src/utils/validity_proofs.rs
@@ -341,7 +341,7 @@ async fn link_and_store_proofs(
     // Gossip the updated proofs to the network
     let message = PubsubMessage::Orderbook(OrderBookManagementMessage::OrderProofUpdated {
         order_id: *order_id,
-        cluster: state.get_cluster_id().await?,
+        cluster: state.get_cluster_id()?,
         proof_bundle,
     });
 
@@ -351,12 +351,10 @@ async fn link_and_store_proofs(
 
 /// Enqueue a job to redeem a relayer fee into the relayer's wallet
 pub(crate) async fn enqueue_relayer_redeem_job(note: Note, state: &State) -> Result<(), String> {
-    let relayer_wallet_id = state
-        .get_relayer_wallet_id()
-        .await?
-        .ok_or_else(|| ERR_RELAYER_WALLET_MISSING.to_string())?;
+    let relayer_wallet_id =
+        state.get_relayer_wallet_id()?.ok_or_else(|| ERR_RELAYER_WALLET_MISSING.to_string())?;
     let decryption_key =
-        state.get_fee_key().await?.secret_key().ok_or_else(|| ERR_FEE_KEY_MISSING.to_string())?;
+        state.get_fee_key()?.secret_key().ok_or_else(|| ERR_FEE_KEY_MISSING.to_string())?;
     let descriptor = RedeemFeeTaskDescriptor::new(relayer_wallet_id, note, decryption_key);
 
     state.append_task(descriptor.into()).await.map_err(|e| e.to_string()).map(|_| ())


### PR DESCRIPTION
### Purpose
This PR adds a `with_blocking_read_tx` and `with_blocking_write_tx` which together expose a blocking transaction interface on top of the MDBX instance. 

This is particularly useful for short-lived transactions in which the Tokio overhead to spawn the transaction on a blocking thread contributes >80% of the latency. This was measured in testnet and locally in benchmarks.

I use the blocking interface for queries that are known to be short, particularly around reading node metadata and fetching orders for the matching engine. Empirically this shaves ~10-15% off quote latency.

### Testing
- [x] All unit tests pass
- [ ] Testing in testnet