### PR TITLE
circuits: zk-gadgets: state-primitives: Add shared prefix commitment

### DIFF
--- a/circuits/src/zk_gadgets/poseidon/mod.rs
+++ b/circuits/src/zk_gadgets/poseidon/mod.rs
@@ -53,7 +53,7 @@ mod test {
 
         // Compute the expected result
         let mut hasher = Poseidon2Sponge::new();
-        hasher.absorb_batch(&absorb_values.iter().map(Scalar::inner).collect_vec());
+        hasher.absorb_batch(absorb_values.iter().map(Scalar::inner).collect_vec());
         let expected_squeeze_values =
             hasher.squeeze_batch(N).into_iter().map(Scalar::new).collect_vec();
 

--- a/circuits/src/zk_gadgets/v2/mod.rs
+++ b/circuits/src/zk_gadgets/v2/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod bitlength;
 pub mod csprng;
+pub mod note;
 pub mod shares;
-pub mod state_elements;
+pub mod state_primitives;
+pub mod state_rotation;
 pub mod stream_cipher;

--- a/circuits/src/zk_gadgets/v2/note.rs
+++ b/circuits/src/zk_gadgets/v2/note.rs
@@ -1,0 +1,79 @@
+//! Helpers for operations on notes
+
+use circuit_types::{
+    PlonkCircuit,
+    elgamal::{ElGamalCiphertextVar, EncryptionKeyVar},
+    note::{NOTE_CIPHERTEXT_SIZE, NoteVar},
+    traits::CircuitVarType,
+};
+use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
+
+use crate::zk_gadgets::elgamal::ElGamalGadget;
+
+use crate::zk_gadgets::{comparators::EqGadget, poseidon::PoseidonHashGadget};
+
+/// A gadget for verifying operations on notes
+pub struct NoteGadget;
+impl NoteGadget {
+    /// Verify the encryption of a note under a given key
+    pub fn verify_note_encryption(
+        note: &NoteVar,
+        encryption_key: &EncryptionKeyVar,
+        randomness: Variable,
+        expected_ciphertext: &ElGamalCiphertextVar<NOTE_CIPHERTEXT_SIZE>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let plaintext_fields = [note.mint, note.amount, note.blinder];
+        ElGamalGadget::check_ciphertext(
+            &plaintext_fields,
+            encryption_key,
+            randomness,
+            expected_ciphertext,
+            cs,
+        )
+    }
+
+    /// Verify a commitment to a note
+    pub fn verify_note_commitment(
+        note: &NoteVar,
+        expected_commitment: Variable,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let comm = Self::compute_note_commitment(note, cs)?;
+        EqGadget::constrain_eq(&comm, &expected_commitment, cs)
+    }
+
+    /// Verify the nullifier of a note
+    pub fn verify_note_nullifier(
+        note_comm: Variable,
+        note_blinder: Variable,
+        expected_nullifier: Variable,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), CircuitError> {
+        let nullifier = Self::compute_note_nullifier(note_comm, note_blinder, cs)?;
+        EqGadget::constrain_eq(&nullifier, &expected_nullifier, cs)
+    }
+
+    /// Compute the commitment to a note
+    pub fn compute_note_commitment(
+        note: &NoteVar,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        let mut hasher = PoseidonHashGadget::new(cs.zero() /* zero_var */);
+        hasher.batch_absorb(&note.to_vars(), cs)?;
+
+        hasher.squeeze(cs)
+    }
+
+    /// Compute the nullifier of a note
+    pub fn compute_note_nullifier(
+        note_comm: Variable,
+        note_blinder: Variable,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        let mut hasher = PoseidonHashGadget::new(cs.zero() /* zero_var */);
+        hasher.batch_absorb(&[note_comm, note_blinder], cs)?;
+
+        hasher.squeeze(cs)
+    }
+}

--- a/circuits/src/zk_gadgets/v2/state_primitives/commitment.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/commitment.rs
@@ -1,0 +1,428 @@
+//! Gadget for computing commitments to state elements
+//!
+//! A commitment to a state element is defined in terms of:
+//! - The public and private shares of the state element's data. These represent
+//!   a stream-cipher encryption of the data
+//! - The recovery stream state of the element
+//! - The share stream state of the element
+//!
+//! We compute a commitment as:
+//!     H(private_commitment || public_commitment)
+//! Where:
+//! - `private_commitment` is a commitment to the private shares of the state
+//!   element and its CSPRNG states. This commitment is evaluated as:
+//!
+//!     H(private_shares || recovery_stream_state || share_stream_state)
+//!
+//! - `public_commitment` is a "resumable" commitment to the public shares of
+//!   the state element. This commitment is evaluated as:
+//!
+//!     H(H(...(H(x_1, x_2), ...), x_{n-1}), x_n)
+//!
+//!   That is, we reset the hasher state after each element is hashed into it.
+//!   This allows us to pre-commit to a partial set of the shares and then
+//!   easily resume the commitment by hashing the remaining shares into the
+//!   commitment
+
+use circuit_types::{
+    PlonkCircuit,
+    state_wrapper::StateWrapperVar,
+    traits::{CircuitVarType, SecretShareVarType},
+};
+use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
+
+use crate::zk_gadgets::poseidon::PoseidonHashGadget;
+
+/// Determine the length of the shared prefix of two state element shares
+///
+/// Note that comparisons in this method are comparisons between pointers, not
+/// values. That is, we are comparing the variable identifiers directly to
+/// determine whether two variables represent the same value. This method does
+/// not capture shared prefixes which come from two different variables assigned
+/// to the same value.
+fn determine_shared_prefix_length<V: SecretShareVarType>(share1: &V, share2: &V) -> usize {
+    let share1_vars = share1.to_vars();
+    let share2_vars = share2.to_vars();
+    assert_eq!(share1_vars.len(), share2_vars.len());
+
+    let mut prefix_length = 0;
+    for i in 0..share1_vars.len() {
+        if share1_vars[i] != share2_vars[i] {
+            break;
+        }
+
+        prefix_length += 1;
+    }
+
+    prefix_length
+}
+
+/// A gadget for computing commitments to state elements
+pub struct CommitmentGadget;
+impl CommitmentGadget {
+    // ---------------------
+    // | Basic Commitments |
+    // ---------------------
+
+    /// Compute the commitment to an abstract state element
+    pub fn compute_commitment<V: SecretShareVarType>(
+        private_share: &V,
+        public_share: &V,
+        element: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        // Serialize the commitment input
+        let private_commitment = Self::compute_private_commitment(private_share, element, cs)?;
+        Self::compute_commitment_from_private(private_commitment, public_share, cs)
+    }
+
+    /// Compute the commitment to the private shares of a state element
+    fn compute_private_commitment<V: SecretShareVarType>(
+        private_share: &V,
+        element: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.batch_absorb(&private_share.to_vars(), cs)?;
+        hasher.batch_absorb(&element.recovery_stream.to_vars(), cs)?;
+        hasher.batch_absorb(&element.share_stream.to_vars(), cs)?;
+
+        hasher.squeeze(cs)
+    }
+
+    /// Compute the commitment to a full state element given a commitment to the
+    /// private shares
+    ///
+    /// As opposed to directly absorbing the public shares into the hasher, we
+    /// iterative 2-1 hash the commitment and the next public share.
+    ///
+    /// The reason for doing this is that it creates a "resumable" partial
+    /// commitment. We can partially commit to a state elements up through
+    /// the public shares that won't change. Then, we can resume the
+    /// commitment in the contracts by hashing the rest of the public shares
+    /// into the commitment. This allows us to pre-commit to a state element
+    /// e.g. before a match and then commit only to the updated shares after
+    /// their values are determined.
+    fn compute_commitment_from_private<V: SecretShareVarType>(
+        private_commitment: Variable,
+        public_share: &V,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        let public_share_vars = public_share.to_vars();
+        let public_commitment = Self::compute_resumable_commitment(&public_share_vars, cs)?;
+
+        // Hash the private commitment and the public commitment together
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.batch_absorb(&[private_commitment, public_commitment], cs)?;
+        hasher.squeeze(cs)
+    }
+
+    // -----------------------------
+    // | Shared Prefix Commitments |
+    // -----------------------------
+
+    /// Compute the commitment to the public shares of two state elements which
+    /// share a prefix
+    ///
+    /// This primitive is useful in state rotation circuits, where frequently
+    /// only one or a handful of shares change between two versions of a state
+    /// element which we need commitments for.
+    pub fn compute_commitments_with_shared_prefix<V: SecretShareVarType>(
+        private_share1: &V,
+        public_share1: &V,
+        element1: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        private_share2: &V,
+        public_share2: &V,
+        element2: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(Variable, Variable), CircuitError> {
+        let (private_comm1, private_comm2) = Self::compute_private_commitments_with_shared_prefix(
+            private_share1,
+            private_share2,
+            element1,
+            element2,
+            cs,
+        )?;
+        let (public_comm1, public_comm2) =
+            Self::compute_public_commitments_with_shared_prefix(public_share1, public_share2, cs)?;
+
+        // Combine the commitments
+        let mut hasher1 = PoseidonHashGadget::new(cs.zero());
+        let mut hasher2 = hasher1.clone();
+        let full_comm1 = hasher1.hash(&[private_comm1, public_comm1], cs)?;
+        let full_comm2 = hasher2.hash(&[private_comm2, public_comm2], cs)?;
+        Ok((full_comm1, full_comm2))
+    }
+
+    /// Compute the commitment to the private shares of two state elements which
+    /// share a prefix
+    ///
+    /// This primitive is useful in state rotation circuits, where frequently
+    /// only one or a handful of shares change between two versions of a state
+    /// element which we need commitments for.
+    fn compute_private_commitments_with_shared_prefix<V: SecretShareVarType>(
+        private_share_1: &V,
+        private_share_2: &V,
+        elt1: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        elt2: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(Variable, Variable), CircuitError> {
+        let prefix_length = determine_shared_prefix_length(private_share_1, private_share_2);
+
+        // Compute the commitment to the shared prefix
+        let share1_vars = private_share_1.to_vars();
+        let share2_vars = private_share_2.to_vars();
+        let shared_prefix = share1_vars[..prefix_length].to_vec();
+        let share1_non_prefix = share1_vars[prefix_length..].to_vec();
+        let share2_non_prefix = share2_vars[prefix_length..].to_vec();
+
+        // Compute the hasher state from the shared prefix only once
+        // If the shared prefix is empty, this `batch_absorb` will do nothing
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.batch_absorb(&shared_prefix, cs)?;
+
+        // Compute the commitments to each of the shares now given the prefix
+        let mut hasher1 = hasher.clone();
+        hasher1.batch_absorb(&share1_non_prefix, cs)?;
+        hasher1.batch_absorb(&elt1.recovery_stream.to_vars(), cs)?;
+        hasher1.batch_absorb(&elt1.share_stream.to_vars(), cs)?;
+        let comm1 = hasher1.squeeze(cs)?;
+
+        let mut hasher2 = hasher.clone();
+        hasher2.batch_absorb(&share2_non_prefix, cs)?;
+        hasher2.batch_absorb(&elt2.recovery_stream.to_vars(), cs)?;
+        hasher2.batch_absorb(&elt2.share_stream.to_vars(), cs)?;
+        let comm2 = hasher2.squeeze(cs)?;
+
+        Ok((comm1, comm2))
+    }
+
+    /// Compute the commitment to the public shares of two state elements which
+    /// share a prefix
+    ///
+    /// This primitive is useful in state rotation circuits, where frequently
+    /// only one or a handful of shares change between two versions of a state
+    /// element which we need commitments for.
+    ///
+    /// In the public case, we use a "resumable" commitment pattern
+    fn compute_public_commitments_with_shared_prefix<V: SecretShareVarType>(
+        public_share_1: &V,
+        public_share_2: &V,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(Variable, Variable), CircuitError> {
+        let prefix_length = determine_shared_prefix_length(public_share_1, public_share_2);
+
+        // Compute the commitment to the shared prefix
+        let share1_vars = public_share_1.to_vars();
+        let share2_vars = public_share_2.to_vars();
+        let shared_prefix = share1_vars[..prefix_length].to_vec();
+
+        // Compute the resumable commitment to the shared prefix only once
+        // Handle the case where the shared prefix is empty by prepending no values to
+        // the hash input
+        let (mut share1_values, mut share2_values) = if prefix_length > 0 {
+            let partial_comm = Self::compute_resumable_commitment(&shared_prefix, cs)?;
+            (vec![partial_comm], vec![partial_comm])
+        } else {
+            (vec![], vec![])
+        };
+
+        // Combine the partial commitment with the remaining values for each share
+        share1_values.extend_from_slice(&share1_vars[prefix_length..]);
+        share2_values.extend_from_slice(&share2_vars[prefix_length..]);
+
+        // Compute the final commitments
+        let comm1 = Self::compute_resumable_commitment(&share1_values, cs)?;
+        let comm2 = Self::compute_resumable_commitment(&share2_values, cs)?;
+        Ok((comm1, comm2))
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Compute a "resumable" commitment to a given set of shares
+    ///
+    /// A resumable commitment is one defined as:
+    ///     H(H(...(H(x_1, x_2), ...), x_{n-1}), x_n)
+    /// That is, we reset the hasher state after each element is hashed into it.
+    /// This allows us to pre-commit to a partial set of the shares and then
+    /// easily resume the commitment by hashing the remaining shares into the
+    /// commitment
+    fn compute_resumable_commitment(
+        values: &[Variable],
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        assert!(!values.is_empty(), "Cannot compute a resumable commitment with no values");
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        let mut comm = values[0];
+        for value in values.iter().skip(1) {
+            comm = hasher.hash(&[comm, *value], cs)?;
+            hasher.reset_state(cs);
+        }
+
+        Ok(comm)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use circuit_types::{PlonkCircuit, traits::*};
+    use constants::Scalar;
+    use eyre::Result;
+    use itertools::Itertools;
+    use mpc_relation::traits::Circuit;
+    use rand::{distributions::uniform::SampleRange, thread_rng};
+
+    use crate::{
+        test_helpers::{random_scalars_array, random_scalars_vec},
+        zk_gadgets::{comparators::EqGadget, test_helpers::create_state_wrapper},
+    };
+
+    use super::*;
+
+    /// The number of scalars in the test state element
+    const N: usize = 50;
+    /// The test type for the state element
+    type TestStateElt = [Scalar; N];
+
+    /// Test the commitment gadget
+    #[test]
+    fn test_commitment_gadget() -> Result<()> {
+        // Generate test data
+        let private_share = random_scalars_array();
+        let public_share = random_scalars_array();
+        let combined = private_share.add_shares(&public_share);
+        let element = create_state_wrapper::<TestStateElt>(combined);
+        let expected_commitment = element.compute_commitment(&private_share, &public_share);
+
+        // Allocate in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let private_share_var = private_share.create_witness(&mut cs);
+        let public_share_var = public_share.create_witness(&mut cs);
+        let element_var = element.create_witness(&mut cs);
+        let expected_commitment_var = expected_commitment.create_witness(&mut cs);
+
+        let commitment = CommitmentGadget::compute_commitment(
+            &private_share_var,
+            &public_share_var,
+            &element_var,
+            &mut cs,
+        )?;
+        EqGadget::constrain_eq(&commitment, &expected_commitment_var, &mut cs)?;
+
+        // Check satisfiability
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+        Ok(())
+    }
+
+    /// Test the commitment gadget with no shared prefix
+    #[test]
+    fn test_commitment_gadget_with_no_shared_prefix() -> Result<()> {
+        // Generate two completely independent elements and shares
+        let private_share1 = random_scalars_array();
+        let public_share1 = random_scalars_array();
+        let private_share2 = random_scalars_array();
+        let public_share2 = random_scalars_array();
+
+        let combined_1 = private_share1.add_shares(&public_share1);
+        let combined_2 = private_share2.add_shares(&public_share2);
+        let elt1 = create_state_wrapper::<TestStateElt>(combined_1);
+        let elt2 = create_state_wrapper::<TestStateElt>(combined_2);
+        let expected_commitment1 = elt1.compute_commitment(&private_share1, &public_share1);
+        let expected_commitment2 = elt2.compute_commitment(&private_share2, &public_share2);
+
+        // Allocate in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let private_share1_var = private_share1.create_witness(&mut cs);
+        let public_share1_var = public_share1.create_witness(&mut cs);
+        let private_share2_var = private_share2.create_witness(&mut cs);
+        let public_share2_var = public_share2.create_witness(&mut cs);
+
+        let element1_var = elt1.create_witness(&mut cs);
+        let element2_var = elt2.create_witness(&mut cs);
+        let expected_commitment1_var = expected_commitment1.create_witness(&mut cs);
+        let expected_commitment2_var = expected_commitment2.create_witness(&mut cs);
+
+        let (commitment1, commitment2) = CommitmentGadget::compute_commitments_with_shared_prefix(
+            &private_share1_var,
+            &public_share1_var,
+            &element1_var,
+            &private_share2_var,
+            &public_share2_var,
+            &element2_var,
+            &mut cs,
+        )?;
+        EqGadget::constrain_eq(&commitment1, &expected_commitment1_var, &mut cs)?;
+        EqGadget::constrain_eq(&commitment2, &expected_commitment2_var, &mut cs)?;
+
+        // Check satisfiability
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+        Ok(())
+    }
+
+    /// Test the commitment gadget with a shared prefix
+    #[test]
+    fn test_commitment_gadget_with_shared_prefix() -> Result<()> {
+        // Generate shared prefixes
+        let mut rng = thread_rng();
+        let public_prefix_length = (0..N).sample_single(&mut rng);
+        let private_prefix_length = (0..N).sample_single(&mut rng);
+        let shared_public_prefix = random_scalars_vec(public_prefix_length);
+        let shared_private_prefix = random_scalars_vec(private_prefix_length);
+
+        // Generate shares with duplicated values
+        let mut private_share1 = random_scalars_array();
+        let mut private_share2 = random_scalars_array();
+        let mut public_share1 = private_share2.add_shares(&random_scalars_array());
+        let mut public_share2 = private_share2.add_shares(&random_scalars_array());
+        private_share1[..private_prefix_length].copy_from_slice(&shared_private_prefix);
+        private_share2[..private_prefix_length].copy_from_slice(&shared_private_prefix);
+        public_share1[..public_prefix_length].copy_from_slice(&shared_public_prefix);
+        public_share2[..public_prefix_length].copy_from_slice(&shared_public_prefix);
+
+        let combined_1 = private_share1.add_shares(&public_share1);
+        let combined_2 = private_share2.add_shares(&public_share2);
+        let elt1 = create_state_wrapper::<TestStateElt>(combined_1);
+        let elt2 = create_state_wrapper::<TestStateElt>(combined_2);
+        let expected_commitment1 = elt1.compute_commitment(&private_share1, &public_share1);
+        let expected_commitment2 = elt2.compute_commitment(&private_share2, &public_share2);
+
+        // Allocate in a constraint system
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let shared_public_vars =
+            shared_public_prefix.iter().map(|v| v.create_witness(&mut cs)).collect_vec();
+        let shared_private_vars =
+            shared_private_prefix.iter().map(|v| v.create_witness(&mut cs)).collect_vec();
+
+        let mut private_share1_var = private_share1.create_witness(&mut cs);
+        let mut public_share1_var = public_share1.create_witness(&mut cs);
+        let mut private_share2_var = private_share2.create_witness(&mut cs);
+        let mut public_share2_var = public_share2.create_witness(&mut cs);
+        private_share1_var[..private_prefix_length].copy_from_slice(&shared_private_vars);
+        public_share1_var[..public_prefix_length].copy_from_slice(&shared_public_vars);
+        private_share2_var[..private_prefix_length].copy_from_slice(&shared_private_vars);
+        public_share2_var[..public_prefix_length].copy_from_slice(&shared_public_vars);
+
+        let element1_var = elt1.create_witness(&mut cs);
+        let element2_var = elt2.create_witness(&mut cs);
+        let expected_commitment1_var = expected_commitment1.create_witness(&mut cs);
+        let expected_commitment2_var = expected_commitment2.create_witness(&mut cs);
+
+        let (commitment1, commitment2) = CommitmentGadget::compute_commitments_with_shared_prefix(
+            &private_share1_var,
+            &public_share1_var,
+            &element1_var,
+            &private_share2_var,
+            &public_share2_var,
+            &element2_var,
+            &mut cs,
+        )?;
+        EqGadget::constrain_eq(&commitment1, &expected_commitment1_var, &mut cs)?;
+        EqGadget::constrain_eq(&commitment2, &expected_commitment2_var, &mut cs)?;
+
+        // Check satisfiability
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+        Ok(())
+    }
+}

--- a/circuits/src/zk_gadgets/v2/state_primitives/mod.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/mod.rs
@@ -1,0 +1,9 @@
+//! Primitives for operating on abstract state elements
+
+pub mod commitment;
+pub mod nullifier;
+pub mod recovery_id;
+
+pub use commitment::CommitmentGadget;
+pub use nullifier::NullifierGadget;
+pub use recovery_id::RecoveryIdGadget;

--- a/circuits/src/zk_gadgets/v2/state_primitives/nullifier.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/nullifier.rs
@@ -1,0 +1,64 @@
+//! Gadget for computing nullifiers of state elements
+
+use circuit_types::{PlonkCircuit, state_wrapper::StateWrapperVar, traits::CircuitBaseType};
+use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
+
+use crate::zk_gadgets::{csprng::CSPRNGGadget, poseidon::PoseidonHashGadget};
+
+/// A gadget for computing nullifiers of state elements
+pub struct NullifierGadget;
+impl NullifierGadget {
+    /// Compute the nullifier of a state element
+    ///
+    /// A state element's nullifier is the hash of the recovery identifier for
+    /// the current version of the element with the seed of the recovery stream.
+    /// This recovery identifier was emitted on the last update of the element.
+    /// So if the current index in the recovery stream is `i`, the recovery
+    /// identifier in question is the value at index `i - 1`.
+    pub fn compute_nullifier<V: CircuitBaseType>(
+        element: &StateWrapperVar<V>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        let last_idx = cs.sub(element.recovery_stream.index, cs.one())?;
+        let recovery_id = CSPRNGGadget::get_ith(&element.recovery_stream, last_idx, cs)?;
+
+        // Compute the nullifier as H(recovery_id || recovery_stream_seed)
+        let mut hasher = PoseidonHashGadget::new(cs.zero());
+        hasher.batch_absorb(&[recovery_id, element.recovery_stream.seed], cs)?;
+        hasher.squeeze(cs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use circuit_types::{PlonkCircuit, traits::CircuitBaseType};
+    use constants::Scalar;
+    use eyre::Result;
+    use rand::thread_rng;
+
+    use super::*;
+
+    use crate::zk_gadgets::{comparators::EqGadget, test_helpers::create_state_wrapper};
+
+    /// Test the nullifier gadget's consistency with the native implementation
+    #[test]
+    fn test_nullifier_gadget_consistency() -> Result<()> {
+        let mut rng = thread_rng();
+
+        // The inner type is unimportant for this test
+        let scalar = Scalar::random(&mut rng);
+        let elt = create_state_wrapper(scalar);
+        let nullifier = elt.compute_nullifier();
+
+        // Check against the gadget
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let elt_var = elt.create_witness(&mut cs);
+        let nullifier_var = NullifierGadget::compute_nullifier(&elt_var, &mut cs)?;
+        let expected_var = nullifier.create_witness(&mut cs);
+        EqGadget::constrain_eq(&nullifier_var, &expected_var, &mut cs)?;
+
+        // Verify satisfiability
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+        Ok(())
+    }
+}

--- a/circuits/src/zk_gadgets/v2/state_primitives/recovery_id.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/recovery_id.rs
@@ -1,0 +1,57 @@
+//! Gadget for computing recovery identifiers of state elements
+
+use circuit_types::{PlonkCircuit, state_wrapper::StateWrapperVar, traits::CircuitBaseType};
+use mpc_relation::{Variable, errors::CircuitError};
+
+use crate::zk_gadgets::csprng::CSPRNGGadget;
+
+/// A gadget for computing recovery identifiers of state elements
+pub struct RecoveryIdGadget;
+impl RecoveryIdGadget {
+    /// Compute the recovery identifier for a given state element    
+    ///
+    /// This is just the current index in the recovery stream
+    ///
+    /// This method mutates the recovery stream state to advance it by one
+    pub fn compute_recovery_id<V: CircuitBaseType>(
+        element: &mut StateWrapperVar<V>,
+        cs: &mut PlonkCircuit,
+    ) -> Result<Variable, CircuitError> {
+        CSPRNGGadget::next(&mut element.recovery_stream, cs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use circuit_types::{PlonkCircuit, traits::CircuitBaseType};
+    use constants::Scalar;
+    use eyre::Result;
+    use mpc_relation::traits::Circuit;
+    use rand::thread_rng;
+
+    use super::*;
+
+    use crate::zk_gadgets::{comparators::EqGadget, test_helpers::create_state_wrapper};
+
+    /// Test the recovery ID gadget's consistency with the native implementation
+    #[test]
+    fn test_recovery_id_gadget_consistency() -> Result<()> {
+        let mut rng = thread_rng();
+
+        // The inner type is unimportant for this test
+        let scalar = Scalar::random(&mut rng);
+        let elt = create_state_wrapper(scalar);
+        let recovery_id = elt.peek_recovery_id();
+
+        // Check against the gadget
+        let mut cs = PlonkCircuit::new_turbo_plonk();
+        let mut elt_var = elt.create_witness(&mut cs);
+        let recovery_id_var = RecoveryIdGadget::compute_recovery_id(&mut elt_var, &mut cs)?;
+        let expected_var = recovery_id.create_witness(&mut cs);
+        EqGadget::constrain_eq(&recovery_id_var, &expected_var, &mut cs)?;
+
+        // Verify satisfiability
+        assert!(cs.check_circuit_satisfiability(&[]).is_ok());
+        Ok(())
+    }
+}

--- a/circuits/src/zk_gadgets/v2/state_rotation.rs
+++ b/circuits/src/zk_gadgets/v2/state_rotation.rs
@@ -1,16 +1,16 @@
-//! Gadgets for operating on abstract state elements
+//! Gadgets for rotating state elements
 
 use circuit_types::{
     PlonkCircuit,
     merkle::MerkleOpeningVar,
     state_wrapper::StateWrapperVar,
-    traits::{CircuitBaseType, CircuitVarType, SecretShareVarType},
+    traits::{CircuitVarType, SecretShareVarType},
 };
-use mpc_relation::traits::Circuit;
-use mpc_relation::{Variable, errors::CircuitError};
+use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::{
-    csprng::CSPRNGGadget, merkle::PoseidonMerkleHashGadget, poseidon::PoseidonHashGadget,
+    merkle::PoseidonMerkleHashGadget,
+    v2::state_primitives::{CommitmentGadget, NullifierGadget, RecoveryIdGadget},
 };
 
 /// The arguments to a state element rotation gadget
@@ -57,25 +57,22 @@ impl<const MERKLE_HEIGHT: usize> StateElementRotationGadget<MERKLE_HEIGHT> {
         args: &mut StateElementRotationArgs<V, MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
-        // Authorize the old version
-        Self::authorize_old_version(args, cs)?;
-        Self::validate_new_version(args, cs)?;
+        // Compute the recovery identifier for the new version and constrain it to the
+        // given value
+        let new_recovery_id = RecoveryIdGadget::compute_recovery_id(&mut args.new_version, cs)?;
+        cs.enforce_equal(new_recovery_id, args.recovery_id)?;
 
-        Ok(())
-    }
-
-    /// Authorize the old version of a state element
-    fn authorize_old_version<V: SecretShareVarType>(
-        args: &StateElementRotationArgs<V, MERKLE_HEIGHT>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        // Compute a commitment to the old version and verify a Merkle opening for it
-        let old_commitment = StateElementGadget::compute_commitment(
-            &args.old_private_share,
-            &args.old_public_share,
-            &args.old_version,
-            cs,
-        )?;
+        let (old_commitment, new_commitment) =
+            CommitmentGadget::compute_commitments_with_shared_prefix(
+                &args.old_private_share,
+                &args.old_public_share,
+                &args.old_version,
+                &args.new_private_share,
+                &args.new_public_share,
+                &args.new_version,
+                cs,
+            )?;
+        cs.enforce_equal(new_commitment, args.new_commitment)?;
 
         // Verify a Merkle opening for the old version
         PoseidonMerkleHashGadget::compute_and_constrain_root_prehashed(
@@ -86,132 +83,10 @@ impl<const MERKLE_HEIGHT: usize> StateElementRotationGadget<MERKLE_HEIGHT> {
         )?;
 
         // Compute a nullifier for the old version
-        let old_nullifier = StateElementGadget::compute_nullifier(&args.old_version, cs)?;
+        let old_nullifier = NullifierGadget::compute_nullifier(&args.old_version, cs)?;
         cs.enforce_equal(old_nullifier, args.nullifier)?;
+
         Ok(())
-    }
-
-    /// Validate the new version of a state element
-    fn validate_new_version<V: SecretShareVarType>(
-        args: &mut StateElementRotationArgs<V, MERKLE_HEIGHT>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<(), CircuitError> {
-        // Compute the recovery identifier for the new version and constrain it to the
-        // given value
-        let new_recovery_id = StateElementGadget::compute_recovery_id(&mut args.new_version, cs)?;
-        cs.enforce_equal(new_recovery_id, args.recovery_id)?;
-
-        // Compute a commitment to the new version of the state element
-        let new_commitment = StateElementGadget::compute_commitment(
-            &args.new_private_share,
-            &args.new_public_share,
-            &args.new_version,
-            cs,
-        )?;
-        cs.enforce_equal(new_commitment, args.new_commitment)?;
-        Ok(())
-    }
-}
-
-/// A gadget for operating on abstract state elements
-pub struct StateElementGadget;
-impl StateElementGadget {
-    // --- Commitments --- //
-
-    /// Compute the commitment to an abstract state element
-    ///
-    /// A commitment is defined as:
-    ///     H(recovery_stream_state || share_stream_state || private_shares ||
-    /// public_shares)
-    pub fn compute_commitment<V: SecretShareVarType>(
-        private_share: &V,
-        public_share: &V,
-        element: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
-        // Serialize the commitment input
-        let private_commitment = Self::compute_private_commitment(private_share, element, cs)?;
-        Self::compute_commitment_from_private(private_commitment, public_share, cs)
-    }
-
-    /// Compute the commitment to the private shares of a state element
-    fn compute_private_commitment<V: SecretShareVarType>(
-        private_share: &V,
-        element: &StateWrapperVar<<V::Base as CircuitVarType>::BaseType>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
-        let mut hasher = PoseidonHashGadget::new(cs.zero());
-        hasher.batch_absorb(&element.recovery_stream.to_vars(), cs)?;
-        hasher.batch_absorb(&element.share_stream.to_vars(), cs)?;
-        hasher.batch_absorb(&private_share.to_vars(), cs)?;
-
-        hasher.squeeze(cs)
-    }
-
-    /// Compute the commitment to a full state element given a commitment to the
-    /// private shares
-    ///
-    /// As opposed to directly absorbing the public shares into the hasher, we
-    /// iterative 2-1 hash the commitment and the next public share.
-    ///
-    /// The reason for doing this is that it creates a "resumable" partial
-    /// commitment. We can partially commit to a state elements up through
-    /// the public shares that won't change. Then, we can resume the
-    /// commitment in the contracts by hashing the rest of the public shares
-    /// into the commitment. This allows us to pre-commit to a state element
-    /// e.g. before a match and then commit only to the updated shares after
-    /// their values are determined.
-    fn compute_commitment_from_private<V: SecretShareVarType>(
-        private_commitment: Variable,
-        public_share: &V,
-        cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
-        let public_share_vars = public_share.to_vars();
-
-        let mut hasher = PoseidonHashGadget::new(cs.zero());
-        let mut comm = private_commitment;
-        for share in public_share_vars.iter() {
-            comm = hasher.hash(&[comm, *share], cs)?;
-            hasher.reset_state(cs);
-        }
-
-        Ok(comm)
-    }
-
-    // --- Nullifiers --- //
-
-    /// Compute the nullifier of a state element
-    ///
-    /// A state element's nullifier is the hash of the recovery identifier for
-    /// the current version of the element with the seed of the recovery stream.
-    /// This recovery identifier was emitted on the last update of the element.
-    /// So if the current index in the recovery stream is `i`, the recovery
-    /// identifier in question is the value at index `i - 1`.
-    pub fn compute_nullifier<V: CircuitBaseType>(
-        element: &StateWrapperVar<V>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
-        let last_idx = cs.sub(element.recovery_stream.index, cs.one())?;
-        let recovery_id = CSPRNGGadget::get_ith(&element.recovery_stream, last_idx, cs)?;
-
-        // Compute the nullifier as H(recovery_id || recovery_stream_seed)
-        let mut hasher = PoseidonHashGadget::new(cs.zero());
-        hasher.batch_absorb(&[recovery_id, element.recovery_stream.seed], cs)?;
-        hasher.squeeze(cs)
-    }
-
-    // --- Recovery Identifiers --- //
-
-    /// Compute the recovery identifier for a given state element    
-    ///
-    /// This is just the current index in the recovery stream
-    ///
-    /// This method mutates the recovery stream state to advance it by one
-    pub fn compute_recovery_id<V: CircuitBaseType>(
-        element: &mut StateWrapperVar<V>,
-        cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
-        CSPRNGGadget::next(&mut element.recovery_stream, cs)
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR makes an optimization to the commitment gadget, by sharing computation between two commitments which overlap in most elements. In specific, for state element rotation, we commonly change one or a handful of shares between the pre- and post-update state element. Their commitments share significant computation, up until the prefix point.

We further expose this shared computation by re-defining the state element commitment to allow for shared circuitry separately in the public and private shares. See the `commitments.rs` file for more info on the new commitment.

Lastly, this PR refactors the state primitive gadgets into a module to isolate the complexity.

### Testing
- [x] All tests pass