### PR TITLE
circuits: settlement; intent-and-balance-private-settlement: Add tests

### DIFF
--- a/circuits/src/test_helpers/fuzzing.rs
+++ b/circuits/src/test_helpers/fuzzing.rs
@@ -183,6 +183,12 @@ pub fn compute_min_amount_out(intent: &Intent, amount_in: Amount) -> Amount {
     scalar_to_u128(&min_amount_out.floor())
 }
 
+/// Compute the implied price for a given amount out and in
+pub fn compute_implied_price(amount_out: Amount, amount_in: Amount) -> FixedPoint {
+    let price = (amount_out as f64) / (amount_in as f64);
+    FixedPoint::from_f64_round_down(price)
+}
+
 /// Create a state wrapper and initialize the share state
 pub fn create_state_wrapper<V>(state: V) -> StateWrapper<V>
 where

--- a/circuits/src/zk_circuits/settlement/settlement_lib.rs
+++ b/circuits/src/zk_circuits/settlement/settlement_lib.rs
@@ -101,12 +101,12 @@ impl SettlementGadget {
         // The output balance's mint must match the obligation's output token
         EqGadget::constrain_eq(&out_balance.mint, &obligation.output_token, cs)?;
 
+        // The output balance must be owned by the intent's owner
+        EqGadget::constrain_eq(&out_balance.owner, &intent.owner, cs)?;
+
         // The output amount must not overflow the receive balance
         let new_bal_amount = cs.add(out_balance.amount, obligation.amount_out)?;
-        AmountGadget::constrain_valid_amount(new_bal_amount, cs)?;
-
-        // The output balance must be owned by the intent's owner
-        EqGadget::constrain_eq(&out_balance.owner, &intent.owner, cs)
+        AmountGadget::constrain_valid_amount(new_bal_amount, cs)
     }
 
     // --- State Update Constraints --- //


### PR DESCRIPTION
### Purpose
This PR adds tests for the `INTENT AND BALANCE PRIVATE SETTLEMENT` circuit. These largely mirror the public settlement tests but use a random branching macro to randomly modify one party's witness share.

### Testing
- [x] All tests pass