### PR TITLE
darkpool-client: Use `quote_amount` from call in share parsing

### DIFF
--- a/circuit-types/src/match.rs
+++ b/circuit-types/src/match.rs
@@ -259,4 +259,19 @@ impl BoundedMatchResult {
             direction: self.direction,
         }
     }
+
+    /// Convert to an external match result given an exact base and quote amount
+    pub fn to_external_match_with_exact_amounts(
+        &self,
+        base_amount: Amount,
+        quote_amount: Amount,
+    ) -> ExternalMatchResult {
+        ExternalMatchResult {
+            quote_mint: self.quote_mint.clone(),
+            base_mint: self.base_mint.clone(),
+            quote_amount,
+            base_amount,
+            direction: self.direction,
+        }
+    }
 }

--- a/darkpool-client/src/arbitrum/helpers.rs
+++ b/darkpool-client/src/arbitrum/helpers.rs
@@ -163,6 +163,7 @@ pub fn parse_shares_from_process_malleable_atomic_match_settle(
     apply_malleable_match_result_to_wallet_share(
         &mut wallet_share,
         call.base_amount,
+        call.quote_amount,
         indices,
         &statement,
     )?;
@@ -190,6 +191,7 @@ pub fn parse_shares_from_process_malleable_atomic_match_settle_with_receiver(
     apply_malleable_match_result_to_wallet_share(
         &mut wallet_share,
         call.base_amount,
+        call.quote_amount,
         indices,
         &statement,
     )?;
@@ -271,14 +273,17 @@ pub fn parse_shares_from_redeem_fee(
 pub fn apply_malleable_match_result_to_wallet_share(
     wallet_share: &mut SizedWalletShare,
     base_amount: U256,
+    quote_amount: U256,
     indices: OrderSettlementIndices,
     statement: &ContractValidMalleableMatchSettleAtomicStatement,
 ) -> Result<(), DarkpoolClientError> {
     let base_amt: Amount = base_amount.try_into().expect("base amount too large");
+    let quote_amt: Amount = quote_amount.try_into().expect("quote amount too large");
 
     // Compute the amounts traded
     let bounded_match = to_circuit_bounded_match_result(&statement.match_result)?;
-    let external_match_res = bounded_match.to_external_match_result(base_amt);
+    let external_match_res =
+        bounded_match.to_external_match_with_exact_amounts(base_amt, quote_amt);
     let match_res = external_match_res.to_match_result();
 
     // Compute the fees due by the internal party

--- a/darkpool-client/src/base/helpers.rs
+++ b/darkpool-client/src/base/helpers.rs
@@ -92,7 +92,9 @@ pub fn parse_shares_from_process_malleable_atomic_match_settle(
     // Compute the match result from the bounded match result and base amount
     let bounded_match = call.matchSettleStatement.matchResult.to_circuit_type()?;
     let base_amount = u256_to_amount(call.baseAmount)?;
-    let external_match = bounded_match.to_external_match_result(base_amount);
+    let quote_amount = u256_to_amount(call.quoteAmount)?;
+    let external_match =
+        bounded_match.to_external_match_with_exact_amounts(base_amount, quote_amount);
     let (_, recv) = external_match.external_party_send();
     let side = external_match.internal_party_side();
     let match_res = external_match.to_match_result();


### PR DESCRIPTION
### Purpose

This PR fixes a bug in parsing shares from a malleable match. In particular, we were previously inferring the quote amount from the swapped base amount.

If a client or the contracts uses a different quote amount--which is valid so long as it represents a worse price for the external party than the price authorized by the relayer--then we will apply an inconsistent `ExternalMatchResult` to the recovered shares.

This was causing a bug with the malleable match connector which can be off by one in its math due to its implementation of fixed point division.

Now, we pull the `quote_amount` directly from the transaction payload.

### Testing

- [x] Tested recovering a wallet that was seeing errors in testnet
- [x] Testing in testnet