### PR TITLE
task-driver: validity-proofs: Link reblind-commitments through proof manager

### DIFF
--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -283,6 +283,15 @@ impl ProofBundle {
         }
     }
 
+    /// Create a new proof bundle from a `VALID COMMITMENTS` <-> `VALID REBLIND`
+    /// proof link
+    pub fn new_valid_commitments_reblind_link(
+        link: PlonkLinkProof,
+        link_hint: ProofLinkingHint,
+    ) -> Self {
+        ProofBundle { proof: R1CSProofBundle::ValidCommitmentsReblindLink(link), link_hint }
+    }
+
     /// Create a new proof bundle from a `VALID MATCH SETTLE` proof
     pub fn new_valid_match_settle(
         statement: SizedValidMatchSettleStatement,
@@ -387,6 +396,9 @@ pub enum R1CSProofBundle {
     ValidReblind(ValidReblindBundle),
     /// A statement and proof of `VALID COMMITMENTS`
     ValidCommitments(ValidCommitmentsBundle),
+    /// A proof link between a proof of `VALID COMMITMENTS` and a proof of
+    /// `VALID REBLIND`
+    ValidCommitmentsReblindLink(PlonkLinkProof),
     /// A statement and proof of `VALID WALLET UPDATE`
     ValidWalletUpdate(ValidWalletUpdateBundle),
     /// A statement and proof of `VALID MATCH SETTLE`
@@ -401,6 +413,18 @@ pub enum R1CSProofBundle {
     ValidOfflineFeeSettlement(OfflineFeeSettlementBundle),
     /// A statement and proof of `VALID FEE REDEMPTION`
     ValidFeeRedemption(FeeRedemptionBundle),
+}
+
+impl R1CSProofBundle {
+    /// Get the proof link for a `VALID COMMITMENTS` and `VALID REBLIND` proof
+    /// link
+    pub fn to_reblind_commitment_link(self) -> PlonkLinkProof {
+        if let R1CSProofBundle::ValidCommitmentsReblindLink(link) = self {
+            link
+        } else {
+            panic!("Proof bundle is not of type ValidCommitmentsReblindLink: {self:?}");
+        }
+    }
 }
 
 /// Unsafe cast implementations, will panic if type is incorrect

--- a/common/src/types/proof_bundles.rs
+++ b/common/src/types/proof_bundles.rs
@@ -76,6 +76,8 @@ pub struct GenericValidReblindBundle<
     pub statement: ValidReblindStatement,
     /// The proof itself
     pub proof: PlonkProof,
+    /// The proof's link hint
+    pub link_hint: ProofLinkingHint,
 }
 
 /// A type alias that specifies default generics for `GenericValidReblindBundle`
@@ -91,6 +93,8 @@ pub struct GenericValidCommitmentsBundle<const MAX_BALANCES: usize, const MAX_OR
     pub statement: ValidCommitmentsStatement,
     /// The proof itself
     pub proof: PlonkProof,
+    /// The proof's link hint
+    pub link_hint: ProofLinkingHint,
 }
 
 /// A type alias that specifies the default generics for
@@ -213,183 +217,12 @@ pub type SizedFeeRedemptionBundle = GenericFeeRedemptionBundle<MAX_BALANCES, MAX
 /// A type alias that heap-allocates a `FeeRedemptionBundle`
 pub type FeeRedemptionBundle = Arc<SizedFeeRedemptionBundle>;
 
-/// The proof bundle returned by the proof generation module
-#[derive(Clone, Debug)]
-pub struct ProofBundle {
-    /// The underlying r1cs satisfaction proof
-    pub proof: R1CSProofBundle,
-    /// The proof linking hint returned by the proof
-    pub link_hint: ProofLinkingHint,
-}
-
-impl ProofBundle {
-    /// Create a new proof bundle from a `VALID WALLET CREATE` proof
-    pub fn new_valid_wallet_create(
-        statement: SizedValidWalletCreateStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidWalletCreate(Arc::new(GenericValidWalletCreateBundle {
-                statement,
-                proof,
-            })),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID WALLET UPDATE` proof
-    pub fn new_valid_wallet_update(
-        statement: SizedValidWalletUpdateStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidWalletUpdate(Arc::new(GenericValidWalletUpdateBundle {
-                statement,
-                proof,
-            })),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID REBLIND` proof
-    pub fn new_valid_reblind(
-        statement: ValidReblindStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidReblind(Arc::new(GenericValidReblindBundle {
-                statement,
-                proof,
-            })),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID COMMITMENTS` proof
-    pub fn new_valid_commitments(
-        statement: ValidCommitmentsStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidCommitments(Arc::new(GenericValidCommitmentsBundle {
-                statement,
-                proof,
-            })),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID COMMITMENTS` <-> `VALID REBLIND`
-    /// proof link
-    pub fn new_valid_commitments_reblind_link(
-        link: PlonkLinkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle { proof: R1CSProofBundle::ValidCommitmentsReblindLink(link), link_hint }
-    }
-
-    /// Create a new proof bundle from a `VALID MATCH SETTLE` proof
-    pub fn new_valid_match_settle(
-        statement: SizedValidMatchSettleStatement,
-        proof: PlonkProof,
-        party0_link: PlonkLinkProof,
-        party1_link: PlonkLinkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidMatchSettle(Arc::new(GenericMatchSettleBundle {
-                statement,
-                proof,
-                commitments_link0: party0_link,
-                commitments_link1: party1_link,
-            })),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID MATCH SETTLE ATOMIC` proof
-    pub fn new_valid_match_settle_atomic(
-        statement: SizedValidMatchSettleAtomicStatement,
-        proof: PlonkProof,
-        commitments_link: PlonkLinkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidMatchSettleAtomic(Arc::new(
-                GenericMatchSettleAtomicBundle { statement, proof, commitments_link },
-            )),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID MALLEABLE MATCH SETTLE ATOMIC`
-    /// proof
-    pub fn new_valid_malleable_match_settle_atomic(
-        statement: SizedValidMalleableMatchSettleAtomicStatement,
-        proof: PlonkProof,
-        commitments_link: PlonkLinkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidMalleableMatchSettleAtomic(Arc::new(
-                GenericMalleableMatchSettleAtomicBundle { statement, proof, commitments_link },
-            )),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID RELAYER FEE SETTLEMENT` proof
-    pub fn new_valid_relayer_fee_settlement(
-        statement: SizedValidRelayerFeeSettlementStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidRelayerFeeSettlement(Arc::new(
-                GenericRelayerFeeSettlementBundle { statement, proof },
-            )),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID OFFLINE FEE SETTLEMENT` proof
-    pub fn new_valid_offline_fee_settlement(
-        statement: SizedValidOfflineFeeSettlementStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidOfflineFeeSettlement(Arc::new(
-                GenericOfflineFeeSettlementBundle { statement, proof },
-            )),
-            link_hint,
-        }
-    }
-
-    /// Create a new proof bundle from a `VALID FEE REDEMPTION` proof
-    pub fn new_valid_fee_redemption(
-        statement: SizedValidFeeRedemptionStatement,
-        proof: PlonkProof,
-        link_hint: ProofLinkingHint,
-    ) -> Self {
-        ProofBundle {
-            proof: R1CSProofBundle::ValidFeeRedemption(Arc::new(GenericFeeRedemptionBundle {
-                statement,
-                proof,
-            })),
-            link_hint,
-        }
-    }
-}
+impl ProofBundle {}
 
 /// The bundle type returned by the proof generation module
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant, clippy::enum_variant_names)]
-pub enum R1CSProofBundle {
+pub enum ProofBundle {
     /// A statement and proof of `VALID WALLET CREATE`
     ValidWalletCreate(ValidWalletCreateBundle),
     /// A statement and proof of `VALID REBLIND`
@@ -415,11 +248,139 @@ pub enum R1CSProofBundle {
     ValidFeeRedemption(FeeRedemptionBundle),
 }
 
-impl R1CSProofBundle {
+impl ProofBundle {
+    // --- Constructors --- //
+
+    /// Create a new proof bundle from a `VALID WALLET CREATE` proof
+    pub fn new_valid_wallet_create(
+        statement: SizedValidWalletCreateStatement,
+        proof: PlonkProof,
+    ) -> Self {
+        ProofBundle::ValidWalletCreate(Arc::new(GenericValidWalletCreateBundle {
+            statement,
+            proof,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID WALLET UPDATE` proof
+    pub fn new_valid_wallet_update(
+        statement: SizedValidWalletUpdateStatement,
+        proof: PlonkProof,
+    ) -> Self {
+        ProofBundle::ValidWalletUpdate(Arc::new(GenericValidWalletUpdateBundle {
+            statement,
+            proof,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID REBLIND` proof
+    pub fn new_valid_reblind(
+        statement: ValidReblindStatement,
+        proof: PlonkProof,
+        link_hint: ProofLinkingHint,
+    ) -> Self {
+        ProofBundle::ValidReblind(Arc::new(GenericValidReblindBundle {
+            statement,
+            proof,
+            link_hint,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID COMMITMENTS` proof
+    pub fn new_valid_commitments(
+        statement: ValidCommitmentsStatement,
+        proof: PlonkProof,
+        link_hint: ProofLinkingHint,
+    ) -> Self {
+        ProofBundle::ValidCommitments(Arc::new(GenericValidCommitmentsBundle {
+            statement,
+            proof,
+            link_hint,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID COMMITMENTS` <-> `VALID REBLIND`
+    /// proof link
+    pub fn new_valid_commitments_reblind_link(link: PlonkLinkProof) -> Self {
+        ProofBundle::ValidCommitmentsReblindLink(link)
+    }
+
+    /// Create a new proof bundle from a `VALID MATCH SETTLE` proof
+    pub fn new_valid_match_settle(
+        statement: SizedValidMatchSettleStatement,
+        proof: PlonkProof,
+        party0_link: PlonkLinkProof,
+        party1_link: PlonkLinkProof,
+    ) -> Self {
+        ProofBundle::ValidMatchSettle(Arc::new(GenericMatchSettleBundle {
+            statement,
+            proof,
+            commitments_link0: party0_link,
+            commitments_link1: party1_link,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID MATCH SETTLE ATOMIC` proof
+    pub fn new_valid_match_settle_atomic(
+        statement: SizedValidMatchSettleAtomicStatement,
+        proof: PlonkProof,
+        commitments_link: PlonkLinkProof,
+    ) -> Self {
+        ProofBundle::ValidMatchSettleAtomic(Arc::new(GenericMatchSettleAtomicBundle {
+            statement,
+            proof,
+            commitments_link,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID MALLEABLE MATCH SETTLE ATOMIC`
+    /// proof
+    pub fn new_valid_malleable_match_settle_atomic(
+        statement: SizedValidMalleableMatchSettleAtomicStatement,
+        proof: PlonkProof,
+        commitments_link: PlonkLinkProof,
+    ) -> Self {
+        ProofBundle::ValidMalleableMatchSettleAtomic(Arc::new(
+            GenericMalleableMatchSettleAtomicBundle { statement, proof, commitments_link },
+        ))
+    }
+
+    /// Create a new proof bundle from a `VALID RELAYER FEE SETTLEMENT` proof
+    pub fn new_valid_relayer_fee_settlement(
+        statement: SizedValidRelayerFeeSettlementStatement,
+        proof: PlonkProof,
+    ) -> Self {
+        ProofBundle::ValidRelayerFeeSettlement(Arc::new(GenericRelayerFeeSettlementBundle {
+            statement,
+            proof,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID OFFLINE FEE SETTLEMENT` proof
+    pub fn new_valid_offline_fee_settlement(
+        statement: SizedValidOfflineFeeSettlementStatement,
+        proof: PlonkProof,
+    ) -> Self {
+        ProofBundle::ValidOfflineFeeSettlement(Arc::new(GenericOfflineFeeSettlementBundle {
+            statement,
+            proof,
+        }))
+    }
+
+    /// Create a new proof bundle from a `VALID FEE REDEMPTION` proof
+    pub fn new_valid_fee_redemption(
+        statement: SizedValidFeeRedemptionStatement,
+        proof: PlonkProof,
+    ) -> Self {
+        ProofBundle::ValidFeeRedemption(Arc::new(GenericFeeRedemptionBundle { statement, proof }))
+    }
+
+    // --- Conversion --- //
+
     /// Get the proof link for a `VALID COMMITMENTS` and `VALID REBLIND` proof
     /// link
     pub fn to_reblind_commitment_link(self) -> PlonkLinkProof {
-        if let R1CSProofBundle::ValidCommitmentsReblindLink(link) = self {
+        if let ProofBundle::ValidCommitmentsReblindLink(link) = self {
             link
         } else {
             panic!("Proof bundle is not of type ValidCommitmentsReblindLink: {self:?}");
@@ -428,9 +389,9 @@ impl R1CSProofBundle {
 }
 
 /// Unsafe cast implementations, will panic if type is incorrect
-impl From<R1CSProofBundle> for ValidWalletCreateBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidWalletCreate(b) = bundle {
+impl From<ProofBundle> for ValidWalletCreateBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidWalletCreate(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidWalletCreate: {:?}", bundle)
@@ -438,9 +399,9 @@ impl From<R1CSProofBundle> for ValidWalletCreateBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidReblindBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidReblind(b) = bundle {
+impl From<ProofBundle> for ValidReblindBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidReblind(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidReblind: {:?}", bundle);
@@ -448,9 +409,9 @@ impl From<R1CSProofBundle> for ValidReblindBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidCommitmentsBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidCommitments(b) = bundle {
+impl From<ProofBundle> for ValidCommitmentsBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidCommitments(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidCommitments: {:?}", bundle)
@@ -458,9 +419,9 @@ impl From<R1CSProofBundle> for ValidCommitmentsBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidWalletUpdateBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidWalletUpdate(b) = bundle {
+impl From<ProofBundle> for ValidWalletUpdateBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidWalletUpdate(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidWalletUpdate: {:?}", bundle);
@@ -468,9 +429,9 @@ impl From<R1CSProofBundle> for ValidWalletUpdateBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidMatchSettleBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidMatchSettle(b) = bundle {
+impl From<ProofBundle> for ValidMatchSettleBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidMatchSettle(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidMatchMpc: {:?}", bundle)
@@ -478,9 +439,9 @@ impl From<R1CSProofBundle> for ValidMatchSettleBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidMatchSettleAtomicBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidMatchSettleAtomic(b) = bundle {
+impl From<ProofBundle> for ValidMatchSettleAtomicBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidMatchSettleAtomic(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidMatchSettleAtomic: {:?}", bundle);
@@ -488,9 +449,9 @@ impl From<R1CSProofBundle> for ValidMatchSettleAtomicBundle {
     }
 }
 
-impl From<R1CSProofBundle> for ValidMalleableMatchSettleAtomicBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidMalleableMatchSettleAtomic(b) = bundle {
+impl From<ProofBundle> for ValidMalleableMatchSettleAtomicBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidMalleableMatchSettleAtomic(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidMalleableMatchSettleAtomic: {:?}", bundle);
@@ -498,9 +459,9 @@ impl From<R1CSProofBundle> for ValidMalleableMatchSettleAtomicBundle {
     }
 }
 
-impl From<R1CSProofBundle> for RelayerFeeSettlementBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidRelayerFeeSettlement(b) = bundle {
+impl From<ProofBundle> for RelayerFeeSettlementBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidRelayerFeeSettlement(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidRelayerFeeSettlement: {:?}", bundle);
@@ -508,9 +469,9 @@ impl From<R1CSProofBundle> for RelayerFeeSettlementBundle {
     }
 }
 
-impl From<R1CSProofBundle> for OfflineFeeSettlementBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidOfflineFeeSettlement(b) = bundle {
+impl From<ProofBundle> for OfflineFeeSettlementBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidOfflineFeeSettlement(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidOfflineFeeSettlement: {:?}", bundle);
@@ -518,9 +479,9 @@ impl From<R1CSProofBundle> for OfflineFeeSettlementBundle {
     }
 }
 
-impl From<R1CSProofBundle> for FeeRedemptionBundle {
-    fn from(bundle: R1CSProofBundle) -> Self {
-        if let R1CSProofBundle::ValidFeeRedemption(b) = bundle {
+impl From<ProofBundle> for FeeRedemptionBundle {
+    fn from(bundle: ProofBundle) -> Self {
+        if let ProofBundle::ValidFeeRedemption(b) = bundle {
             b
         } else {
             panic!("Proof bundle is not of type ValidFeeRedemption: {:?}", bundle);
@@ -711,13 +672,17 @@ pub mod mocks {
     /// Create a dummy proof bundle for `VALID REBLIND`
     pub fn dummy_valid_reblind_bundle() -> SizedValidReblindBundle {
         let statement = ValidReblindStatement::from_scalars(&mut iter::repeat(Scalar::one()));
-        SizedValidReblindBundle { statement, proof: dummy_proof() }
+        SizedValidReblindBundle { statement, proof: dummy_proof(), link_hint: dummy_link_hint() }
     }
 
     /// Create a dummy proof bundle for `VALID COMMITMENTS`
     pub fn dummy_valid_commitments_bundle() -> SizedValidCommitmentsBundle {
         let statement = ValidCommitmentsStatement::from_scalars(&mut iter::repeat(Scalar::one()));
-        SizedValidCommitmentsBundle { statement, proof: dummy_proof() }
+        SizedValidCommitmentsBundle {
+            statement,
+            proof: dummy_proof(),
+            link_hint: dummy_link_hint(),
+        }
     }
 
     /// Create a dummy proof bundle for `VALID RELAYER FEE SETTLEMENT`

--- a/darkpool-client/src/arbitrum/mod.rs
+++ b/darkpool-client/src/arbitrum/mod.rs
@@ -486,7 +486,7 @@ impl DarkpoolImpl for ArbitrumDarkpool {
             serialize_calldata(&internal_party_match_payload)?;
         let contract_valid_match_settle_atomic_statement =
             to_contract_valid_malleable_match_settle_atomic_statement(
-                &valid_match_settle_atomic_statement,
+                valid_match_settle_atomic_statement,
             )?;
         let valid_match_settle_atomic_statement_calldata =
             serialize_calldata(&contract_valid_match_settle_atomic_statement)?;

--- a/workers/job-types/src/proof_manager.rs
+++ b/workers/job-types/src/proof_manager.rs
@@ -87,6 +87,13 @@ pub enum ProofJob {
         /// COMMITMENTS`
         statement: ValidCommitmentsStatement,
     },
+    /// Link a proof of `VALID COMMITMENTS` with a proof of `VALID REBLIND`
+    ValidCommitmentsReblindLink {
+        /// The proof link hint for the proof of `VALID COMMITMENTS`
+        commitments_hint: ProofLinkingHint,
+        /// The proof link hint for the proof of `VALID REBLIND`
+        reblind_hint: ProofLinkingHint,
+    },
     /// a request to create a proof of `VALID WALLET UPDATE` specifying a user
     /// generated change to the underlying wallet. This nullifies the old
     /// wallet and becomes a new entry in the commitment tree

--- a/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -1,6 +1,5 @@
 //! An implementation of the proof manager which uses an external prover service
 
-use circuit_types::ProofLinkingHint;
 use common::types::CancelChannel;
 use constants::in_bootstrap_mode;
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
@@ -156,19 +155,5 @@ impl ExternalProofManager {
         // Ignore send errors
         let _err = job.response_channel.send(bundle);
         Ok(())
-    }
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Create a default proof linking hint
-///
-/// Used for circuits whose linking hints are unused and so omitted from the API
-pub fn default_link_hint() -> ProofLinkingHint {
-    ProofLinkingHint {
-        linking_wire_poly: Default::default(),
-        linking_wire_comm: Default::default(),
     }
 }

--- a/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -1,5 +1,6 @@
 //! An implementation of the proof manager which uses an external prover service
 
+use circuit_types::ProofLinkingHint;
 use common::types::CancelChannel;
 use constants::in_bootstrap_mode;
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerReceiver};
@@ -111,6 +112,10 @@ impl ExternalProofManager {
                 // Prove `VALID REBLIND`
                 client.prove_valid_reblind(witness, statement).await
             },
+            ProofJob::ValidCommitmentsReblindLink { commitments_hint, reblind_hint } => {
+                // Link a proof of `VALID COMMITMENTS` with a proof of `VALID REBLIND`
+                client.prove_valid_commitments_reblind_link(commitments_hint, reblind_hint).await
+            },
             ProofJob::ValidMatchSettleSingleprover {
                 witness,
                 statement,
@@ -151,5 +156,19 @@ impl ExternalProofManager {
         // Ignore send errors
         let _err = job.response_channel.send(bundle);
         Ok(())
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a default proof linking hint
+///
+/// Used for circuits whose linking hints are unused and so omitted from the API
+pub fn default_link_hint() -> ProofLinkingHint {
+    ProofLinkingHint {
+        linking_wire_poly: Default::default(),
+        linking_wire_comm: Default::default(),
     }
 }

--- a/workers/proof-manager/src/implementations/external_proof_manager/prover_service_client.rs
+++ b/workers/proof-manager/src/implementations/external_proof_manager/prover_service_client.rs
@@ -28,15 +28,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::ProofManagerError,
-    implementations::external_proof_manager::{
-        api_types::{
-            LinkCommitmentsReblindRequest, ProofAndHintResponse, ProofAndLinkResponse,
-            ProofLinkResponse, ProofResponse, ValidCommitmentsRequest, ValidFeeRedemptionRequest,
-            ValidMalleableMatchSettleAtomicRequest, ValidMatchSettleAtomicRequest,
-            ValidMatchSettleRequest, ValidMatchSettleResponse, ValidOfflineFeeSettlementRequest,
-            ValidReblindRequest, ValidWalletCreateRequest, ValidWalletUpdateRequest,
-        },
-        default_link_hint,
+    implementations::external_proof_manager::api_types::{
+        LinkCommitmentsReblindRequest, ProofAndHintResponse, ProofAndLinkResponse,
+        ProofLinkResponse, ProofResponse, ValidCommitmentsRequest, ValidFeeRedemptionRequest,
+        ValidMalleableMatchSettleAtomicRequest, ValidMatchSettleAtomicRequest,
+        ValidMatchSettleRequest, ValidMatchSettleResponse, ValidOfflineFeeSettlementRequest,
+        ValidReblindRequest, ValidWalletCreateRequest, ValidWalletUpdateRequest,
     },
     worker::ProofManagerConfig,
 };
@@ -133,8 +130,7 @@ impl ProofServiceClient {
         let req = ValidWalletCreateRequest { statement: statement.clone(), witness };
         let res = self.send_request::<_, ProofResponse>(VALID_WALLET_CREATE_PATH, req).await?;
 
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_wallet_create(statement, res.proof, link_hint);
+        let bundle = ProofBundle::new_valid_wallet_create(statement, res.proof);
         Ok(bundle)
     }
 
@@ -147,8 +143,7 @@ impl ProofServiceClient {
         let req = ValidWalletUpdateRequest { statement: statement.clone(), witness };
         let res = self.send_request::<_, ProofResponse>(VALID_WALLET_UPDATE_PATH, req).await?;
 
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_wallet_update(statement, res.proof, link_hint);
+        let bundle = ProofBundle::new_valid_wallet_update(statement, res.proof);
         Ok(bundle)
     }
 
@@ -194,8 +189,7 @@ impl ProofServiceClient {
             self.send_request::<_, ProofLinkResponse>(LINK_COMMITMENTS_REBLIND_PATH, req).await?;
 
         // Build the proof bundle
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_commitments_reblind_link(res.link_proof, link_hint);
+        let bundle = ProofBundle::new_valid_commitments_reblind_link(res.link_proof);
         Ok(bundle)
     }
 
@@ -216,13 +210,11 @@ impl ProofServiceClient {
         let res =
             self.send_request::<_, ValidMatchSettleResponse>(VALID_MATCH_SETTLE_PATH, req).await?;
 
-        let link_hint = default_link_hint();
         let bundle = ProofBundle::new_valid_match_settle(
             statement,
             res.plonk_proof,
             res.link_proof0,
             res.link_proof1,
-            link_hint,
         );
         Ok(bundle)
     }
@@ -245,13 +237,8 @@ impl ProofServiceClient {
             .await?;
 
         // Build the proof bundle
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_match_settle_atomic(
-            statement,
-            res.plonk_proof,
-            res.link_proof,
-            link_hint,
-        );
+        let bundle =
+            ProofBundle::new_valid_match_settle_atomic(statement, res.plonk_proof, res.link_proof);
         Ok(bundle)
     }
 
@@ -274,12 +261,10 @@ impl ProofServiceClient {
             .await?;
 
         // Build the proof bundle
-        let link_hint = default_link_hint();
         let bundle = ProofBundle::new_valid_malleable_match_settle_atomic(
             statement,
             res.plonk_proof,
             res.link_proof,
-            link_hint,
         );
         Ok(bundle)
     }
@@ -293,8 +278,7 @@ impl ProofServiceClient {
         let req = ValidFeeRedemptionRequest { statement: statement.clone(), witness };
         let res = self.send_request::<_, ProofResponse>(VALID_FEE_REDEMPTION_PATH, req).await?;
 
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_fee_redemption(statement, res.proof, link_hint);
+        let bundle = ProofBundle::new_valid_fee_redemption(statement, res.proof);
         Ok(bundle)
     }
 
@@ -308,8 +292,7 @@ impl ProofServiceClient {
         let res =
             self.send_request::<_, ProofResponse>(VALID_OFFLINE_FEE_SETTLEMENT_PATH, req).await?;
 
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_offline_fee_settlement(statement, res.proof, link_hint);
+        let bundle = ProofBundle::new_valid_offline_fee_settlement(statement, res.proof);
         Ok(bundle)
     }
 }

--- a/workers/proof-manager/src/implementations/native_proof_manager.rs
+++ b/workers/proof-manager/src/implementations/native_proof_manager.rs
@@ -161,9 +161,9 @@ impl NativeProofManager {
                 self.prove_valid_commitments(witness, statement)
             },
 
-            ProofJob::ValidCommitmentsReblindLink { commitments_hint, reblind_hint } => {
+            ProofJob::ValidCommitmentsReblindLink { reblind_hint, commitments_hint } => {
                 // Link a proof of `VALID COMMITMENTS` with a proof of `VALID REBLIND`
-                self.link_commitments_reblind(commitments_hint, reblind_hint)
+                self.link_commitments_reblind(reblind_hint, commitments_hint)
             },
 
             ProofJob::ValidWalletUpdate { witness, statement } => {
@@ -294,10 +294,10 @@ impl NativeProofManager {
     #[instrument(skip_all, err)]
     fn link_commitments_reblind(
         &self,
-        commitments_hint: ProofLinkingHint,
         reblind_hint: ProofLinkingHint,
+        commitments_hint: ProofLinkingHint,
     ) -> Result<ProofBundle, ProofManagerError> {
-        let link_proof = link_sized_commitments_reblind(&commitments_hint, &reblind_hint)?;
+        let link_proof = link_sized_commitments_reblind(&reblind_hint, &commitments_hint)?;
         let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof);
         Ok(bundle)
     }
@@ -317,8 +317,8 @@ impl NativeProofManager {
 
         // Link the individual proofs of `VALID COMMITMENTS` into the proof of
         // `VALID MATCH SETTLE`
-        let thread1 = || self.link_commitments_match_settle(PARTY0, &commitment_link1, &link_hint);
-        let thread0 = || self.link_commitments_match_settle(PARTY1, &commitment_link0, &link_hint);
+        let thread0 = || self.link_commitments_match_settle(PARTY0, &commitment_link0, &link_hint);
+        let thread1 = || self.link_commitments_match_settle(PARTY1, &commitment_link1, &link_hint);
         let (link_res0, link_res1) = self.thread_pool.join(thread0, thread1);
         let link0 = link_res0?;
         let link1 = link_res1?;

--- a/workers/proof-manager/src/implementations/native_proof_manager.rs
+++ b/workers/proof-manager/src/implementations/native_proof_manager.rs
@@ -8,7 +8,7 @@ use circuit_types::{
     traits::{SingleProverCircuit, setup_preprocessed_keys},
 };
 use circuits::{
-    singleprover_prove_with_hint,
+    singleprover_prove, singleprover_prove_with_hint,
     zk_circuits::{
         proof_linking::{
             link_sized_commitments_atomic_match_settle, link_sized_commitments_match_settle,
@@ -59,10 +59,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder};
 use tracing::{error, info, info_span, instrument};
 use util::{channels::TracedMessage, concurrency::runtime::sleep_forever_blocking, err_str};
 
-use crate::{
-    error::ProofManagerError, implementations::external_proof_manager::default_link_hint,
-    worker::ProofManagerConfig,
-};
+use crate::{error::ProofManagerError, worker::ProofManagerConfig};
 
 /// The name prefix for worker threads
 const WORKER_THREAD_PREFIX: &str = "proof-generation-worker";
@@ -251,9 +248,8 @@ impl NativeProofManager {
         statement: SizedValidWalletCreateStatement,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID WALLET CREATE`
-        let (proof, link_hint) =
-            singleprover_prove_with_hint::<SizedValidWalletCreate>(witness, statement.clone())?;
-        Ok(ProofBundle::new_valid_wallet_create(statement, proof, link_hint))
+        let proof = singleprover_prove::<SizedValidWalletCreate>(witness, statement.clone())?;
+        Ok(ProofBundle::new_valid_wallet_create(statement, proof))
     }
 
     /// Create a proof of `VALID WALLET UPDATE`
@@ -264,9 +260,8 @@ impl NativeProofManager {
         statement: SizedValidWalletUpdateStatement,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID WALLET UPDATE`
-        let (proof, link_hint) =
-            singleprover_prove_with_hint::<SizedValidWalletUpdate>(witness, statement.clone())?;
-        Ok(ProofBundle::new_valid_wallet_update(statement, proof, link_hint))
+        let proof = singleprover_prove::<SizedValidWalletUpdate>(witness, statement.clone())?;
+        Ok(ProofBundle::new_valid_wallet_update(statement, proof))
     }
 
     /// Create a proof of `VALID REBLIND`
@@ -303,8 +298,7 @@ impl NativeProofManager {
         reblind_hint: ProofLinkingHint,
     ) -> Result<ProofBundle, ProofManagerError> {
         let link_proof = link_sized_commitments_reblind(&commitments_hint, &reblind_hint)?;
-        let link_hint = default_link_hint();
-        let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof, link_hint);
+        let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof);
         Ok(bundle)
     }
 
@@ -328,7 +322,7 @@ impl NativeProofManager {
         let (link_res0, link_res1) = self.thread_pool.join(thread0, thread1);
         let link0 = link_res0?;
         let link1 = link_res1?;
-        Ok(ProofBundle::new_valid_match_settle(statement, proof, link0, link1, link_hint))
+        Ok(ProofBundle::new_valid_match_settle(statement, proof, link0, link1))
     }
 
     /// Generate a link proof for a party's proof of `VALID COMMITMENTS` and a
@@ -363,7 +357,7 @@ impl NativeProofManager {
 
         // Prove the `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC` link
         let link_proof = link_sized_commitments_atomic_match_settle(&commitments_link, &link_hint)?;
-        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_proof, link_hint))
+        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_proof))
     }
 
     /// Create a proof of `VALID MALLEABLE MATCH SETTLE ATOMIC`
@@ -381,9 +375,7 @@ impl NativeProofManager {
 
         // Prove the `VALID COMMITMENTS` <-> `VALID MALLEABLE MATCH SETTLE ATOMIC` link
         let link_proof = link_sized_commitments_atomic_match_settle(&commitments_link, &link_hint)?;
-        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(
-            statement, proof, link_proof, link_hint,
-        ))
+        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(statement, proof, link_proof))
     }
 
     /// Create a proof of `VALID RELAYER FEE SETTLEMENT`
@@ -394,12 +386,9 @@ impl NativeProofManager {
         statement: SizedValidRelayerFeeSettlementStatement,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID RELAYER FEE SETTLEMENT`
-        let (proof, link_hint) = singleprover_prove_with_hint::<SizedValidRelayerFeeSettlement>(
-            witness,
-            statement.clone(),
-        )?;
-
-        Ok(ProofBundle::new_valid_relayer_fee_settlement(statement, proof, link_hint))
+        let proof =
+            singleprover_prove::<SizedValidRelayerFeeSettlement>(witness, statement.clone())?;
+        Ok(ProofBundle::new_valid_relayer_fee_settlement(statement, proof))
     }
 
     /// Create a proof of `VALID OFFLINE FEE SETTLEMENT`
@@ -410,13 +399,9 @@ impl NativeProofManager {
         statement: SizedValidOfflineFeeSettlementStatement,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID OFFLINE FEE SETTLEMENT`
-        let (proof, link_hint) = singleprover_prove_with_hint::<SizedValidOfflineFeeSettlement>(
-            witness,
-            statement.clone(),
-        )
-        .map_err(|err| ProofManagerError::Prover(err.to_string()))?;
-
-        Ok(ProofBundle::new_valid_offline_fee_settlement(statement, proof, link_hint))
+        let proof =
+            singleprover_prove::<SizedValidOfflineFeeSettlement>(witness, statement.clone())?;
+        Ok(ProofBundle::new_valid_offline_fee_settlement(statement, proof))
     }
 
     /// Create a proof of `VALID FEE REDEMPTION`
@@ -427,9 +412,7 @@ impl NativeProofManager {
         statement: SizedValidFeeRedemptionStatement,
     ) -> Result<ProofBundle, ProofManagerError> {
         // Prove the statement `VALID FEE REDEMPTION`
-        let (proof, link_hint) =
-            singleprover_prove_with_hint::<SizedValidFeeRedemption>(witness, statement.clone())?;
-
-        Ok(ProofBundle::new_valid_fee_redemption(statement, proof, link_hint))
+        let proof = singleprover_prove::<SizedValidFeeRedemption>(witness, statement.clone())?;
+        Ok(ProofBundle::new_valid_fee_redemption(statement, proof))
     }
 }

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -104,6 +104,7 @@ impl MockProofManager {
             ProofJob::ValidCommitments { witness, statement } => {
                 Self::valid_commitments(witness, statement, skip_constraints)
             },
+            ProofJob::ValidCommitmentsReblindLink { .. } => Self::valid_commitments_reblind_link(),
             ProofJob::ValidMatchSettleSingleprover { witness, statement, .. } => {
                 Self::valid_match_settle(witness, statement, skip_constraints)
             },
@@ -186,6 +187,14 @@ impl MockProofManager {
         let proof = dummy_proof();
         let link_hint = dummy_link_hint();
         Ok(ProofBundle::new_valid_commitments(statement, proof, link_hint))
+    }
+
+    /// Create a dummy link proof of `VALID COMMITMENTS` <-> `VALID REBLIND`
+    fn valid_commitments_reblind_link() -> Result<ProofBundle, ProofManagerError> {
+        let link_proof = dummy_link_proof();
+        let link_hint = dummy_link_hint();
+        let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof, link_hint);
+        Ok(bundle)
     }
 
     /// Create a dummy proof of `VALID MATCH SETTLE`

--- a/workers/proof-manager/src/mock.rs
+++ b/workers/proof-manager/src/mock.rs
@@ -140,8 +140,7 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_wallet_create(statement, proof, link_hint))
+        Ok(ProofBundle::new_valid_wallet_create(statement, proof))
     }
 
     /// Generate a dummy proof of `VALID WALLET UPDATE`
@@ -155,8 +154,7 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_wallet_update(statement, proof, link_hint))
+        Ok(ProofBundle::new_valid_wallet_update(statement, proof))
     }
 
     /// Generate a dummy proof of `VALID REBLIND`
@@ -192,8 +190,7 @@ impl MockProofManager {
     /// Create a dummy link proof of `VALID COMMITMENTS` <-> `VALID REBLIND`
     fn valid_commitments_reblind_link() -> Result<ProofBundle, ProofManagerError> {
         let link_proof = dummy_link_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof, link_hint);
+        let bundle = ProofBundle::new_valid_commitments_reblind_link(link_proof);
         Ok(bundle)
     }
 
@@ -208,16 +205,9 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
         let link_proof0 = dummy_link_proof();
         let link_proof1 = dummy_link_proof();
-        Ok(ProofBundle::new_valid_match_settle(
-            statement,
-            proof,
-            link_proof0,
-            link_proof1,
-            link_hint,
-        ))
+        Ok(ProofBundle::new_valid_match_settle(statement, proof, link_proof0, link_proof1))
     }
 
     /// Create a dummy proof of `VALID MATCH SETTLE ATOMIC`
@@ -231,9 +221,8 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
         let link_proof = dummy_link_proof();
-        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_proof, link_hint))
+        Ok(ProofBundle::new_valid_match_settle_atomic(statement, proof, link_proof))
     }
 
     /// Create a dummy proof of `VALID MALLEABLE MATCH SETTLE ATOMIC`
@@ -247,11 +236,8 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
         let link_proof = dummy_link_proof();
-        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(
-            statement, proof, link_proof, link_hint,
-        ))
+        Ok(ProofBundle::new_valid_malleable_match_settle_atomic(statement, proof, link_proof))
     }
 
     /// Generate a dummy proof of `VALID RELAYER FEE SETTLEMENT`
@@ -265,8 +251,7 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_relayer_fee_settlement(statement, proof, link_hint))
+        Ok(ProofBundle::new_valid_relayer_fee_settlement(statement, proof))
     }
 
     /// Generate a dummy proof of `VALID OFFLINE FEE SETTLEMENT`
@@ -280,8 +265,7 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_offline_fee_settlement(statement, proof, link_hint))
+        Ok(ProofBundle::new_valid_offline_fee_settlement(statement, proof))
     }
 
     /// Generate a dummy proof of `VALID FEE REDEMPTION`
@@ -295,8 +279,7 @@ impl MockProofManager {
         }
 
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        Ok(ProofBundle::new_valid_fee_redemption(statement, proof, link_hint))
+        Ok(ProofBundle::new_valid_fee_redemption(statement, proof))
     }
 
     /// Check constraint satisfaction for a witness and statement

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -269,7 +269,7 @@ impl NewWalletTask {
         // Await the proof
         let bundle =
             proof_recv.await.map_err(|e| NewWalletTaskError::ProofGeneration(e.to_string()))?;
-        self.proof_bundle = Some(bundle.proof.into());
+        self.proof_bundle = Some(bundle.into());
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -274,7 +274,7 @@ impl PayOfflineFeeTask {
 
         // Await the proof
         let bundle = proof_recv.await.map_err(err_str!(PayOfflineFeeTaskError::ProofGeneration))?;
-        self.proof = Some(bundle.proof.into());
+        self.proof = Some(bundle.into());
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -282,7 +282,7 @@ impl PayRelayerFeeTask {
 
         // Await the proof
         let bundle = proof_recv.await.map_err(err_str!(PayRelayerFeeTaskError::ProofGeneration))?;
-        self.proof = Some(bundle.proof.into());
+        self.proof = Some(bundle.into());
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/redeem_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_fee.rs
@@ -270,7 +270,7 @@ impl RedeemFeeTask {
 
         // Await the proof
         let bundle = proof.await.map_err(err_str!(RedeemFeeError::ProofGeneration))?;
-        self.proof = Some(bundle.proof.into());
+        self.proof = Some(bundle.into());
 
         Ok(())
     }

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -330,7 +330,7 @@ impl SettleMalleableExternalMatchTask {
 
         // Create proof-links between the atomic match settle proof and the internal
         // party's proof of `VALID COMMITMENTS`
-        let atomic_match_bundle = ValidMalleableMatchSettleAtomicBundle::from(bundle.proof);
+        let atomic_match_bundle = ValidMalleableMatchSettleAtomicBundle::from(bundle);
         self.atomic_match_bundle = Some(atomic_match_bundle);
         Ok(())
     }

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -325,7 +325,7 @@ impl SettleMatchExternalTask {
 
         // Create proof-links between the atomic match settle proof and the internal
         // party's proof of `VALID COMMITMENTS`
-        let proof_bundle = ValidMatchSettleAtomicBundle::from(bundle.proof);
+        let proof_bundle = ValidMatchSettleAtomicBundle::from(bundle);
         self.atomic_match_bundle = Some(proof_bundle);
         Ok(())
     }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -328,7 +328,7 @@ impl SettleMatchInternalTask {
         let bundle = proof_recv.await.map_err(|_| {
             SettleMatchInternalTaskError::EnqueuingJob(ERR_AWAITING_PROOF.to_string())
         })?;
-        self.match_bundle = Some(bundle.proof.into());
+        self.match_bundle = Some(bundle.into());
         Ok(())
     }
 

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -358,7 +358,7 @@ impl UpdateWalletTask {
         let bundle =
             proof_recv.await.map_err(|e| UpdateWalletTaskError::ProofGeneration(e.to_string()))?;
 
-        self.proof_bundle = Some(bundle.proof.into());
+        self.proof_bundle = Some(bundle.into());
         Ok(())
     }
 

--- a/workers/task-driver/src/utils/validity_proofs.rs
+++ b/workers/task-driver/src/utils/validity_proofs.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use alloy::rpc::types::TransactionReceipt;
-use circuit_types::SizedWallet;
 use circuit_types::balance::Balance;
 use circuit_types::r#match::OrderSettlementIndices;
 use circuit_types::native_helpers::{
@@ -12,7 +11,7 @@ use circuit_types::native_helpers::{
 };
 use circuit_types::note::Note;
 use circuit_types::order::Order;
-use circuits::zk_circuits::proof_linking::link_sized_commitments_reblind;
+use circuit_types::{PlonkLinkProof, ProofLinkingHint, SizedWallet};
 use circuits::zk_circuits::valid_commitments::{
     SizedValidCommitmentsWitness, ValidCommitmentsStatement, ValidCommitmentsWitness,
 };
@@ -20,8 +19,7 @@ use circuits::zk_circuits::valid_reblind::{
     SizedValidReblindWitness, ValidReblindStatement, ValidReblindWitness,
 };
 use common::types::proof_bundles::{
-    OrderValidityProofBundle, OrderValidityWitnessBundle, ProofBundle, ValidCommitmentsBundle,
-    ValidReblindBundle,
+    OrderValidityProofBundle, OrderValidityWitnessBundle, ProofBundle,
 };
 use common::types::tasks::RedeemFeeTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, Wallet, WalletAuthenticationPath};
@@ -36,6 +34,8 @@ use state::State;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver as TokioReceiver;
 use tracing::instrument;
+
+use crate::tasks::ERR_AWAITING_PROOF;
 
 use super::{
     ERR_BALANCE_NOT_FOUND, ERR_ENQUEUING_JOB, ERR_MISSING_AUTHENTICATION_PATH, ERR_ORDER_NOT_FOUND,
@@ -279,16 +279,14 @@ pub(crate) async fn update_wallet_validity_proofs(
     }
 
     // Await the proof of `VALID REBLIND`
-    let reblind_proof: ProofBundle =
+    let reblind_bundle: ProofBundle =
         reblind_response_channel.await.map_err(|_| ERR_PROVE_REBLIND_FAILED.to_string())?;
-    let reblind_bundle = ValidReblindBundle::from(reblind_proof);
 
     // Await proofs of `VALID COMMITMENTS` for each order, store them in the state
     for (order_id, commitments_witness, receiver) in commitments_instances.into_iter() {
         // Await a proof
-        let commitment_proof: ProofBundle =
+        let commitments_bundle: ProofBundle =
             receiver.await.map_err(|_| ERR_PROVE_COMMITMENTS_FAILED.to_string())?;
-        let commitments_bundle = ValidCommitmentsBundle::from(commitment_proof);
 
         link_and_store_proofs(
             &order_id,
@@ -298,6 +296,7 @@ pub(crate) async fn update_wallet_validity_proofs(
             reblind_bundle.clone(),
             &state,
             &network_sender,
+            &proof_manager_work_queue,
         )
         .await?;
     }
@@ -310,32 +309,34 @@ pub(crate) async fn update_wallet_validity_proofs(
 /// The proof is gossipped to the network so that peers may verify the validity
 /// bundle and schedule matches on the proven order
 #[instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
 async fn link_and_store_proofs(
     order_id: &OrderIdentifier,
     commitments_witness: &SizedValidCommitmentsWitness,
     reblind_witness: &SizedValidReblindWitness,
-    commitments_bundle: ValidCommitmentsBundle,
-    reblind_bundle: ValidReblindBundle,
+    commitments_bundle: ProofBundle,
+    reblind_bundle: ProofBundle,
     state: &State,
     network_sender: &NetworkManagerQueue,
+    proof_queue: &ProofManagerQueue,
 ) -> Result<(), String> {
     // Prove the link between the reblind and commitments proofs
-    let reblind_link_hint = &reblind_bundle.link_hint;
-    let comms_link_hint = &commitments_bundle.link_hint;
-    let linking_proof = link_sized_commitments_reblind(reblind_link_hint, comms_link_hint)
-        .map_err(|e| e.to_string())?;
+    let (reblind_proof, reblind_hint) = reblind_bundle.to_valid_reblind();
+    let (commitments_proof, commitments_hint) = commitments_bundle.to_valid_commitments();
+    let linking_proof =
+        link_reblind_commitments(&commitments_hint, &reblind_hint, proof_queue).await?;
 
     // Record the bundle in the global state
     let proof_bundle = OrderValidityProofBundle {
-        reblind_proof: reblind_bundle,
-        commitment_proof: commitments_bundle.clone(),
+        reblind_proof,
+        commitment_proof: commitments_proof,
         linking_proof,
     };
 
     let witness_bundle = OrderValidityWitnessBundle {
         reblind_witness: Arc::new(reblind_witness.clone()),
         commitment_witness: Arc::new(commitments_witness.clone()),
-        commitment_linking_hint: Arc::new(comms_link_hint.clone()),
+        commitment_linking_hint: Arc::new(commitments_hint.clone()),
     };
 
     let waiter = state
@@ -352,6 +353,26 @@ async fn link_and_store_proofs(
 
     let job = NetworkManagerJob::pubsub(ORDER_BOOK_TOPIC.to_string(), message);
     network_sender.send(job).map_err(|e| e.to_string())
+}
+
+/// Request the proof manager to link the reblind and commitments proofs
+pub(crate) async fn link_reblind_commitments(
+    commitments_hint: &ProofLinkingHint,
+    reblind_hint: &ProofLinkingHint,
+    proof_queue: &ProofManagerQueue,
+) -> Result<PlonkLinkProof, String> {
+    // Enqueue a job to link the proofs
+    let job = ProofJob::ValidCommitmentsReblindLink {
+        commitments_hint: commitments_hint.clone(),
+        reblind_hint: reblind_hint.clone(),
+    };
+    let proof_recv =
+        enqueue_proof_job(job, proof_queue).map_err(|_| ERR_ENQUEUING_JOB.to_string())?;
+
+    // Await a response from the proof manager
+    let bundle = proof_recv.await.map_err(|_| ERR_AWAITING_PROOF.to_string())?;
+    let link_proof = bundle.to_reblind_commitment_link();
+    Ok(link_proof)
 }
 
 /// Enqueue a job to redeem a relayer fee into the relayer's wallet


### PR DESCRIPTION
### Purpose
This PR adds a proof manager job to link a proof of `VALID REBLIND` and a proof of `VALID COMMITMENTS` and uses this job in the task driver when we need to re-prove validity proofs. 

I also implemented the external prover client handler for this job.

### Testing
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Tested against a locally running prover service instance