### PR TITLE
Joey/multi party proof linking

### DIFF
--- a/circuits/src/test_helpers/fuzzing.rs
+++ b/circuits/src/test_helpers/fuzzing.rs
@@ -93,6 +93,15 @@ pub fn random_intent() -> Intent {
     random_bounded_intent(max_amount())
 }
 
+/// Create a random intent at half the bitlength of the maximum amount
+///
+/// We do this so that a match on the intent does not overflow the bitlength of
+/// the receive balance amount
+pub fn random_small_intent() -> Intent {
+    let max_amount_in = 1u128.pow((AMOUNT_BITS / 2) as u32);
+    random_bounded_intent(max_amount_in)
+}
+
 /// Create a random bounded intent
 pub fn random_bounded_intent(max_amount_in: Amount) -> Intent {
     let mut rng = thread_rng();
@@ -106,8 +115,21 @@ pub fn random_bounded_intent(max_amount_in: Amount) -> Intent {
     }
 }
 
+/// Create a random balance with a small initial amount
+pub fn random_small_balance() -> Balance {
+    let max_amount = 1u128.pow((AMOUNT_BITS / 2) as u32);
+    random_bounded_balance(max_amount)
+}
+
 /// Create a random balance
 pub fn random_balance() -> Balance {
+    random_bounded_balance(max_amount())
+}
+
+/// Create a random balance with a bounded initial amount
+pub fn random_bounded_balance(max_amount: Amount) -> Balance {
+    let mut rng = thread_rng();
+    let amount = rng.gen_range(0..=max_amount);
     Balance {
         mint: random_address(),
         owner: random_address(),
@@ -115,7 +137,7 @@ pub fn random_balance() -> Balance {
         one_time_authority: random_address(),
         relayer_fee_balance: random_amount(),
         protocol_fee_balance: random_amount(),
-        amount: random_amount(),
+        amount,
     }
 }
 

--- a/circuits/src/zk_circuits/proof_linking/output_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/output_balance.rs
@@ -10,7 +10,7 @@ use mpc_relation::proof_linking::GroupLayout;
 
 use crate::zk_circuits::{
     settlement::{
-        OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK, OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
+        OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK,
         intent_and_balance_public_settlement::IntentAndBalancePublicSettlementCircuit,
     },
     validity_proofs::output_balance::OutputBalanceValidityCircuit,
@@ -97,7 +97,10 @@ mod test {
     use super::*;
     use crate::{
         singleprover_prove_with_hint,
-        test_helpers::{create_settlement_obligation_with_balance, random_intent},
+        test_helpers::{
+            create_settlement_obligation_with_balance, random_intent, random_small_balance,
+            random_small_intent,
+        },
         zk_circuits::{
             settlement::intent_and_balance_public_settlement::{
                 IntentAndBalancePublicSettlementStatement, IntentAndBalancePublicSettlementWitness,
@@ -114,7 +117,7 @@ mod test {
                 },
                 output_balance::{
                     OutputBalanceValidityStatement, OutputBalanceValidityWitness,
-                    test_helpers::create_witness_statement as create_validity_witness_statement,
+                    test_helpers::create_witness_statement_with_balance as create_validity_witness_statement,
                 },
             },
         },
@@ -171,15 +174,14 @@ mod test {
         IntentAndBalancePublicSettlementWitness,
         IntentAndBalancePublicSettlementStatement,
     ) {
-        use crate::test_helpers::{create_settlement_obligation_with_balance, random_intent};
-
         // Create the validity witness and statement
+        let balance = random_small_balance();
         let (validity_witness, validity_statement) =
-            create_validity_witness_statement::<TEST_MERKLE_HEIGHT>();
+            create_validity_witness_statement::<TEST_MERKLE_HEIGHT>(balance.clone());
 
         // Create an intent and input balance for the settlement
         let output_balance = validity_witness.balance.clone();
-        let mut intent = random_intent();
+        let mut intent = random_small_intent();
         intent.out_token = output_balance.mint;
         intent.owner = output_balance.owner;
         let input_balance = create_matching_balance_for_intent(&intent);

--- a/circuits/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
+++ b/circuits/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
@@ -349,20 +349,15 @@ mod test {
     use crate::{
         test_helpers::{
             compute_min_amount_out, create_settlement_obligation_with_balance, random_address,
-            random_bounded_intent, random_scalar,
+            random_scalar, random_small_intent,
         },
         zk_circuits::settlement::intent_and_balance_public_settlement::test_helpers::create_matching_balance_for_intent,
     };
 
     use super::*;
-    use circuit_types::{AMOUNT_BITS, Amount, max_amount, traits::SingleProverCircuit};
+    use circuit_types::{max_amount, traits::SingleProverCircuit};
     use constants::MERKLE_HEIGHT;
     use rand::{Rng, thread_rng};
-
-    /// The maximum input amount for intents; this leaves room for the whole
-    /// intent to be executed at sampled prices; i.e. `amount_out` does not
-    /// violate `AMOUNT_BITS` bounds.
-    const MAX_AMOUNT_IN: Amount = 1u128 << (AMOUNT_BITS / 2);
 
     /// A helper to print the number of constraints in the circuit
     ///
@@ -387,7 +382,7 @@ mod test {
     /// Test the case in which the intent is fully matched
     #[test]
     fn test_valid_intent_and_balance_public_settlement_constraints_full_match() {
-        let intent = random_bounded_intent(MAX_AMOUNT_IN);
+        let intent = random_small_intent();
         let mut balance = create_matching_balance_for_intent(&intent);
         balance.amount = intent.amount_in;
         let mut obligation = create_settlement_obligation_with_balance(&intent, balance.amount);
@@ -403,7 +398,7 @@ mod test {
     /// Test the case in which the balance undercapitalizes the obligation
     #[test]
     fn test_valid_intent_and_balance_public_settlement_constraints_undercapitalized() {
-        let intent = random_bounded_intent(MAX_AMOUNT_IN);
+        let intent = random_small_intent();
         let mut balance = create_matching_balance_for_intent(&intent);
         balance.amount = intent.amount_in / 2;
         let obligation = create_settlement_obligation_with_balance(&intent, balance.amount);
@@ -438,7 +433,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid_obligation__amount_in_exceeds_intent_size() {
-        let intent = random_bounded_intent(MAX_AMOUNT_IN);
+        let intent = random_small_intent();
         let mut balance = create_matching_balance_for_intent(&intent);
         balance.amount = intent.amount_in + 1; // Fully capitalize the intent   
         let mut obligation = create_settlement_obligation_with_balance(&intent, balance.amount);
@@ -458,7 +453,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid_obligation__amount_out_violates_min_price() {
-        let intent = random_bounded_intent(MAX_AMOUNT_IN);
+        let intent = random_small_intent();
         let mut balance = create_matching_balance_for_intent(&intent);
         balance.amount = intent.amount_in;
         let mut obligation = create_settlement_obligation_with_balance(&intent, balance.amount);
@@ -476,7 +471,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid_obligation__undercapitalized() {
-        let intent = random_bounded_intent(MAX_AMOUNT_IN);
+        let intent = random_small_intent();
         let mut balance = create_matching_balance_for_intent(&intent);
         balance.amount = intent.amount_in - 1;
         let mut obligation = create_settlement_obligation_with_balance(&intent, balance.amount);

--- a/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
+++ b/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
@@ -28,7 +28,6 @@ use crate::{
     zk_circuits::settlement::{
         OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK, OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
         intent_and_balance_private_settlement::IntentAndBalancePrivateSettlementCircuit,
-        intent_and_balance_public_settlement::IntentAndBalancePublicSettlementCircuit,
     },
     zk_gadgets::{
         comparators::EqGadget,

--- a/circuits/src/zk_circuits/validity_proofs/output_balance.rs
+++ b/circuits/src/zk_circuits/validity_proofs/output_balance.rs
@@ -221,7 +221,7 @@ pub mod test_helpers {
 
     use crate::test_helpers::{
         check_constraints_satisfied, create_merkle_opening, create_random_state_wrapper,
-        random_address, random_amount,
+        random_balance,
     };
 
     use super::*;
@@ -241,19 +241,17 @@ pub mod test_helpers {
         )
     }
 
-    /// Construct a witness and statement with valid data
+    /// Construct a witness and statement with valid data using a random balance
     pub fn create_witness_statement<const MERKLE_HEIGHT: usize>()
     -> (OutputBalanceValidityWitness<MERKLE_HEIGHT>, OutputBalanceValidityStatement) {
-        // Create a random balance
-        let balance_inner = Balance {
-            mint: random_address(),
-            owner: random_address(),
-            relayer_fee_recipient: random_address(),
-            one_time_authority: random_address(),
-            relayer_fee_balance: random_amount(),
-            protocol_fee_balance: random_amount(),
-            amount: random_amount(),
-        };
+        create_witness_statement_with_balance::<MERKLE_HEIGHT>(random_balance())
+    }
+
+    /// Construct a witness and statement with valid data using the provided
+    /// balance
+    pub fn create_witness_statement_with_balance<const MERKLE_HEIGHT: usize>(
+        balance_inner: Balance,
+    ) -> (OutputBalanceValidityWitness<MERKLE_HEIGHT>, OutputBalanceValidityStatement) {
         let old_balance = create_random_state_wrapper(balance_inner.clone());
 
         // Compute commitment, nullifier, and create Merkle opening for the balance


### PR DESCRIPTION
### Purpose
This PR fixes the test helpers for the output balance linking tests; which would previously generate an invalid settlement witness by overflowing the receive balance in some cases.

### Testing
- [x] Crate unit tests pass