### PR TITLE
circuit-types: csprng: Add encryption to CSPRNG

### DIFF
--- a/circuit-types/src/v2/balance.rs
+++ b/circuit-types/src/v2/balance.rs
@@ -71,4 +71,9 @@ impl Balance {
             amount: 0,
         }
     }
+
+    /// Create a new balance with the given amount
+    pub fn with_amount(self, amount: Amount) -> Self {
+        Self { amount, ..self }
+    }
 }

--- a/circuit-types/src/v2/csprng.rs
+++ b/circuit-types/src/v2/csprng.rs
@@ -2,6 +2,7 @@
 
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
+use itertools::Itertools;
 use renegade_crypto::hash::compute_poseidon_hash;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
@@ -29,6 +30,18 @@ pub struct PoseidonCSPRNG {
     pub index: u64,
 }
 
+impl Iterator for PoseidonCSPRNG {
+    type Item = Scalar;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let elts = [self.seed, self.index.into()];
+        let hash_res = compute_poseidon_hash(&elts);
+        self.index += 1;
+
+        Some(hash_res)
+    }
+}
+
 impl PoseidonCSPRNG {
     /// Constructor
     pub fn new(seed: Scalar) -> Self {
@@ -47,16 +60,63 @@ impl PoseidonCSPRNG {
         let elts = [self.seed, i.into()];
         compute_poseidon_hash(&elts)
     }
+
+    /// Encrypt a value using the CSPRNG as a stream cipher
+    pub fn stream_cipher_encrypt<T: SecretShareBaseType>(&mut self, value: &T) -> T::ShareType {
+        // Sample one-time pads for each value
+        let value_scalars = value.to_scalars();
+        let pads = self.take(value_scalars.len()).collect_vec();
+
+        // Apply the pads to the values to get the ciphertexts
+        let ciphertexts =
+            value_scalars.iter().zip(pads.iter()).map(|(value, pad)| value - pad).collect_vec();
+        T::ShareType::from_scalars(&mut ciphertexts.into_iter())
+    }
+
+    /// Encrypt a value using the CSPRNG as a stream cipher without mutating the
+    /// state
+    pub fn peek_stream_cipher_encrypt<T: SecretShareBaseType>(&self, value: &T) -> T::ShareType {
+        // Sample one-time pads for each value
+        let value_scalars = value.to_scalars();
+        let num_values = value_scalars.len();
+        let start_index = self.index;
+        let mut pads = Vec::with_capacity(num_values);
+        for i in start_index..start_index + num_values as u64 {
+            pads.push(self.get_ith(i));
+        }
+
+        // Apply the pads to the values to get the ciphertexts
+        let ciphertexts =
+            value_scalars.iter().zip(pads.iter()).map(|(value, pad)| value - pad).collect_vec();
+        T::ShareType::from_scalars(&mut ciphertexts.into_iter())
+    }
 }
 
-impl Iterator for PoseidonCSPRNG {
-    type Item = Scalar;
+#[cfg(test)]
+mod test {
+    use super::*;
+    use constants::Scalar;
+    use rand::thread_rng;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let elts = [self.seed, self.index.into()];
-        let hash_res = compute_poseidon_hash(&elts);
-        self.index += 1;
+    /// Test that peek_stream_cipher_encrypt returns the same values as
+    /// stream_cipher_encrypt would before mutation
+    #[test]
+    fn test_peek_stream_cipher_encrypt_matches_compute() {
+        const N: usize = 10;
+        let mut rng = thread_rng();
+        let values = (0..N).map(|_| Scalar::random(&mut rng)).collect_vec();
+        let values_arr = <[Scalar; N]>::from_scalars(&mut values.into_iter());
 
-        Some(hash_res)
+        // Compute the encryption in both ways
+        let mut csprng = PoseidonCSPRNG::new(Scalar::random(&mut rng));
+        let peeked_public = csprng.peek_stream_cipher_encrypt::<[Scalar; N]>(&values_arr);
+        let computed_public = csprng.stream_cipher_encrypt::<[Scalar; N]>(&values_arr);
+
+        // Check that the public shares match
+        assert_eq!(
+            peeked_public.to_scalars(),
+            computed_public.to_scalars(),
+            "peek_stream_cipher_encrypt public shares should match stream_cipher_encrypt"
+        );
     }
 }

--- a/circuits/src/zk_circuits/v2/valid_balance_create.rs
+++ b/circuits/src/zk_circuits/v2/valid_balance_create.rs
@@ -191,10 +191,7 @@ impl SingleProverCircuit for ValidBalanceCreate {
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    use circuit_types::{
-        balance::{Balance, BalanceShare},
-        deposit::Deposit,
-    };
+    use circuit_types::{balance::Balance, deposit::Deposit};
 
     use crate::{
         test_helpers::{check_constraints_satisfied, random_address, random_amount},
@@ -252,8 +249,7 @@ pub mod test_helpers {
         let mut new_balance = balance.clone();
 
         // Encrypt the entire balance using the stream cipher
-        let balance_public_shares =
-            new_balance.stream_cipher_encrypt::<BalanceShare>(balance_inner);
+        let balance_public_shares = new_balance.stream_cipher_encrypt::<Balance>(balance_inner);
         new_balance.public_share = balance_public_shares;
         let recovery_id = new_balance.compute_recovery_id();
 

--- a/circuits/src/zk_gadgets/test_helpers.rs
+++ b/circuits/src/zk_gadgets/test_helpers.rs
@@ -24,16 +24,20 @@ where
     V::ShareType: CircuitBaseType,
 {
     let mut rng = thread_rng();
-    let recovery_seed = Scalar::random(&mut rng);
-    let share_seed = Scalar::random(&mut rng);
     let (_, public_share) = create_random_shares::<V>(&state);
-
-    let mut recovery_stream = PoseidonCSPRNG::new(recovery_seed);
-    let mut share_stream = PoseidonCSPRNG::new(share_seed);
+    let mut recovery_stream = random_csprng();
+    let mut share_stream = random_csprng();
     recovery_stream.index = rng.r#gen();
     share_stream.index = rng.r#gen();
 
     StateWrapper { recovery_stream, share_stream, inner: state, public_share }
+}
+
+/// Build a random CSPRNG
+pub fn random_csprng() -> PoseidonCSPRNG {
+    let mut rng = thread_rng();
+    let seed = Scalar::random(&mut rng);
+    PoseidonCSPRNG::new(seed)
 }
 
 // ----------------

--- a/renegade-crypto/src/fields.rs
+++ b/renegade-crypto/src/fields.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Neg;
 
-use alloy_primitives::{Address, U160};
+use alloy_primitives::{Address, U160, U256};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use bigdecimal::BigDecimal;
@@ -51,6 +51,14 @@ pub fn scalar_to_address(a: &Scalar) -> Address {
     // Convert to address
     let u160 = U160::from_be_slice(&address_bytes);
     Address::from(u160)
+}
+
+/// Convert a scalar to a U256
+pub fn scalar_to_u256(a: &Scalar) -> U256 {
+    let bytes = a.to_bytes_be();
+    let mut u256_bytes = [0u8; U256::BYTES];
+    u256_bytes.copy_from_slice(&bytes[bytes.len() - U256::BYTES..]);
+    U256::from_be_bytes(u256_bytes)
 }
 
 /// Convert a scalar to a BabyJubJub scalar
@@ -125,13 +133,19 @@ pub fn bigint_to_scalar_bits<const D: usize>(a: &BigInt) -> Vec<Scalar> {
     res
 }
 
-// ------------------------------
-// | Conversions from Addresses |
-// ------------------------------
+// --------------------------------
+// | Conversions from Alloy Types |
+// --------------------------------
 
 /// Convert an Address to a scalar
 pub fn address_to_scalar(a: &Address) -> Scalar {
     Scalar::from_be_bytes_mod_order(&a.0.0)
+}
+
+/// Convert a U256 to a scalar
+pub fn u256_to_scalar(a: &U256) -> Scalar {
+    let bytes: [u8; U256::BYTES] = a.to_be_bytes();
+    Scalar::from_be_bytes_mod_order(&bytes)
 }
 
 // ---------------------------------------


### PR DESCRIPTION
### Purpose
This PR moves the encryption implementation from the `StateWrapper` to the `PoseidonCSPRNG` type and references it from the state wrapper.

### Testing
- [x] Unit tests pass