### PR TITLE
task-driver: simulation: correct fee computation

### DIFF
--- a/workers/task-driver/src/simulation/wallet_tasks.rs
+++ b/workers/task-driver/src/simulation/wallet_tasks.rs
@@ -141,8 +141,6 @@ fn simulate_settle_internal_match(
         .cloned()
         .ok_or(TaskSimulationError::InvalidTask(ERR_ORDER_MISSING))?;
 
-    let fees = compute_fee_obligation(wallet.max_match_fee, my_order.side, &desc.match_result);
-
     // Get the new public and private shares
     let witness =
         if is_party0 { &desc.order1_validity_witness } else { &desc.order2_validity_witness };
@@ -151,6 +149,9 @@ fn simulate_settle_internal_match(
     } else {
         &desc.order2_proof.commitment_proof.statement.indices
     };
+
+    let relayer_fee = witness.commitment_witness.relayer_fee;
+    let fees = compute_fee_obligation(relayer_fee, my_order.side, &desc.match_result);
 
     let mut new_public = witness.commitment_witness.augmented_public_shares.clone();
     let new_private = witness.reblind_witness.reblinded_wallet_private_shares.clone();


### PR DESCRIPTION
This PR fixes the way in which we simulate fee obligations for internal match tasks in the task driver. Namely, we use the relayer fee from the wallet's `VALID COMMITMENTS` witness, as opposed to using the wallet's `max_match_fee`. This is guaranteed to be the same relayer fee that is used in the actual match task, which can differ from `wallet.max_match_fee` in the case that the relayer's fee for the base asset is lower than the wallet's max match fee (see `get_relayer_fee_for_order`). In this case, task simulation would be incorrect, leading to errors creating/running tasks enqueued behind an in-progress internal match.

### Testing
- [x] A/B tested the change on a local relayer, attempting to enqueue a withdrawal behind an ongoing WBTC match. Before the change, the simulated fee would be higher than the actual fee, resulting in `insufficient balance` when attempting to withdraw the correct post-match balance from the improperly simulated wallet. After the change, the balance in the simulated wallet was correct and the enqueued withdrawal executed without issue.