### PR TITLE
external-api: external-match: impl Default on ExternalMatchRequest

### DIFF
--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -91,7 +91,7 @@ fn process_settlement_tx(tx: &mut TransactionRequest) {
 // -------------------------------
 
 /// The request type for requesting an external match
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct ExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]


### PR DESCRIPTION
### Purpose
This PR adds Default derive to ExternalMatchRequest so  `..Default::default()` syntax can be used when constructing ExternalMatchRequest instances.

### Testing
- [x] Tested locally