### PR TITLE
task-driver: tasks: update-wallet: Modularize update wallet impl

### DIFF
--- a/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
+++ b/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
@@ -1,0 +1,131 @@
+//! Helpers for emitting events after a wallet update
+
+use common::types::{
+    MatchingPoolName,
+    tasks::WalletUpdateType,
+    wallet::{Order, OrderIdentifier},
+};
+use itertools::Itertools;
+use job_types::event_manager::{
+    ExternalTransferEvent, OrderCancellationEvent, OrderPlacementEvent, OrderUpdateEvent,
+    RelayerEventType, try_send_event,
+};
+use state::storage::tx::matching_pools::GLOBAL_MATCHING_POOL;
+use util::err_str;
+
+use crate::tasks::update_wallet::{UpdateWalletTask, UpdateWalletTaskError};
+
+/// A deposit or withdrawal wallet update type is missing an external transfer
+const ERR_MISSING_TRANSFER: &str = "missing external transfer";
+/// A cancelled order cannot be found in an order cancellation wallet update
+/// type
+const ERR_MISSING_CANCELLED_ORDER: &str = "missing cancelled order";
+/// An order metadata is missing from the global state
+const ERR_MISSING_ORDER_METADATA: &str = "missing order metadata";
+
+impl UpdateWalletTask {
+    // --- Event Helpers --- //
+
+    /// Emit the completion event to the event manager
+    pub(crate) fn emit_event(&mut self) -> Result<(), UpdateWalletTaskError> {
+        try_send_event(self.completion_event.take().unwrap(), &self.ctx.event_queue)
+            .map_err(err_str!(UpdateWalletTaskError::SendEvent))
+    }
+
+    /// Construct the event to emit after the task is complete & record
+    /// it in the task
+    pub(crate) async fn prepare_completion_event(&mut self) -> Result<(), UpdateWalletTaskError> {
+        let event = match &self.update_type {
+            WalletUpdateType::Deposit { .. } | WalletUpdateType::Withdraw { .. } => {
+                self.construct_external_transfer_event()?
+            },
+            WalletUpdateType::PlaceOrder { order, id, matching_pool, .. } => {
+                self.construct_order_placement_or_update_event(id, order, matching_pool)
+            },
+            WalletUpdateType::CancelOrder { order } => {
+                self.construct_order_cancellation_event(order).await?
+            },
+        };
+
+        self.completion_event = Some(event);
+        Ok(())
+    }
+
+    /// Construct an external transfer event
+    fn construct_external_transfer_event(&self) -> Result<RelayerEventType, UpdateWalletTaskError> {
+        let wallet_id = self.new_wallet.wallet_id;
+        let transfer = self
+            .transfer
+            .clone()
+            .map(|t| t.external_transfer)
+            .ok_or(UpdateWalletTaskError::Missing(ERR_MISSING_TRANSFER.to_string()))?;
+
+        Ok(RelayerEventType::ExternalTransfer(ExternalTransferEvent::new(wallet_id, transfer)))
+    }
+
+    /// Construct either an order placement or an order update event,
+    /// depending on whether the order already exists in the new wallet
+    fn construct_order_placement_or_update_event(
+        &self,
+        order_id: &OrderIdentifier,
+        order: &Order,
+        matching_pool: &Option<MatchingPoolName>,
+    ) -> RelayerEventType {
+        let wallet_id = self.new_wallet.wallet_id;
+        let order_id = *order_id;
+        let order = order.clone();
+        let matching_pool = matching_pool.clone().unwrap_or(GLOBAL_MATCHING_POOL.to_string());
+
+        if self.old_wallet.contains_order(&order_id) {
+            RelayerEventType::OrderUpdate(OrderUpdateEvent::new(
+                wallet_id,
+                order_id,
+                order,
+                matching_pool,
+            ))
+        } else {
+            RelayerEventType::OrderPlacement(OrderPlacementEvent::new(
+                wallet_id,
+                order_id,
+                order,
+                matching_pool,
+            ))
+        }
+    }
+
+    /// Construct an order cancellation event
+    async fn construct_order_cancellation_event(
+        &self,
+        order: &Order,
+    ) -> Result<RelayerEventType, UpdateWalletTaskError> {
+        let wallet_id = self.new_wallet.wallet_id;
+        let order = order.clone();
+
+        // Find the ID of the cancelled order
+        let mut new_order_ids = self.new_wallet.get_nonzero_orders().into_keys();
+        let order_id = self
+            .old_wallet
+            .get_nonzero_orders()
+            .into_keys()
+            .find(|id| !new_order_ids.contains(id))
+            .ok_or(UpdateWalletTaskError::Missing(ERR_MISSING_CANCELLED_ORDER.to_string()))?;
+
+        let amount_remaining = order.amount;
+
+        let amount_filled = self
+            .ctx
+            .state
+            .get_order_metadata(&order_id)
+            .await?
+            .ok_or(UpdateWalletTaskError::Missing(ERR_MISSING_ORDER_METADATA.to_string()))?
+            .total_filled();
+
+        Ok(RelayerEventType::OrderCancellation(OrderCancellationEvent::new(
+            wallet_id,
+            order_id,
+            order,
+            amount_remaining,
+            amount_filled,
+        )))
+    }
+}

--- a/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
+++ b/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
@@ -1,0 +1,58 @@
+//! Helpers for the update wallet task
+
+use circuit_types::SizedWallet as CircuitWallet;
+use common::types::tasks::WalletUpdateType;
+use common::types::wallet::Wallet;
+
+use crate::tasks::update_wallet::UpdateWalletTask;
+
+pub(crate) mod events;
+pub(crate) mod witness_generation;
+
+impl UpdateWalletTask {
+    // --- General Helpers --- //
+
+    /// Whether the wallet update requires an on-chain update
+    ///
+    /// Some wallet updates do not modify the on-chain state, e.g. marking an
+    /// order as externally matchable. In these cases, we can skip the on-chain
+    /// interaction and just update the local copy of the wallet
+    ///
+    /// Concretely, if an update doesn't change the circuit representation of
+    /// the wallet, we can skip the on-chain update
+    ///
+    /// TODO: In the future we'll want to allow reblind-only updates, for which
+    /// we can force an on-chain update
+    pub(crate) fn requires_onchain_update(&self) -> bool {
+        let old_circuit_wallet: CircuitWallet = self.old_wallet.clone().into();
+        let mut new_circuit_wallet: CircuitWallet = self.new_wallet.clone().into();
+
+        // The wallet blinders are allowed to be different, all other fields must
+        // match exactly to skip the on-chain update
+        new_circuit_wallet.blinder = self.old_wallet.blinder;
+        new_circuit_wallet != old_circuit_wallet
+    }
+
+    /// Check that the wallet's blinder and private shares are the result of
+    /// applying a reblind to the old wallet
+    pub fn check_reblind_progression(old_wallet: &Wallet, new_wallet: &Wallet) -> bool {
+        let mut old_wallet_clone = old_wallet.clone();
+        old_wallet_clone.reblind_wallet();
+        let expected_private_shares = old_wallet_clone.private_shares;
+        let expected_blinder = old_wallet_clone.blinder;
+
+        new_wallet.private_shares == expected_private_shares
+            && new_wallet.blinder == expected_blinder
+    }
+
+    /// Whether the given wallet update requests a precomputed cancellation
+    /// proof
+    pub fn should_precompute_cancellation_proof(&self) -> bool {
+        match &self.update_type {
+            WalletUpdateType::PlaceOrder { precompute_cancellation_proof, .. } => {
+                *precompute_cancellation_proof
+            },
+            _ => false,
+        }
+    }
+}

--- a/workers/task-driver/src/tasks/update_wallet/helpers/witness_generation.rs
+++ b/workers/task-driver/src/tasks/update_wallet/helpers/witness_generation.rs
@@ -1,0 +1,71 @@
+//! Helpers for generating witness statements for `VALID WALLET UPDATE`
+
+use circuit_types::transfers::ExternalTransferDirection;
+use circuits::zk_circuits::valid_wallet_update::{
+    SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
+};
+
+use crate::tasks::update_wallet::{UpdateWalletTask, UpdateWalletTaskError};
+
+/// The wallet does not have a known Merkle proof attached
+const ERR_NO_MERKLE_PROOF: &str = "merkle proof for wallet not found";
+
+impl UpdateWalletTask {
+    // --- Proof Helpers --- //
+
+    /// Construct a witness and statement for `VALID WALLET UPDATE`
+    pub(crate) fn get_witness_statement(
+        &self,
+    ) -> Result<
+        (SizedValidWalletUpdateWitness, SizedValidWalletUpdateStatement),
+        UpdateWalletTaskError,
+    > {
+        // Get the Merkle opening previously stored to the wallet
+        let merkle_opening = self
+            .old_wallet
+            .merkle_proof
+            .clone()
+            .ok_or_else(|| UpdateWalletTaskError::Missing(ERR_NO_MERKLE_PROOF.to_string()))?;
+        let merkle_root = merkle_opening.compute_root();
+
+        // Build the witness and statement
+        let old_wallet = &self.old_wallet;
+        let new_wallet = &self.new_wallet;
+        let new_wallet_commitment = self.new_wallet.get_wallet_share_commitment();
+
+        let transfer_index = self.get_transfer_idx()?;
+        let transfer = self.transfer.clone().map(|t| t.external_transfer).unwrap_or_default();
+        let statement = SizedValidWalletUpdateStatement {
+            old_shares_nullifier: old_wallet.get_wallet_nullifier(),
+            new_wallet_commitment,
+            new_public_shares: new_wallet.blinded_public_shares.clone(),
+            merkle_root,
+            external_transfer: transfer,
+            old_pk_root: old_wallet.key_chain.public_keys.pk_root.clone(),
+        };
+
+        let witness = SizedValidWalletUpdateWitness {
+            old_wallet_private_shares: old_wallet.private_shares.clone(),
+            old_wallet_public_shares: old_wallet.blinded_public_shares.clone(),
+            old_shares_opening: merkle_opening.into(),
+            new_wallet_private_shares: new_wallet.private_shares.clone(),
+            transfer_index,
+        };
+
+        Ok((witness, statement))
+    }
+
+    /// Get the index that the transfer is applied to
+    fn get_transfer_idx(&self) -> Result<usize, UpdateWalletTaskError> {
+        if let Some(transfer) = self.transfer.as_ref().map(|t| &t.external_transfer) {
+            let mint = &transfer.mint;
+            match transfer.direction {
+                ExternalTransferDirection::Deposit => self.new_wallet.get_balance_index(mint),
+                ExternalTransferDirection::Withdrawal => self.old_wallet.get_balance_index(mint),
+            }
+            .ok_or(UpdateWalletTaskError::Missing(format!("transfer mint {mint:#x} not found")))
+        } else {
+            Ok(0)
+        }
+    }
+}

--- a/workers/task-driver/src/tasks/update_wallet/mod.rs
+++ b/workers/task-driver/src/tasks/update_wallet/mod.rs
@@ -1,0 +1,5 @@
+//! Defines the update wallet task
+
+mod helpers;
+mod task;
+pub use task::{UpdateWalletTask, UpdateWalletTaskError, UpdateWalletTaskState};


### PR DESCRIPTION
### Purpose
This PR modularizes the `update_wallet` task's implementation.

This comes ahead of additional logic to precompute cancellation proofs.
Breaking the helpers into a module will help segment components of the
update wallet task into more discoverable locations.

### Testing
- [x] Unit tests pass