### PR TITLE
circuits: proof-linking: Add multi-party proof linking

### DIFF
--- a/circuits/src/zk_circuits/proof_linking/intent_and_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/intent_and_balance.rs
@@ -10,7 +10,7 @@ use mpc_relation::proof_linking::GroupLayout;
 
 use crate::zk_circuits::{
     settlement::{
-        INTENT_AND_BALANCE_PUBLIC_SETTLEMENT_LINK,
+        INTENT_AND_BALANCE_SETTLEMENT_PARTY0_LINK,
         intent_and_balance_public_settlement::IntentAndBalancePublicSettlementCircuit,
     },
     validity_proofs::intent_and_balance::IntentAndBalanceValidityCircuit,
@@ -89,7 +89,7 @@ pub fn validate_intent_and_balance_settlement_link<const MERKLE_HEIGHT: usize>(
 pub fn get_group_layout<const MERKLE_HEIGHT: usize>() -> Result<GroupLayout, ProverError> {
     let circuit_layout = IntentAndBalancePublicSettlementCircuit::get_circuit_layout()
         .map_err(ProverError::Plonk)?;
-    Ok(circuit_layout.get_group_layout(INTENT_AND_BALANCE_PUBLIC_SETTLEMENT_LINK))
+    Ok(circuit_layout.get_group_layout(INTENT_AND_BALANCE_SETTLEMENT_PARTY0_LINK))
 }
 
 #[cfg(test)]

--- a/circuits/src/zk_circuits/proof_linking/output_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/output_balance.rs
@@ -10,7 +10,7 @@ use mpc_relation::proof_linking::GroupLayout;
 
 use crate::zk_circuits::{
     settlement::{
-        OUTPUT_BALANCE_SETTLEMENT_LINK,
+        OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK, OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
         intent_and_balance_public_settlement::IntentAndBalancePublicSettlementCircuit,
     },
     validity_proofs::output_balance::OutputBalanceValidityCircuit,
@@ -89,7 +89,7 @@ pub fn validate_output_balance_settlement_link<const MERKLE_HEIGHT: usize>(
 pub fn get_group_layout<const MERKLE_HEIGHT: usize>() -> Result<GroupLayout, ProverError> {
     let circuit_layout = IntentAndBalancePublicSettlementCircuit::get_circuit_layout()
         .map_err(ProverError::Plonk)?;
-    Ok(circuit_layout.get_group_layout(OUTPUT_BALANCE_SETTLEMENT_LINK))
+    Ok(circuit_layout.get_group_layout(OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK))
 }
 
 #[cfg(test)]

--- a/circuits/src/zk_circuits/settlement/mod.rs
+++ b/circuits/src/zk_circuits/settlement/mod.rs
@@ -13,13 +13,18 @@ pub mod intent_and_balance_public_settlement;
 pub mod intent_only_public_settlement;
 pub mod settlement_lib;
 
-/// The group name for the INTENT ONLY (FIRST FILL) VALIDITY <-> INTENT ONLY
+/// The group name for the INTENT ONLY VALIDITY <-> INTENT ONLY
 /// SETTLEMENT link
 pub const INTENT_ONLY_PUBLIC_SETTLEMENT_LINK: &str = "intent_only_settlement";
 
-/// The group name for the INTENT AND BALANCE (FIRST FILL) VALIDITY <-> INTENT
+/// The group name for the INTENT AND BALANCE VALIDITY <-> INTENT
 /// AND BALANCE SETTLEMENT link
-pub const INTENT_AND_BALANCE_PUBLIC_SETTLEMENT_LINK: &str = "intent_and_balance_settlement";
+pub const INTENT_AND_BALANCE_SETTLEMENT_PARTY0_LINK: &str = "intent_and_balance_settlement_party0";
+/// The group name for the INTENT AND BALANCE SETTLEMENT link for the
+/// second party
+pub const INTENT_AND_BALANCE_SETTLEMENT_PARTY1_LINK: &str = "intent_and_balance_settlement_party1";
 
 /// The group name for the OUTPUT BALANCE SETTLEMENT link
-pub const OUTPUT_BALANCE_SETTLEMENT_LINK: &str = "output_balance_settlement";
+pub const OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK: &str = "output_balance_settlement_party0";
+/// The group name for the OUTPUT BALANCE SETTLEMENT link for the second party
+pub const OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK: &str = "output_balance_settlement_party1";


### PR DESCRIPTION
### Purpose
This PR adds multi-party proof linking groups to all circuits. The groups are all placed by the common private intent settlement circuit and inherited by all other circuits.

### Testing
- [x] All tests pass