### PR TITLE
common: types: order: Move precompute cancellation flag to `Order`

### DIFF
--- a/common/src/types/tasks/descriptors/mod.rs
+++ b/common/src/types/tasks/descriptors/mod.rs
@@ -347,7 +347,6 @@ mod test {
             wallet.clone(),
             wallet,
             vec![],
-            false, // precompute_cancellation_proof
         )
         .unwrap();
     }
@@ -365,7 +364,6 @@ mod test {
             wallet.clone(),
             wallet,
             sig,
-            false, // precompute_cancellation_proof
         )
         .unwrap();
     }
@@ -384,7 +382,6 @@ mod test {
             wallet.clone(),
             wallet,
             sig,
-            false, // precompute_cancellation_proof
         )
         .unwrap();
     }

--- a/common/src/types/tasks/descriptors/update_wallet.rs
+++ b/common/src/types/tasks/descriptors/update_wallet.rs
@@ -50,8 +50,6 @@ pub enum WalletUpdateType {
         /// The matching pool to assign the order to.
         /// If `None`, the order is placed in the global pool.
         matching_pool: Option<MatchingPoolName>,
-        /// Whether to precompute a cancellation proof for the order
-        precompute_cancellation_proof: bool,
     },
     /// Cancel an order
     CancelOrder {
@@ -164,7 +162,6 @@ impl UpdateWalletTaskDescriptor {
         old_wallet: Wallet,
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
-        precompute_cancellation_proof: bool,
     ) -> Result<Self, String> {
         Self::new_order_with_maybe_pool(
             id,
@@ -173,7 +170,6 @@ impl UpdateWalletTaskDescriptor {
             new_wallet,
             wallet_update_signature,
             None, // matching_pool
-            precompute_cancellation_proof,
         )
     }
 
@@ -185,14 +181,8 @@ impl UpdateWalletTaskDescriptor {
         new_wallet: Wallet,
         wallet_update_signature: Vec<u8>,
         matching_pool: Option<MatchingPoolName>,
-        precompute_cancellation_proof: bool,
     ) -> Result<Self, String> {
-        let desc = WalletUpdateType::PlaceOrder {
-            order,
-            id,
-            matching_pool,
-            precompute_cancellation_proof,
-        };
+        let desc = WalletUpdateType::PlaceOrder { order, id, matching_pool };
         Self::new(desc, None, old_wallet, new_wallet, wallet_update_signature)
     }
 

--- a/common/src/types/tasks/history.rs
+++ b/common/src/types/tasks/history.rs
@@ -117,12 +117,7 @@ pub mod historical_mocks {
     pub fn mock_historical_task() -> HistoricalTask {
         let mut rng = thread_rng();
         let id = OrderIdentifier::new_v4();
-        let ty = WalletUpdateType::PlaceOrder {
-            order: mock_order(),
-            id,
-            matching_pool: None,
-            precompute_cancellation_proof: false,
-        };
+        let ty = WalletUpdateType::PlaceOrder { order: mock_order(), id, matching_pool: None };
 
         HistoricalTask {
             id: TaskIdentifier::new_v4(),

--- a/common/src/types/wallet/orders.rs
+++ b/common/src/types/wallet/orders.rs
@@ -71,6 +71,9 @@ pub struct Order {
     /// this in order to source external crossing liquidity
     #[serde(default)]
     pub allow_external_matches: bool,
+    /// Whether or not to pre-compute a cancellation proof for the order
+    #[serde(default)]
+    pub precompute_cancellation_proof: bool,
 }
 
 impl From<Order> for CircuitOrder {
@@ -95,6 +98,7 @@ impl From<CircuitOrder> for Order {
             worst_case_price: order.worst_case_price,
             min_fill_size: 0,
             allow_external_matches: false,
+            precompute_cancellation_proof: false,
         }
     }
 }
@@ -143,6 +147,7 @@ impl Order {
             worst_case_price,
             min_fill_size,
             allow_external_matches,
+            precompute_cancellation_proof: false,
         }
     }
 
@@ -231,6 +236,7 @@ pub struct OrderBuilder {
     worst_case_price: Option<FixedPoint>,
     min_fill_size: Option<Amount>,
     allow_external_matches: Option<bool>,
+    precompute_cancellation_proof: Option<bool>,
 }
 
 impl OrderBuilder {
@@ -281,6 +287,12 @@ impl OrderBuilder {
         self
     }
 
+    /// Set whether or not to pre-compute a cancellation proof
+    pub fn precompute_cancellation_proof(mut self, precompute: bool) -> Self {
+        self.precompute_cancellation_proof = Some(precompute);
+        self
+    }
+
     /// Build the order
     pub fn build(self) -> Result<Order, String> {
         let quote_mint = self.quote_mint.ok_or("Quote mint is required")?;
@@ -293,6 +305,7 @@ impl OrderBuilder {
         });
         let min_fill_size = self.min_fill_size.unwrap_or(0);
         let allow_external_matches = self.allow_external_matches.unwrap_or(false);
+        let precompute_cancellation_proof = self.precompute_cancellation_proof.unwrap_or(false);
 
         Ok(Order {
             quote_mint,
@@ -302,6 +315,7 @@ impl OrderBuilder {
             worst_case_price,
             min_fill_size,
             allow_external_matches,
+            precompute_cancellation_proof,
         })
     }
 }

--- a/external-api/src/http/external_match.rs
+++ b/external-api/src/http/external_match.rs
@@ -273,6 +273,7 @@ impl ExternalOrder {
             min_fill_size,
             worst_case_price,
             allow_external_matches: true,
+            precompute_cancellation_proof: false,
         }
     }
 

--- a/workers/api-server/benches/api-server-bench-util/src/lib.rs
+++ b/workers/api-server/benches/api-server-bench-util/src/lib.rs
@@ -91,6 +91,7 @@ fn internal_party_order(base: &Token, side: OrderSide) -> Order {
         worst_case_price: FixedPoint::zero(),
         min_fill_size: 0,
         allow_external_matches: true,
+        precompute_cancellation_proof: false,
     }
 }
 

--- a/workers/api-server/src/http/admin.rs
+++ b/workers/api-server/src/http/admin.rs
@@ -404,7 +404,8 @@ impl TypedHandler for AdminCreateOrderInMatchingPoolHandler {
         let mut new_wallet = old_wallet.clone();
         maybe_rotate_root_key(&req.update_auth, &mut new_wallet)?;
 
-        let new_order: Order = req.order.try_into().map_err(bad_request)?;
+        let mut new_order: Order = req.order.try_into().map_err(bad_request)?;
+        new_order.precompute_cancellation_proof = req.options.precompute_cancellation_proof;
         new_wallet.add_order(oid, new_order.clone()).map_err(bad_request)?;
         new_wallet.reblind_wallet();
 
@@ -415,7 +416,6 @@ impl TypedHandler for AdminCreateOrderInMatchingPoolHandler {
             new_wallet,
             req.update_auth.statement_sig,
             Some(matching_pool),
-            req.options.precompute_cancellation_proof,
         )
         .map_err(bad_request)?;
 

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
         merkle_path::find_merkle_path,
-        validity_proofs::update_wallet_validity_proofs,
+        proofs::update_wallet_proofs,
     },
 };
 
@@ -250,7 +250,7 @@ impl LookupWalletTask {
             .clone()
             .expect("wallet should be present when CreateValidityProofs state is reached");
 
-        update_wallet_validity_proofs(&wallet, &self.ctx)
+        update_wallet_proofs(&wallet, &self.ctx)
             .await
             .map_err(LookupWalletTaskError::ProofGeneration)
     }

--- a/workers/task-driver/src/tasks/pay_offline_fee.rs
+++ b/workers/task-driver/src/tasks/pay_offline_fee.rs
@@ -29,7 +29,7 @@ use crate::{
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{
         enqueue_proof_job, enqueue_relayer_redeem_job, merkle_path::find_merkle_path_with_tx,
-        validity_proofs::update_wallet_validity_proofs,
+        proofs::update_wallet_proofs,
     },
 };
 
@@ -319,7 +319,7 @@ impl PayOfflineFeeTask {
 
     /// Update the validity proofs for the wallet after fee payment
     async fn update_validity_proofs(&self) -> Result<(), PayOfflineFeeTaskError> {
-        update_wallet_validity_proofs(&self.new_wallet, &self.ctx)
+        update_wallet_proofs(&self.new_wallet, &self.ctx)
             .await
             .map_err(PayOfflineFeeTaskError::UpdateValidityProofs)
     }

--- a/workers/task-driver/src/tasks/pay_relayer_fee.rs
+++ b/workers/task-driver/src/tasks/pay_relayer_fee.rs
@@ -26,7 +26,7 @@ use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::enqueue_proof_job;
 use crate::utils::merkle_path::find_merkle_path_with_tx;
-use crate::utils::validity_proofs::update_wallet_validity_proofs;
+use crate::utils::proofs::update_wallet_proofs;
 
 use super::{ERR_BALANCE_MISSING, ERR_NO_MERKLE_PROOF, ERR_WALLET_MISSING};
 
@@ -318,7 +318,7 @@ impl PayRelayerFeeTask {
     /// The recipient (relayer) wallet does not need to be updated as it holds
     /// no orders
     async fn update_validity_proofs(&self) -> Result<(), PayRelayerFeeTaskError> {
-        update_wallet_validity_proofs(&self.new_sender_wallet, &self.ctx)
+        update_wallet_proofs(&self.new_sender_wallet, &self.ctx)
             .await
             .map_err(PayRelayerFeeTaskError::UpdateValidityProofs)
     }

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -28,7 +28,7 @@ use crate::{
     utils::{
         find_wallet::{find_latest_wallet_tx, gen_private_shares},
         merkle_path::find_merkle_path,
-        validity_proofs::update_validity_proofs__skip_queue_check,
+        proofs::update_wallet_proofs,
     },
 };
 
@@ -250,7 +250,7 @@ impl RefreshWalletTask {
     /// Update validity proofs for the wallet
     async fn update_validity_proofs(&self) -> Result<(), RefreshWalletTaskError> {
         let wallet = self.get_wallet().await?;
-        update_validity_proofs__skip_queue_check(&wallet, &self.ctx)
+        update_wallet_proofs(&wallet, &self.ctx)
             .await
             .map_err(RefreshWalletTaskError::ProofGeneration)
     }

--- a/workers/task-driver/src/tasks/settle_match.rs
+++ b/workers/task-driver/src/tasks/settle_match.rs
@@ -30,7 +30,7 @@ use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
 use crate::utils::{
     merkle_path::{find_merkle_path, find_merkle_path_with_tx},
-    validity_proofs::update_wallet_validity_proofs,
+    proofs::update_wallet_proofs,
 };
 
 /// The error message the contract emits when a nullifier has been used
@@ -347,7 +347,7 @@ impl SettleMatchTask {
     /// Update the validity proofs for all orders in the wallet after settlement
     async fn update_validity_proofs(&self) -> Result<(), SettleMatchTaskError> {
         let wallet = self.ctx.state.get_wallet(&self.wallet_id).await?.unwrap();
-        update_wallet_validity_proofs(&wallet, &self.ctx)
+        update_wallet_proofs(&wallet, &self.ctx)
             .await
             .map_err(SettleMatchTaskError::UpdatingValidityProofs)
     }

--- a/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -8,8 +8,7 @@ use crate::task_state::StateWrapper;
 use crate::traits::{Descriptor, Task, TaskContext, TaskError, TaskState};
 use crate::utils::order_states::{record_order_fill, transition_order_settling};
 use crate::utils::{
-    enqueue_proof_job, merkle_path::find_merkle_path_with_tx,
-    validity_proofs::update_wallet_validity_proofs,
+    enqueue_proof_job, merkle_path::find_merkle_path_with_tx, proofs::update_wallet_proofs,
 };
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
@@ -540,9 +539,7 @@ impl SettleMatchInternalTask {
         wallet: Wallet,
         ctx: TaskContext,
     ) -> TokioJoinHandle<Result<(), String>> {
-        tokio::spawn(
-            async move { update_wallet_validity_proofs(&wallet, &ctx).await }.in_current_span(),
-        )
+        tokio::spawn(async move { update_wallet_proofs(&wallet, &ctx).await }.in_current_span())
     }
 
     /// Emit a pair of fill events to the event manager

--- a/workers/task-driver/src/tasks/update_merkle_proof.rs
+++ b/workers/task-driver/src/tasks/update_merkle_proof.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 use crate::{
     task_state::StateWrapper,
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
-    utils::validity_proofs::update_wallet_validity_proofs,
+    utils::proofs::update_wallet_proofs,
 };
 
 /// The human-readable name of the the task
@@ -212,7 +212,7 @@ impl UpdateMerkleProofTask {
 
     /// Update the validity proofs for all orders in the wallet
     pub async fn update_validity_proofs(&self) -> Result<(), UpdateMerkleProofTaskError> {
-        update_wallet_validity_proofs(&self.wallet, &self.ctx)
+        update_wallet_proofs(&self.wallet, &self.ctx)
             .await
             .map_err(|e| UpdateMerkleProofTaskError::UpdatingValidityProofs(e.to_string()))
     }

--- a/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
+++ b/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
@@ -1,7 +1,6 @@
 //! Helpers for the update wallet task
 
 use circuit_types::SizedWallet as CircuitWallet;
-use common::types::tasks::WalletUpdateType;
 use common::types::wallet::Wallet;
 
 use crate::tasks::update_wallet::UpdateWalletTask;
@@ -43,14 +42,5 @@ impl UpdateWalletTask {
 
         new_wallet.private_shares == expected_private_shares
             && new_wallet.blinder == expected_blinder
-    }
-
-    /// Whether the given wallet update requests a precomputed cancellation
-    /// proof
-    pub fn should_compute_cancellation_proof(&self) -> bool {
-        match &self.update_type {
-            WalletUpdateType::PlaceOrder { order, .. } => order.precompute_cancellation_proof,
-            _ => false,
-        }
     }
 }

--- a/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
+++ b/workers/task-driver/src/tasks/update_wallet/helpers/mod.rs
@@ -49,9 +49,7 @@ impl UpdateWalletTask {
     /// proof
     pub fn should_compute_cancellation_proof(&self) -> bool {
         match &self.update_type {
-            WalletUpdateType::PlaceOrder { precompute_cancellation_proof, .. } => {
-                *precompute_cancellation_proof
-            },
+            WalletUpdateType::PlaceOrder { order, .. } => order.precompute_cancellation_proof,
             _ => false,
         }
     }

--- a/workers/task-driver/src/utils/mod.rs
+++ b/workers/task-driver/src/utils/mod.rs
@@ -11,7 +11,7 @@ use crate::traits::TaskContext;
 pub mod find_wallet;
 pub(crate) mod merkle_path;
 pub mod order_states;
-pub mod validity_proofs;
+pub mod proofs;
 
 /// Error message emitted when enqueuing a job with the proof manager fails
 const ERR_ENQUEUING_JOB: &str = "error enqueuing job with proof manager";

--- a/workers/task-driver/src/utils/proofs/cancellation_proofs.rs
+++ b/workers/task-driver/src/utils/proofs/cancellation_proofs.rs
@@ -1,0 +1,77 @@
+//! Utils for precomputing cancellation proofs for orders
+
+use common::types::{
+    proof_bundles::ValidWalletUpdateBundle,
+    wallet::{OrderIdentifier, Wallet},
+};
+use job_types::proof_manager::ProofJob;
+use tracing::error;
+use util::raw_err_str;
+
+use crate::{
+    tasks::update_wallet::UpdateWalletTask,
+    traits::TaskContext,
+    utils::{enqueue_proof_job, proofs::map_proof_result},
+};
+
+/// Precompute cancellation proofs for a wallet
+pub(crate) async fn precompute_cancellation_proofs(
+    wallet: &Wallet,
+    ctx: &TaskContext,
+) -> Result<(), String> {
+    // Spawn a task for each order that requires a cancellation proof
+    let mut handles = Vec::new();
+    for (id, order) in wallet.orders.iter() {
+        if !order.precompute_cancellation_proof {
+            continue;
+        }
+
+        let oid = *id;
+        let wallet_clone = wallet.clone();
+        let ctx_clone = ctx.clone();
+        let handle = tokio::spawn(async move {
+            precompute_cancellation_proof_for_order(oid, wallet_clone, &ctx_clone).await
+        });
+        handles.push(handle);
+    }
+
+    // Await the tasks
+    let mut proofs = Vec::new();
+    for handle in handles {
+        // Do not fail the whole operation if one proof fails
+        match map_proof_result(handle.await) {
+            Ok((oid, proof)) => proofs.push((oid, proof)),
+            Err(e) => error!("Failed to precompute cancellation proof: {e}"),
+        }
+    }
+
+    // Store the proofs in the state
+    let waiter = ctx.state.add_local_order_cancellation_proofs(proofs).await?;
+    waiter.await?;
+    Ok(())
+}
+
+/// Precompute a cancellation proof for a given order
+async fn precompute_cancellation_proof_for_order(
+    order_id: OrderIdentifier,
+    old_wallet: Wallet,
+    ctx: &TaskContext,
+) -> Result<(OrderIdentifier, ValidWalletUpdateBundle), String> {
+    let mut new_wallet = old_wallet.clone();
+    new_wallet.remove_order(&order_id);
+    new_wallet.reblind_wallet();
+
+    let (witness, statement) =
+        UpdateWalletTask::construct_witness_statement(&old_wallet, &new_wallet).map_err(
+            raw_err_str!("Failed to construct witness statement for cancellation proof: {}"),
+        )?;
+
+    // Forward a job to the proof manager
+    let job = ProofJob::ValidWalletUpdate { witness, statement };
+    let recv =
+        enqueue_proof_job(job, ctx).map_err(raw_err_str!("Failed to enqueue proof job: {}"))?;
+
+    // Await the proof
+    let bundle = recv.await.map_err(raw_err_str!("Failed to await proof: {}"))?;
+    Ok((order_id, bundle.into()))
+}

--- a/workers/task-driver/src/utils/proofs/mod.rs
+++ b/workers/task-driver/src/utils/proofs/mod.rs
@@ -1,0 +1,40 @@
+//! Proof utils for the task driver
+pub(crate) mod cancellation_proofs;
+pub(crate) mod validity_proofs;
+
+use cancellation_proofs::precompute_cancellation_proofs;
+use common::types::wallet::Wallet;
+use tokio::task::JoinError;
+use validity_proofs::update_wallet_validity_proofs;
+
+use crate::traits::TaskContext;
+
+/// Update all precomputed proofs for a wallet
+pub(crate) async fn update_wallet_proofs(
+    new_wallet: &Wallet,
+    task_ctx: &TaskContext,
+) -> Result<(), String> {
+    // 1. Update the validity proofs for the wallet, that is the proofs of `VALID
+    //    COMMITMENTS` and `VALID REBLIND`
+    let ctx = task_ctx.clone();
+    let wallet = new_wallet.clone();
+    let validity_jh =
+        tokio::spawn(async move { update_wallet_validity_proofs(&wallet, &ctx).await });
+
+    // 2. Precompute cancellation proofs for each order that requires one
+    let ctx = task_ctx.clone();
+    let wallet = new_wallet.clone();
+    let cancellation_jh =
+        tokio::spawn(async move { precompute_cancellation_proofs(&wallet, &ctx).await });
+
+    // Join both threads and handle errors
+    let (validity_res, cancellation_res) = tokio::join!(validity_jh, cancellation_jh);
+    map_proof_result(validity_res)?;
+    map_proof_result(cancellation_res)
+}
+
+/// Map a proof result to a string error
+#[inline]
+fn map_proof_result<T>(result: Result<Result<T, String>, JoinError>) -> Result<T, String> {
+    result.map_err(|e| e.to_string())?
+}

--- a/workers/task-driver/src/utils/proofs/validity_proofs.rs
+++ b/workers/task-driver/src/utils/proofs/validity_proofs.rs
@@ -33,11 +33,9 @@ use tracing::instrument;
 
 use crate::tasks::ERR_AWAITING_PROOF;
 use crate::traits::TaskContext;
-use crate::utils::enqueue_proof_job;
-
-use super::{
+use crate::utils::{
     ERR_BALANCE_NOT_FOUND, ERR_MISSING_AUTHENTICATION_PATH, ERR_ORDER_NOT_FOUND,
-    ERR_PROVE_COMMITMENTS_FAILED, ERR_PROVE_REBLIND_FAILED,
+    ERR_PROVE_COMMITMENTS_FAILED, ERR_PROVE_REBLIND_FAILED, enqueue_proof_job,
 };
 
 /// The default ticker to use when no ticker is found for an order
@@ -52,7 +50,7 @@ const DEFAULT_FEE_TICKER: &str = "DEFAULT";
 
 /// Update the validity proofs for a wallet iff there are no other tasks in the
 /// serial queue for the wallet
-pub(crate) async fn update_wallet_validity_proofs(
+pub(super) async fn update_wallet_validity_proofs(
     wallet: &Wallet,
     ctx: &TaskContext,
 ) -> Result<(), String> {
@@ -73,7 +71,7 @@ pub(crate) async fn update_wallet_validity_proofs(
 /// - Linking the reblind and commitments proofs
 /// - Storing the proofs in the global state
 #[allow(non_snake_case)]
-pub(crate) async fn update_validity_proofs__skip_queue_check(
+pub(super) async fn update_validity_proofs__skip_queue_check(
     wallet: &Wallet,
     ctx: &TaskContext,
 ) -> Result<(), String> {


### PR DESCRIPTION
### Purpose
This PR makes two changes:
- Moves the `precompute_cancellation_proofs` flag to the `Order` type.
- Creates logic to recompute cancellation proofs for all orders in the same path as the validity proofs, so that pre-computed cancellation proofs will always stay up to date.

### Todo
- Delete cancellation proofs from state when an order is cancelled.

### Testing
- [x] Unit tests pass
- [x] Tested locally using a variety of tasks to make sure that valid cancellation proofs are in-place after each task.