### PR TITLE
zk-gadgets: v2: state-elements: Add state rotation gadget

### DIFF
--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -26,3 +26,6 @@ pub use v1::*;
 // Re-exports from v2
 #[cfg(feature = "v2")]
 pub use v2::*;
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers;

--- a/circuits/src/zk_gadgets/test_helpers.rs
+++ b/circuits/src/zk_gadgets/test_helpers.rs
@@ -1,0 +1,136 @@
+//! Test helpers for ZK gadgets
+
+use circuit_types::{
+    merkle::MerkleOpening,
+    traits::{BaseType, SecretShareType},
+};
+use constants::Scalar;
+use itertools::Itertools;
+use renegade_crypto::hash::compute_poseidon_hash;
+
+use crate::test_helpers::random_scalars_vec;
+
+// ----------------
+// | Secret Share |
+// ----------------
+
+/// Create a random sharing of the given type
+///
+/// Returns a tuple of the private and public shares
+pub fn create_random_shares<V: SecretShareType>(v: &V::Base) -> (V, V) {
+    let values = v.to_scalars();
+    let private_shares = random_scalars_vec(values.len());
+    let public_shares = values.iter().zip(private_shares.iter()).map(|(v, s)| v - s).collect_vec();
+
+    // Deserialize
+    let private = V::from_scalars(&mut private_shares.into_iter());
+    let public = V::from_scalars(&mut public_shares.into_iter());
+    (private, public)
+}
+
+// ----------
+// | Merkle |
+// ----------
+
+/// Create a Merkle opening for a single leaf
+///
+/// Returns the root and the opening
+pub fn create_merkle_opening<const HEIGHT: usize>(leaf: Scalar) -> (Scalar, MerkleOpening<HEIGHT>) {
+    let (root, mut openings) = create_multi_opening(&[leaf]);
+    (root, openings.pop().unwrap())
+}
+
+/// Create a multi-item opening in a Merkle tree, do so by constructing the
+/// Merkle tree from the given items, padded with zeros
+///
+/// The return type is structured as a tuple with the following elements in
+/// order:
+///     - root: The root of the Merkle tree
+///     - openings: A vector of opening vectors; the sister nodes hashed with
+///       the Merkle path
+///     - opening_indices: A vector of opening index vectors; the left/right
+///       booleans for the path
+pub fn create_multi_opening<const HEIGHT: usize>(
+    items: &[Scalar],
+) -> (Scalar, Vec<MerkleOpening<HEIGHT>>) {
+    create_multi_opening_with_default_leaf(items, Scalar::zero() /* default_value */)
+}
+
+/// Create a multi opening with a non-zero default (empty) leaf value
+pub fn create_multi_opening_with_default_leaf<const HEIGHT: usize>(
+    items: &[Scalar],
+    default_leaf: Scalar,
+) -> (Scalar, Vec<MerkleOpening<HEIGHT>>) {
+    let tree_capacity = 2usize.pow(HEIGHT as u32);
+    assert!(items.len() <= tree_capacity, "tree capacity exceeded by seed items");
+    assert!(!items.is_empty(), "cannot create a multi-opening for an empty tree");
+
+    let (root, mut opening_paths) =
+        create_multi_opening_helper(items.to_vec(), default_leaf, HEIGHT);
+    opening_paths.truncate(items.len());
+
+    // Create Merkle opening paths from each of the results
+    let merkle_paths = opening_paths
+        .into_iter()
+        .enumerate()
+        .map(|(i, path)| (get_opening_indices(i, HEIGHT), path))
+        .map(|(indices, path)| MerkleOpening {
+            indices: indices.try_into().unwrap(),
+            elems: path.try_into().unwrap(),
+        })
+        .collect_vec();
+
+    (root, merkle_paths)
+}
+
+/// A recursive helper to compute a multi-opening for a set of leaves
+///
+/// Returns the root and a set of paths, where path[i] is hte path for
+/// leaves[i]
+fn create_multi_opening_helper(
+    mut leaves: Vec<Scalar>,
+    zero_value: Scalar,
+    height: usize,
+) -> (Scalar, Vec<Vec<Scalar>>) {
+    // If the height is zero we are at the root of the tree, return
+    if height == 0 {
+        return (leaves[0], vec![Vec::new()]);
+    }
+
+    // Otherwise, pad the leaves with zeros to an even number and fold into the next
+    // recursive level
+    let pad_length = leaves.len() % 2;
+    leaves.append(&mut vec![zero_value; pad_length]);
+    let next_level_leaves = leaves.chunks_exact(2).map(compute_poseidon_hash).collect_vec();
+
+    // Recurse up the tree
+    let zero_value = compute_poseidon_hash(&[zero_value, zero_value]);
+    let (root, parent_openings) =
+        create_multi_opening_helper(next_level_leaves, zero_value, height - 1);
+
+    // Append sister nodes to each recursive result
+    let mut openings: Vec<Vec<Scalar>> = Vec::with_capacity(leaves.len());
+    for (leaf_chunk, recursive_opening) in leaves.chunks_exact(2).zip(parent_openings) {
+        // Add the leaves to each other's paths
+        let (left, right) = (leaf_chunk[0], leaf_chunk[1]);
+        openings.push([vec![right], recursive_opening.clone()].concat());
+        openings.push([vec![left], recursive_opening].concat());
+    }
+
+    (root, openings)
+}
+
+/// Get the opening indices for a given insertion index into a Merkle tree
+///
+/// Here, the indices are represented as `Scalar` values where `0`
+/// represents a left child and `1` represents a right child
+fn get_opening_indices(leaf_index: usize, height: usize) -> Vec<bool> {
+    let mut leaf_index = leaf_index as u64;
+    let mut indices = Vec::with_capacity(height);
+
+    for _ in 0..height {
+        indices.push(leaf_index % 2 == 1);
+        leaf_index >>= 1;
+    }
+    indices
+}

--- a/circuits/src/zk_gadgets/v1/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/v1/wallet_operations.rs
@@ -342,6 +342,7 @@ impl MultiproverPriceGadget {
 mod test {
     use std::iter;
 
+    use circuit_types::csprng_state::PoseidonCSPRNG;
     use circuit_types::{
         AMOUNT_BITS, FEE_BITS, PRICE_BITS, PlonkCircuit, SizedWalletShare,
         fixed_point::FixedPoint,
@@ -356,7 +357,6 @@ mod test {
     use itertools::Itertools;
     use mpc_relation::traits::Circuit;
     use rand::{Rng, thread_rng};
-    use renegade_crypto::hash::PoseidonCSPRNG;
     use std::ops::Neg;
 
     use super::{AmountGadget, FeeGadget, PriceGadget, WalletGadget};

--- a/circuits/src/zk_gadgets/v2/csprng.rs
+++ b/circuits/src/zk_gadgets/v2/csprng.rs
@@ -1,6 +1,6 @@
 //! Gadgets for operating on CSPRNGs
 
-use circuit_types::{PlonkCircuit, csprng_state::CSPRNGStateVar};
+use circuit_types::{PlonkCircuit, csprng_state::PoseidonCSPRNGVar};
 use mpc_relation::traits::Circuit;
 use mpc_relation::{Variable, errors::CircuitError};
 
@@ -13,7 +13,7 @@ impl CSPRNGGadget {
     ///
     /// Does *not* mutate the CSPRNG state
     pub fn get_ith(
-        csprng_state: &CSPRNGStateVar,
+        csprng_state: &PoseidonCSPRNGVar,
         i: Variable,
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError> {
@@ -25,7 +25,7 @@ impl CSPRNGGadget {
 
     /// Generate a value from a CSPRNG
     pub fn next(
-        csprng_state: &mut CSPRNGStateVar,
+        csprng_state: &mut PoseidonCSPRNGVar,
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError> {
         // Compute the next value as H(seed || index)
@@ -40,7 +40,7 @@ impl CSPRNGGadget {
 
     /// Generate the next `k` values from a CSPRNG
     pub fn next_k(
-        csprng_state: &mut CSPRNGStateVar,
+        csprng_state: &mut PoseidonCSPRNGVar,
         k: usize,
         cs: &mut PlonkCircuit,
     ) -> Result<Vec<Variable>, CircuitError> {
@@ -50,20 +50,19 @@ impl CSPRNGGadget {
 
 #[cfg(test)]
 mod test {
-    use circuit_types::{PlonkCircuit, csprng_state::CSPRNGState, traits::CircuitBaseType};
+    use circuit_types::{PlonkCircuit, csprng_state::PoseidonCSPRNG, traits::CircuitBaseType};
     use constants::Scalar;
     use eyre::Result;
     use mpc_relation::traits::Circuit;
     use rand::{Rng, thread_rng};
-    use renegade_crypto::hash::PoseidonCSPRNG;
 
     use crate::zk_gadgets::{comparators::EqGadget, csprng::CSPRNGGadget};
 
     /// Get a random CSPRNG state
-    fn random_csprng() -> CSPRNGState {
+    fn random_csprng() -> PoseidonCSPRNG {
         let mut rng = thread_rng();
         let seed = Scalar::random(&mut rng);
-        CSPRNGState::new(seed)
+        PoseidonCSPRNG::new(seed)
     }
 
     /// Get the ith value in a CSPRNG with the given seed

--- a/circuits/src/zk_gadgets/v2/state_elements.rs
+++ b/circuits/src/zk_gadgets/v2/state_elements.rs
@@ -2,13 +2,116 @@
 
 use circuit_types::{
     PlonkCircuit,
+    merkle::MerkleOpeningVar,
     state_wrapper::StateWrapperVar,
     traits::{CircuitBaseType, CircuitVarType, SecretShareVarType},
 };
 use mpc_relation::traits::Circuit;
 use mpc_relation::{Variable, errors::CircuitError};
 
-use crate::zk_gadgets::{csprng::CSPRNGGadget, poseidon::PoseidonHashGadget};
+use crate::zk_gadgets::{
+    csprng::CSPRNGGadget, merkle::PoseidonMerkleHashGadget, poseidon::PoseidonHashGadget,
+};
+
+/// The arguments to a state element rotation gadget
+pub struct StateElementRotationArgs<V: SecretShareVarType, const MERKLE_HEIGHT: usize> {
+    // --- Old Version --- //
+    /// The old version of the state element
+    pub old_version: StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+    /// The old private share of the state element
+    pub old_private_share: V,
+    /// The old public share of the state element
+    pub old_public_share: V,
+    /// The opening of the old version to the Merkle root
+    pub old_opening: MerkleOpeningVar<MERKLE_HEIGHT>,
+    /// The Merkle root to which the old version opens
+    pub merkle_root: Variable,
+    /// The nullifier of the old version
+    pub nullifier: Variable,
+
+    // --- New Version --- //
+    /// The new version of the state element
+    pub new_version: StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+    /// The new private share of the state element
+    pub new_private_share: V,
+    /// The new public share of the state element
+    pub new_public_share: V,
+    /// The commitment to the new version of the state element
+    pub new_commitment: Variable,
+    /// The new recovery identifier of the state element
+    pub recovery_id: Variable,
+}
+
+/// A gadget for rotating a version of a state element
+pub struct StateElementRotationGadget<const MERKLE_HEIGHT: usize>;
+impl<const MERKLE_HEIGHT: usize> StateElementRotationGadget<MERKLE_HEIGHT> {
+    /// Rotate a version of the state element to the next version
+    ///
+    /// This involves:
+    /// 1. Compute a commitment to the old version and verify a Merkle opening
+    ///    for it
+    /// 2. Compute a nullifier for the old version
+    /// 3. Compute the recovery identifier for the new version
+    /// 4. Compute a commitment to the new version of the state element
+    pub fn rotate_version<V: SecretShareVarType>(
+        args: &mut StateElementRotationArgs<V, MERKLE_HEIGHT>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        // Authorize the old version
+        Self::authorize_old_version(args, cs)?;
+        Self::validate_new_version(args, cs)?;
+
+        Ok(())
+    }
+
+    /// Authorize the old version of a state element
+    fn authorize_old_version<V: SecretShareVarType>(
+        args: &StateElementRotationArgs<V, MERKLE_HEIGHT>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        // Compute a commitment to the old version and verify a Merkle opening for it
+        let old_commitment = StateElementGadget::compute_commitment(
+            &args.old_private_share,
+            &args.old_public_share,
+            &args.old_version,
+            cs,
+        )?;
+
+        // Verify a Merkle opening for the old version
+        PoseidonMerkleHashGadget::compute_and_constrain_root_prehashed(
+            old_commitment,
+            &args.old_opening,
+            args.merkle_root,
+            cs,
+        )?;
+
+        // Compute a nullifier for the old version
+        let old_nullifier = StateElementGadget::compute_nullifier(&args.old_version, cs)?;
+        cs.enforce_equal(old_nullifier, args.nullifier)?;
+        Ok(())
+    }
+
+    /// Validate the new version of a state element
+    fn validate_new_version<V: SecretShareVarType>(
+        args: &mut StateElementRotationArgs<V, MERKLE_HEIGHT>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        // Compute the recovery identifier for the new version and constrain it to the
+        // given value
+        let new_recovery_id = StateElementGadget::compute_recovery_id(&mut args.new_version, cs)?;
+        cs.enforce_equal(new_recovery_id, args.recovery_id)?;
+
+        // Compute a commitment to the new version of the state element
+        let new_commitment = StateElementGadget::compute_commitment(
+            &args.new_private_share,
+            &args.new_public_share,
+            &args.new_version,
+            cs,
+        )?;
+        cs.enforce_equal(new_commitment, args.new_commitment)?;
+        Ok(())
+    }
+}
 
 /// A gadget for operating on abstract state elements
 pub struct StateElementGadget;
@@ -95,5 +198,336 @@ impl StateElementGadget {
         let mut hasher = PoseidonHashGadget::new(cs.zero());
         hasher.batch_absorb(&[recovery_id, element.recovery_stream.seed], cs)?;
         hasher.squeeze(cs)
+    }
+
+    // --- Recovery Identifiers --- //
+
+    /// Compute the recovery identifier for a given state element    
+    ///
+    /// This is just the current index in the recovery stream
+    ///
+    /// This method mutates the recovery stream state to advance it by one
+    pub fn compute_recovery_id<V: CircuitBaseType>(
+        element: &mut StateWrapperVar<V>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        CSPRNGGadget::next(&mut element.recovery_stream, cs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use circuit_macros::circuit_type;
+    use circuit_types::merkle::MerkleOpening;
+    use circuit_types::state_wrapper::StateWrapper;
+    use circuit_types::{PlonkCircuit, traits::*};
+    use circuit_types::{csprng_state::PoseidonCSPRNG, fixed_point::FixedPoint};
+    use constants::{Scalar, ScalarField};
+    use eyre::Result;
+    use mpc_relation::{Variable, traits::Circuit};
+    use rand::{Rng, thread_rng};
+    use std::ops::Add;
+
+    use crate::zk_gadgets::test_helpers::{create_merkle_opening, create_random_shares};
+
+    use super::*;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    // --- Test Struct --- //
+
+    /// The height of the Merkle tree to test on
+    const MERKLE_HEIGHT: usize = 10;
+
+    /// A test state element
+    #[derive(Clone)]
+    #[circuit_type(singleprover_circuit, secret_share)]
+    struct TestStateElement {
+        /// A scalar value
+        pub scalar: Scalar,
+        /// An array of scalars
+        pub array: [Scalar; 2],
+        /// Nested type
+        pub nested: TestNestedStateElement,
+    }
+
+    /// A test nested state element
+    #[derive(Clone)]
+    #[circuit_type(singleprover_circuit, secret_share)]
+    struct TestNestedStateElement {
+        /// A fixed point value
+        fp: FixedPoint,
+        /// A scalar value
+        scalar: Scalar,
+    }
+
+    /// A native version of the state element rotation args
+    #[derive(Clone)]
+    struct NativeStateElementRotationArgs<V: SecretShareType, const MERKLE_HEIGHT: usize>
+    where
+        V::Base: CircuitBaseType,
+    {
+        /// The old version of the state element
+        old_version: StateWrapper<V::Base>,
+        /// The old private share of the state element
+        old_private_share: V,
+        /// The old public share of the state element
+        old_public_share: V,
+        /// The opening of the old version to the Merkle root
+        old_opening: MerkleOpening<MERKLE_HEIGHT>,
+        /// The Merkle root to which the old version opens
+        merkle_root: Scalar,
+        /// The nullifier of the old version
+        nullifier: Scalar,
+        /// The new version of the state element
+        new_version: StateWrapper<V::Base>,
+        /// The new private share of the state element
+        new_private_share: V,
+        /// The new public share of the state element
+        new_public_share: V,
+        /// The commitment to the new version of the state element
+        new_commitment: Scalar,
+        /// The new recovery identifier of the state element
+        recovery_id: Scalar,
+    }
+
+    // --- Test Helpers --- //
+
+    /// Allocate a random scalar in the constraint system and return its pointer
+    fn allocate_random_scalar(cs: &mut PlonkCircuit) -> Variable {
+        let mut rng = thread_rng();
+        let value = Scalar::random(&mut rng);
+        value.create_witness(cs)
+    }
+
+    /// Create a rotation bundle and allocate it in a constraint system
+    fn create_and_allocate_rotation_bundle()
+    -> (PlonkCircuit, StateElementRotationArgs<TestStateElementShareVar, MERKLE_HEIGHT>) {
+        let bundle = create_rotation_bundle();
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let args = StateElementRotationArgs {
+            old_version: bundle.old_version.create_witness(&mut cs),
+            old_private_share: bundle.old_private_share.create_witness(&mut cs),
+            old_public_share: bundle.old_public_share.create_witness(&mut cs),
+            old_opening: bundle.old_opening.create_witness(&mut cs),
+            merkle_root: bundle.merkle_root.create_witness(&mut cs),
+            nullifier: bundle.nullifier.create_witness(&mut cs),
+            new_version: bundle.new_version.create_witness(&mut cs),
+            new_private_share: bundle.new_private_share.create_witness(&mut cs),
+            new_public_share: bundle.new_public_share.create_witness(&mut cs),
+            new_commitment: bundle.new_commitment.create_witness(&mut cs),
+            recovery_id: bundle.recovery_id.create_witness(&mut cs),
+        };
+
+        (cs, args)
+    }
+
+    /// Generate a valid rotation bundle
+    fn create_rotation_bundle()
+    -> NativeStateElementRotationArgs<TestStateElementShare, MERKLE_HEIGHT> {
+        let old_elt = create_random_state_element();
+        let new_elt = create_random_state_element();
+        let old_version = create_state_wrapper(old_elt.clone());
+        let mut new_version = create_state_wrapper(new_elt.clone());
+        let new_version_copy = new_version.clone();
+
+        let (old_private_share, old_public_share): (TestStateElementShare, TestStateElementShare) =
+            create_random_shares(&old_elt);
+        let (new_private_share, new_public_share): (TestStateElementShare, TestStateElementShare) =
+            create_random_shares(&new_elt);
+
+        // Compute commitments to the old and new shares
+        let new_recovery_id = new_version.compute_recovery_id();
+        let old_share_commitment =
+            old_version.compute_commitment(&old_private_share, &old_public_share);
+        let new_share_commitment =
+            new_version.compute_commitment(&new_private_share, &new_public_share);
+
+        // Create an opening for the old version
+        let (root, old_opening) = create_merkle_opening(old_share_commitment);
+
+        // Compute the nullifier for the old version
+        let old_nullifier = old_version.compute_nullifier();
+        NativeStateElementRotationArgs {
+            old_version: old_version.clone(),
+            old_private_share,
+            old_public_share,
+            old_opening,
+            merkle_root: root,
+            nullifier: old_nullifier,
+            new_version: new_version_copy,
+            new_private_share: new_private_share.clone(),
+            new_public_share: new_public_share.clone(),
+            new_commitment: new_share_commitment,
+            recovery_id: new_recovery_id,
+        }
+    }
+
+    /// Create a random state element
+    fn create_random_state_element() -> TestStateElement {
+        let mut rng = thread_rng();
+        TestStateElement {
+            scalar: Scalar::random(&mut rng),
+            array: [Scalar::random(&mut rng), Scalar::random(&mut rng)],
+            nested: create_random_nested_state_element(),
+        }
+    }
+
+    /// Create a random nested state element
+    fn create_random_nested_state_element() -> TestNestedStateElement {
+        let mut rng = thread_rng();
+        TestNestedStateElement {
+            fp: FixedPoint::from_f64_round_down(rng.r#gen()),
+            scalar: Scalar::random(&mut rng),
+        }
+    }
+
+    /// Create a state wrapper from a state element
+    fn create_state_wrapper(state: TestStateElement) -> StateWrapper<TestStateElement> {
+        let mut rng = thread_rng();
+        let recovery_seed = Scalar::random(&mut rng);
+        let share_seed = Scalar::random(&mut rng);
+
+        // Build the streams at a random index
+        let mut recovery_stream = PoseidonCSPRNG::new(recovery_seed);
+        let mut share_stream = PoseidonCSPRNG::new(share_seed);
+        recovery_stream.index = rng.r#gen();
+        share_stream.index = rng.r#gen();
+
+        StateWrapper { recovery_stream, share_stream, inner: state }
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// Test a valid rotation bundle
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation_bundle__valid() -> Result<()> {
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+
+        cs.check_circuit_satisfiability(&[])?;
+        Ok(())
+    }
+
+    /// Test an invalid root
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__invalid_merkle_proof() -> Result<()> {
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        args.merkle_root = allocate_random_scalar(&mut cs);
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test a modified public share in the old version
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__modified_old_public_share() -> Result<()> {
+        let mut rng = thread_rng();
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        // Modify a random share
+        let mut shares = args.old_public_share.to_vars();
+        let random_index = rng.r#gen_range(0..shares.len());
+        shares[random_index] = allocate_random_scalar(&mut cs);
+        args.old_public_share =
+            TestStateElementShareVar::from_vars(&mut shares.into_iter(), &mut cs);
+
+        // Apply the constraints and check that they are not satisfied
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test a modified private share in the old version
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__modified_old_private_share() -> Result<()> {
+        let mut rng = thread_rng();
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        // Modify a random share
+        let mut shares = args.old_private_share.to_vars();
+        let random_index = rng.r#gen_range(0..shares.len());
+        shares[random_index] = allocate_random_scalar(&mut cs);
+        args.old_private_share =
+            TestStateElementShareVar::from_vars(&mut shares.into_iter(), &mut cs);
+
+        // Apply the constraints and check that they are not satisfied
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test a modified public share in the new version
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__modified_new_public_share() -> Result<()> {
+        let mut rng = thread_rng();
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        // Modify a random share
+        let mut shares = args.new_public_share.to_vars();
+        let random_index = rng.r#gen_range(0..shares.len());
+        shares[random_index] = allocate_random_scalar(&mut cs);
+        args.new_public_share =
+            TestStateElementShareVar::from_vars(&mut shares.into_iter(), &mut cs);
+
+        // Apply the constraints and check that they are not satisfied
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test a modified private share in the new version
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__modified_new_private_share() -> Result<()> {
+        let mut rng = thread_rng();
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        // Modify a random share
+        let mut shares = args.new_private_share.to_vars();
+        let random_index = rng.r#gen_range(0..shares.len());
+        shares[random_index] = allocate_random_scalar(&mut cs);
+        args.new_private_share =
+            TestStateElementShareVar::from_vars(&mut shares.into_iter(), &mut cs);
+
+        // Apply the constraints and check that they are not satisfied
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test an invalid nullifier
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__invalid_nullifier() -> Result<()> {
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        args.nullifier = allocate_random_scalar(&mut cs);
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
+    }
+
+    /// Test an invalid recovery identifier
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_rotation__invalid_recovery_identifier() -> Result<()> {
+        let (mut cs, mut args) = create_and_allocate_rotation_bundle();
+
+        args.recovery_id = allocate_random_scalar(&mut cs);
+        StateElementRotationGadget::rotate_version(&mut args, &mut cs)?;
+        assert!(cs.check_circuit_satisfiability(&[]).is_err());
+        Ok(())
     }
 }

--- a/circuits/src/zk_gadgets/v2/stream_cipher.rs
+++ b/circuits/src/zk_gadgets/v2/stream_cipher.rs
@@ -2,10 +2,8 @@
 
 use circuit_types::{
     PlonkCircuit,
-    csprng_state::{CSPRNGState, CSPRNGStateVar},
-    traits::{
-        CircuitBaseType, CircuitVarType, SecretShareBaseType, SecretShareType, SecretShareVarType,
-    },
+    csprng_state::PoseidonCSPRNGVar,
+    traits::{CircuitVarType, SecretShareVarType},
 };
 use itertools::Itertools;
 use mpc_relation::traits::Circuit;
@@ -22,7 +20,7 @@ impl StreamCipherGadget {
     /// (ciphertext)
     pub fn encrypt<V: SecretShareVarType>(
         value: &V::Base,
-        csprng_state: &mut CSPRNGStateVar,
+        csprng_state: &mut PoseidonCSPRNGVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(V, V), CircuitError> {
         // Generate new one-time pads (private shares) for the values


### PR DESCRIPTION
### Purpose
This PR adds gadgets for verifying the rotation of a state object. This includes:
- Verifying the commitment and opening of the state element's old version
- Verifying the nullifier of the old version
- Verifying the commitment of the new version
- Verifying the recovery ID emitted for the new version
Higher level circuits/gadgets must verify the actual transition between the fields of the old and new version, but the commitment/nullifier transition is verified in this gadget.

### Testing
- [x] Added tests for valid and invalid test cases
- [x] All unit tests pass