### PR TITLE
workers: task-driver: simulation: skip simulation depending on task state

### DIFF
--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -28,7 +28,6 @@ use external_api::{
     types::ApiOrder,
 };
 use hyper::HeaderMap;
-use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use price_state::PriceStreamStates;
@@ -74,8 +73,7 @@ pub(crate) async fn find_wallet_for_update(
         .ok_or_else(|| not_found(ERR_WALLET_NOT_FOUND.to_string()))?;
 
     // Apply tasks to the wallet
-    let descriptors = tasks.into_iter().map(|t| t.descriptor).collect_vec();
-    simulate_wallet_tasks(&mut wallet, descriptors).map_err(internal_error)?;
+    simulate_wallet_tasks(&mut wallet, tasks).map_err(internal_error)?;
     Ok(wallet)
 }
 

--- a/workers/task-driver/src/simulation/error.rs
+++ b/workers/task-driver/src/simulation/error.rs
@@ -12,6 +12,8 @@ pub enum TaskSimulationError {
     InvalidTask(&'static str),
     /// Invalid wallet state to apply a transition
     InvalidWalletState(&'static str),
+    /// Invalid task state on a task provided to the simulator
+    InvalidTaskState(String),
 }
 
 impl Display for TaskSimulationError {
@@ -20,3 +22,11 @@ impl Display for TaskSimulationError {
     }
 }
 impl Error for TaskSimulationError {}
+
+impl TaskSimulationError {
+    /// Create a new task simulation error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn invalid_task_state<T: ToString>(message: T) -> Self {
+        Self::InvalidTaskState(message.to_string())
+    }
+}

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -10,6 +10,7 @@
 use core::panic;
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
@@ -78,6 +79,21 @@ impl Display for NewWalletTaskState {
             NewWalletTaskState::SubmittingTx => write!(f, "Submitting Tx"),
             NewWalletTaskState::FindingMerkleOpening => write!(f, "Finding Opening"),
             NewWalletTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl FromStr for NewWalletTaskState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(NewWalletTaskState::Pending),
+            "Proving" => Ok(NewWalletTaskState::Proving),
+            "Submitting Tx" => Ok(NewWalletTaskState::SubmittingTx),
+            "Finding Opening" => Ok(NewWalletTaskState::FindingMerkleOpening),
+            "Completed" => Ok(NewWalletTaskState::Completed),
+            _ => Err(format!("invalid {NEW_WALLET_TASK_NAME} task state: {s}")),
         }
     }
 }

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -4,6 +4,7 @@
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
+    str::FromStr,
 };
 
 use alloy::rpc::types::TransactionReceipt;
@@ -81,6 +82,22 @@ impl Display for PayOfflineFeeTaskState {
             PayOfflineFeeTaskState::FindingOpening => write!(f, "Finding Opening"),
             PayOfflineFeeTaskState::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
             PayOfflineFeeTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl FromStr for PayOfflineFeeTaskState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(PayOfflineFeeTaskState::Pending),
+            "Proving Payment" => Ok(PayOfflineFeeTaskState::ProvingPayment),
+            "Submitting Payment" => Ok(PayOfflineFeeTaskState::SubmittingPayment),
+            "Finding Opening" => Ok(PayOfflineFeeTaskState::FindingOpening),
+            "Updating Validity Proofs" => Ok(PayOfflineFeeTaskState::UpdatingValidityProofs),
+            "Completed" => Ok(PayOfflineFeeTaskState::Completed),
+            _ => Err(format!("invalid {TASK_NAME} task state: {s}")),
         }
     }
 }

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -7,6 +7,7 @@
 
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 
 use alloy::rpc::types::TransactionReceipt;
 use ark_mpc::PARTY0;
@@ -88,6 +89,21 @@ impl Display for SettleMatchTaskState {
             SettleMatchTaskState::UpdatingState => write!(f, "Updating State"),
             SettleMatchTaskState::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
             SettleMatchTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl FromStr for SettleMatchTaskState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(SettleMatchTaskState::Pending),
+            "Submitting Match" => Ok(SettleMatchTaskState::SubmittingMatch),
+            "Updating State" => Ok(SettleMatchTaskState::UpdatingState),
+            "Updating Validity Proofs" => Ok(SettleMatchTaskState::UpdatingValidityProofs),
+            "Completed" => Ok(SettleMatchTaskState::Completed),
+            _ => Err(format!("invalid {SETTLE_MATCH_TASK_NAME} task state: {s}")),
         }
     }
 }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 
 use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
@@ -97,6 +98,22 @@ impl Display for SettleMatchInternalTaskState {
             Self::UpdatingState => write!(f, "Updating State"),
             Self::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
             Self::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl FromStr for SettleMatchInternalTaskState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(Self::Pending),
+            "Proving Match Settle" => Ok(Self::ProvingMatchSettle),
+            "Submitting Match" => Ok(Self::SubmittingMatch),
+            "Updating State" => Ok(Self::UpdatingState),
+            "Updating Validity Proofs" => Ok(Self::UpdatingValidityProofs),
+            "Completed" => Ok(Self::Completed),
+            _ => Err(format!("invalid {SETTLE_MATCH_INTERNAL_TASK_NAME} task state: {s}")),
         }
     }
 }

--- a/workers/task-driver/src/tasks/update_wallet.rs
+++ b/workers/task-driver/src/tasks/update_wallet.rs
@@ -6,6 +6,7 @@
 
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
@@ -104,6 +105,23 @@ impl Display for UpdateWalletTaskState {
             Self::UpdatingValidityProofs => write!(f, "Updating Validity Proofs"),
             Self::UpdatingConsensusState => write!(f, "Updating Consensus State"),
             Self::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl FromStr for UpdateWalletTaskState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(Self::Pending),
+            "Proving" => Ok(Self::Proving),
+            "Submitting Tx" => Ok(Self::SubmittingTx),
+            "Finding Opening" => Ok(Self::FindingOpening),
+            "Updating Validity Proofs" => Ok(Self::UpdatingValidityProofs),
+            "Updating Consensus State" => Ok(Self::UpdatingConsensusState),
+            "Completed" => Ok(Self::Completed),
+            _ => Err(format!("invalid {UPDATE_WALLET_TASK_NAME} task state: {s}")),
         }
     }
 }


### PR DESCRIPTION
In this PR, we augment the task simulation logic to skip simulation for any tasks which are already past the point at which they've updated wallet state.

### Testing
- [x] Run local relayer, enqueue fee payment + withdrawal while internal match is in `Updating Validity Proofs` step, ensure that simulation is skipped
    - In this test, the back-of-queue wallet request used for the withdrawal auth is issued before the last fee payment task is popped. I ensured that task is also skipped by the simulator.