### PR TITLE
circuits: zk-circuits: proof-linking: Add new-output-balance test

### DIFF
--- a/circuits/src/zk_circuits/v2/validity_proofs/new_output_balance.rs
+++ b/circuits/src/zk_circuits/v2/validity_proofs/new_output_balance.rs
@@ -15,7 +15,12 @@ use circuit_types::{
 };
 use constants::{Scalar, ScalarField};
 use mpc_plonk::errors::PlonkError;
-use mpc_relation::{Variable, errors::CircuitError, proof_linking::GroupLayout, traits::Circuit};
+use mpc_relation::{
+    Variable,
+    errors::CircuitError,
+    proof_linking::{GroupLayout, LinkableCircuit},
+    traits::Circuit,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -146,10 +151,12 @@ impl NewOutputBalanceValidityCircuit {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NewOutputBalanceValidityWitness {
     /// The balance
+    #[link_groups = "output_balance_settlement"]
     pub balance: Balance,
     /// The balance public shares which are updated in the settlement circuit
     ///
     /// These values are proof-linked into the settlement circuit
+    #[link_groups = "output_balance_settlement"]
     pub post_match_balance_shares: PostMatchBalanceShare,
     /// The initial share stream of the balance
     pub initial_share_stream: PoseidonCSPRNG,


### PR DESCRIPTION
### Purpose
This PR adds a test for linking `NEW OUTPUT BALANCE VALIDITY` <> `INTENT AND BALANCE PUBLIC SETTLEMENT` directly.

### Testing
- [x] All tests pass