### PR TITLE
api-server: external-match: processor: Remove exlusive bundles

### DIFF
--- a/common/src/types/tasks/descriptors/settle_match.rs
+++ b/common/src/types/tasks/descriptors/settle_match.rs
@@ -97,12 +97,6 @@ pub struct SettleExternalMatchTaskDescriptor {
     pub match_res: MatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
     pub atomic_match_bundle_topic: String,
-    /// Whether the resulting bundle is shared across requests
-    ///
-    /// Exclusive (shared = false) bundles lock the task queue and gain
-    /// exclusive access to the bundle for the `bundle_duration`
-    #[serde(default)]
-    pub shared: bool,
 }
 
 impl SettleExternalMatchTaskDescriptor {
@@ -116,7 +110,6 @@ impl SettleExternalMatchTaskDescriptor {
         relayer_fee_rate: FixedPoint,
         match_res: MatchResult,
         atomic_match_bundle_topic: String,
-        shared: bool,
     ) -> Self {
         SettleExternalMatchTaskDescriptor {
             bundle_duration,
@@ -126,7 +119,6 @@ impl SettleExternalMatchTaskDescriptor {
             execution_price,
             relayer_fee_rate,
             match_res,
-            shared,
         }
     }
 }
@@ -152,12 +144,6 @@ pub struct SettleMalleableExternalMatchTaskDescriptor {
     pub match_res: BoundedMatchResult,
     /// The system bus topic on which to send the atomic match settle bundle
     pub atomic_match_bundle_topic: String,
-    /// Whether the resulting bundle is shared across requests
-    ///
-    /// Exclusive (shared = false) bundles lock the task queue and gain
-    /// exclusive access to the bundle for the `bundle_duration`
-    #[serde(default)]
-    pub shared: bool,
 }
 
 impl SettleMalleableExternalMatchTaskDescriptor {
@@ -169,7 +155,6 @@ impl SettleMalleableExternalMatchTaskDescriptor {
         relayer_fee_rate: FixedPoint,
         match_res: BoundedMatchResult,
         atomic_match_bundle_topic: String,
-        shared: bool,
     ) -> Self {
         SettleMalleableExternalMatchTaskDescriptor {
             bundle_duration,
@@ -178,7 +163,6 @@ impl SettleMalleableExternalMatchTaskDescriptor {
             atomic_match_bundle_topic,
             relayer_fee_rate,
             match_res,
-            shared,
         }
     }
 }

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -29,7 +29,7 @@ use util::{
     on_chain::get_external_match_fee,
 };
 
-use crate::{default_true, deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
+use crate::{deserialize_biguint_from_hex_string, serialize_biguint_to_hex_addr};
 
 #[cfg(feature = "full-api")]
 use common::types::{
@@ -147,12 +147,6 @@ pub struct AssembleExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
-    /// Whether or not to allow shared access to the resulting bundle
-    ///
-    /// If true, the bundle may be sent to other clients requesting an external
-    /// match. If false, the bundle will be exclusively held for some time
-    #[serde(default = "default_true")]
-    pub allow_shared: bool,
     /// The matching pool to request a quote from
     pub matching_pool: Option<MatchingPoolName>,
     /// The fee take rate for the relayer in the match

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -30,11 +30,6 @@ pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiratio
 // | Serialization Helpers |
 // -------------------------
 
-/// Serde helper that defaults a boolean to `true`
-pub(crate) fn default_true() -> bool {
-    true
-}
-
 /// An empty request/response type
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmptyRequestResponse {}

--- a/workers/api-server/integration/ctx/external_match.rs
+++ b/workers/api-server/integration/ctx/external_match.rs
@@ -89,7 +89,6 @@ impl IntegrationTestCtx {
         let req = AssembleExternalMatchRequest {
             signed_quote: quote.clone(),
             do_gas_estimation: false,
-            allow_shared: false,
             receiver_address: None,
             updated_order: None,
             relayer_fee_rate,

--- a/workers/api-server/src/http/external_match/handlers.rs
+++ b/workers/api-server/src/http/external_match/handlers.rs
@@ -209,7 +209,6 @@ impl TypedHandler for AssembleExternalMatchHandler {
             .processor
             .assemble_external_match(
                 req.do_gas_estimation,
-                req.allow_shared,
                 receiver,
                 price,
                 relayer_fee_rate,
@@ -267,7 +266,6 @@ impl TypedHandler for AssembleMalleableExternalMatchHandler {
             .processor
             .assemble_malleable_external_match(
                 req.do_gas_estimation,
-                req.allow_shared,
                 receiver,
                 price,
                 relayer_fee_rate,

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -171,7 +171,6 @@ impl ExternalMatchProcessor {
     pub(crate) async fn assemble_external_match(
         &self,
         gas_estimation: bool,
-        allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
         relayer_fee_rate: FixedPoint,
@@ -180,7 +179,6 @@ impl ExternalMatchProcessor {
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
-            .with_allow_shared(allow_shared)
             .with_price(price)
             .with_matching_pool(matching_pool)
             .with_relayer_fee_rate(relayer_fee_rate);
@@ -207,7 +205,6 @@ impl ExternalMatchProcessor {
     pub(crate) async fn assemble_malleable_external_match(
         &self,
         gas_estimation: bool,
-        allow_shared: bool,
         receiver: Option<Address>,
         price: TimestampedPrice,
         relayer_fee_rate: FixedPoint,
@@ -216,7 +213,6 @@ impl ExternalMatchProcessor {
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
-            .with_allow_shared(allow_shared)
             .with_bounded_match(true)
             .with_price(price)
             .with_matching_pool(matching_pool)
@@ -249,7 +245,6 @@ impl ExternalMatchProcessor {
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
         let opt = ExternalMatchingEngineOptions::new()
-            .with_allow_shared(true)
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
             .with_matching_pool(matching_pool)
             .with_relayer_fee_rate(relayer_fee_rate);

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -252,9 +252,8 @@ impl HandshakeExecutor {
             options.relayer_fee_rate,
             match_res,
             response_topic,
-            options.allow_shared,
         );
-        self.enqueue_settlement_task(task, options).await
+        self.enqueue_settlement_task(task).await
     }
 
     // --- Bounded Match Handler --- //
@@ -311,9 +310,8 @@ impl HandshakeExecutor {
             options.relayer_fee_rate,
             bounded_res,
             response_topic,
-            options.allow_shared,
         );
-        self.enqueue_settlement_task(task, options).await
+        self.enqueue_settlement_task(task).await
     }
 
     /// Derive the bounds for a match
@@ -395,14 +393,9 @@ impl HandshakeExecutor {
     async fn enqueue_settlement_task<T: Into<TaskDescriptor>>(
         &self,
         descriptor: T,
-        options: &ExternalMatchingEngineOptions,
     ) -> Result<(), HandshakeManagerError> {
         let descriptor = descriptor.into();
-        if options.allow_shared {
-            self.forward_bypassing_task(descriptor).await
-        } else {
-            self.forward_queued_task(descriptor).await
-        }
+        self.forward_bypassing_task(descriptor).await
     }
 
     /// Forward a quote to the client

--- a/workers/job-types/src/handshake_manager.rs
+++ b/workers/job-types/src/handshake_manager.rs
@@ -159,12 +159,6 @@ pub struct ExternalMatchingEngineOptions {
     /// Whether or not to only generate a quote, without proving validity
     /// for the order's match
     pub only_quote: bool,
-    /// Whether or not to allow shared access to the resulting bundle
-    ///
-    /// If true, the bundle may be sent to other clients requesting an external
-    /// match. If false, the bundle will be exclusively held for
-    /// `bundle_duration`
-    pub allow_shared: bool,
     /// Whether or not to emit a bounded match rather than an exact match
     ///
     /// A `BoundedMatchResult` is one in which the exact `base_amount` is not
@@ -213,12 +207,6 @@ impl ExternalMatchingEngineOptions {
     /// Set whether to only generate a quote
     pub fn with_only_quote(mut self, only_quote: bool) -> Self {
         self.only_quote = only_quote;
-        self
-    }
-
-    /// Set whether to allow shared access to the resulting bundle
-    pub fn with_allow_shared(mut self, allow_shared: bool) -> Self {
-        self.allow_shared = allow_shared;
         self
     }
 

--- a/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -195,11 +195,6 @@ pub struct SettleMalleableExternalMatchTask {
     match_res: BoundedMatchResult,
     /// The duration for which the external match bundle is valid
     bundle_duration: Duration,
-    /// Whether the resulting bundle is shared across requests
-    ///
-    /// Exclusive (shared = false) bundles lock the task queue and gain
-    /// exclusive access to the bundle for the `bundle_duration`
-    shared: bool,
     /// The validity proofs for the internal order
     internal_order_validity_bundle: OrderValidityProofBundle,
     /// The validity witness for an internal order
@@ -234,7 +229,6 @@ impl Task for SettleMalleableExternalMatchTask {
             relayer_fee_rate,
             match_res,
             atomic_match_bundle_topic,
-            shared,
         } = descriptor;
         let (internal_order_validity_bundle, internal_order_validity_witness) =
             Self::fetch_internal_order_validity_bundle(internal_order_id, &ctx.state).await?;
@@ -244,7 +238,6 @@ impl Task for SettleMalleableExternalMatchTask {
             relayer_fee_rate,
             match_res,
             bundle_duration,
-            shared,
             internal_order_validity_bundle,
             internal_order_validity_witness,
             atomic_match_bundle: None,
@@ -302,16 +295,16 @@ impl Task for SettleMalleableExternalMatchTask {
         self.task_state.clone()
     }
 
-    /// Shared bundles will always have a much higher rate limit than exclusive
-    /// For this reason, we bypass the task queue to prevent raft contention
+    /// External matches have a high rate limit and bypass the task queue to
+    /// prevent raft contention
     fn bypass_task_queue(&self) -> bool {
-        self.shared
+        true
     }
 }
 
 impl Descriptor for SettleMalleableExternalMatchTaskDescriptor {
     fn bypass_task_queue(&self) -> bool {
-        self.shared
+        true
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR removes shared bundles from the relayer. We now implicitly assume all bundles are shared and bypass the task queues.

### Testing
- [x] All unit tests pass
- [x] Integration tests pass
- [ ] Testing in testnet