### PR TITLE
darkpool-client: add timeout to tx submission

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,6 +1,6 @@
 # Used for running integration tests on a simulated MPC network
 
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -52,7 +52,7 @@ RUN cargo build --release --package event-export-sidecar
 RUN cargo build --release --bin renegade-relayer --features "$CARGO_FEATURES"
 
 # Release stage
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y libssl-dev && \


### PR DESCRIPTION
This PR makes a couple changes to TX submission in the darkpool client(s):
1. We add a 1-minute timeout to the awaiting of tx mining
2. We use `eth_gasPrice` as an estimate of gas price, rather than the latest block's basefee

We do this because we have seen a number of tasks get stuck indefinitely in the "submitting tx" phase, presumably because the pending txs are stuck in the mempool. As such, we use `eth_gasPrice` because it is an all-in estimate (basefee + priority fee) of the gas price to set, and it's a cheaper RPC call. We add the timeout to ensure that tasks don't hang indefinitely, but rather error out.

### Testing
- [x] Test internal trade on Base Sepolia