### PR TITLE
temp: tasks: settle_match_internal, update_wallet: log submitted roots

### DIFF
--- a/darkpool-client/src/client/event_indexing.rs
+++ b/darkpool-client/src/client/event_indexing.rs
@@ -93,6 +93,11 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         commitment: Scalar,
         tx: &TransactionReceipt,
     ) -> Result<MerkleAuthenticationPath, DarkpoolClientError> {
+        info!(
+            "Finding Merkle authentication path for tx {:#x} in block {:?}",
+            tx.transaction_hash, tx.block_number
+        );
+
         // The number of Merkle insertions that occurred in a transaction
         let mut n_insertions = 0;
         let mut insertion_idx = 0;


### PR DESCRIPTION
In this PR, we log the Merkle root w/ which an `update_wallet` or `process_match_settle` call is invoked for debugging purposes.