### PR TITLE
circuit-types: csprng-state: Add Poseidon CSPRNG circuit type

### DIFF
--- a/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
+++ b/circuit-macros/src/circuit_type/singleprover_circuit_types.rs
@@ -97,7 +97,7 @@ fn build_circuit_base_type_impl(base_type: &ItemStruct) -> TokenStream2 {
 pub(crate) fn build_var_type(base_type: &ItemStruct) -> TokenStream2 {
     let base_name = base_type.ident.clone();
     let var_name = ident_with_suffix(&base_name.to_string(), VAR_TYPE_SUFFIX);
-    let derive_clone: Attribute = parse_quote!(#[derive(Clone, Debug)]);
+    let derive_clone: Attribute = parse_quote!(#[derive(Clone)]);
 
     let generics = base_type.generics.clone();
     let var_struct = build_modified_struct_from_associated_types(

--- a/circuit-types/src/v2/balance.rs
+++ b/circuit-types/src/v2/balance.rs
@@ -7,7 +7,7 @@ use std::ops::Add;
 use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::{Amount, csprng_state::CSPRNGState, state_wrapper::StateWrapper};
+use crate::{Amount, state_wrapper::StateWrapper};
 
 #[cfg(feature = "proof-system-types")]
 use {
@@ -29,6 +29,8 @@ pub type DarkpoolStateBalance = StateWrapper<Balance>;
 pub struct Balance {
     /// The mint of the token in the balance
     pub mint: Address,
+    /// The owner of the balance
+    pub owner: Address,
     /// A one-time signing authority for the balance
     ///
     /// This authorizes the balance to be spent by an order for the first time,

--- a/circuit-types/src/v2/csprng.rs
+++ b/circuit-types/src/v2/csprng.rs
@@ -2,7 +2,7 @@
 
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-use renegade_crypto::hash::PoseidonCSPRNG;
+use renegade_crypto::hash::compute_poseidon_hash;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
 
@@ -22,24 +22,41 @@ use {
 /// A CSPRNG's state
 #[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit, secret_share))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CSPRNGState {
+pub struct PoseidonCSPRNG {
     /// The seed of the CSPRNG
     pub seed: Scalar,
     /// The index into the CSPRNG's stream
     pub index: u64,
 }
 
-impl CSPRNGState {
+impl PoseidonCSPRNG {
     /// Constructor
     pub fn new(seed: Scalar) -> Self {
         Self { seed, index: 0 }
     }
+
+    /// Advance the index by the given amount
+    pub fn advance_by(&mut self, amount: usize) {
+        self.index += amount as u64;
+    }
+
+    /// Get the ith value in the stream without mutating the state
+    ///
+    /// Returns `H(seed || i)` where `H` is the Poseidon hash function
+    pub fn get_ith(&self, i: u64) -> Scalar {
+        let elts = [self.seed, i.into()];
+        compute_poseidon_hash(&elts)
+    }
 }
 
-impl From<CSPRNGState> for PoseidonCSPRNG {
-    fn from(state: CSPRNGState) -> Self {
-        let mut csprng = PoseidonCSPRNG::new(state.seed);
-        csprng.advance_by(state.index as usize);
-        csprng
+impl Iterator for PoseidonCSPRNG {
+    type Item = Scalar;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let elts = [self.seed, self.index.into()];
+        let hash_res = compute_poseidon_hash(&elts);
+        self.index += 1;
+
+        Some(hash_res)
     }
 }

--- a/circuit-types/src/v2/mod.rs
+++ b/circuit-types/src/v2/mod.rs
@@ -1,7 +1,7 @@
 //! V2 circuit types
 
 pub mod balance;
-pub mod csprng_state;
+pub mod csprng;
 pub mod deposit;
 pub mod state_wrapper;
 

--- a/circuit-types/src/v2/state_wrapper.rs
+++ b/circuit-types/src/v2/state_wrapper.rs
@@ -15,13 +15,15 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt::Debug;
 
-use crate::csprng_state::CSPRNGState;
+use crate::csprng::PoseidonCSPRNG;
+use crate::traits::BaseType;
+use constants::Scalar;
 
 #[cfg(feature = "proof-system-types")]
 use {
-    crate::traits::{BaseType, CircuitBaseType, CircuitVarType},
+    crate::traits::{CircuitBaseType, CircuitVarType},
     circuit_macros::circuit_type,
-    constants::{Scalar, ScalarField},
+    constants::ScalarField,
     mpc_relation::{Variable, traits::Circuit},
 };
 
@@ -33,9 +35,94 @@ where
     T: CircuitBaseType,
 {
     /// The recovery identifier CSPRNG
-    pub recovery_stream: CSPRNGState,
+    pub recovery_stream: PoseidonCSPRNG,
     /// The private share CSPRNG
-    pub share_stream: CSPRNGState,
+    pub share_stream: PoseidonCSPRNG,
     /// The state element
     pub inner: T,
+}
+
+impl<T> StateWrapper<T>
+where
+    T: CircuitBaseType,
+{
+    /// Compute a commitment to the private shares of a state element
+    pub fn compute_private_commitment<V: crate::traits::SecretShareType>(
+        &self,
+        private_share: &V,
+    ) -> Scalar
+    where
+        T: BaseType,
+    {
+        // Build a list of inputs
+        let num_inputs = T::NUM_SCALARS + 2 * PoseidonCSPRNG::NUM_SCALARS;
+        let mut inputs = Vec::with_capacity(num_inputs);
+        inputs.extend(self.recovery_stream.to_scalars());
+        inputs.extend(self.share_stream.to_scalars());
+        inputs.extend(private_share.to_scalars());
+
+        // Hash the inputs to commit to them
+        renegade_crypto::hash::compute_poseidon_hash(&inputs)
+    }
+
+    /// Compute a commitment to a state element given a commitment to the
+    /// private shares and public shares
+    pub fn compute_commitment_from_private<V: crate::traits::SecretShareType>(
+        private_commitment: Scalar,
+        public_share: &V,
+    ) -> Scalar {
+        let mut comm = private_commitment;
+        for share in public_share.to_scalars().iter() {
+            comm = renegade_crypto::hash::compute_poseidon_hash(&[comm, *share]);
+        }
+
+        comm
+    }
+
+    /// Compute a commitment to a value
+    pub fn compute_commitment<V: crate::traits::SecretShareType>(
+        &self,
+        private_share: &V,
+        public_share: &V,
+    ) -> Scalar
+    where
+        T: BaseType,
+    {
+        // Compute the commitment to the private shares then append the public shares to
+        // it
+        let private_commitment = self.compute_private_commitment(private_share);
+        Self::compute_commitment_from_private(private_commitment, public_share)
+    }
+
+    /// Compute a nullifier for a state element
+    ///
+    /// The nullifier is defined as:
+    ///     H(recovery_id || recovery_stream_seed)
+    ///
+    /// Where `recovery_id` is the recovery identifier for the current version
+    /// of the element and `recovery_stream_seed` is the seed of the
+    /// recovery stream. Since we need the recovery identifier of the
+    /// current version, this will be the *last* index in the recovery
+    /// stream.
+    pub fn compute_nullifier(&self) -> Scalar {
+        // Compute the last recovery identifier
+        let index = self.recovery_stream.index - 1;
+        let recovery_id = self.recovery_stream.get_ith(index);
+
+        // Compute the nullifier as H(recovery_id || recovery_stream_seed)
+        let recovery_stream_seed = self.recovery_stream.seed;
+        renegade_crypto::hash::compute_poseidon_hash(&[recovery_id, recovery_stream_seed])
+    }
+
+    /// Compute a recovery identifier for a state element
+    ///
+    /// This is just the current index in the recovery stream
+    ///
+    /// This method mutates the recovery stream state to advance it by one
+    pub fn compute_recovery_id(&mut self) -> Scalar {
+        let mut csprng = self.recovery_stream.clone();
+        let rid = csprng.next().unwrap();
+        self.recovery_stream.index += 1;
+        rid
+    }
 }

--- a/circuits/src/zk_gadgets/v2/csprng.rs
+++ b/circuits/src/zk_gadgets/v2/csprng.rs
@@ -1,6 +1,6 @@
 //! Gadgets for operating on CSPRNGs
 
-use circuit_types::{PlonkCircuit, csprng_state::PoseidonCSPRNGVar};
+use circuit_types::{PlonkCircuit, csprng::PoseidonCSPRNGVar};
 use mpc_relation::traits::Circuit;
 use mpc_relation::{Variable, errors::CircuitError};
 
@@ -50,7 +50,7 @@ impl CSPRNGGadget {
 
 #[cfg(test)]
 mod test {
-    use circuit_types::{PlonkCircuit, csprng_state::PoseidonCSPRNG, traits::CircuitBaseType};
+    use circuit_types::{PlonkCircuit, csprng::PoseidonCSPRNG, traits::CircuitBaseType};
     use constants::Scalar;
     use eyre::Result;
     use mpc_relation::traits::Circuit;

--- a/circuits/src/zk_gadgets/v2/state_elements.rs
+++ b/circuits/src/zk_gadgets/v2/state_elements.rs
@@ -221,7 +221,7 @@ mod test {
     use circuit_types::merkle::MerkleOpening;
     use circuit_types::state_wrapper::StateWrapper;
     use circuit_types::{PlonkCircuit, traits::*};
-    use circuit_types::{csprng_state::PoseidonCSPRNG, fixed_point::FixedPoint};
+    use circuit_types::{csprng::PoseidonCSPRNG, fixed_point::FixedPoint};
     use constants::{Scalar, ScalarField};
     use eyre::Result;
     use mpc_relation::{Variable, traits::Circuit};

--- a/circuits/src/zk_gadgets/v2/stream_cipher.rs
+++ b/circuits/src/zk_gadgets/v2/stream_cipher.rs
@@ -2,7 +2,7 @@
 
 use circuit_types::{
     PlonkCircuit,
-    csprng_state::PoseidonCSPRNGVar,
+    csprng::PoseidonCSPRNGVar,
     traits::{CircuitVarType, SecretShareVarType},
 };
 use itertools::Itertools;


### PR DESCRIPTION
### Purpose
This PR adds a Poseidon hash implementation to the CSPRNG circuit type.

### Testing
- [x] Unit tests pass