### PR TITLE
temp: darkpool-client, tasks: check root history for pending & latest block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ futures = "0.3"
 tokio = { version = "1" }
 
 # === Ethereum Libraries === #
-alloy = "1.0.1"
-alloy-contract = "1.0.1"
-alloy-primitives = "1.0.1"
-alloy-sol-types = "1.0.1"
+alloy = "1.0.32"
+alloy-contract = "1.0.32"
+alloy-primitives = "1.0.32"
+alloy-sol-types = "1.0.32"
 
 # === HTTP === #
 reqwest = { version = "0.12", features = ["json"] }

--- a/darkpool-client/src/arbitrum/mod.rs
+++ b/darkpool-client/src/arbitrum/mod.rs
@@ -29,6 +29,7 @@ use abi::{
 };
 use alloy::{
     consensus::constants::SELECTOR_LEN,
+    eips::BlockNumberOrTag,
     rpc::types::{TransactionReceipt, TransactionRequest},
 };
 use alloy_primitives::{Address, Bytes, Selector, U256};
@@ -168,6 +169,22 @@ impl DarkpoolImpl for ArbitrumDarkpool {
         self.darkpool()
             .rootInHistory(root_u256)
             .call()
+            .block(BlockNumberOrTag::Pending.into()) // This is the default behavior, we're just making it explicit
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+    }
+
+    /// Check (against the latest block) whether a given root is in the
+    /// contract's history
+    async fn check_merkle_root_latest(
+        &self,
+        root: MerkleRoot,
+    ) -> Result<bool, DarkpoolClientError> {
+        let root_u256 = scalar_to_u256(root);
+        self.darkpool()
+            .rootInHistory(root_u256)
+            .call()
+            .block(BlockNumberOrTag::Latest.into())
             .await
             .map_err(DarkpoolClientError::contract_interaction)
     }

--- a/darkpool-client/src/base/mod.rs
+++ b/darkpool-client/src/base/mod.rs
@@ -4,6 +4,7 @@ mod helpers;
 
 use alloy::{
     consensus::constants::SELECTOR_LEN,
+    eips::BlockNumberOrTag,
     rpc::types::{TransactionReceipt, TransactionRequest},
 };
 use alloy_primitives::{Address, Bytes, Selector};
@@ -146,6 +147,20 @@ impl DarkpoolImpl for BaseDarkpool {
         self.darkpool()
             .rootInHistory(root_u256)
             .call()
+            .block(BlockNumberOrTag::Pending.into()) // This is the default behavior, we're just making it explicit
+            .await
+            .map_err(DarkpoolClientError::contract_interaction)
+    }
+
+    async fn check_merkle_root_latest(
+        &self,
+        root: MerkleRoot,
+    ) -> Result<bool, DarkpoolClientError> {
+        let root_u256 = scalar_to_u256(root);
+        self.darkpool()
+            .rootInHistory(root_u256)
+            .call()
+            .block(BlockNumberOrTag::Latest.into())
             .await
             .map_err(DarkpoolClientError::contract_interaction)
     }

--- a/darkpool-client/src/client/contract_interaction.rs
+++ b/darkpool-client/src/client/contract_interaction.rs
@@ -67,6 +67,16 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         self.darkpool.check_merkle_root(root).await
     }
 
+    /// Check (against the latest block) whether the given Merkle root is a
+    /// valid historical root
+    #[instrument(skip_all, err, fields(root = %root))]
+    pub async fn check_merkle_root_valid_latest(
+        &self,
+        root: MerkleRoot,
+    ) -> Result<bool, DarkpoolClientError> {
+        self.darkpool.check_merkle_root_latest(root).await
+    }
+
     /// Check whether the given nullifier is used
     ///
     /// Returns `true` if the nullifier is used, `false` otherwise

--- a/darkpool-client/src/client/mod.rs
+++ b/darkpool-client/src/client/mod.rs
@@ -4,6 +4,7 @@
 use std::{str::FromStr, time::Duration};
 
 use alloy::{
+    eips::BlockNumberOrTag,
     providers::{
         DynProvider, Provider, ProviderBuilder,
         fillers::{BlobGasFiller, ChainIdFiller, GasFiller},
@@ -136,9 +137,18 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         self.provider().get_chain_id().await.map_err(err_str!(DarkpoolClientError::Rpc))
     }
 
-    /// Get the current Stylus block number
+    /// Get the current block number
     pub async fn block_number(&self) -> Result<BlockNumber, DarkpoolClientError> {
         self.provider().get_block_number().await.map_err(err_str!(DarkpoolClientError::Rpc))
+    }
+
+    /// Get the current pending block number
+    pub async fn pending_block_number(&self) -> Result<Option<BlockNumber>, DarkpoolClientError> {
+        self.provider()
+            .get_block_by_number(BlockNumberOrTag::Pending)
+            .await
+            .map_err(err_str!(DarkpoolClientError::Rpc))
+            .map(|b| b.map(|b| b.header.number))
     }
 
     /// Create an event filter

--- a/workers/task-driver/src/tasks/update_wallet/task.rs
+++ b/workers/task-driver/src/tasks/update_wallet/task.rs
@@ -8,9 +8,6 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 
-use alloy::eips::BlockNumberOrTag;
-use alloy::hex;
-use alloy::providers::Provider;
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use common::types::tasks::WalletUpdateType;
@@ -371,20 +368,23 @@ impl UpdateWalletTask {
         let sig = self.wallet_update_signature.clone();
 
         let merkle_root = proof.statement.merkle_root;
-        let merkle_root_hex = hex::encode_prefixed(merkle_root.to_bytes_be());
+
+        let root_check_pending =
+            self.ctx.darkpool_client.check_merkle_root_valid(merkle_root).await?;
+        let root_check_latest =
+            self.ctx.darkpool_client.check_merkle_root_valid_latest(merkle_root).await?;
 
         let pending_block_num = self
             .ctx
             .darkpool_client
-            .provider()
-            .get_block_by_number(BlockNumberOrTag::Pending)
+            .pending_block_number()
             .await
-            .map_err(err_str!(UpdateWalletTaskError::Darkpool))?
-            .map(|b| b.header.number);
+            .map_err(err_str!(UpdateWalletTaskError::Darkpool))?;
 
         info!(
             merkle_root = %merkle_root,
-            merkle_root_hex = %merkle_root_hex,
+            root_check_pending = %root_check_pending,
+            root_check_latest = %root_check_latest,
             pending_block_num = ?pending_block_num,
             "Submitting update wallet tx"
         );


### PR DESCRIPTION
In this PR, we check whether a merkle root is a valid historical root against the pending & latest block before submitting a transaction. We do this in tandem w/ requiring 2 confirmations for TX receipts, so that we are sure Merkle authentication paths are constructed only from fully-confirmed receipts. With this, we expect to see all roots to be valid when checked against the latest block. If, however, roots are considered invalid against the pending block, it will indicate that our RPC's pending state is lagging behind the actual latest confirmed state.