### PR TITLE
circuit-types: v2: Add state wrapper and CSPRNG state elements

### DIFF
--- a/circuit-types/src/v2/csprng_state.rs
+++ b/circuit-types/src/v2/csprng_state.rs
@@ -1,0 +1,45 @@
+//! Circuit types for a CSPRNG's state
+
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+
+use renegade_crypto::hash::PoseidonCSPRNG;
+use serde::{Deserialize, Serialize};
+use std::ops::Add;
+
+use constants::Scalar;
+
+#[cfg(feature = "proof-system-types")]
+use {
+    crate::traits::{
+        BaseType, CircuitBaseType, CircuitVarType, SecretShareBaseType, SecretShareType,
+        SecretShareVarType,
+    },
+    circuit_macros::circuit_type,
+    constants::ScalarField,
+    mpc_relation::{Variable, traits::Circuit},
+};
+
+/// A CSPRNG's state
+#[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit, secret_share))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CSPRNGState {
+    /// The seed of the CSPRNG
+    pub seed: Scalar,
+    /// The index into the CSPRNG's stream
+    pub index: u64,
+}
+
+impl CSPRNGState {
+    /// Constructor
+    pub fn new(seed: Scalar) -> Self {
+        Self { seed, index: 0 }
+    }
+}
+
+impl From<CSPRNGState> for PoseidonCSPRNG {
+    fn from(state: CSPRNGState) -> Self {
+        let mut csprng = PoseidonCSPRNG::new(state.seed);
+        csprng.advance_by(state.index as usize);
+        csprng
+    }
+}

--- a/circuit-types/src/v2/state_wrapper.rs
+++ b/circuit-types/src/v2/state_wrapper.rs
@@ -1,0 +1,41 @@
+//! A wrapper type for state elements allocated in the darkpool
+//!
+//! All state elements are endowed with two CSPRNGs:
+//! 1. A recovery identifier CSPRNG. This stream leaks one element per update to
+//!    enable off-chain indexers to track the state element's evolution on-chain
+//! 2. A private share CSPRNG. This CSPRNG backs a stream cipher with which we
+//!    encrypt the plaintext data
+//!
+//! We commit to the entire state wrapper--including the CSPRNG states--but only
+//! generate ciphertext for the plaintext data in `state`
+
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+
+use serde::{Deserialize, Serialize};
+
+use std::fmt::Debug;
+
+use crate::csprng_state::CSPRNGState;
+
+#[cfg(feature = "proof-system-types")]
+use {
+    crate::traits::{BaseType, CircuitBaseType, CircuitVarType},
+    circuit_macros::circuit_type,
+    constants::{Scalar, ScalarField},
+    mpc_relation::{Variable, traits::Circuit},
+};
+
+/// A wrapper type for state elements allocated in the darkpool
+#[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateWrapper<T>
+where
+    T: CircuitBaseType,
+{
+    /// The recovery identifier CSPRNG
+    pub recovery_stream: CSPRNGState,
+    /// The private share CSPRNG
+    pub share_stream: CSPRNGState,
+    /// The state element
+    pub inner: T,
+}


### PR DESCRIPTION
### Purpose
This PR adds new types for a `StateWrapper` and `CSPRNGState` which form the basis of a recoverable, encrypt-able circuit type. 