### PR TITLE
circuits: zk-circuits: proof-linking: Define proof linking relation

### DIFF
--- a/circuits/src/test_helpers/fuzzing.rs
+++ b/circuits/src/test_helpers/fuzzing.rs
@@ -62,8 +62,8 @@ pub fn random_address() -> Address {
 
 /// Generate a random price
 pub fn random_price() -> FixedPoint {
-    let min_price = 1.0e-18;
-    let max_price = 1.0e18;
+    let min_price = 1.0e-12;
+    let max_price = 1.0e12;
     let price_f64 = thread_rng().gen_range(min_price..max_price);
 
     FixedPoint::from_f64_round_down(price_f64)

--- a/circuits/src/zk_circuits/v2/proof_linking.rs
+++ b/circuits/src/zk_circuits/v2/proof_linking.rs
@@ -1,0 +1,270 @@
+//! Helpers for linking proofs between circuits
+
+use circuit_types::{
+    PlonkLinkProof, PlonkProof, ProofLinkingHint, errors::ProverError, traits::SingleProverCircuit,
+};
+use constants::MERKLE_HEIGHT;
+use mpc_plonk::{proof_system::PlonkKzgSnark, transcript::SolidityTranscript};
+use mpc_relation::proof_linking::GroupLayout;
+
+use crate::zk_circuits::{
+    v2::settlement::{
+        INTENT_ONLY_PUBLIC_SETTLEMENT_LINK,
+        intent_only_public_settlement::IntentOnlyPublicSettlementCircuit,
+    },
+    validity_proofs::intent_only_first_fill::IntentOnlyFirstFillValidityCircuit,
+};
+
+// ------------------------------------------------
+// | Intent Only First Fill <-> Public Settlement |
+// ------------------------------------------------
+
+/// Link a proof of INTENT ONLY FIRST FILL VALIDITY with a proof of INTENT ONLY
+/// PUBLIC SETTLEMENT using the system wide sizing constants
+pub fn link_sized_intent_first_fill_settlement(
+    first_fill_link_hint: &ProofLinkingHint,
+    settlement_link_hint: &ProofLinkingHint,
+) -> Result<PlonkLinkProof, ProverError> {
+    link_intent_first_fill_settlement::<MERKLE_HEIGHT>(first_fill_link_hint, settlement_link_hint)
+}
+
+/// Link a proof of INTENT ONLY FIRST FILL VALIDITY with a proof of INTENT ONLY
+/// PUBLIC SETTLEMENT
+pub fn link_intent_first_fill_settlement<const MERKLE_HEIGHT: usize>(
+    first_fill_link_hint: &ProofLinkingHint,
+    settlement_link_hint: &ProofLinkingHint,
+) -> Result<PlonkLinkProof, ProverError> {
+    // Get the group layout for the first fill <-> settlement link group
+    let layout = get_intent_public_settlement_group_layout::<MERKLE_HEIGHT>()?;
+    let pk = IntentOnlyFirstFillValidityCircuit::proving_key();
+
+    PlonkKzgSnark::link_proofs::<SolidityTranscript>(
+        first_fill_link_hint,
+        settlement_link_hint,
+        &layout,
+        &pk.commit_key,
+    )
+    .map_err(ProverError::Plonk)
+}
+
+/// Validate a link between a proof of INTENT ONLY FIRST FILL VALIDITY with a
+/// proof of INTENT ONLY PUBLIC SETTLEMENT using the system wide sizing
+/// constants
+pub fn validate_sized_intent_first_fill_settlement_link(
+    link_proof: &PlonkLinkProof,
+    first_fill_proof: &PlonkProof,
+    settlement_proof: &PlonkProof,
+) -> Result<(), ProverError> {
+    validate_intent_first_fill_settlement_link::<MERKLE_HEIGHT>(
+        link_proof,
+        first_fill_proof,
+        settlement_proof,
+    )
+}
+
+/// Validate a link between a proof of INTENT ONLY FIRST FILL VALIDITY with a
+/// proof of INTENT ONLY PUBLIC SETTLEMENT
+pub fn validate_intent_first_fill_settlement_link<const MERKLE_HEIGHT: usize>(
+    link_proof: &PlonkLinkProof,
+    first_fill_proof: &PlonkProof,
+    settlement_proof: &PlonkProof,
+) -> Result<(), ProverError> {
+    // Get the group layout for the first fill <-> settlement link group
+    let layout = get_intent_public_settlement_group_layout::<MERKLE_HEIGHT>()?;
+    let vk = IntentOnlyFirstFillValidityCircuit::verifying_key();
+
+    PlonkKzgSnark::verify_link_proof::<SolidityTranscript>(
+        first_fill_proof,
+        settlement_proof,
+        link_proof,
+        &layout,
+        &vk.open_key,
+    )
+    .map_err(ProverError::Plonk)
+}
+
+/// Get the group layout for the intent first fill <-> settlement link group
+pub fn get_intent_public_settlement_group_layout<const MERKLE_HEIGHT: usize>()
+-> Result<GroupLayout, ProverError> {
+    let circuit_layout = IntentOnlyPublicSettlementCircuit::<MERKLE_HEIGHT>::get_circuit_layout()
+        .map_err(ProverError::Plonk)?;
+    Ok(circuit_layout.get_group_layout(INTENT_ONLY_PUBLIC_SETTLEMENT_LINK))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        singleprover_prove_with_hint,
+        zk_circuits::v2::validity_proofs::intent_only_first_fill::IntentOnlyFirstFillValidityCircuit,
+    };
+    use circuit_types::traits::SingleProverCircuit;
+    use constants::Scalar;
+
+    /// The Merkle height used for testing
+    const TEST_MERKLE_HEIGHT: usize = 3;
+    /// Intent only first fill validity with testing sizing
+    type SizedIntentOnlyFirstFillValidity = IntentOnlyFirstFillValidityCircuit;
+    /// Intent only public settlement with testing sizing
+    type SizedIntentOnlyPublicSettlement = IntentOnlyPublicSettlementCircuit<TEST_MERKLE_HEIGHT>;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Prove INTENT ONLY FIRST FILL VALIDITY and INTENT ONLY PUBLIC SETTLEMENT,
+    /// then link the proofs and verify the link
+    fn test_intent_first_fill_settlement_link(
+        first_fill_witness: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
+        first_fill_statement: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
+        settlement_witness: <SizedIntentOnlyPublicSettlement as SingleProverCircuit>::Witness,
+        settlement_statement: <SizedIntentOnlyPublicSettlement as SingleProverCircuit>::Statement,
+    ) -> Result<(), ProverError> {
+        // Create a proof of INTENT ONLY FIRST FILL VALIDITY and one of INTENT ONLY
+        // PUBLIC SETTLEMENT
+        let (first_fill_proof, first_fill_hint) = singleprover_prove_with_hint::<
+            SizedIntentOnlyFirstFillValidity,
+        >(
+            first_fill_witness, first_fill_statement
+        )?;
+        let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
+            SizedIntentOnlyPublicSettlement,
+        >(
+            settlement_witness, settlement_statement
+        )?;
+
+        // Link the proofs and verify the link
+        let link_proof = link_intent_first_fill_settlement::<TEST_MERKLE_HEIGHT>(
+            &first_fill_hint,
+            &settlement_hint,
+        )?;
+        validate_intent_first_fill_settlement_link::<TEST_MERKLE_HEIGHT>(
+            &link_proof,
+            &first_fill_proof,
+            &settlement_proof,
+        )
+    }
+
+    /// Build a first fill and settlement witness and statement with valid data
+    ///
+    /// This involves modifying the witness and statements for each circuit to
+    /// align with one another so that they may be linked
+    fn build_intent_first_fill_settlement_data() -> (
+        <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
+        <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
+        <SizedIntentOnlyPublicSettlement as SingleProverCircuit>::Witness,
+        <SizedIntentOnlyPublicSettlement as SingleProverCircuit>::Statement,
+    ) {
+        use crate::test_helpers::random_intent;
+        use crate::zk_circuits::v2::{
+            settlement::intent_only_public_settlement::test_helpers::create_witness_statement_with_intent as create_settlement_witness_statement,
+            validity_proofs::intent_only_first_fill::test_helpers::create_witness_statement_with_intent as create_first_fill_witness_statement,
+        };
+
+        // Create a random intent
+        let intent = random_intent();
+
+        // Create the first fill witness and statement
+        let (first_fill_witness, first_fill_statement) =
+            create_first_fill_witness_statement(&intent);
+
+        // Create the settlement witness and statement with the same intent
+        let (mut settlement_witness, mut settlement_statement) =
+            create_settlement_witness_statement::<TEST_MERKLE_HEIGHT>(&intent);
+
+        // Align the settlement witness with the first fill witness
+        settlement_witness.pre_settlement_amount_public_share =
+            first_fill_witness.new_amount_public_share;
+        let amt_int = Scalar::from(settlement_statement.settlement_obligation.amount_in);
+        settlement_statement.new_amount_public_share =
+            settlement_witness.pre_settlement_amount_public_share - amt_int;
+
+        (first_fill_witness, first_fill_statement, settlement_witness, settlement_statement)
+    }
+
+    // --------------
+    // | Test Cases |
+    // --------------
+
+    /// Tests a valid link between a proof of INTENT ONLY FIRST FILL VALIDITY
+    /// and a proof of INTENT ONLY PUBLIC SETTLEMENT
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    fn test_intent_first_fill_settlement_valid_link() {
+        let (first_fill_witness, first_fill_statement, settlement_witness, settlement_statement) =
+            build_intent_first_fill_settlement_data();
+
+        test_intent_first_fill_settlement_link(
+            first_fill_witness,
+            first_fill_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+
+    /// Tests an invalid link between a proof of INTENT ONLY FIRST FILL VALIDITY
+    /// and a proof of INTENT ONLY PUBLIC SETTLEMENT wherein the intent is
+    /// modified between the two proofs
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    #[should_panic(expected = "ProofLinkVerification")]
+    #[allow(non_snake_case)]
+    fn test_intent_first_fill_settlement_invalid_link__modified_intent() {
+        let (
+            first_fill_witness,
+            first_fill_statement,
+            mut settlement_witness,
+            settlement_statement,
+        ) = build_intent_first_fill_settlement_data();
+
+        // Modify the intent in the settlement witness to break the link
+        settlement_witness.intent.amount_in += 1;
+
+        test_intent_first_fill_settlement_link(
+            first_fill_witness,
+            first_fill_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+
+    /// Tests an invalid link between a proof of INTENT ONLY FIRST FILL VALIDITY
+    /// and a proof of INTENT ONLY PUBLIC SETTLEMENT wherein the amount public
+    /// share is modified between the two proofs
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    #[should_panic(expected = "ProofLinkVerification")]
+    #[allow(non_snake_case)]
+    fn test_intent_first_fill_settlement_invalid_link__modified_amount_public_share() {
+        use constants::Scalar;
+        use rand::thread_rng;
+
+        let (
+            first_fill_witness,
+            first_fill_statement,
+            mut settlement_witness,
+            mut settlement_statement,
+        ) = build_intent_first_fill_settlement_data();
+
+        // Modify the amount public share in the settlement witness to break the link
+        // We also need to update the statement to keep the settlement circuit valid
+        let mut rng = thread_rng();
+        let modification = Scalar::random(&mut rng);
+        settlement_witness.pre_settlement_amount_public_share += modification;
+        // Update the statement to keep the settlement circuit constraints satisfied
+        settlement_statement.new_amount_public_share += modification;
+
+        // Now the settlement circuit is valid, but the link will fail because
+        // settlement_witness.pre_settlement_amount_public_share doesn't match
+        // first_fill_witness.new_amount_public_share
+        test_intent_first_fill_settlement_link(
+            first_fill_witness,
+            first_fill_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds proof linking helpers and tests for the link between `INTENT ONLY FIRST FILL VALIDITY` <-> `INTENT ONLY PUBLIC SETTLEMENT`. 

### Testing
- [x] All tests pass