### PR TITLE
api-server: compliance: Fix URL + path join

### DIFF
--- a/workers/api-server/src/compliance/client.rs
+++ b/workers/api-server/src/compliance/client.rs
@@ -31,7 +31,8 @@ impl ComplianceServerClient {
 
         // Send a request to the compliance service
         let base_url = self.url.clone().unwrap();
-        let url = format!("{base_url}{WALLET_SCREEN_PATH}/{wallet_address}");
+        let path = format!("{WALLET_SCREEN_PATH}/{wallet_address}");
+        let url = base_url.join(&path).map_err(err_str!(ApiServerError::ComplianceService))?;
         let resp = client
             .get(url)
             .header("Content-Type", "application/json")


### PR DESCRIPTION
### Purpose
This PR fixes a double slash `/` issue in the compliance URL that was introduced in #1085 by passing the compliance url as type `Url`, which automatically suffixes a `/`.

### Testing
- [x] Testing in mainnet