### PR TITLE
circuits: zk-gadgets: bitlength: Add bitlength gadgets

### DIFF
--- a/circuits/src/zk_gadgets/mod.rs
+++ b/circuits/src/zk_gadgets/mod.rs
@@ -27,5 +27,5 @@ pub use v1::*;
 #[cfg(feature = "v2")]
 pub use v2::*;
 
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers;

--- a/circuits/src/zk_gadgets/v1/wallet_operations.rs
+++ b/circuits/src/zk_gadgets/v1/wallet_operations.rs
@@ -222,58 +222,10 @@ impl OrderGadget {
     }
 }
 
-/// Constrain a value to be a valid `Amount`, i.e. a non-negative `Scalar`
-/// representable in at most `AMOUNT_BITS` bits
-pub struct AmountGadget;
-impl AmountGadget {
-    /// Constrain an value to be a valid `Amount`
-    pub fn constrain_valid_amount(
-        amount: Variable,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        BitRangeGadget::constrain_bit_range(amount, AMOUNT_BITS, cs)
-    }
-}
-
-/// Constrain a value to be a valid `Amount` in a multiprover context
-pub struct MultiproverAmountGadget;
-impl MultiproverAmountGadget {
-    /// Constrain an value to be a valid `Amount`
-    pub fn constrain_valid_amount(
-        amount: Variable,
-        fabric: &Fabric,
-        cs: &mut MpcPlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        MultiproverBitRangeGadget::constrain_bit_range(amount, AMOUNT_BITS, fabric, cs)
-    }
-}
-
-/// Constrain a fee to be in the range of valid take rates
-///
-/// This is [0, 2^FEE_BITS-1]
-pub struct FeeGadget;
-impl FeeGadget {
-    /// Constrain a value to be a valid fee
-    pub fn constrain_valid_fee(
-        fee: FixedPointVar,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        BitRangeGadget::constrain_bit_range(fee.repr, FEE_BITS, cs)
-    }
-}
-
 /// Constrain a `FixedPoint` value to be a valid price, i.e. with a non-negative
 /// `Scalar` repr representable in at most `PRICE_BITS` bits
 pub struct PriceGadget;
 impl PriceGadget {
-    /// Constrain a value to be a valid `FixedPoint` price
-    pub fn constrain_valid_price(
-        price: FixedPointVar,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        BitRangeGadget::constrain_bit_range(price.repr, PRICE_BITS, cs)
-    }
-
     /// Validate that an execution price is within the user-defined limits
     pub fn validate_price_protection(
         price: &FixedPointVar,

--- a/circuits/src/zk_gadgets/v2/bitlength.rs
+++ b/circuits/src/zk_gadgets/v2/bitlength.rs
@@ -1,0 +1,61 @@
+//! Gadgets for validating bit-lengths of state types
+
+use circuit_types::{
+    AMOUNT_BITS, FEE_BITS, Fabric, MpcPlonkCircuit, PRICE_BITS, PlonkCircuit,
+    fixed_point::FixedPointVar,
+};
+use mpc_relation::{Variable, errors::CircuitError};
+
+use crate::zk_gadgets::bits::{BitRangeGadget, MultiproverBitRangeGadget};
+
+/// Constrain a value to be a valid `Amount`, i.e. a non-negative `Scalar`
+/// representable in at most `AMOUNT_BITS` bits
+pub struct AmountGadget;
+impl AmountGadget {
+    /// Constrain an value to be a valid `Amount`
+    pub fn constrain_valid_amount(
+        amount: Variable,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        BitRangeGadget::constrain_bit_range(amount, AMOUNT_BITS, cs)
+    }
+}
+
+/// Constrain a value to be a valid `Amount` in a multiprover context
+pub struct MultiproverAmountGadget;
+impl MultiproverAmountGadget {
+    /// Constrain an value to be a valid `Amount`
+    pub fn constrain_valid_amount(
+        amount: Variable,
+        fabric: &Fabric,
+        cs: &mut MpcPlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        MultiproverBitRangeGadget::constrain_bit_range(amount, AMOUNT_BITS, fabric, cs)
+    }
+}
+
+/// Constrain a fee to be in the range of valid take rates
+///
+/// This is [0, 2^FEE_BITS-1]
+pub struct FeeGadget;
+impl FeeGadget {
+    /// Constrain a value to be a valid fee
+    pub fn constrain_valid_fee(
+        fee: FixedPointVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        BitRangeGadget::constrain_bit_range(fee.repr, FEE_BITS, cs)
+    }
+}
+
+/// Constrain a value to be a valid `FixedPoint` price
+pub struct PriceGadget;
+impl PriceGadget {
+    /// Constrain a value to be a valid `FixedPoint` price
+    pub fn constrain_valid_price(
+        price: FixedPointVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        BitRangeGadget::constrain_bit_range(price.repr, PRICE_BITS, cs)
+    }
+}

--- a/circuits/src/zk_gadgets/v2/mod.rs
+++ b/circuits/src/zk_gadgets/v2/mod.rs
@@ -1,5 +1,6 @@
 //! V2 gadgets for zero knowledge circuits
 
+pub mod bitlength;
 pub mod csprng;
 pub mod shares;
 pub mod state_elements;


### PR DESCRIPTION
### Purpose
This PR adds bitlength gadgets for the v2 circuits.

### Testing
- [x] All unit tests pass