### PR TITLE
proof-manager: external-proof-manager: Immplement basic methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,13 +825,13 @@ dependencies = [
  "api-server-bench-util",
  "async-trait",
  "base64 0.21.7",
- "circuit-types 0.1.0",
+ "circuit-types",
  "clap 4.5.40",
  "colored",
  "common",
  "compliance-api",
  "config",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "crossbeam",
  "ctor",
@@ -857,7 +857,7 @@ dependencies = [
  "price-state",
  "rand 0.8.5",
  "ratelimit_meter",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "reqwest",
  "serde",
  "serde_json",
@@ -871,7 +871,7 @@ dependencies = [
  "tokio-tungstenite 0.18.0",
  "tracing",
  "tungstenite 0.18.0",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -880,7 +880,7 @@ name = "api-server-bench-util"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
  "config",
  "darkpool-client",
@@ -893,7 +893,7 @@ dependencies = [
  "serde_json",
  "state",
  "tokio",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2207,7 +2207,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2378,9 +2378,9 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-trait",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "futures-util",
@@ -2388,12 +2388,12 @@ dependencies = [
  "job-types",
  "lazy_static",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "state",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2460,17 +2460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "circuit-macros"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
-dependencies = [
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "circuit-types"
 version = "0.1.0"
 dependencies = [
@@ -2482,8 +2471,8 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "byteorder",
- "circuit-macros 0.1.0",
- "constants 0.1.0",
+ "circuit-macros",
+ "constants",
  "futures",
  "hex 0.4.3",
  "itertools 0.10.5",
@@ -2496,43 +2485,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "test-helpers",
  "tokio",
-]
-
-[[package]]
-name = "circuit-types"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "ark-serialize 0.4.2",
- "async-trait",
- "bigdecimal",
- "byteorder",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "futures",
- "hex 0.4.3",
- "itertools 0.10.5",
- "jf-primitives",
- "k256",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2545,11 +2502,11 @@ dependencies = [
  "ark-mpc",
  "bigdecimal",
  "bitvec",
- "circuit-macros 0.1.0",
- "circuit-types 0.1.0",
+ "circuit-macros",
+ "circuit-types",
  "clap 4.5.40",
  "colored",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "ctor",
  "dns-lookup",
@@ -2565,41 +2522,12 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "test-helpers",
  "tokio",
- "util 0.1.0",
-]
-
-[[package]]
-name = "circuits"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
-dependencies = [
- "ark-crypto-primitives",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal",
- "bitvec",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "futures",
- "itertools 0.10.5",
- "jf-primitives",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "serde",
- "serde_json",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
+ "util",
 ]
 
 [[package]]
@@ -2746,9 +2674,9 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bimap",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "circuits",
+ "constants",
  "crossbeam",
  "derivative",
  "ecdsa 0.16.9",
@@ -2768,14 +2696,14 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rand_core 0.5.1",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "signature 2.2.0",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -2804,11 +2732,11 @@ dependencies = [
  "alloy",
  "base64 0.13.1",
  "bimap",
- "circuit-types 0.1.0",
+ "circuit-types",
  "clap 4.5.40",
  "colored",
  "common",
- "constants 0.1.0",
+ "constants",
  "darkpool-client",
  "ed25519-dalek 1.0.1",
  "json",
@@ -2822,7 +2750,7 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "url",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -2873,17 +2801,6 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "constants"
 version = "0.1.0"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ed-on-bn254",
- "ark-mpc",
-]
-
-[[package]]
-name = "constants"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3252,12 +3169,12 @@ dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.40",
  "colored",
  "common",
- "constants 0.1.0",
+ "constants",
  "eyre",
  "inventory",
  "itertools 0.12.1",
@@ -3267,14 +3184,14 @@ dependencies = [
  "num-traits",
  "postcard",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "ruint",
  "serde",
  "serde_with",
  "test-helpers",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -3349,7 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3747,9 +3664,9 @@ name = "event-manager"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
- "constants 0.1.0",
+ "constants",
  "futures",
  "job-types",
  "metrics",
@@ -3760,7 +3677,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -3779,20 +3696,20 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "base64 0.22.1",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
- "constants 0.1.0",
+ "constants",
  "hex 0.4.3",
  "http 1.3.1",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -4149,7 +4066,7 @@ name = "gossip-api"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
  "hmac",
  "libp2p",
@@ -4158,7 +4075,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tracing",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -4167,10 +4084,10 @@ name = "gossip-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "common",
- "constants 0.1.0",
+ "constants",
  "darkpool-client",
  "futures",
  "gossip-api",
@@ -4183,7 +4100,7 @@ dependencies = [
  "state",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -4287,12 +4204,12 @@ dependencies = [
  "ark-mpc",
  "ark-serialize 0.4.2",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.40",
  "colored",
  "common",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "external-api",
@@ -4311,7 +4228,7 @@ dependencies = [
  "price-state",
  "proof-manager",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "serde",
  "state",
@@ -4320,7 +4237,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -4485,6 +4402,15 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-auth-basic"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c088bddfd73005b09807131224ad12c302655436b1270c8346a3ae8aaa37a"
+dependencies = [
+ "base64 0.22.1",
 ]
 
 [[package]]
@@ -5093,10 +5019,10 @@ name = "job-types"
 version = "0.1.0"
 dependencies = [
  "ark-mpc",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "common",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "external-api",
  "gossip-api",
@@ -5107,7 +5033,7 @@ dependencies = [
  "renegade-metrics",
  "serde",
  "tokio",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -5860,7 +5786,7 @@ dependencies = [
  "price-state",
  "state",
  "system-clock",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -5950,7 +5876,7 @@ dependencies = [
  "alloy",
  "api-server",
  "chain-events",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
  "config",
  "darkpool-client",
@@ -5976,7 +5902,7 @@ dependencies = [
  "task-driver",
  "test-helpers",
  "tokio",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -6242,7 +6168,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -7077,7 +7003,7 @@ dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
  "common",
- "constants 0.1.0",
+ "constants",
  "external-api",
  "futures",
  "futures-util",
@@ -7097,7 +7023,7 @@ dependencies = [
  "tracing",
  "tungstenite 0.18.0",
  "url",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7109,7 +7035,7 @@ dependencies = [
  "itertools 0.10.5",
  "statrs",
  "thiserror 2.0.12",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7226,21 +7152,23 @@ version = "0.1.0"
 dependencies = [
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "common",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
+ "http-auth-basic",
  "job-types",
  "mpc-plonk",
- "prover-service-api",
  "rayon",
  "renegade-metrics",
  "reqwest",
  "serde",
+ "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7284,16 +7212,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prover-service-api"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/relayer-extensions#2b4c1d00488263cb8254375e6d652d0855f56e80"
-dependencies = [
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "serde",
 ]
 
 [[package]]
@@ -7714,7 +7632,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "itertools 0.10.5",
  "lazy_static",
@@ -7726,35 +7644,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "renegade-crypto"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "itertools 0.10.5",
- "lazy_static",
- "num-bigint",
- "rand 0.8.5",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "renegade-metrics"
 version = "0.1.0"
 dependencies = [
  "atomic_float 1.1.0",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
  "lazy_static",
  "metrics",
  "num-bigint",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -7763,11 +7663,11 @@ version = "0.1.0"
 dependencies = [
  "api-server",
  "chain-events",
- "circuit-types 0.1.0",
+ "circuit-types",
  "clap 3.2.25",
  "common",
  "config",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "event-manager",
@@ -7789,7 +7689,7 @@ dependencies = [
  "task-driver",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -8703,7 +8603,7 @@ dependencies = [
  "reqwest",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -8774,10 +8674,10 @@ dependencies = [
  "async-trait",
  "bincode",
  "ciborium",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
  "config",
- "constants 0.1.0",
+ "constants",
  "criterion",
  "crossbeam",
  "crossterm 0.27.0",
@@ -8814,7 +8714,7 @@ dependencies = [
  "tracing-slog",
  "tui",
  "tui-logger",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -8968,7 +8868,7 @@ dependencies = [
  "tokio",
  "tokio-cron-scheduler",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -9032,12 +8932,12 @@ dependencies = [
  "alloy-primitives",
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
- "circuits 0.1.0",
+ "circuit-types",
+ "circuits",
  "clap 4.5.40",
  "colored",
  "common",
- "constants 0.1.0",
+ "constants",
  "crossbeam",
  "darkpool-client",
  "external-api",
@@ -9053,7 +8953,7 @@ dependencies = [
  "num-traits",
  "proof-manager",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "renegade-metrics",
  "serde",
  "serde_json",
@@ -9063,7 +8963,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
  "uuid",
 ]
 
@@ -9098,9 +8998,9 @@ dependencies = [
  "alloy-sol-types",
  "ark-mpc",
  "async-trait",
- "circuit-types 0.1.0",
+ "circuit-types",
  "common",
- "constants 0.1.0",
+ "constants",
  "darkpool-client",
  "dns-lookup",
  "eyre",
@@ -9109,12 +9009,12 @@ dependencies = [
  "k256",
  "num-bigint",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "util 0.1.0",
+ "util",
 ]
 
 [[package]]
@@ -9942,8 +9842,8 @@ dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",
  "chrono",
- "circuit-types 0.1.0",
- "constants 0.1.0",
+ "circuit-types",
+ "constants",
  "criterion",
  "crossbeam",
  "eyre",
@@ -9964,46 +9864,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "renegade-crypto 0.1.0",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-serde 0.1.3",
- "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "util"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
-dependencies = [
- "alloy",
- "ark-ec",
- "ark-serialize 0.4.2",
- "chrono",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
- "crossbeam",
- "eyre",
- "futures",
- "hex 0.4.3",
- "json",
- "libp2p",
- "metrics",
- "metrics-exporter-statsd",
- "metrics-tracing-context",
- "metrics-util",
- "num-bigint",
- "num-traits",
- "opentelemetry",
- "opentelemetry-datadog",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tokio",

--- a/workers/proof-manager/Cargo.toml
+++ b/workers/proof-manager/Cargo.toml
@@ -18,8 +18,9 @@ rayon = { version = "1.5.3" }
 tokio = { workspace = true }
 
 # === External Service Client === #
+http-auth-basic = "0.3"
 reqwest = { version = "0.12.10", features = ["json"] }
-prover-service-api = { git = "https://github.com/renegade-fi/relayer-extensions" }
+serde_json = { workspace = true }
 
 # === Workspace Dependencies === #
 circuits = { workspace = true }
@@ -33,3 +34,4 @@ util = { workspace = true }
 # === Misc Dependencies === #
 serde = { workspace = true }
 tracing = { workspace = true }
+thiserror = { workspace = true }

--- a/workers/proof-manager/src/error.rs
+++ b/workers/proof-manager/src/error.rs
@@ -1,27 +1,56 @@
 //! Defines error types emitted during the course of the proof generation
 //! module's execution
 
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use thiserror::Error;
 
 /// The abstract error type the proof manager emits
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Error)]
 pub enum ProofManagerError {
     /// The coordinator cancelled the proof manager's execution
+    #[error("proof manager cancelled: {0}")]
     Cancelled(String),
+    /// An HTTP error
+    #[error("HTTP error: {0}")]
+    Http(String),
     /// The job queue has been closed, recv fails
+    #[error("job queue closed: {0}")]
     JobQueueClosed(String),
     /// Error proving a statement
+    #[error("error proving statement: {0}")]
     Prover(String),
     /// An error receiving on a channel
+    #[error("error receiving on a channel: {0}")]
     RecvError(String),
-    /// Error sending response along a job's response channel
+    /// Error sending response to a proof job
+    #[error("error sending response to proof job: {0}")]
     Response(String),
     /// Error setting up the proof generation manager
+    #[error("error setting up the proof manager: {0}")]
     Setup(String),
 }
 
-impl Display for ProofManagerError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{:?}", self)
+impl ProofManagerError {
+    /// Create an error from an HTTP error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn http<T: ToString>(err: T) -> Self {
+        Self::Http(err.to_string())
+    }
+
+    /// Create an error from a prover error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn prover<T: ToString>(err: T) -> Self {
+        Self::Prover(err.to_string())
+    }
+
+    /// Create a setup error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn setup<T: ToString>(err: T) -> Self {
+        Self::Setup(err.to_string())
+    }
+}
+
+impl From<reqwest::Error> for ProofManagerError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::http(err)
     }
 }

--- a/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
@@ -1,0 +1,194 @@
+//! API types for the prover service
+//!
+//! Copied here to avoid cyclic dependencies between the relayer and the prover
+//! service
+
+//! The API for the prover service
+
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(unsafe_code)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::unused_async)]
+
+use circuit_types::{PlonkLinkProof, PlonkProof, ProofLinkingHint};
+use circuits::{
+    self,
+    zk_circuits::{
+        valid_commitments::{SizedValidCommitmentsWitness, ValidCommitmentsStatement},
+        valid_fee_redemption::{SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness},
+        valid_malleable_match_settle_atomic::{
+            SizedValidMalleableMatchSettleAtomicStatement,
+            SizedValidMalleableMatchSettleAtomicWitness,
+        },
+        valid_match_settle::{SizedValidMatchSettleStatement, SizedValidMatchSettleWitness},
+        valid_match_settle_atomic::{
+            SizedValidMatchSettleAtomicStatement, SizedValidMatchSettleAtomicWitness,
+        },
+        valid_offline_fee_settlement::{
+            SizedValidOfflineFeeSettlementStatement, SizedValidOfflineFeeSettlementWitness,
+        },
+        valid_reblind::{SizedValidReblindWitness, ValidReblindStatement},
+        valid_wallet_create::{SizedValidWalletCreateStatement, SizedValidWalletCreateWitness},
+        valid_wallet_update::{SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness},
+    },
+};
+use serde::{Deserialize, Serialize};
+
+// ------------------
+// | Response Types |
+// ------------------
+
+/// A generic response representing a Plonk proof
+#[derive(Serialize, Deserialize)]
+pub struct ProofResponse {
+    /// The proof
+    pub proof: PlonkProof,
+}
+
+/// A generic response type representing a Plonk proof and a linking hint
+#[derive(Serialize, Deserialize)]
+pub struct ProofAndHintResponse {
+    /// The proof
+    pub proof: PlonkProof,
+    /// The proof's link hint
+    pub link_hint: ProofLinkingHint,
+}
+
+/// A proof-link response
+///
+/// Sent by the prover service when only a linking proof has been requested
+#[derive(Serialize, Deserialize)]
+pub struct ProofLinkResponse {
+    /// The proof-linking proof
+    pub link_proof: PlonkLinkProof,
+}
+
+/// A response including a plonk proof and a proof-linking proof
+///
+/// This type is returned in response to requests which themselves include a
+/// link hint for the prover service to link against
+#[derive(Serialize, Deserialize)]
+pub struct ProofAndLinkResponse {
+    /// The plonk proof
+    pub plonk_proof: PlonkProof,
+    /// The proof-linking proof
+    pub link_proof: PlonkLinkProof,
+}
+
+// -----------------
+// | Request Types |
+// -----------------
+
+/// A request to prove `VALID WALLET CREATE`
+#[derive(Serialize, Deserialize)]
+pub struct ValidWalletCreateRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidWalletCreateStatement,
+    /// The witness
+    pub witness: SizedValidWalletCreateWitness,
+}
+
+/// A request to prove `VALID WALLET UPDATE`
+#[derive(Serialize, Deserialize)]
+pub struct ValidWalletUpdateRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidWalletUpdateStatement,
+    /// The witness
+    pub witness: SizedValidWalletUpdateWitness,
+}
+
+/// A request to prove `VALID COMMITMENTS`
+#[derive(Serialize, Deserialize)]
+pub struct ValidCommitmentsRequest {
+    /// The statement (public variables)
+    pub statement: ValidCommitmentsStatement,
+    /// The witness
+    pub witness: SizedValidCommitmentsWitness,
+}
+
+/// A request to generate a proof-link of `VALID COMMITMENTS` <-> `VALID
+/// REBLIND`
+#[derive(Serialize, Deserialize)]
+pub struct LinkCommitmentsReblindRequest {
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
+    /// The link hint for `VALID REBLIND`
+    pub valid_reblind_hint: ProofLinkingHint,
+}
+
+/// A request to prove `VALID REBLIND`
+#[derive(Serialize, Deserialize)]
+pub struct ValidReblindRequest {
+    /// The statement (public variables)
+    pub statement: ValidReblindStatement,
+    /// The witness
+    pub witness: SizedValidReblindWitness,
+}
+
+/// A request to prove `VALID MATCH SETTLE`
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidMatchSettleStatement,
+    /// The witness
+    pub witness: SizedValidMatchSettleWitness,
+    /// The link hint for `VALID COMMITMENTS` for party 0
+    pub valid_commitments_hint0: ProofLinkingHint,
+    /// The link hint for `VALID COMMITMENTS` for party 1
+    pub valid_commitments_hint1: ProofLinkingHint,
+}
+
+/// A response to a request to prove `VALID MATCH SETTLE`
+///
+/// This type includes two link proofs, so it warrants its own type
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleResponse {
+    /// The plonk proof
+    pub plonk_proof: PlonkProof,
+    /// The proof-linking proof for party 0
+    pub link_proof0: PlonkLinkProof,
+    /// The proof-linking proof for party 1
+    pub link_proof1: PlonkLinkProof,
+}
+
+/// A request to prove `VALID MATCH SETTLE ATOMIC`
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleAtomicRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidMatchSettleAtomicStatement,
+    /// The witness
+    pub witness: SizedValidMatchSettleAtomicWitness,
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
+}
+
+/// A request to prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
+#[derive(Serialize, Deserialize)]
+pub struct ValidMalleableMatchSettleAtomicRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidMalleableMatchSettleAtomicStatement,
+    /// The witness
+    pub witness: SizedValidMalleableMatchSettleAtomicWitness,
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
+}
+
+/// A request to prove `VALID FEE REDEMPTION`
+#[derive(Serialize, Deserialize)]
+pub struct ValidFeeRedemptionRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidFeeRedemptionStatement,
+    /// The witness
+    pub witness: SizedValidFeeRedemptionWitness,
+}
+
+/// A request to prove `VALID OFFLINE FEE SETTLEMENT`
+#[derive(Serialize, Deserialize)]
+pub struct ValidOfflineFeeSettlementRequest {
+    /// The statement (public variables)
+    pub statement: SizedValidOfflineFeeSettlementStatement,
+    /// The witness
+    pub witness: SizedValidOfflineFeeSettlementWitness,
+}

--- a/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -1,0 +1,376 @@
+//! An implementation of the proof manager which uses an external prover service
+
+use circuit_types::ProofLinkingHint;
+use circuits::zk_circuits::{
+    valid_commitments::{SizedValidCommitmentsWitness, ValidCommitmentsStatement},
+    valid_fee_redemption::{SizedValidFeeRedemptionStatement, SizedValidFeeRedemptionWitness},
+    valid_malleable_match_settle_atomic::{
+        SizedValidMalleableMatchSettleAtomicStatement, SizedValidMalleableMatchSettleAtomicWitness,
+    },
+    valid_match_settle::{SizedValidMatchSettleStatement, SizedValidMatchSettleWitness},
+    valid_match_settle_atomic::{
+        SizedValidMatchSettleAtomicStatement, SizedValidMatchSettleAtomicWitness,
+    },
+    valid_offline_fee_settlement::{
+        SizedValidOfflineFeeSettlementStatement, SizedValidOfflineFeeSettlementWitness,
+    },
+    valid_reblind::{SizedValidReblindWitness, ValidReblindStatement},
+    valid_wallet_create::{SizedValidWalletCreateStatement, SizedValidWalletCreateWitness},
+    valid_wallet_update::{SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness},
+};
+use common::types::{CancelChannel, proof_bundles::ProofBundle};
+use constants::in_bootstrap_mode;
+use http_auth_basic::Credentials;
+use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
+use reqwest::{
+    Client, Url,
+    header::{AUTHORIZATION, HeaderMap, HeaderValue},
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, instrument};
+use util::concurrency::runtime::sleep_forever_blocking;
+
+use crate::{
+    error::ProofManagerError,
+    implementations::external_proof_manager::api_types::{
+        ProofAndHintResponse, ProofResponse, ValidCommitmentsRequest, ValidFeeRedemptionRequest,
+        ValidOfflineFeeSettlementRequest, ValidReblindRequest, ValidWalletCreateRequest,
+        ValidWalletUpdateRequest,
+    },
+    worker::ProofManagerConfig,
+};
+
+mod api_types;
+
+/// The number of worker threads to use for the external proof manager
+const WORKER_THREADS: usize = 3;
+/// The HTTP basic auth user name to use
+const HTTP_BASIC_AUTH_USER: &str = "admin";
+
+// ---------
+// | Paths |
+// ---------
+
+/// The path at which to request a `VALID WALLET CREATE` proof
+const VALID_WALLET_CREATE_PATH: &str = "prove-valid-wallet-create";
+/// The path at which to request a `VALID WALLET UPDATE` proof
+const VALID_WALLET_UPDATE_PATH: &str = "prove-valid-wallet-update";
+/// The path at which to request a `VALID COMMITMENTS` proof
+const VALID_COMMITMENTS_PATH: &str = "prove-valid-commitments";
+/// The path at which to request a `VALID REBLIND` proof
+const VALID_REBLIND_PATH: &str = "prove-valid-reblind";
+/// The path at which to link commitments and reblind
+const LINK_COMMITMENTS_REBLIND_PATH: &str = "link-commitments-reblind";
+/// The path at which to request a `VALID MATCH SETTLE` proof
+const VALID_MATCH_SETTLE_PATH: &str = "prove-valid-match-settle";
+/// The path at which to request a `VALID MATCH SETTLE ATOMIC` proof
+const VALID_MATCH_SETTLE_ATOMIC_PATH: &str = "prove-valid-match-settle-atomic";
+/// The path at which to request a `VALID MALLEABLE MATCH SETTLE ATOMIC` proof
+const VALID_MALLEABLE_MATCH_SETTLE_ATOMIC_PATH: &str = "prove-valid-malleable-match-settle-atomic";
+/// The path at which to request a `VALID FEE REDEMPTION` proof
+const VALID_FEE_REDEMPTION_PATH: &str = "prove-valid-fee-redemption";
+/// The path at which to request a `VALID OFFLINE FEE SETTLEMENT` proof
+const VALID_OFFLINE_FEE_SETTLEMENT_PATH: &str = "prove-valid-offline-fee-settlement";
+
+// -----------
+// | Manager |
+// -----------
+
+/// An external proof service client
+pub struct ExternalProofManager {
+    /// The HTTP client to use for connecting to the prover service
+    client: ProofServiceClient,
+    /// The job queue on which to receive proof generation jobs
+    job_queue: ProofManagerReceiver,
+    /// The channel on which a coordinator may cancel execution
+    cancel_channel: CancelChannel,
+}
+
+impl ExternalProofManager {
+    /// Create a new external proof manager
+    pub fn new(config: ProofManagerConfig) -> Result<Self, ProofManagerError> {
+        Ok(Self {
+            client: ProofServiceClient::new(&config)?,
+            job_queue: config.job_queue,
+            cancel_channel: config.cancel_channel,
+        })
+    }
+
+    /// Run the proof manager's execution loop
+    pub fn run(self) -> Result<(), ProofManagerError> {
+        // If the relayer is in bootstrap mode, sleep forever
+        if in_bootstrap_mode() {
+            sleep_forever_blocking();
+        }
+
+        // Otherwise, start a Tokio runtime for the worker and spawn the work loop
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(WORKER_THREADS)
+            .enable_all()
+            .build()
+            .map_err(ProofManagerError::setup)?;
+        runtime.block_on(async { self.work_loop() })
+    }
+
+    /// The work loop of the external proof manager
+    fn work_loop(self) -> Result<(), ProofManagerError> {
+        loop {
+            // Check the cancel channel before blocking on a job
+            if self
+                .cancel_channel
+                .has_changed()
+                .map_err(|err| ProofManagerError::RecvError(err.to_string()))?
+            {
+                info!("Proof manager cancelled, shutting down...");
+                return Err(ProofManagerError::Cancelled("received cancel signal".to_string()));
+            }
+
+            // Block on a job
+            let job = self
+                .job_queue
+                .recv()
+                .map_err(|err| ProofManagerError::RecvError(err.to_string()))?
+                .consume();
+
+            // Handle the job
+            let client = self.client.clone();
+            tokio::spawn(async move {
+                if let Err(err) = Self::handle_proof_job(client, job).await {
+                    error!("Error handling proof job: {err:?}");
+                }
+            });
+        }
+    }
+
+    /// Handle a proof generation job
+    #[instrument(name = "handle_proof_job", skip_all)]
+    async fn handle_proof_job(
+        client: ProofServiceClient,
+        job: ProofManagerJob,
+    ) -> Result<(), ProofManagerError> {
+        let bundle = match job.type_ {
+            ProofJob::ValidWalletCreate { witness, statement } => {
+                // Prove `VALID WALLET CREATE`
+                client.prove_valid_wallet_create(witness, statement).await
+            },
+            ProofJob::ValidWalletUpdate { witness, statement } => {
+                // Prove `VALID WALLET UPDATE`
+                client.prove_valid_wallet_update(witness, statement).await
+            },
+            ProofJob::ValidCommitments { witness, statement } => {
+                // Prove `VALID COMMITMENTS`
+                client.prove_valid_commitments(witness, statement).await
+            },
+            ProofJob::ValidReblind { witness, statement } => {
+                // Prove `VALID REBLIND`
+                client.prove_valid_reblind(witness, statement).await
+            },
+            ProofJob::ValidMatchSettleSingleprover { witness, statement } => {
+                // Prove `VALID MATCH SETTLE`
+                client.prove_valid_match_settle(witness, statement).await
+            },
+            ProofJob::ValidMatchSettleAtomic { witness, statement } => {
+                // Prove `VALID MATCH SETTLE ATOMIC`
+                client.prove_valid_match_settle_atomic(witness, statement).await
+            },
+            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement } => {
+                // Prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
+                client.prove_valid_malleable_match_settle_atomic(witness, statement).await
+            },
+            ProofJob::ValidFeeRedemption { witness, statement } => {
+                // Prove `VALID FEE REDEMPTION`
+                client.prove_valid_fee_redemption(witness, statement).await
+            },
+            ProofJob::ValidOfflineFeeSettlement { witness, statement } => {
+                // Prove `VALID OFFLINE FEE SETTLEMENT`
+                client.prove_valid_offline_fee_settlement(witness, statement).await
+            },
+            _ => return Err(ProofManagerError::prover("unsupported proof type")),
+        }?;
+
+        // Ignore send errors
+        let _err = job.response_channel.send(bundle);
+        Ok(())
+    }
+}
+
+// ------------------------
+// | Proof Service Client |
+// ------------------------
+
+/// A client for the proof service
+#[derive(Clone)]
+struct ProofServiceClient {
+    /// The HTTP client to use for connecting to the prover service
+    client: Client,
+    /// The URL of the prover service
+    url: Url,
+    /// The password for the prover service
+    password: String,
+}
+
+impl ProofServiceClient {
+    /// Create a new proof service client
+    pub fn new(config: &ProofManagerConfig) -> Result<Self, ProofManagerError> {
+        let client = Client::new();
+        let url = config
+            .prover_service_url
+            .clone()
+            .ok_or(ProofManagerError::setup("no prover service URL provided"))?;
+        let password = config
+            .prover_service_password
+            .clone()
+            .ok_or(ProofManagerError::setup("no prover service password provided"))?;
+
+        Ok(Self { client, url, password })
+    }
+
+    // --- HTTP Helpers --- //
+
+    /// Send a request to the prover service
+    async fn send_request<Req: Serialize, Resp: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        req: Req,
+    ) -> Result<Resp, ProofManagerError> {
+        // Add the auth header
+        let mut headers = HeaderMap::new();
+        let cred = Credentials::new(HTTP_BASIC_AUTH_USER, &self.password);
+        let header = cred.as_http_header();
+        let auth_header = HeaderValue::from_str(&header).map_err(ProofManagerError::http)?;
+        headers.insert(AUTHORIZATION, auth_header);
+
+        // Build the URL and send the request
+        let full_path = format!("{}{path}", self.url);
+        let resp = self.client.post(full_path).json(&req).headers(headers).send().await?;
+        let res = resp.json::<Resp>().await?;
+        Ok(res)
+    }
+
+    // --- Prover Methods --- //
+
+    /// Request a `VALID WALLET CREATE` proof from the prover service
+    async fn prove_valid_wallet_create(
+        &self,
+        witness: SizedValidWalletCreateWitness,
+        statement: SizedValidWalletCreateStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidWalletCreateRequest { statement: statement.clone(), witness };
+        let res = self.send_request::<_, ProofResponse>(VALID_WALLET_CREATE_PATH, req).await?;
+
+        let link_hint = default_link_hint();
+        let bundle = ProofBundle::new_valid_wallet_create(statement, res.proof, link_hint);
+        Ok(bundle)
+    }
+
+    /// Request a `VALID WALLET UPDATE` proof from the prover service
+    async fn prove_valid_wallet_update(
+        &self,
+        witness: SizedValidWalletUpdateWitness,
+        statement: SizedValidWalletUpdateStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidWalletUpdateRequest { statement: statement.clone(), witness };
+        let res = self.send_request::<_, ProofResponse>(VALID_WALLET_UPDATE_PATH, req).await?;
+
+        let link_hint = default_link_hint();
+        let bundle = ProofBundle::new_valid_wallet_update(statement, res.proof, link_hint);
+        Ok(bundle)
+    }
+
+    /// Request a `VALID COMMITMENTS` proof from the prover service
+    async fn prove_valid_commitments(
+        &self,
+        witness: SizedValidCommitmentsWitness,
+        statement: ValidCommitmentsStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidCommitmentsRequest { statement, witness };
+        let res = self.send_request::<_, ProofAndHintResponse>(VALID_COMMITMENTS_PATH, req).await?;
+
+        let bundle = ProofBundle::new_valid_commitments(statement, res.proof, res.link_hint);
+        Ok(bundle)
+    }
+
+    /// Request a `VALID REBLIND` proof from the prover service
+    async fn prove_valid_reblind(
+        &self,
+        witness: SizedValidReblindWitness,
+        statement: ValidReblindStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidReblindRequest { statement: statement.clone(), witness };
+        let res = self.send_request::<_, ProofAndHintResponse>(VALID_REBLIND_PATH, req).await?;
+
+        let bundle = ProofBundle::new_valid_reblind(statement, res.proof, res.link_hint);
+        Ok(bundle)
+    }
+
+    /// Request a `VALID MATCH SETTLE` proof from the prover service
+    async fn prove_valid_match_settle(
+        &self,
+        witness: SizedValidMatchSettleWitness,
+        statement: SizedValidMatchSettleStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        todo!()
+    }
+
+    /// Request a `VALID MATCH SETTLE ATOMIC` proof from the prover service
+    async fn prove_valid_match_settle_atomic(
+        &self,
+        witness: SizedValidMatchSettleAtomicWitness,
+        statement: SizedValidMatchSettleAtomicStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        todo!()
+    }
+
+    /// Request a `VALID MALLEABLE MATCH SETTLE ATOMIC` proof from the prover
+    /// service
+    async fn prove_valid_malleable_match_settle_atomic(
+        &self,
+        witness: SizedValidMalleableMatchSettleAtomicWitness,
+        statement: SizedValidMalleableMatchSettleAtomicStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        todo!()
+    }
+
+    /// Request a `VALID FEE REDEMPTION` proof from the prover service
+    async fn prove_valid_fee_redemption(
+        &self,
+        witness: SizedValidFeeRedemptionWitness,
+        statement: SizedValidFeeRedemptionStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidFeeRedemptionRequest { statement: statement.clone(), witness };
+        let res = self.send_request::<_, ProofResponse>(VALID_FEE_REDEMPTION_PATH, req).await?;
+
+        let link_hint = default_link_hint();
+        let bundle = ProofBundle::new_valid_fee_redemption(statement, res.proof, link_hint);
+        Ok(bundle)
+    }
+
+    /// Request a `VALID OFFLINE FEE SETTLEMENT` proof from the prover service
+    async fn prove_valid_offline_fee_settlement(
+        &self,
+        witness: SizedValidOfflineFeeSettlementWitness,
+        statement: SizedValidOfflineFeeSettlementStatement,
+    ) -> Result<ProofBundle, ProofManagerError> {
+        let req = ValidOfflineFeeSettlementRequest { statement: statement.clone(), witness };
+        let res =
+            self.send_request::<_, ProofResponse>(VALID_OFFLINE_FEE_SETTLEMENT_PATH, req).await?;
+
+        let link_hint = default_link_hint();
+        let bundle = ProofBundle::new_valid_offline_fee_settlement(statement, res.proof, link_hint);
+        Ok(bundle)
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a default proof linking hint
+///
+/// Used for circuits whose linking hints are unused and so omitted from the API
+fn default_link_hint() -> ProofLinkingHint {
+    ProofLinkingHint {
+        linking_wire_poly: Default::default(),
+        linking_wire_comm: Default::default(),
+    }
+}

--- a/workers/proof-manager/src/implementations/mod.rs
+++ b/workers/proof-manager/src/implementations/mod.rs
@@ -1,3 +1,4 @@
 //! Implementations of the proof manager
 
+pub(crate) mod external_proof_manager;
 pub(crate) mod native_proof_manager;


### PR DESCRIPTION
### Purpose
This PR implements the basic methods on the external proof manager. This is effectively the methods which only return a proof, and require no proof linking. 

I'll follow up by reworking the proof manager's job interface to look more like the prover service's API -- especially with link proofs in the same request.

### Testing
- [x] Tested locally against a prover service