### PR TITLE
circuits: zk-circuits: intent-only: Add test suite

### DIFF
--- a/circuits/src/test_helpers/circuits.rs
+++ b/circuits/src/test_helpers/circuits.rs
@@ -6,7 +6,7 @@ use circuit_types::{
 };
 use constants::Scalar;
 use itertools::Itertools;
-use mpc_relation::traits::Circuit;
+use mpc_relation::{proof_linking::LinkableCircuit, traits::Circuit};
 
 /// Check that the constraints for a given circuit are satisfied on the
 /// given witness, statement pair
@@ -15,9 +15,17 @@ pub fn check_constraints_satisfied<C: SingleProverCircuit>(
     statement: &C::Statement,
 ) -> bool {
     let mut cs = PlonkCircuit::new_turbo_plonk();
+
+    // Create link groups before allocating variables if the circuit defines any
+    if let Ok(layout) = C::get_circuit_layout() {
+        for (id, group_layout) in layout.group_layouts.into_iter() {
+            cs.create_link_group(id, Some(group_layout));
+        }
+    }
+
+    // Allocate the witness and statement in the constraint system
     let witness_var = witness.create_witness(&mut cs);
     let statement_var = statement.create_public_var(&mut cs);
-
     C::apply_constraints(witness_var, statement_var, &mut cs).unwrap();
 
     let statement_scalars = statement.to_scalars().iter().map(Scalar::inner).collect_vec();


### PR DESCRIPTION
### Purpose
This PR adds a test suite for the `INTENT ONLY VALIDITY PROOF`.

### Testing
- [x] All tests pass