### PR TITLE
state: storage: proof: Add storage methods for cancellation proofs

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -85,6 +85,9 @@ impl StateApplicator {
             StateTransition::AddOrderValidityBundle { order_id, proof, witness } => {
                 self.add_order_validity_proof(order_id, &proof, &witness)
             },
+            StateTransition::AddOrderCancellationProofs { proofs } => {
+                self.add_order_cancellation_proofs(&proofs)
+            },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
             StateTransition::CreateMatchingPool { pool_name } => {
                 self.create_matching_pool(&pool_name)

--- a/state/src/interface/order_book.rs
+++ b/state/src/interface/order_book.rs
@@ -10,7 +10,9 @@ use common::types::{
     MatchingPoolName,
     gossip::WrappedPeerId,
     network_order::NetworkOrder,
-    proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
+    proof_bundles::{
+        OrderValidityProofBundle, OrderValidityWitnessBundle, ValidWalletUpdateBundle,
+    },
     wallet::{OrderIdentifier, Pair},
 };
 use constants::ORDER_STATE_CHANGE_TOPIC;
@@ -362,6 +364,14 @@ impl StateInner {
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::AddOrderValidityBundle { order_id, proof, witness })
             .await
+    }
+
+    /// Add cancellation proofs for a batch of orders managed by the local node
+    pub async fn add_local_order_cancellation_proofs(
+        &self,
+        proofs: Vec<(OrderIdentifier, ValidWalletUpdateBundle)>,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::AddOrderCancellationProofs { proofs }).await
     }
 
     /// Nullify all orders on the given nullifier

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -17,7 +17,9 @@
 use common::types::{
     MatchingPoolName,
     gossip::WrappedPeerId,
-    proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle},
+    proof_bundles::{
+        OrderValidityProofBundle, OrderValidityWitnessBundle, ValidWalletUpdateBundle,
+    },
     tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey},
     wallet::{OrderIdentifier, Wallet, order_metadata::OrderMetadata},
 };
@@ -137,12 +139,16 @@ pub enum StateTransition {
     AddWallet { wallet: Wallet },
     /// Update a wallet in the managed state
     UpdateWallet { wallet: Wallet },
+
+    // --- Order Book --- //
     /// Add a validity proof to an existing order in the book
     AddOrderValidityBundle {
         order_id: OrderIdentifier,
         proof: OrderValidityProofBundle,
         witness: OrderValidityWitnessBundle,
     },
+    /// Add cancellation proofs for a batch of orders in the book
+    AddOrderCancellationProofs { proofs: Vec<(OrderIdentifier, ValidWalletUpdateBundle)> },
 
     // --- Order History --- //
     /// Update the metadata for a given order


### PR DESCRIPTION
### Purpose
This PR adds state methods for precomputed cancellation proofs. Specifically this PR introduces a new state transition for appending cancellation proofs which will be done by the task driver on order placement.

### Todo
- Use this state transition in the task driver
- Recompute cancellation proofs for orders on wallet update

### Testing
- [x] Unit tests pass