### PR TITLE
proof-manager: Prove malleable match settle + commitments link together

### DIFF
--- a/darkpool-client/src/arbitrum/mod.rs
+++ b/darkpool-client/src/arbitrum/mod.rs
@@ -40,12 +40,12 @@ use circuit_types::{
 };
 use common::types::{
     proof_bundles::{
-        GenericFeeRedemptionBundle, GenericMalleableMatchSettleAtomicBundle,
-        GenericOfflineFeeSettlementBundle, GenericRelayerFeeSettlementBundle,
-        GenericValidWalletCreateBundle, GenericValidWalletUpdateBundle,
-        MalleableAtomicMatchSettleBundle, OrderValidityProofBundle, SizedFeeRedemptionBundle,
+        GenericFeeRedemptionBundle, GenericOfflineFeeSettlementBundle,
+        GenericRelayerFeeSettlementBundle, GenericValidWalletCreateBundle,
+        GenericValidWalletUpdateBundle, OrderValidityProofBundle, SizedFeeRedemptionBundle,
         SizedOfflineFeeSettlementBundle, SizedRelayerFeeSettlementBundle,
-        SizedValidWalletCreateBundle, SizedValidWalletUpdateBundle, ValidMatchSettleAtomicBundle,
+        SizedValidWalletCreateBundle, SizedValidWalletUpdateBundle,
+        ValidMalleableMatchSettleAtomicBundle, ValidMatchSettleAtomicBundle,
         ValidMatchSettleBundle,
     },
     transfer_auth::TransferAuth,
@@ -453,12 +453,11 @@ impl DarkpoolImpl for ArbitrumDarkpool {
         &self,
         receiver_address: Option<Address>,
         internal_party_validity_proofs: &OrderValidityProofBundle,
-        match_atomic_bundle: &MalleableAtomicMatchSettleBundle,
+        match_atomic_bundle: ValidMalleableMatchSettleAtomicBundle,
     ) -> Result<TransactionRequest, DarkpoolClientError> {
-        let GenericMalleableMatchSettleAtomicBundle {
-            statement: valid_match_settle_atomic_statement,
-            proof: valid_match_settle_atomic_proof,
-        } = match_atomic_bundle.copy_atomic_match_proof();
+        let valid_match_settle_atomic_statement = &match_atomic_bundle.statement;
+        let valid_match_settle_atomic_proof = &match_atomic_bundle.proof;
+        let commitments_link = &match_atomic_bundle.commitments_link;
 
         let commitments_statement = internal_party_validity_proofs.commitment_proof.statement;
         let reblind_statement = &internal_party_validity_proofs.reblind_proof.statement;
@@ -474,11 +473,10 @@ impl DarkpoolImpl for ArbitrumDarkpool {
         // proofs and statements here encode a different relation
         let match_proofs = build_atomic_match_proofs(
             internal_party_validity_proofs,
-            &valid_match_settle_atomic_proof,
+            valid_match_settle_atomic_proof,
         )
         .map_err(DarkpoolClientError::Conversion)?;
 
-        let commitments_link = &match_atomic_bundle.commitments_link;
         let link_proofs =
             build_atomic_match_linking_proofs(internal_party_validity_proofs, commitments_link)
                 .map_err(DarkpoolClientError::Conversion)?;

--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -15,10 +15,10 @@ use circuit_types::{
 };
 use common::types::{
     proof_bundles::{
-        MalleableAtomicMatchSettleBundle, OrderValidityProofBundle, SizedFeeRedemptionBundle,
-        SizedOfflineFeeSettlementBundle, SizedRelayerFeeSettlementBundle,
-        SizedValidWalletCreateBundle, SizedValidWalletUpdateBundle, ValidMatchSettleAtomicBundle,
-        ValidMatchSettleBundle,
+        OrderValidityProofBundle, SizedFeeRedemptionBundle, SizedOfflineFeeSettlementBundle,
+        SizedRelayerFeeSettlementBundle, SizedValidWalletCreateBundle,
+        SizedValidWalletUpdateBundle, ValidMalleableMatchSettleAtomicBundle,
+        ValidMatchSettleAtomicBundle, ValidMatchSettleBundle,
     },
     transfer_auth::TransferAuth,
 };
@@ -342,15 +342,15 @@ impl DarkpoolImpl for BaseDarkpool {
         &self,
         receiver_address: Option<Address>,
         validity_proofs: &OrderValidityProofBundle,
-        match_atomic_bundle: &MalleableAtomicMatchSettleBundle,
+        match_atomic_bundle: ValidMalleableMatchSettleAtomicBundle,
     ) -> Result<TransactionRequest, DarkpoolClientError> {
         let internal_party_payload = validity_proofs.to_contract_type()?;
-        let statement = match_atomic_bundle.atomic_match_proof.statement.to_contract_type()?;
+        let statement = match_atomic_bundle.statement.to_contract_type()?;
 
         // Build the match proofs bundle
         let commitments_proof = validity_proofs.commitment_proof.proof.to_contract_type()?;
         let reblind_proof = validity_proofs.reblind_proof.proof.to_contract_type()?;
-        let match_proof = match_atomic_bundle.atomic_match_proof.proof.to_contract_type()?;
+        let match_proof = match_atomic_bundle.proof.to_contract_type()?;
         let match_proofs = MalleableMatchAtomicProofs {
             validCommitments: commitments_proof,
             validReblind: reblind_proof,
@@ -365,7 +365,7 @@ impl DarkpoolImpl for BaseDarkpool {
         };
 
         // Compute the quote and base amounts, defaulting to the max tradable amounts
-        let match_res = &match_atomic_bundle.atomic_match_proof.statement.bounded_match_result;
+        let match_res = &match_atomic_bundle.statement.bounded_match_result;
         let price = match_res.price;
         let base_amount = match_res.max_base_amount;
         let base_amount_calldata = amount_to_u256(base_amount)?;

--- a/darkpool-client/src/client/contract_interaction.rs
+++ b/darkpool-client/src/client/contract_interaction.rs
@@ -6,12 +6,14 @@ use alloy::{primitives::Address, rpc::types::TransactionReceipt};
 use circuit_types::{
     elgamal::EncryptionKey, fixed_point::FixedPoint, merkle::MerkleRoot, wallet::Nullifier,
 };
-use common::types::proof_bundles::{ValidMatchSettleAtomicBundle, ValidMatchSettleBundle};
+use common::types::proof_bundles::{
+    ValidMalleableMatchSettleAtomicBundle, ValidMatchSettleAtomicBundle, ValidMatchSettleBundle,
+};
 use common::types::{
     proof_bundles::{
-        MalleableAtomicMatchSettleBundle, OrderValidityProofBundle, SizedFeeRedemptionBundle,
-        SizedOfflineFeeSettlementBundle, SizedRelayerFeeSettlementBundle,
-        SizedValidWalletCreateBundle, SizedValidWalletUpdateBundle,
+        OrderValidityProofBundle, SizedFeeRedemptionBundle, SizedOfflineFeeSettlementBundle,
+        SizedRelayerFeeSettlementBundle, SizedValidWalletCreateBundle,
+        SizedValidWalletUpdateBundle,
     },
     transfer_auth::TransferAuth,
 };
@@ -185,7 +187,7 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         &self,
         receiver_address: Option<Address>,
         internal_party_validity_proofs: &OrderValidityProofBundle,
-        match_atomic_bundle: &MalleableAtomicMatchSettleBundle,
+        match_atomic_bundle: ValidMalleableMatchSettleAtomicBundle,
     ) -> Result<TransactionRequest, DarkpoolClientError> {
         self.darkpool.gen_malleable_atomic_match_settle_calldata(
             receiver_address,

--- a/darkpool-client/src/traits.rs
+++ b/darkpool-client/src/traits.rs
@@ -13,12 +13,14 @@ use circuit_types::{
     SizedWalletShare, elgamal::EncryptionKey, fixed_point::FixedPoint, merkle::MerkleRoot,
     wallet::Nullifier,
 };
-use common::types::proof_bundles::{ValidMatchSettleAtomicBundle, ValidMatchSettleBundle};
+use common::types::proof_bundles::{
+    ValidMalleableMatchSettleAtomicBundle, ValidMatchSettleAtomicBundle, ValidMatchSettleBundle,
+};
 use common::types::{
     proof_bundles::{
-        MalleableAtomicMatchSettleBundle, OrderValidityProofBundle, SizedFeeRedemptionBundle,
-        SizedOfflineFeeSettlementBundle, SizedRelayerFeeSettlementBundle,
-        SizedValidWalletCreateBundle, SizedValidWalletUpdateBundle,
+        OrderValidityProofBundle, SizedFeeRedemptionBundle, SizedOfflineFeeSettlementBundle,
+        SizedRelayerFeeSettlementBundle, SizedValidWalletCreateBundle,
+        SizedValidWalletUpdateBundle,
     },
     transfer_auth::TransferAuth,
 };
@@ -151,7 +153,7 @@ pub trait DarkpoolImpl: Clone {
         &self,
         receiver_address: Option<Address>,
         internal_party_validity_proofs: &OrderValidityProofBundle,
-        match_atomic_bundle: &MalleableAtomicMatchSettleBundle,
+        match_atomic_bundle: ValidMalleableMatchSettleAtomicBundle,
     ) -> Result<TransactionRequest, DarkpoolClientError>;
 
     // ------------

--- a/external-api/src/bus_message.rs
+++ b/external-api/src/bus_message.rs
@@ -6,7 +6,8 @@ use common::types::{
     gossip::{PeerInfo, WrappedPeerId},
     network_order::NetworkOrder,
     proof_bundles::{
-        MalleableAtomicMatchSettleBundle, OrderValidityProofBundle, ValidMatchSettleAtomicBundle,
+        OrderValidityProofBundle, ValidMalleableMatchSettleAtomicBundle,
+        ValidMatchSettleAtomicBundle,
     },
     tasks::TaskIdentifier,
     token::Token,
@@ -179,7 +180,7 @@ pub enum SystemBusMessage {
     /// to its client
     MalleableAtomicMatchFound {
         /// The match bundle
-        match_bundle: MalleableAtomicMatchSettleBundle,
+        match_bundle: ValidMalleableMatchSettleAtomicBundle,
         /// The validity proofs for the internal party
         validity_proofs: OrderValidityProofBundle,
     },

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -33,7 +33,7 @@ use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
 
 #[cfg(feature = "full-api")]
 use common::types::{
-    proof_bundles::{MalleableAtomicMatchSettleBundle, ValidMatchSettleAtomicBundle},
+    proof_bundles::{ValidMalleableMatchSettleAtomicBundle, ValidMatchSettleAtomicBundle},
     wallet::Order,
 };
 
@@ -453,10 +453,10 @@ impl MalleableAtomicMatchApiBundle {
     /// settlement transaction
     #[cfg(feature = "full-api")]
     pub fn new(
-        match_bundle: &MalleableAtomicMatchSettleBundle,
+        match_bundle: &ValidMalleableMatchSettleAtomicBundle,
         mut settlement_tx: TransactionRequest,
     ) -> Self {
-        let statement = &match_bundle.atomic_match_proof.statement;
+        let statement = &match_bundle.statement;
         let match_result = statement.bounded_match_result.clone();
         let fee_rates = statement.external_fee_rates;
 

--- a/workers/job-types/src/proof_manager.rs
+++ b/workers/job-types/src/proof_manager.rs
@@ -132,6 +132,9 @@ pub enum ProofJob {
         /// The statement (public variables) to use in the proof of `VALID
         /// MALLEABLE MATCH SETTLE ATOMIC`
         statement: SizedValidMalleableMatchSettleAtomicStatement,
+        /// The proof link hint for the internal party's proof of `VALID
+        /// COMMITMENTS`
+        commitments_link: ProofLinkingHint,
     },
     /// A request to create a proof of `VALID RELAYER FEE SETTLEMENT` in a
     /// single prover context

--- a/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -131,9 +131,11 @@ impl ExternalProofManager {
                 // Prove `VALID MATCH SETTLE ATOMIC`
                 client.prove_valid_match_settle_atomic(witness, statement, commitments_link).await
             },
-            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement } => {
+            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement, commitments_link } => {
                 // Prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
-                client.prove_valid_malleable_match_settle_atomic(witness, statement).await
+                client
+                    .prove_valid_malleable_match_settle_atomic(witness, statement, commitments_link)
+                    .await
             },
             ProofJob::ValidFeeRedemption { witness, statement } => {
                 // Prove `VALID FEE REDEMPTION`

--- a/workers/proof-manager/src/implementations/native_proof_manager.rs
+++ b/workers/proof-manager/src/implementations/native_proof_manager.rs
@@ -179,9 +179,9 @@ impl NativeProofManager {
                 self.prove_valid_match_settle_atomic(witness, statement, commitments_link)
             },
 
-            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement } => {
+            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement, commitments_link } => {
                 // Prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
-                self.prove_valid_malleable_match_settle_atomic(witness, statement)
+                self.prove_valid_malleable_match_settle_atomic(witness, statement, commitments_link)
             },
 
             ProofJob::ValidRelayerFeeSettlement { witness, statement } => {
@@ -350,13 +350,18 @@ impl NativeProofManager {
         &self,
         witness: SizedValidMalleableMatchSettleAtomicWitness,
         statement: SizedValidMalleableMatchSettleAtomicStatement,
+        commitments_link: ProofLinkingHint,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID MALLEABLE MATCH SETTLE ATOMIC`
         let (proof, link_hint) = singleprover_prove_with_hint::<
             SizedValidMalleableMatchSettleAtomic,
         >(witness, statement.clone())?;
 
-        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(statement, proof, link_hint))
+        // Prove the `VALID COMMITMENTS` <-> `VALID MALLEABLE MATCH SETTLE ATOMIC` link
+        let link_proof = link_sized_commitments_atomic_match_settle(&commitments_link, &link_hint)?;
+        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(
+            statement, proof, link_proof, link_hint,
+        ))
     }
 
     /// Create a proof of `VALID RELAYER FEE SETTLEMENT`

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -110,7 +110,7 @@ impl MockProofManager {
             ProofJob::ValidMatchSettleAtomic { witness, statement, .. } => {
                 Self::valid_match_settle_atomic(witness, statement, skip_constraints)
             },
-            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement } => {
+            ProofJob::ValidMalleableMatchSettleAtomic { witness, statement, .. } => {
                 Self::valid_malleable_match_settle_atomic(witness, statement, skip_constraints)
             },
             ProofJob::ValidRelayerFeeSettlement { witness, statement } => {
@@ -239,7 +239,10 @@ impl MockProofManager {
 
         let proof = dummy_proof();
         let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(statement, proof, link_hint))
+        let link_proof = dummy_link_proof();
+        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(
+            statement, proof, link_proof, link_hint,
+        ))
     }
 
     /// Generate a dummy proof of `VALID RELAYER FEE SETTLEMENT`


### PR DESCRIPTION
### Purpose
This PR refactors the malleable atomic match settle job of the proof manager to also prove the `VALID MALLEABLE MATCH SETTLE ATOMIC` <-> `VALID COMMITMENTS` proof link. This is an analogous change to that in #1088.

### Testing
- [x] Unit tests pass
- [x] Tested locally