### PR TITLE
temp: darkpool-client: require 2 tx confirmations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ futures = "0.3"
 tokio = { version = "1" }
 
 # === Ethereum Libraries === #
-alloy = "1.0.1"
-alloy-contract = "1.0.1"
-alloy-primitives = "1.0.1"
-alloy-sol-types = "1.0.1"
+alloy = "1.0.32"
+alloy-contract = "1.0.32"
+alloy-primitives = "1.0.32"
+alloy-sol-types = "1.0.32"
 
 # === HTTP === #
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
In this PR, we require 2 tx confirmations to ensure that we're getting fully-confirmed tx receipts on Base.