### PR TITLE
darkpool-client: traits: send-tx: Add debug logging

### DIFF
--- a/darkpool-client/src/traits.rs
+++ b/darkpool-client/src/traits.rs
@@ -26,6 +26,7 @@ use common::types::{
     transfer_auth::TransferAuth,
 };
 use constants::Scalar;
+use tracing::info;
 
 use crate::client::{DarkpoolCallBuilder, RenegadeProvider};
 use crate::errors::DarkpoolClientError;
@@ -35,7 +36,7 @@ use crate::errors::DarkpoolClientError;
 // -------------
 
 /// The timeout for awaiting the receipt of a pending transaction
-const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// The multiple of the gas price estimate we use for submitting a transaction
 const GAS_PRICE_MULTIPLIER: u128 = 2;
@@ -218,6 +219,8 @@ pub trait DarkpoolImplExt: DarkpoolImpl {
             .await
             .map_err(DarkpoolClientError::contract_interaction)?;
 
+        // TODO: Remove this debug log
+        info!("Pending tx hash: {:#x}", pending_tx.tx_hash());
         let receipt = pending_tx
             .with_timeout(Some(TX_RECEIPT_TIMEOUT))
             .get_receipt()


### PR DESCRIPTION
### Purpose
This PR adds a debug log to the `send_tx` helper which logs the pending transaction before it's receipt is awaited.

We'll use this to debug transaction confirmation failures.