### PR TITLE
util: chore: use workspace http crate

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry = { version = "0.21", default-features = false, features = [
 ] }
 opentelemetry-semantic-conventions = "0.13"
 opentelemetry-datadog = "0.9"
-http = "1"
+http = { workspace = true }
 
 # === Metrics === #
 metrics = { workspace = true }


### PR DESCRIPTION
### Purpose



example:   
```
error: failed to select a version for `http`.
... required by package `util v0.1.0 (https://github.com/renegade-fi/renegade.git#ead248eb)`
... which satisfies git dependency `renegade-util` of package `historical-state-engine v0.1.0 (/Users/s/code/historical-state-engine)`
versions that meet the requirements `^1` (locked to 1.2.0) are: 1.2.0

all possible versions conflict with previously selected packages.

previously selected package `http v1.3.1`
... which satisfies dependency `http = "^1.3.1"` of package `external-api v0.1.0 (https://github.com/renegade-fi/renegade.git#ead248eb)`
... which satisfies git dependency `renegade-external-api` of package `historical-state-engine v0.1.0 (/Users/s/code/historical-state-engine)`

failed to select a version for `http` which could resolve this conflict  
```