### PR TITLE
util: Fix feature flag configuration for `telemetry` only builds

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -20,8 +20,6 @@ use ark_mpc::algebra::{
 // | Configuration Constants |
 // ---------------------------
 
-/// The current relayer version
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Whether or not the relayer is in bootstrap mode
 pub static BOOTSTRAP_MODE: OnceLock<bool> = OnceLock::new();
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -17,7 +17,7 @@ use api_server::worker::{ApiServer, ApiServerConfig};
 use chain_events::listener::{OnChainEventListener, OnChainEventListenerConfig};
 use common::worker::{new_worker_failure_channel, watch_worker, Worker};
 use common::{default_wrapper::default_option, types::new_cancel_channel};
-use constants::{in_bootstrap_mode, VERSION};
+use constants::in_bootstrap_mode;
 use darkpool_client::constants::{BLOCK_POLLING_INTERVAL, EVENT_FILTER_POLLING_INTERVAL};
 use darkpool_client::{client::DarkpoolClientConfig, DarkpoolClient};
 use event_manager::{manager::EventManager, worker::EventManagerConfig};
@@ -89,10 +89,7 @@ async fn main() -> Result<(), CoordinatorError> {
     args.configure_telemetry().expect("failed to configure telemetry");
     let min_order_size = args.min_fill_size_decimal_adjusted();
 
-    info!(
-        "Relayer running with\n\t version: {}\n\t port: {}\n\t cluster: {:?}",
-        VERSION, args.p2p_port, args.cluster_id
-    );
+    info!("Relayer running with\n\t port: {}\n\t cluster: {:?}", args.p2p_port, args.cluster_id);
 
     if in_bootstrap_mode() {
         info!("Running in bootstrap mode");

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -8,13 +8,20 @@ default = ["hex", "errors"]
 blockchain = ["hex", "concurrency"]
 concurrency = []
 errors = []
-hex = ["errors"]
+hex = [
+    "errors",
+    "dep:circuit-types",
+    "dep:constants",
+    "dep:renegade-crypto",
+    "constants/default",
+    "circuit-types/default",
+]
 matching-engine = ["blockchain"]
 mocks = []
 channels = []
 networking = []
 serde = []
-telemetry = []
+telemetry = ["errors"]
 
 [dependencies]
 # === Arithmetic === #
@@ -35,9 +42,9 @@ tokio = { workspace = true }
 crossbeam = { workspace = true }
 
 # === Workspace Dependencies === #
-circuit-types = { workspace = true }
-constants = { workspace = true }
-renegade-crypto = { workspace = true }
+circuit-types = { workspace = true, optional = true }
+constants = { workspace = true, optional = true }
+renegade-crypto = { workspace = true, optional = true }
 
 # === Misc === #
 eyre = { workspace = true }

--- a/util/src/telemetry/datadog/mod.rs
+++ b/util/src/telemetry/datadog/mod.rs
@@ -2,9 +2,10 @@
 
 use std::env;
 
-use constants::VERSION;
-
 use super::TelemetrySetupError;
+
+/// The current relayer version
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod formatter;
 


### PR DESCRIPTION
### Purpose
This PR fixes the `util` Cargo features configuration so that the crate builds when only `telemetry` is enabled.

### Testing
- [x] Tested with a dummy binary importing the package using `default-features = false, features = ["utils"]`