### PR TITLE
task-driver: tasks: refresh-wallet: Always reprove validity in `VALID REBLIND`

### DIFF
--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -32,7 +32,8 @@ use util::err_str;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
-use crate::utils::validity_proofs::{enqueue_proof_job, find_merkle_path_with_tx};
+use crate::utils::enqueue_proof_job;
+use crate::utils::merkle_path::find_merkle_path_with_tx;
 
 /// The task name to display when logging
 const NEW_WALLET_TASK_NAME: &str = "create-new-wallet";

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -23,7 +23,8 @@ use crate::{
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
-        validity_proofs::{find_merkle_path, update_wallet_validity_proofs},
+        merkle_path::find_merkle_path,
+        validity_proofs::update_wallet_validity_proofs,
     },
 };
 

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -26,9 +26,9 @@ use util::{err_str, on_chain::get_protocol_pubkey};
 use crate::{
     task_state::StateWrapper,
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
-    utils::validity_proofs::{
-        enqueue_proof_job, enqueue_relayer_redeem_job, find_merkle_path_with_tx,
-        update_wallet_validity_proofs,
+    utils::{
+        enqueue_proof_job, enqueue_relayer_redeem_job, merkle_path::find_merkle_path_with_tx,
+        validity_proofs::update_wallet_validity_proofs,
     },
 };
 

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -13,14 +13,11 @@ use circuits::zk_circuits::valid_relayer_fee_settlement::{
 use common::types::proof_bundles::RelayerFeeSettlementBundle;
 use common::types::tasks::PayRelayerFeeTaskDescriptor;
 use common::types::wallet::Wallet;
-use darkpool_client::DarkpoolClient;
 use darkpool_client::errors::DarkpoolClientError;
-use job_types::network_manager::NetworkManagerQueue;
-use job_types::proof_manager::{ProofJob, ProofManagerQueue};
+use job_types::proof_manager::ProofJob;
 use num_bigint::BigUint;
 use renegade_metrics::helpers::record_relayer_fee_settlement;
 use serde::Serialize;
-use state::State;
 use state::error::StateError;
 use tracing::instrument;
 use util::err_str;
@@ -160,16 +157,10 @@ pub struct PayRelayerFeeTask {
     pub proof: Option<RelayerFeeSettlementBundle>,
     /// The transaction receipt of the fee payment
     pub tx: Option<TransactionReceipt>,
-    /// The darkpool client used for submitting transactions
-    pub darkpool_client: DarkpoolClient,
-    /// A hand to the global state
-    pub state: State,
-    /// The work queue for the proof manager
-    pub proof_queue: ProofManagerQueue,
-    /// A sender to the network manager's queue
-    pub network_sender: NetworkManagerQueue,
     /// The current state of the task
     pub task_state: PayRelayerFeeTaskState,
+    /// The context of the task
+    pub ctx: TaskContext,
 }
 
 #[async_trait]
@@ -206,11 +197,8 @@ impl Task for PayRelayerFeeTask {
             new_recipient_wallet,
             proof: None,
             tx: None,
-            darkpool_client: ctx.darkpool_client,
-            state: ctx.state,
-            proof_queue: ctx.proof_queue,
-            network_sender: ctx.network_queue,
             task_state: PayRelayerFeeTaskState::Pending,
+            ctx,
         })
     }
 
@@ -279,8 +267,8 @@ impl PayRelayerFeeTask {
         let (witness, statement) = self.get_witness_statement()?;
         let job = ProofJob::ValidRelayerFeeSettlement { witness, statement };
 
-        let proof_recv = enqueue_proof_job(job, &self.proof_queue)
-            .map_err(PayRelayerFeeTaskError::ProofGeneration)?;
+        let proof_recv =
+            enqueue_proof_job(job, &self.ctx).map_err(PayRelayerFeeTaskError::ProofGeneration)?;
 
         // Await the proof
         let bundle = proof_recv.await.map_err(err_str!(PayRelayerFeeTaskError::ProofGeneration))?;
@@ -300,7 +288,7 @@ impl PayRelayerFeeTask {
             .map_err(err_str!(PayRelayerFeeTaskError::Signature))?;
         let sig_bytes = sig.as_bytes().to_vec();
 
-        let tx = self.darkpool_client.settle_online_relayer_fee(&proof, sig_bytes).await?;
+        let tx = self.ctx.darkpool_client.settle_online_relayer_fee(&proof, sig_bytes).await?;
         self.tx = Some(tx);
         Ok(())
     }
@@ -308,18 +296,18 @@ impl PayRelayerFeeTask {
     /// Find the new Merkle opening for the user and relayer's wallets
     async fn find_opening(&mut self) -> Result<(), PayRelayerFeeTaskError> {
         // Find the opening for the sender's wallet
+        let state = &self.ctx.state;
         let tx = self.tx.as_ref().unwrap();
-        let sender_opening =
-            find_merkle_path_with_tx(&self.new_sender_wallet, &self.darkpool_client, tx)?;
+        let sender_opening = find_merkle_path_with_tx(&self.new_sender_wallet, tx, &self.ctx)?;
         self.new_sender_wallet.merkle_proof = Some(sender_opening);
 
         // Find the opening for the recipient's wallet
         let recipient_opening =
-            find_merkle_path_with_tx(&self.new_recipient_wallet, &self.darkpool_client, tx)?;
+            find_merkle_path_with_tx(&self.new_recipient_wallet, tx, &self.ctx)?;
         self.new_recipient_wallet.merkle_proof = Some(recipient_opening);
 
-        let waiter1 = self.state.update_wallet(self.new_sender_wallet.clone()).await?;
-        let waiter2 = self.state.update_wallet(self.new_recipient_wallet.clone()).await?;
+        let waiter1 = state.update_wallet(self.new_sender_wallet.clone()).await?;
+        let waiter2 = state.update_wallet(self.new_recipient_wallet.clone()).await?;
         waiter1.await?;
         waiter2.await?;
         Ok(())
@@ -330,14 +318,9 @@ impl PayRelayerFeeTask {
     /// The recipient (relayer) wallet does not need to be updated as it holds
     /// no orders
     async fn update_validity_proofs(&self) -> Result<(), PayRelayerFeeTaskError> {
-        update_wallet_validity_proofs(
-            &self.new_sender_wallet,
-            self.proof_queue.clone(),
-            self.state.clone(),
-            self.network_sender.clone(),
-        )
-        .await
-        .map_err(PayRelayerFeeTaskError::UpdateValidityProofs)
+        update_wallet_validity_proofs(&self.new_sender_wallet, &self.ctx)
+            .await
+            .map_err(PayRelayerFeeTaskError::UpdateValidityProofs)
     }
 
     // -----------
@@ -376,7 +359,7 @@ impl PayRelayerFeeTask {
             .ok_or_else(|| PayRelayerFeeTaskError::State(ERR_NO_MERKLE_PROOF.to_string()))?;
 
         let recipient_decryption_key =
-            self.state.get_fee_key()?.secret_key().expect("decryption key missing");
+            self.ctx.state.get_fee_key()?.secret_key().expect("decryption key missing");
         let sender_balance_index = sender_wallet.get_balance_index(&self.mint).unwrap();
         let recipient_balance_index = new_recipient_wallet.get_balance_index(&self.mint).unwrap();
 

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -24,9 +24,9 @@ use util::err_str;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
-use crate::utils::validity_proofs::{
-    enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
-};
+use crate::utils::enqueue_proof_job;
+use crate::utils::merkle_path::find_merkle_path_with_tx;
+use crate::utils::validity_proofs::update_wallet_validity_proofs;
 
 use super::{ERR_BALANCE_MISSING, ERR_NO_MERKLE_PROOF, ERR_WALLET_MISSING};
 

--- a/workers/task-driver/src/tasks/redeem_fee.rs
+++ b/workers/task-driver/src/tasks/redeem_fee.rs
@@ -23,7 +23,7 @@ use crate::{
     task_state::StateWrapper,
     tasks::ERR_NO_MERKLE_PROOF,
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
-    utils::validity_proofs::{enqueue_proof_job, find_merkle_path_with_tx},
+    utils::{enqueue_proof_job, merkle_path::find_merkle_path_with_tx},
 };
 
 /// The name of the task

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -27,7 +27,8 @@ use crate::{
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
-        validity_proofs::{find_merkle_path, update_wallet_validity_proofs},
+        merkle_path::find_merkle_path,
+        validity_proofs::update_wallet_validity_proofs,
     },
 };
 

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -28,7 +28,7 @@ use crate::{
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
         merkle_path::find_merkle_path,
-        validity_proofs::update_wallet_validity_proofs,
+        validity_proofs::update_validity_proofs__skip_queue_check,
     },
 };
 
@@ -250,7 +250,7 @@ impl RefreshWalletTask {
     /// Update validity proofs for the wallet
     async fn update_validity_proofs(&self) -> Result<(), RefreshWalletTaskError> {
         let wallet = self.get_wallet().await?;
-        update_wallet_validity_proofs(&wallet, &self.ctx)
+        update_validity_proofs__skip_queue_check(&wallet, &self.ctx)
             .await
             .map_err(RefreshWalletTaskError::ProofGeneration)
     }

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -27,11 +27,10 @@ use common::types::tasks::SettleMalleableExternalMatchTaskDescriptor;
 use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use darkpool_client::errors::DarkpoolClientError;
 use external_api::bus_message::SystemBusMessage;
-use job_types::proof_manager::{ProofJob, ProofManagerQueue};
+use job_types::proof_manager::ProofJob;
 use serde::Serialize;
 use state::State;
 use state::error::StateError;
-use system_bus::SystemBus;
 use tracing::instrument;
 use util::on_chain::get_external_match_fee;
 
@@ -209,14 +208,10 @@ pub struct SettleMalleableExternalMatchTask {
     atomic_match_bundle: Option<ValidMalleableMatchSettleAtomicBundle>,
     /// The system bus topic on which to send the atomic match settle bundle
     atomic_match_bundle_topic: String,
-    /// A copy of the relayer-global state
-    state: State,
-    /// A handle on the system bus
-    bus: SystemBus<SystemBusMessage>,
-    /// The work queue to add proof management jobs to
-    proof_queue: ProofManagerQueue,
     /// The state of the task
     task_state: SettleMalleableExternalMatchTaskState,
+    /// The context of the task
+    ctx: TaskContext,
 }
 
 #[async_trait]
@@ -254,10 +249,8 @@ impl Task for SettleMalleableExternalMatchTask {
             internal_order_validity_witness,
             atomic_match_bundle: None,
             atomic_match_bundle_topic,
-            state: ctx.state,
-            proof_queue: ctx.proof_queue,
-            bus: ctx.bus,
             task_state: SettleMalleableExternalMatchTaskState::Pending,
+            ctx,
         })
     }
 
@@ -339,7 +332,7 @@ impl SettleMalleableExternalMatchTask {
         let commitments_link = self.internal_order_validity_witness.copy_commitment_linking_hint();
         let job =
             ProofJob::ValidMalleableMatchSettleAtomic { witness, statement, commitments_link };
-        let proof_recv = enqueue_proof_job(job, &self.proof_queue)
+        let proof_recv = enqueue_proof_job(job, &self.ctx)
             .map_err(SettleMalleableExternalMatchTaskError::EnqueuingJob)?;
 
         // Await the proof from the proof manager
@@ -360,7 +353,7 @@ impl SettleMalleableExternalMatchTask {
         let match_bundle = self.atomic_match_bundle.clone().unwrap();
         let validity_proofs = self.internal_order_validity_bundle.clone();
         let message = SystemBusMessage::MalleableAtomicMatchFound { match_bundle, validity_proofs };
-        self.bus.publish(self.atomic_match_bundle_topic.clone(), message);
+        self.ctx.bus.publish(self.atomic_match_bundle_topic.clone(), message);
 
         Ok(())
     }
@@ -406,7 +399,7 @@ impl SettleMalleableExternalMatchTask {
     )> {
         let match_res = &self.match_res;
         let commitments_witness = &self.internal_order_validity_witness.commitment_witness;
-        let relayer_fee_address = self.state.get_external_fee_addr()?.unwrap();
+        let relayer_fee_address = self.ctx.state.get_external_fee_addr()?.unwrap();
 
         // Copy values from the witnesses and statements of the order validity proofs
         let internal_party_order = commitments_witness.order.clone();

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
-use crate::utils::validity_proofs::enqueue_proof_job;
+use crate::utils::enqueue_proof_job;
 use async_trait::async_trait;
 use circuit_types::fees::FeeTakeRate;
 use circuit_types::fixed_point::FixedPoint;

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -27,8 +27,9 @@ use tracing::instrument;
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
-use crate::utils::validity_proofs::{
-    find_merkle_path, find_merkle_path_with_tx, update_wallet_validity_proofs,
+use crate::utils::{
+    merkle_path::{find_merkle_path, find_merkle_path_with_tx},
+    validity_proofs::update_wallet_validity_proofs,
 };
 
 /// The error message the contract emits when a nullifier has been used

--- a/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/workers/task-driver/src/tasks/settle_match_external.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::task_state::StateWrapper;
 use crate::tasks::ERR_AWAITING_PROOF;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
-use crate::utils::validity_proofs::enqueue_proof_job;
+use crate::utils::enqueue_proof_job;
 use async_trait::async_trait;
 use circuit_types::fixed_point::FixedPoint;
 use circuit_types::r#match::MatchResult;

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -6,8 +6,9 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
-use crate::utils::validity_proofs::{
-    enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
+use crate::utils::{
+    enqueue_proof_job, merkle_path::find_merkle_path_with_tx,
+    validity_proofs::update_wallet_validity_proofs,
 };
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -36,8 +36,9 @@ use util::err_str;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
-use crate::utils::validity_proofs::{
-    enqueue_proof_job, find_merkle_path_with_tx, update_wallet_validity_proofs,
+use crate::utils::{
+    enqueue_proof_job, merkle_path::find_merkle_path_with_tx,
+    validity_proofs::update_wallet_validity_proofs,
 };
 
 /// The human-readable name of the the task

--- a/workers/task-driver/src/utils/merkle_path.rs
+++ b/workers/task-driver/src/utils/merkle_path.rs
@@ -1,0 +1,28 @@
+//! Helpers for finding Merkle authentication paths
+
+use alloy::rpc::types::TransactionReceipt;
+use common::types::wallet::{Wallet, WalletAuthenticationPath};
+use darkpool_client::errors::DarkpoolClientError;
+
+use crate::traits::TaskContext;
+
+/// Find the merkle authentication path of a wallet
+pub(crate) async fn find_merkle_path(
+    wallet: &Wallet,
+    ctx: &TaskContext,
+) -> Result<WalletAuthenticationPath, DarkpoolClientError> {
+    // The contract indexes the wallet by its commitment to the public and private
+    // secret shares, find this in the Merkle tree
+    ctx.darkpool_client.find_merkle_authentication_path(wallet.get_wallet_share_commitment()).await
+}
+
+/// Find the merkle authentication path of a wallet given an updating
+/// transaction
+pub(crate) fn find_merkle_path_with_tx(
+    wallet: &Wallet,
+    tx: &TransactionReceipt,
+    ctx: &TaskContext,
+) -> Result<WalletAuthenticationPath, DarkpoolClientError> {
+    let commitment = wallet.get_wallet_share_commitment();
+    ctx.darkpool_client.find_merkle_authentication_path_with_tx(commitment, tx)
+}

--- a/workers/task-driver/src/utils/mod.rs
+++ b/workers/task-driver/src/utils/mod.rs
@@ -1,6 +1,15 @@
 //! Helpers for the task driver
 
+use circuit_types::note::Note;
+use common::types::{proof_bundles::ProofBundle, tasks::RedeemFeeTaskDescriptor};
+use job_types::proof_manager::{ProofJob, ProofManagerJob};
+use state::State;
+use tokio::sync::oneshot::{self, Receiver as TokioReceiver};
+
+use crate::traits::TaskContext;
+
 pub mod find_wallet;
+pub(crate) mod merkle_path;
 pub mod order_states;
 pub mod validity_proofs;
 
@@ -18,3 +27,33 @@ const ERR_PROVE_COMMITMENTS_FAILED: &str = "failed to prove valid commitments";
 const ERR_PROVE_REBLIND_FAILED: &str = "failed to prove valid reblind";
 /// The error thrown when the wallet cannot be found in tx history
 pub const ERR_WALLET_NOT_FOUND: &str = "wallet not found in wallet_last_updated map";
+/// The error message emitted by the task when the fee decryption key is missing
+const ERR_FEE_KEY_MISSING: &str = "fee decryption key is missing";
+/// The error message emitted by the task when the relayer wallet is missing
+const ERR_RELAYER_WALLET_MISSING: &str = "relayer wallet is missing";
+
+/// Enqueue a job with the proof manager
+///
+/// Returns a channel on which the proof manager will send the response
+pub(crate) fn enqueue_proof_job(
+    job: ProofJob,
+    ctx: &TaskContext,
+) -> Result<TokioReceiver<ProofBundle>, String> {
+    let (response_sender, response_receiver) = oneshot::channel();
+    ctx.proof_queue
+        .send(ProofManagerJob { type_: job, response_channel: response_sender })
+        .map_err(|_| ERR_ENQUEUING_JOB.to_string())?;
+
+    Ok(response_receiver)
+}
+
+/// Enqueue a job to redeem a relayer fee into the relayer's wallet
+pub(crate) async fn enqueue_relayer_redeem_job(note: Note, state: &State) -> Result<(), String> {
+    let relayer_wallet_id =
+        state.get_relayer_wallet_id()?.ok_or_else(|| ERR_RELAYER_WALLET_MISSING.to_string())?;
+    let decryption_key =
+        state.get_fee_key()?.secret_key().ok_or_else(|| ERR_FEE_KEY_MISSING.to_string())?;
+    let descriptor = RedeemFeeTaskDescriptor::new(relayer_wallet_id, note, decryption_key);
+
+    state.append_task(descriptor.into()).await.map_err(|e| e.to_string()).map(|_| ())
+}


### PR DESCRIPTION
### Purpose
This PR exposes a second method for re-proving validity proofs for a wallet; `update_validity_proofs__skip_queue_check`. This method removes the check that the wallet's task queue is empty. In the case of a wallet refresh, we want to always prove validity for orders, so we use this method.

I also made a new cleanups to the task driver utils.

### Testing
- [x] All unit tests pass
- [x] Integration tests pass
- [x] Testing in testnet