### PR TITLE
circuits: zk-gadgets: commitment: Implement partial commitments

### DIFF
--- a/circuit-types/src/v2/mod.rs
+++ b/circuit-types/src/v2/mod.rs
@@ -5,6 +5,7 @@ pub mod csprng;
 pub mod deposit;
 pub mod intent;
 pub mod note;
+pub mod settlement_obligation;
 pub mod state_wrapper;
 pub mod withdrawal;
 


### PR DESCRIPTION
### Purpose
This PR adds gadgets and helpers for computing partial commitments to state elements; as well as for pairs of state elements with shared prefixes.

### Testing
- [x] All unit tests pass