### PR TITLE
task-driver: tasks: Add `bypass_task_queue` method to task descriptors

### DIFF
--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -35,7 +35,7 @@ use tracing::instrument;
 use util::err_str;
 
 use crate::task_state::StateWrapper;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::validity_proofs::{enqueue_proof_job, find_merkle_path_with_tx};
 
 /// The task name to display when logging
@@ -246,6 +246,8 @@ impl Task for NewWalletTask {
         NEW_WALLET_TASK_NAME.to_string()
     }
 }
+
+impl Descriptor for NewWalletTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -21,7 +21,7 @@ use tracing::instrument;
 
 use crate::{
     task_state::StateWrapper,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
         validity_proofs::{find_merkle_path, update_wallet_validity_proofs},
@@ -215,6 +215,8 @@ impl Task for LookupWalletTask {
         self.task_state.clone()
     }
 }
+
+impl Descriptor for LookupWalletTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -39,7 +39,7 @@ use crate::{
     await_task,
     state_migration::remove_phantom_orders,
     task_state::StateWrapper,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::ERR_WALLET_NOT_FOUND,
 };
 
@@ -273,6 +273,12 @@ impl Task for NodeStartupTask {
 
     fn name(&self) -> String {
         NODE_STARTUP_TASK_NAME.to_string()
+    }
+}
+
+impl Descriptor for NodeStartupTaskDescriptor {
+    fn bypass_task_queue(&self) -> bool {
+        true
     }
 }
 

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -28,7 +28,7 @@ use util::{err_str, on_chain::get_protocol_pubkey};
 
 use crate::{
     task_state::StateWrapper,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::validity_proofs::{
         enqueue_proof_job, enqueue_relayer_redeem_job, find_merkle_path_with_tx,
         update_wallet_validity_proofs,
@@ -257,6 +257,8 @@ impl Task for PayOfflineFeeTask {
         TASK_NAME.to_string()
     }
 }
+
+impl Descriptor for PayOfflineFeeTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -26,7 +26,7 @@ use tracing::instrument;
 use util::err_str;
 
 use crate::task_state::StateWrapper;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::validity_proofs::{
     enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
 };
@@ -266,6 +266,8 @@ impl Task for PayRelayerFeeTask {
         TASK_NAME.to_string()
     }
 }
+
+impl Descriptor for PayRelayerFeeTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/redeem_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_fee.rs
@@ -25,7 +25,7 @@ use util::err_str;
 use crate::{
     task_state::StateWrapper,
     tasks::ERR_NO_MERKLE_PROOF,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::validity_proofs::{enqueue_proof_job, find_merkle_path_with_tx},
 };
 
@@ -246,6 +246,8 @@ impl Task for RedeemFeeTask {
         TASK_NAME.to_string()
     }
 }
+
+impl Descriptor for RedeemFeeTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -25,7 +25,7 @@ use tracing::{info, instrument};
 
 use crate::{
     task_state::StateWrapper,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
         validity_proofs::{find_merkle_path, update_wallet_validity_proofs},
@@ -210,6 +210,8 @@ impl Task for RefreshWalletTask {
         self.task_state.clone()
     }
 }
+
+impl Descriptor for RefreshWalletTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::validity_proofs::enqueue_proof_job;
 use async_trait::async_trait;
 use circuit_types::fees::FeeTakeRate;
@@ -311,6 +311,12 @@ impl Task for SettleMalleableExternalMatchTask {
 
     /// Shared bundles will always have a much higher rate limit than exclusive
     /// For this reason, we bypass the task queue to prevent raft contention
+    fn bypass_task_queue(&self) -> bool {
+        self.shared
+    }
+}
+
+impl Descriptor for SettleMalleableExternalMatchTaskDescriptor {
     fn bypass_task_queue(&self) -> bool {
         self.shared
     }

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -29,7 +29,7 @@ use state::error::StateError;
 use tracing::instrument;
 
 use crate::task_state::StateWrapper;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
 use crate::utils::validity_proofs::{
     find_merkle_path, find_merkle_path_with_tx, update_wallet_validity_proofs,
@@ -94,6 +94,8 @@ impl Display for SettleMatchTaskState {
         }
     }
 }
+
+impl Descriptor for SettleMatchTaskDescriptor {}
 
 // --------------
 // | Task Error |

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::validity_proofs::enqueue_proof_job;
 use async_trait::async_trait;
 use circuit_types::fixed_point::FixedPoint;
@@ -307,6 +307,12 @@ impl Task for SettleMatchExternalTask {
 
     /// Shared bundles will always have a much higher rate limit than exclusive
     /// For this reason, we bypass the task queue to prevent raft contention
+    fn bypass_task_queue(&self) -> bool {
+        self.shared
+    }
+}
+
+impl Descriptor for SettleExternalMatchTaskDescriptor {
     fn bypass_task_queue(&self) -> bool {
         self.shared
     }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::task_state::StateWrapper;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
 use crate::utils::validity_proofs::{
     enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
@@ -298,6 +298,8 @@ impl Task for SettleMatchInternalTask {
         self.task_state.clone()
     }
 }
+
+impl Descriptor for SettleMatchInternalTaskDescriptor {}
 
 // -----------------------
 // | Task Implementation |

--- a/workers/task-driver/src/tasks/update_merkle_proof.rs
+++ b/workers/task-driver/src/tasks/update_merkle_proof.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 
 use crate::{
     task_state::StateWrapper,
-    traits::{Task, TaskContext, TaskError, TaskState},
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::validity_proofs::update_wallet_validity_proofs,
 };
 
@@ -124,6 +124,8 @@ impl From<DarkpoolClientError> for UpdateMerkleProofTaskError {
         UpdateMerkleProofTaskError::Darkpool(value.to_string())
     }
 }
+
+impl Descriptor for UpdateMerkleProofTaskDescriptor {}
 
 // -------------------
 // | Task Definition |

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -38,7 +38,7 @@ use tracing::{info, instrument};
 use util::err_str;
 
 use crate::task_state::StateWrapper;
-use crate::traits::{Task, TaskContext, TaskError, TaskState};
+use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::validity_proofs::{
     enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
 };
@@ -124,6 +124,8 @@ impl From<UpdateWalletTaskState> for StateWrapper {
         StateWrapper::UpdateWallet(state)
     }
 }
+
+impl Descriptor for UpdateWalletTaskDescriptor {}
 
 // ---------------
 // | Task Errors |

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -33,7 +33,7 @@ pub trait Task: Send + Sized {
     ///
     /// The descriptor must be serializable so that it can be placed into the
     /// task queue and managed by the consensus engine
-    type Descriptor: Debug + Serialize + for<'de> Deserialize<'de>;
+    type Descriptor: Descriptor;
     /// The state type of the task, used for task introspection
     ///
     /// The state must be orderable so that a commit point can be defined and
@@ -65,6 +65,14 @@ pub trait Task: Send + Sized {
     /// A cleanup step that is run in the event of a task failure
     async fn cleanup(&mut self) -> Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+/// A descriptor for a task, from which the task is constructable
+pub trait Descriptor: Debug + Serialize + for<'de> Deserialize<'de> {
+    /// Whether the task should bypass the task queue
+    fn bypass_task_queue(&self) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds the `Descriptor` trait which all task descriptors must implement. This trait then exposes a `bypass_task_queue` method, analogous to the method defined on the `Task` trait. We use this method to skip calling `pop_task` on tasks which bypass the queue.

This was the cause of the "key not found for task" errors that we've been seeing in production.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Test in testnet