### PR TITLE
circuit: intent-only-first-fill: Only leak partial intent share

### DIFF
--- a/circuit-types/src/v2/intent.rs
+++ b/circuit-types/src/v2/intent.rs
@@ -45,3 +45,45 @@ pub struct Intent {
     /// The amount of the input token to trade
     pub amount_in: Amount,
 }
+
+/// A pre-match intent is an intent without the `amount_in` field
+///
+/// We use this type to represent intents whose `amount_in` field is determined
+/// in a later circuit within a proof-linked chain of circuits. For example, we
+/// may leak a `PreMatchIntentShare` in a validity circuit and separately leak
+/// the `amount_in` field thereafter.
+#[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit, secret_share))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PreMatchIntent {
+    /// The token to buy
+    pub in_token: Address,
+    /// The token to sell
+    pub out_token: Address,
+    /// The owner of the intent
+    pub owner: Address,
+    /// The minimum price at which a party may settle a partial fill
+    /// This is in units of `out_token/in_token`
+    pub min_price: FixedPoint,
+}
+
+impl From<Intent> for PreMatchIntent {
+    fn from(intent: Intent) -> Self {
+        PreMatchIntent {
+            in_token: intent.in_token,
+            out_token: intent.out_token,
+            owner: intent.owner,
+            min_price: intent.min_price,
+        }
+    }
+}
+
+impl From<IntentShare> for PreMatchIntentShare {
+    fn from(intent_share: IntentShare) -> Self {
+        PreMatchIntentShare {
+            in_token: intent_share.in_token,
+            out_token: intent_share.out_token,
+            owner: intent_share.owner,
+            min_price: intent_share.min_price,
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR changes the `INTENT ONLY FIRST FILL VALIDITY` circuit to only leak the initial public shares of a partial "pre-match" intent. That is, all shares except for the `amount_in` field. The `amount_in` field will be leaked in the settlement circuit.

For intent-only validity, the fills are still public (as their balance updates can be seen on-chain), so this change provides no privacy improvements. This pattern will be carried forward to the intent-and-balance validity circuit, in which it is necesssary to avoid leaking the pre- and post-match `amount_in` fields--and thereby leaking the match size.

### Testing
- [x] All tests pass