### PR TITLE
circuit-types: state-wrapper: Move public shares to state wrapper

### DIFF
--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -300,9 +300,9 @@ pub trait SecretShareType: Sized + BaseType {
 }
 
 /// Implementing types represent a secret share allocated in a constraint system
-pub trait SecretShareVarType: Sized + CircuitVarType {
+pub trait SecretShareVarType: Sized + CircuitVarType<BaseType: SecretShareType> {
     /// The base type that this secret share is a representation of
-    type Base: CircuitVarType;
+    type Base: CircuitVarType<BaseType: SecretShareBaseType>;
 
     /// Apply an additive blinder to each element of the secret shares
     fn blind<C: Circuit<ScalarField>>(self, blinder: Variable, circuit: &mut C) -> Self {

--- a/circuit-types/src/v2/balance.rs
+++ b/circuit-types/src/v2/balance.rs
@@ -52,3 +52,23 @@ pub struct Balance {
     /// The amount of the token in the balance
     pub amount: Amount,
 }
+
+impl Balance {
+    /// Create a new balance with zero values
+    pub fn new(
+        mint: Address,
+        owner: Address,
+        relayer_fee_recipient: Address,
+        one_time_authority: Address,
+    ) -> Self {
+        Self {
+            mint,
+            owner,
+            relayer_fee_recipient,
+            one_time_authority,
+            relayer_fee_balance: 0,
+            protocol_fee_balance: 0,
+            amount: 0,
+        }
+    }
+}

--- a/circuits/src/zk_circuits/v2/fees/valid_public_protocol_fee_payment.rs
+++ b/circuits/src/zk_circuits/v2/fees/valid_public_protocol_fee_payment.rs
@@ -5,9 +5,7 @@
 //! needed.
 
 use circuit_macros::circuit_type;
-use circuit_types::balance::{
-    BalanceShare, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
-};
+use circuit_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
 use circuit_types::merkle::{MerkleOpening, MerkleRoot};
 use circuit_types::note::Note;
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
@@ -46,30 +44,27 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicProtocolFeePayment<MERKLE_HEIGHT> {
 
         // Verify the state transition of the balance
         let old_balance_private_shares = ShareGadget::compute_complementary_shares(
-            &witness.old_balance_public_shares,
+            &witness.old_balance.public_share,
             &witness.old_balance.inner,
             cs,
         )?;
 
-        let (new_balance, new_balance_private_shares, new_balance_public_shares) =
-            Self::compute_post_payment_balance(
-                &old_balance_private_shares,
-                statement,
-                witness,
-                cs,
-            )?;
+        let (new_balance, new_balance_private_shares) = Self::compute_post_payment_balance(
+            &old_balance_private_shares,
+            statement,
+            witness,
+            cs,
+        )?;
 
         // Verify state element rotation
         let mut rotation_args = StateElementRotationArgs {
             old_version: witness.old_balance.clone(),
             old_private_share: old_balance_private_shares,
-            old_public_share: witness.old_balance_public_shares.clone(),
             old_opening: witness.old_balance_opening.clone(),
             merkle_root: statement.merkle_root,
             nullifier: statement.old_balance_nullifier,
             new_version: new_balance,
             new_private_share: new_balance_private_shares,
-            new_public_share: new_balance_public_shares,
             new_commitment: statement.new_balance_commitment,
             recovery_id: statement.recovery_id,
         };
@@ -107,11 +102,10 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicProtocolFeePayment<MERKLE_HEIGHT> {
         statement: &ValidPublicProtocolFeePaymentStatementVar,
         witness: &ValidPublicProtocolFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
-        let mut new_balance_public_shares = witness.old_balance_public_shares.clone();
 
         // Re-encrypt the protocol fee balance field as it's changed
         new_balance.inner.protocol_fee_balance = cs.zero();
@@ -121,14 +115,14 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicProtocolFeePayment<MERKLE_HEIGHT> {
             cs,
         )?;
         new_balance_private_shares.protocol_fee_balance = new_fee_private_share;
-        new_balance_public_shares.protocol_fee_balance = new_fee_public_share;
+        new_balance.public_share.protocol_fee_balance = new_fee_public_share;
         EqGadget::constrain_eq(
             &new_fee_public_share,
             &statement.new_protocol_fee_balance_share,
             cs,
         )?;
 
-        Ok((new_balance, new_balance_private_shares, new_balance_public_shares))
+        Ok((new_balance, new_balance_private_shares))
     }
 }
 
@@ -142,8 +136,6 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicProtocolFeePayment<MERKLE_HEIGHT> {
 pub struct ValidPublicProtocolFeePaymentWitness<const MERKLE_HEIGHT: usize> {
     /// The old balance
     pub old_balance: DarkpoolStateBalance,
-    /// The old public shares of the balance
-    pub old_balance_public_shares: BalanceShare,
     /// The opening of the old balance to the Merkle root
     pub old_balance_opening: MerkleOpening<MERKLE_HEIGHT>,
 }
@@ -209,7 +201,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 pub mod test_helpers {
     use alloy_primitives::Address;
     use circuit_types::{
-        balance::{Balance, BalanceShare, DarkpoolStateBalance},
+        balance::{Balance, DarkpoolStateBalance},
         note::Note,
     };
     use constants::Scalar;
@@ -220,9 +212,7 @@ pub mod test_helpers {
         zk_circuits::v2::fees::valid_public_protocol_fee_payment::{
             SizedValidPublicProtocolFeePayment, SizedValidPublicProtocolFeePaymentWitness,
         },
-        zk_gadgets::test_helpers::{
-            create_merkle_opening, create_random_shares, create_state_wrapper,
-        },
+        zk_gadgets::test_helpers::{create_merkle_opening, create_state_wrapper},
     };
 
     use super::ValidPublicProtocolFeePaymentStatement;
@@ -263,13 +253,8 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement_with_balance(
         old_balance: DarkpoolStateBalance,
     ) -> (SizedValidPublicProtocolFeePaymentWitness, ValidPublicProtocolFeePaymentStatement) {
-        // Create valid complementary shares for the old balance
-        let (old_balance_private_shares, old_balance_public_shares) =
-            create_random_shares::<BalanceShare>(&old_balance.inner);
-
         // Compute commitment, nullifier, and Merkle opening for the old balance
-        let old_balance_commitment =
-            old_balance.compute_commitment(&old_balance_private_shares, &old_balance_public_shares);
+        let old_balance_commitment = old_balance.compute_commitment();
         let old_balance_nullifier = old_balance.compute_nullifier();
         let (merkle_root, old_balance_opening) =
             create_merkle_opening::<MERKLE_HEIGHT>(old_balance_commitment);
@@ -278,30 +263,22 @@ pub mod test_helpers {
         let note = create_note(&old_balance.inner);
 
         // Create the new balance with protocol fee balance = 0
-        let (mut new_balance, new_private_shares, new_public_shares) = create_new_balance(
-            &old_balance,
-            &old_balance_private_shares,
-            &old_balance_public_shares,
-        );
+        let mut new_balance = create_new_balance(&old_balance);
 
         // Compute recovery_id, which will advance the recovery stream
         let recovery_id = new_balance.compute_recovery_id();
-        let new_balance_commitment =
-            new_balance.compute_commitment(&new_private_shares, &new_public_shares);
+        let new_balance_commitment = new_balance.compute_commitment();
 
         // Build the witness and statement
-        let witness = SizedValidPublicProtocolFeePaymentWitness {
-            old_balance,
-            old_balance_public_shares,
-            old_balance_opening,
-        };
+        let witness =
+            SizedValidPublicProtocolFeePaymentWitness { old_balance, old_balance_opening };
 
         let statement = ValidPublicProtocolFeePaymentStatement {
             merkle_root,
             old_balance_nullifier,
             new_balance_commitment,
             recovery_id,
-            new_protocol_fee_balance_share: new_public_shares.protocol_fee_balance,
+            new_protocol_fee_balance_share: new_balance.public_share.protocol_fee_balance,
             note,
         };
 
@@ -325,21 +302,13 @@ pub mod test_helpers {
     ///
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
-    fn create_new_balance(
-        old_balance: &DarkpoolStateBalance,
-        old_private_shares: &BalanceShare,
-        old_public_shares: &BalanceShare,
-    ) -> (DarkpoolStateBalance, BalanceShare, BalanceShare) {
+    fn create_new_balance(old_balance: &DarkpoolStateBalance) -> DarkpoolStateBalance {
         let mut new_balance = old_balance.clone();
-        let mut new_balance_private_shares = old_private_shares.clone();
-        let mut new_balance_public_shares = old_public_shares.clone();
+        new_balance.inner.protocol_fee_balance = 0;
+        let new_fee_balance_public_share = new_balance.stream_cipher_encrypt(&Scalar::zero());
+        new_balance.public_share.protocol_fee_balance = new_fee_balance_public_share;
 
-        let (new_fee_balance_private_share, new_fee_balance_public_share) =
-            new_balance.stream_cipher_encrypt(&Scalar::zero());
-        new_balance_private_shares.protocol_fee_balance = new_fee_balance_private_share;
-        new_balance_public_shares.protocol_fee_balance = new_fee_balance_public_share;
-
-        (new_balance, new_balance_private_shares, new_balance_public_shares)
+        new_balance
     }
 }
 

--- a/circuits/src/zk_circuits/v2/fees/valid_public_relayer_fee_payment.rs
+++ b/circuits/src/zk_circuits/v2/fees/valid_public_relayer_fee_payment.rs
@@ -5,9 +5,7 @@
 //! needed.
 
 use circuit_macros::circuit_type;
-use circuit_types::balance::{
-    BalanceShare, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
-};
+use circuit_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
 use circuit_types::merkle::{MerkleOpening, MerkleRoot};
 use circuit_types::note::Note;
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
@@ -46,30 +44,27 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicRelayerFeePayment<MERKLE_HEIGHT> {
 
         // Verify the state transition of the balance
         let old_balance_private_shares = ShareGadget::compute_complementary_shares(
-            &witness.old_balance_public_shares,
+            &witness.old_balance.public_share,
             &witness.old_balance.inner,
             cs,
         )?;
 
-        let (new_balance, new_balance_private_shares, new_balance_public_shares) =
-            Self::compute_post_payment_balance(
-                &old_balance_private_shares,
-                statement,
-                witness,
-                cs,
-            )?;
+        let (new_balance, new_balance_private_shares) = Self::compute_post_payment_balance(
+            &old_balance_private_shares,
+            statement,
+            witness,
+            cs,
+        )?;
 
         // Verify state element rotation
         let mut rotation_args = StateElementRotationArgs {
             old_version: witness.old_balance.clone(),
             old_private_share: old_balance_private_shares,
-            old_public_share: witness.old_balance_public_shares.clone(),
             old_opening: witness.old_balance_opening.clone(),
             merkle_root: statement.merkle_root,
             nullifier: statement.old_balance_nullifier,
             new_version: new_balance,
             new_private_share: new_balance_private_shares,
-            new_public_share: new_balance_public_shares,
             new_commitment: statement.new_balance_commitment,
             recovery_id: statement.recovery_id,
         };
@@ -107,11 +102,10 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicRelayerFeePayment<MERKLE_HEIGHT> {
         statement: &ValidPublicRelayerFeePaymentStatementVar,
         witness: &ValidPublicRelayerFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
-        let mut new_balance_public_shares = witness.old_balance_public_shares.clone();
 
         // Re-encrypt the relayer fee balance field as it's changed
         new_balance.inner.relayer_fee_balance = cs.zero();
@@ -121,14 +115,14 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicRelayerFeePayment<MERKLE_HEIGHT> {
             cs,
         )?;
         new_balance_private_shares.relayer_fee_balance = new_fee_private_share;
-        new_balance_public_shares.relayer_fee_balance = new_fee_public_share;
+        new_balance.public_share.relayer_fee_balance = new_fee_public_share;
         EqGadget::constrain_eq(
             &new_fee_public_share,
             &statement.new_relayer_fee_balance_share,
             cs,
         )?;
 
-        Ok((new_balance, new_balance_private_shares, new_balance_public_shares))
+        Ok((new_balance, new_balance_private_shares))
     }
 }
 
@@ -142,8 +136,6 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicRelayerFeePayment<MERKLE_HEIGHT> {
 pub struct ValidPublicRelayerFeePaymentWitness<const MERKLE_HEIGHT: usize> {
     /// The old balance
     pub old_balance: DarkpoolStateBalance,
-    /// The old public shares of the balance
-    pub old_balance_public_shares: BalanceShare,
     /// The opening of the old balance to the Merkle root
     pub old_balance_opening: MerkleOpening<MERKLE_HEIGHT>,
 }
@@ -209,7 +201,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 pub mod test_helpers {
     use alloy_primitives::Address;
     use circuit_types::{
-        balance::{Balance, BalanceShare, DarkpoolStateBalance},
+        balance::{Balance, DarkpoolStateBalance},
         note::Note,
     };
     use constants::Scalar;
@@ -220,9 +212,7 @@ pub mod test_helpers {
         zk_circuits::v2::fees::valid_public_relayer_fee_payment::{
             SizedValidPublicRelayerFeePayment, SizedValidPublicRelayerFeePaymentWitness,
         },
-        zk_gadgets::test_helpers::{
-            create_merkle_opening, create_random_shares, create_state_wrapper,
-        },
+        zk_gadgets::test_helpers::{create_merkle_opening, create_state_wrapper},
     };
 
     use super::ValidPublicRelayerFeePaymentStatement;
@@ -263,13 +253,8 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement_with_balance(
         old_balance: DarkpoolStateBalance,
     ) -> (SizedValidPublicRelayerFeePaymentWitness, ValidPublicRelayerFeePaymentStatement) {
-        // Create valid complementary shares for the old balance
-        let (old_balance_private_shares, old_balance_public_shares) =
-            create_random_shares::<BalanceShare>(&old_balance.inner);
-
         // Compute commitment, nullifier, and Merkle opening for the old balance
-        let old_balance_commitment =
-            old_balance.compute_commitment(&old_balance_private_shares, &old_balance_public_shares);
+        let old_balance_commitment = old_balance.compute_commitment();
         let old_balance_nullifier = old_balance.compute_nullifier();
         let (merkle_root, old_balance_opening) =
             create_merkle_opening::<MERKLE_HEIGHT>(old_balance_commitment);
@@ -278,30 +263,21 @@ pub mod test_helpers {
         let note = create_note(&old_balance.inner);
 
         // Create the new balance with relayer fee balance = 0
-        let (mut new_balance, new_private_shares, new_public_shares) = create_new_balance(
-            &old_balance,
-            &old_balance_private_shares,
-            &old_balance_public_shares,
-        );
+        let mut new_balance = create_new_balance(&old_balance);
 
         // Compute recovery_id, which will advance the recovery stream
         let recovery_id = new_balance.compute_recovery_id();
-        let new_balance_commitment =
-            new_balance.compute_commitment(&new_private_shares, &new_public_shares);
+        let new_balance_commitment = new_balance.compute_commitment();
 
         // Build the witness and statement
-        let witness = SizedValidPublicRelayerFeePaymentWitness {
-            old_balance,
-            old_balance_public_shares,
-            old_balance_opening,
-        };
+        let witness = SizedValidPublicRelayerFeePaymentWitness { old_balance, old_balance_opening };
 
         let statement = ValidPublicRelayerFeePaymentStatement {
             merkle_root,
             old_balance_nullifier,
             new_balance_commitment,
             recovery_id,
-            new_relayer_fee_balance_share: new_public_shares.relayer_fee_balance,
+            new_relayer_fee_balance_share: new_balance.public_share.relayer_fee_balance,
             note,
         };
 
@@ -325,21 +301,13 @@ pub mod test_helpers {
     ///
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
-    fn create_new_balance(
-        old_balance: &DarkpoolStateBalance,
-        old_private_shares: &BalanceShare,
-        old_public_shares: &BalanceShare,
-    ) -> (DarkpoolStateBalance, BalanceShare, BalanceShare) {
+    fn create_new_balance(old_balance: &DarkpoolStateBalance) -> DarkpoolStateBalance {
         let mut new_balance = old_balance.clone();
-        let mut new_balance_private_shares = old_private_shares.clone();
-        let mut new_balance_public_shares = old_public_shares.clone();
+        new_balance.inner.relayer_fee_balance = 0;
+        let new_fee_balance_public_share = new_balance.stream_cipher_encrypt(&Scalar::zero());
+        new_balance.public_share.relayer_fee_balance = new_fee_balance_public_share;
 
-        let (new_fee_balance_private_share, new_fee_balance_public_share) =
-            new_balance.stream_cipher_encrypt(&Scalar::zero());
-        new_balance_private_shares.relayer_fee_balance = new_fee_balance_private_share;
-        new_balance_public_shares.relayer_fee_balance = new_fee_balance_public_share;
-
-        (new_balance, new_balance_private_shares, new_balance_public_shares)
+        new_balance
     }
 }
 

--- a/circuits/src/zk_gadgets/v2/state_primitives/nullifier.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/nullifier.rs
@@ -1,6 +1,10 @@
 //! Gadget for computing nullifiers of state elements
 
-use circuit_types::{PlonkCircuit, state_wrapper::StateWrapperVar, traits::CircuitBaseType};
+use circuit_types::{
+    PlonkCircuit,
+    state_wrapper::StateWrapperVar,
+    traits::{CircuitBaseType, SecretShareBaseType},
+};
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::{csprng::CSPRNGGadget, poseidon::PoseidonHashGadget};
@@ -15,10 +19,14 @@ impl NullifierGadget {
     /// This recovery identifier was emitted on the last update of the element.
     /// So if the current index in the recovery stream is `i`, the recovery
     /// identifier in question is the value at index `i - 1`.
-    pub fn compute_nullifier<V: CircuitBaseType>(
+    pub fn compute_nullifier<V>(
         element: &StateWrapperVar<V>,
         cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
+    ) -> Result<Variable, CircuitError>
+    where
+        V: CircuitBaseType + SecretShareBaseType,
+        V::ShareType: CircuitBaseType,
+    {
         let last_idx = cs.sub(element.recovery_stream.index, cs.one())?;
         let recovery_id = CSPRNGGadget::get_ith(&element.recovery_stream, last_idx, cs)?;
 

--- a/circuits/src/zk_gadgets/v2/state_primitives/recovery_id.rs
+++ b/circuits/src/zk_gadgets/v2/state_primitives/recovery_id.rs
@@ -1,6 +1,10 @@
 //! Gadget for computing recovery identifiers of state elements
 
-use circuit_types::{PlonkCircuit, state_wrapper::StateWrapperVar, traits::CircuitBaseType};
+use circuit_types::{
+    PlonkCircuit,
+    state_wrapper::StateWrapperVar,
+    traits::{CircuitBaseType, SecretShareBaseType},
+};
 use mpc_relation::{Variable, errors::CircuitError};
 
 use crate::zk_gadgets::csprng::CSPRNGGadget;
@@ -13,10 +17,14 @@ impl RecoveryIdGadget {
     /// This is just the current index in the recovery stream
     ///
     /// This method mutates the recovery stream state to advance it by one
-    pub fn compute_recovery_id<V: CircuitBaseType>(
+    pub fn compute_recovery_id<V>(
         element: &mut StateWrapperVar<V>,
         cs: &mut PlonkCircuit,
-    ) -> Result<Variable, CircuitError> {
+    ) -> Result<Variable, CircuitError>
+    where
+        V: CircuitBaseType + SecretShareBaseType,
+        V::ShareType: CircuitBaseType,
+    {
         CSPRNGGadget::next(&mut element.recovery_stream, cs)
     }
 }

--- a/circuits/src/zk_gadgets/v2/stream_cipher.rs
+++ b/circuits/src/zk_gadgets/v2/stream_cipher.rs
@@ -63,11 +63,14 @@ mod test {
         let mut state_var = state.create_witness(&mut cs);
 
         // Generate test data to encrypt
-        const N: usize = 1;
+        const N: usize = 10;
         let values = random_scalars_array::<N>();
         let values_var = values.create_witness(&mut cs);
-        let (expected_private, expected_public) =
-            state.stream_cipher_encrypt::<[Scalar; N]>(&values);
+        let expected_public = state.stream_cipher_encrypt::<[Scalar; N]>(&values);
+        let mut expected_private = [Scalar::zero(); N];
+        for (i, (v, p)) in values.into_iter().zip(expected_public.into_iter()).enumerate() {
+            expected_private[i] = v - p;
+        }
 
         // Encrypt in a constraint system
         let (private_share, public_share) = StreamCipherGadget::encrypt::<[Variable; N]>(


### PR DESCRIPTION
### Purpose
This PR adds public shares as a member of the `StateWrapper` type. This cleans up much of the logic for committing to values and makes manipulating secret shares simpler.

### Testing
- [x] All tests pass