### PR TITLE
common: types: network-order: Remove validity proofs from network order

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -83,7 +83,7 @@ impl StateApplicator {
             StateTransition::AddWallet { wallet } => self.add_wallet(&wallet),
             StateTransition::UpdateWallet { wallet } => self.update_wallet(&wallet),
             StateTransition::AddOrderValidityBundle { order_id, proof, witness } => {
-                self.add_order_validity_proof(order_id, proof, witness)
+                self.add_order_validity_proof(order_id, &proof, witness)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
             StateTransition::CreateMatchingPool { pool_name } => {

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -335,9 +335,7 @@ impl StateInner {
     ) -> Result<(), StateError> {
         let bus = self.bus.clone();
         self.with_write_tx(move |tx| {
-            // TODO: Remove backwards compatibility stores
-            tx.write_validity_proof_bundle(&order_id, &proof)?;
-            tx.attach_validity_proof(&order_id, proof)?;
+            tx.attach_validity_proof(&order_id, &proof)?;
 
             // Read back the order and check if it is local, if so, abort
             let order = tx.get_order_info(&order_id)?.unwrap();
@@ -503,8 +501,9 @@ mod test {
 
         // Check for the order in the state
         let stored_order = state.get_order(&order.id).await.unwrap().unwrap();
+        let proof = state.get_validity_proofs(&order.id).await.unwrap();
         assert_eq!(stored_order.state, NetworkOrderState::Verified);
-        assert!(stored_order.validity_proofs.is_some());
+        assert!(proof.is_some());
     }
 
     /// Tests nullifying an order

--- a/workers/task-driver/src/state_migration/double_write_validity_proofs.rs
+++ b/workers/task-driver/src/state_migration/double_write_validity_proofs.rs
@@ -23,11 +23,6 @@ async fn copy_validity_proofs(order: NetworkOrder, state: &State) -> Result<(), 
     // for the duration of the migration
     state
         .with_write_tx(move |tx| {
-            // Write the validity proof bundle
-            if let Some(p) = order.validity_proofs {
-                tx.write_validity_proof_bundle(&order.id, &p)?;
-            }
-
             // Write the validity proof witness
             if let Some(w) = order.validity_proof_witnesses {
                 tx.write_validity_proof_witness(&order.id, &w)?;


### PR DESCRIPTION
### Purpose

This PR removes the `validity_proofs` field from the `NetworkOrder` type and replaces all use of the field with the appropriate lookups to the new `proofs` table.

### Todo

- Remove the `validity_proof_witnesses` field

### Testing

- [x] Unit tests pass
- [x] Test in testnet