### PR TITLE
circuits: proof-linking: output-balance: Link with private settlement

### DIFF
--- a/circuits/src/zk_circuits/proof_linking/output_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/output_balance.rs
@@ -10,8 +10,8 @@ use mpc_relation::proof_linking::GroupLayout;
 
 use crate::zk_circuits::{
     settlement::{
-        OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK,
-        intent_and_balance_public_settlement::IntentAndBalancePublicSettlementCircuit,
+        OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK, OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
+        intent_and_balance_private_settlement::IntentAndBalancePrivateSettlementCircuit,
     },
     validity_proofs::output_balance::OutputBalanceValidityCircuit,
 };
@@ -20,23 +20,42 @@ use crate::zk_circuits::{
 // | Output Balance Validity <-> Intent And Balance Public Settlement |
 // --------------------------------------------------------------------
 
-/// Link an output balance validity proof with a proof of INTENT AND BALANCE
-/// PUBLIC SETTLEMENT using the system wide sizing constants
+/// Link an output balance validity proof with an INTENT AND BALANCE settlement
+/// proof using the system wide sizing constants for party 0
 pub fn link_sized_output_balance_settlement(
     validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
 ) -> Result<PlonkLinkProof, ProverError> {
-    link_output_balance_settlement::<MERKLE_HEIGHT>(validity_link_hint, settlement_link_hint)
+    link_output_balance_settlement_with_party::<MERKLE_HEIGHT>(
+        0, // party_id
+        validity_link_hint,
+        settlement_link_hint,
+    )
 }
 
-/// Link an output balance validity proof with a proof of INTENT AND BALANCE
-/// PUBLIC SETTLEMENT
-pub fn link_output_balance_settlement<const MERKLE_HEIGHT: usize>(
+/// Link an output balance validity proof with an INTENT AND BALANCE settlement
+/// proof using the system wide sizing constants for the given party
+pub fn link_sized_output_balance_settlement_with_party(
+    party_id: u8,
+    validity_link_hint: &ProofLinkingHint,
+    settlement_link_hint: &ProofLinkingHint,
+) -> Result<PlonkLinkProof, ProverError> {
+    link_output_balance_settlement_with_party::<MERKLE_HEIGHT>(
+        party_id,
+        validity_link_hint,
+        settlement_link_hint,
+    )
+}
+
+/// Link an output balance validity proof with an INTENT AND BALANCE settlement
+/// proof
+pub fn link_output_balance_settlement_with_party<const MERKLE_HEIGHT: usize>(
+    party_id: u8,
     validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
 ) -> Result<PlonkLinkProof, ProverError> {
     // Get the group layout for the validity <-> settlement link group
-    let layout = get_group_layout::<MERKLE_HEIGHT>()?;
+    let layout = get_group_layout::<MERKLE_HEIGHT>(party_id)?;
     let pk = OutputBalanceValidityCircuit::<MERKLE_HEIGHT>::proving_key();
 
     PlonkKzgSnark::link_proofs::<SolidityTranscript>(
@@ -49,14 +68,15 @@ pub fn link_output_balance_settlement<const MERKLE_HEIGHT: usize>(
 }
 
 /// Validate a link between an output balance validity proof with a
-/// proof of INTENT AND BALANCE PUBLIC SETTLEMENT using the system wide sizing
-/// constants
-pub fn validate_sized_output_balance_settlement_link(
+/// an INTENT AND BALANCE settlement proof using the system wide sizing
+/// constants for party 0
+pub fn validate_output_balance_settlement_link<const MERKLE_HEIGHT: usize>(
     link_proof: &PlonkLinkProof,
     validity_proof: &PlonkProof,
     settlement_proof: &PlonkProof,
 ) -> Result<(), ProverError> {
-    validate_output_balance_settlement_link::<MERKLE_HEIGHT>(
+    validate_output_balance_settlement_link_with_party::<MERKLE_HEIGHT>(
+        0, // party_id
         link_proof,
         validity_proof,
         settlement_proof,
@@ -64,14 +84,32 @@ pub fn validate_sized_output_balance_settlement_link(
 }
 
 /// Validate a link between an output balance validity proof with a
-/// proof of INTENT AND BALANCE PUBLIC SETTLEMENT
-pub fn validate_output_balance_settlement_link<const MERKLE_HEIGHT: usize>(
+/// an INTENT AND BALANCE settlement proof using the system wide sizing
+/// constants
+pub fn validate_sized_output_balance_settlement_link_with_party(
+    party_id: u8,
+    link_proof: &PlonkLinkProof,
+    validity_proof: &PlonkProof,
+    settlement_proof: &PlonkProof,
+) -> Result<(), ProverError> {
+    validate_output_balance_settlement_link_with_party::<MERKLE_HEIGHT>(
+        party_id,
+        link_proof,
+        validity_proof,
+        settlement_proof,
+    )
+}
+
+/// Validate a link between an output balance validity proof with a
+/// an INTENT AND BALANCE settlement proof
+pub fn validate_output_balance_settlement_link_with_party<const MERKLE_HEIGHT: usize>(
+    party_id: u8,
     link_proof: &PlonkLinkProof,
     validity_proof: &PlonkProof,
     settlement_proof: &PlonkProof,
 ) -> Result<(), ProverError> {
     // Get the group layout for the validity <-> settlement link group
-    let layout = get_group_layout::<MERKLE_HEIGHT>()?;
+    let layout = get_group_layout::<MERKLE_HEIGHT>(party_id)?;
     let vk = OutputBalanceValidityCircuit::<MERKLE_HEIGHT>::verifying_key();
 
     PlonkKzgSnark::verify_link_proof::<SolidityTranscript>(
@@ -84,12 +122,20 @@ pub fn validate_output_balance_settlement_link<const MERKLE_HEIGHT: usize>(
     .map_err(ProverError::Plonk)
 }
 
-/// Get the group layout for the output balance validity <-> public
-/// settlement link group
-pub fn get_group_layout<const MERKLE_HEIGHT: usize>() -> Result<GroupLayout, ProverError> {
-    let circuit_layout = IntentAndBalancePublicSettlementCircuit::get_circuit_layout()
+/// Get the group layout for the output balance validity <-> settlement
+/// link group
+pub fn get_group_layout<const MERKLE_HEIGHT: usize>(
+    party_id: u8,
+) -> Result<GroupLayout, ProverError> {
+    let layout_name = match party_id {
+        0 => OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK,
+        1 => OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
+        _ => panic!("Invalid proof linking party ID: {party_id}"),
+    };
+
+    let circuit_layout = IntentAndBalancePrivateSettlementCircuit::get_circuit_layout()
         .map_err(ProverError::Plonk)?;
-    Ok(circuit_layout.get_group_layout(OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK))
+    Ok(circuit_layout.get_group_layout(layout_name))
 }
 
 #[cfg(test)]
@@ -99,21 +145,34 @@ mod test {
         singleprover_prove_with_hint,
         test_helpers::{
             create_settlement_obligation_with_balance, random_intent, random_small_balance,
-            random_small_intent,
+            random_small_intent, random_zeroed_balance,
         },
         zk_circuits::{
-            settlement::intent_and_balance_public_settlement::{
-                IntentAndBalancePublicSettlementStatement, IntentAndBalancePublicSettlementWitness,
-                test_helpers::{
-                    create_matching_balance_for_intent,
-                    create_witness_statement_with_intent_balance_and_obligation as create_settlement_witness_statement,
+            settlement::{
+                intent_and_balance_private_settlement::{
+                    IntentAndBalancePrivateSettlementCircuit,
+                    IntentAndBalancePrivateSettlementStatement,
+                    IntentAndBalancePrivateSettlementWitness,
+                    test_helpers::create_witness_statement as create_private_settlement_witness_statement,
+                },
+                intent_and_balance_public_settlement::{
+                    IntentAndBalancePublicSettlementCircuit,
+                    IntentAndBalancePublicSettlementStatement,
+                    IntentAndBalancePublicSettlementWitness,
+                    test_helpers::{
+                        create_matching_balance_for_intent,
+                        create_witness_statement_with_intent_balance_and_obligation as create_settlement_witness_statement,
+                    },
                 },
             },
             validity_proofs::{
                 new_output_balance::{
                     NewOutputBalanceValidityCircuit, NewOutputBalanceValidityStatement,
                     NewOutputBalanceValidityWitness,
-                    test_helpers::create_witness_statement as create_new_output_balance_witness_statement,
+                    test_helpers::{
+                        create_witness_statement as create_new_output_balance_witness_statement,
+                        create_witness_statement_with_balance as create_new_output_balance_witness_statement_with_balance,
+                    },
                 },
                 output_balance::{
                     OutputBalanceValidityStatement, OutputBalanceValidityWitness,
@@ -124,7 +183,7 @@ mod test {
     };
     use circuit_types::balance::PostMatchBalanceShare;
     use constants::Scalar;
-    use rand::thread_rng;
+    use rand::{seq::SliceRandom, thread_rng};
 
     /// The Merkle height used for testing
     const TEST_MERKLE_HEIGHT: usize = 3;
@@ -134,6 +193,8 @@ mod test {
     // -----------
     // | Helpers |
     // -----------
+
+    // --- Output Balance Public Settlement Link --- //
 
     /// Prove OUTPUT BALANCE VALIDITY and INTENT AND BALANCE PUBLIC
     /// SETTLEMENT, then link the proofs and verify the link
@@ -155,9 +216,14 @@ mod test {
         )?;
 
         // Link the proofs and verify the link
-        let link_proof =
-            link_output_balance_settlement::<TEST_MERKLE_HEIGHT>(&validity_hint, &settlement_hint)?;
-        validate_output_balance_settlement_link::<TEST_MERKLE_HEIGHT>(
+        let party_id = 0;
+        let link_proof = link_output_balance_settlement_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &validity_hint,
+            &settlement_hint,
+        )?;
+        validate_output_balance_settlement_link_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
             &link_proof,
             &validity_proof,
             &settlement_proof,
@@ -213,6 +279,8 @@ mod test {
         (validity_witness, validity_statement, settlement_witness, settlement_statement)
     }
 
+    // --- New Output Balance Public Settlement Link --- //
+
     /// Prove NEW OUTPUT BALANCE VALIDITY and INTENT AND BALANCE PUBLIC
     /// SETTLEMENT, then link the proofs and verify the link
     fn test_new_output_balance_validity_settlement_link(
@@ -233,8 +301,14 @@ mod test {
         )?;
 
         // Link the proofs and verify the link using the existing sized methods
-        let link_proof = link_sized_output_balance_settlement(&validity_hint, &settlement_hint)?;
-        validate_sized_output_balance_settlement_link(
+        let party_id = 0;
+        let link_proof = link_output_balance_settlement_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &validity_hint,
+            &settlement_hint,
+        )?;
+        validate_output_balance_settlement_link_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
             &link_proof,
             &validity_proof,
             &settlement_proof,
@@ -289,9 +363,196 @@ mod test {
         (validity_witness, validity_statement, settlement_witness, settlement_statement)
     }
 
+    // --- Output Balance Private Settlement Link --- //
+
+    /// Prove OUTPUT BALANCE VALIDITY and INTENT AND BALANCE PRIVATE
+    /// SETTLEMENT, then link the proofs and verify the link
+    fn test_output_balance_private_settlement_link(
+        party_id: u8,
+        validity_witness: OutputBalanceValidityWitness<TEST_MERKLE_HEIGHT>,
+        validity_statement: OutputBalanceValidityStatement,
+        settlement_witness: IntentAndBalancePrivateSettlementWitness,
+        settlement_statement: IntentAndBalancePrivateSettlementStatement,
+    ) -> Result<(), ProverError> {
+        // Create a proof of OUTPUT BALANCE VALIDITY
+        let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
+            SizedOutputBalanceValidity,
+        >(validity_witness, validity_statement)?;
+
+        // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
+        let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
+            IntentAndBalancePrivateSettlementCircuit,
+        >(
+            settlement_witness, settlement_statement
+        )?;
+
+        // Link the proofs and verify the link
+        let link_proof = link_output_balance_settlement_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &validity_hint,
+            &settlement_hint,
+        )?;
+        validate_output_balance_settlement_link_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &link_proof,
+            &validity_proof,
+            &settlement_proof,
+        )
+    }
+
+    /// Build output balance validity and private settlement witness and
+    /// statement data with valid data
+    ///
+    /// This involves modifying the witness and statements for each circuit to
+    /// align with one another so that they may be linked
+    fn build_output_balance_private_settlement_data(
+        party_id: u8,
+    ) -> (
+        OutputBalanceValidityWitness<TEST_MERKLE_HEIGHT>,
+        OutputBalanceValidityStatement,
+        IntentAndBalancePrivateSettlementWitness,
+        IntentAndBalancePrivateSettlementStatement,
+    ) {
+        // Create the private settlement witness and statement with compatible intents
+        let (mut settlement_witness, mut settlement_statement) =
+            create_private_settlement_witness_statement::<TEST_MERKLE_HEIGHT>();
+
+        // Get mutable references to the relevant fields based on the party ID
+        let (output_balance, pre_settlement_out_balance_shares) = if party_id == 0 {
+            (
+                &mut settlement_witness.output_balance0,
+                &mut settlement_witness.pre_settlement_out_balance_shares0,
+            )
+        } else {
+            (
+                &mut settlement_witness.output_balance1,
+                &mut settlement_witness.pre_settlement_out_balance_shares1,
+            )
+        };
+
+        // Create the validity witness and statement using the output balance from
+        // settlement
+        let (validity_witness, validity_statement) =
+            create_validity_witness_statement::<TEST_MERKLE_HEIGHT>(output_balance.clone());
+
+        // Align the settlement witness with the validity witness
+        *output_balance = validity_witness.balance.clone();
+        *pre_settlement_out_balance_shares = validity_witness.post_match_balance_shares.clone();
+
+        // Update the settlement statement to reflect the settlement
+        let amt_out0 = Scalar::from(settlement_witness.settlement_obligation0.amount_out);
+        let amt_out1 = Scalar::from(settlement_witness.settlement_obligation1.amount_out);
+
+        settlement_statement.new_out_balance_public_shares0 =
+            settlement_witness.pre_settlement_out_balance_shares0.clone();
+        settlement_statement.new_out_balance_public_shares1 =
+            settlement_witness.pre_settlement_out_balance_shares1.clone();
+        settlement_statement.new_out_balance_public_shares0.amount += amt_out0;
+        settlement_statement.new_out_balance_public_shares1.amount += amt_out1;
+
+        (validity_witness, validity_statement, settlement_witness, settlement_statement)
+    }
+
+    // --- New Output Balance Private Settlement Link --- //
+
+    /// Prove NEW OUTPUT BALANCE VALIDITY and INTENT AND BALANCE PRIVATE
+    /// SETTLEMENT, then link the proofs and verify the link
+    fn test_new_output_balance_private_settlement_link(
+        party_id: u8,
+        validity_witness: NewOutputBalanceValidityWitness,
+        validity_statement: NewOutputBalanceValidityStatement,
+        settlement_witness: IntentAndBalancePrivateSettlementWitness,
+        settlement_statement: IntentAndBalancePrivateSettlementStatement,
+    ) -> Result<(), ProverError> {
+        // Create a proof of NEW OUTPUT BALANCE VALIDITY
+        let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
+            NewOutputBalanceValidityCircuit,
+        >(validity_witness, validity_statement)?;
+
+        // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
+        let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
+            IntentAndBalancePrivateSettlementCircuit,
+        >(
+            settlement_witness, settlement_statement
+        )?;
+
+        // Link the proofs and verify the link
+        let link_proof = link_output_balance_settlement_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &validity_hint,
+            &settlement_hint,
+        )?;
+        validate_output_balance_settlement_link_with_party::<TEST_MERKLE_HEIGHT>(
+            party_id,
+            &link_proof,
+            &validity_proof,
+            &settlement_proof,
+        )
+    }
+
+    /// Build new output balance validity and private settlement witness and
+    /// statement data with valid data
+    ///
+    /// This involves modifying the witness and statements for each circuit to
+    /// align with one another so that they may be linked
+    fn build_new_output_balance_private_settlement_data(
+        party_id: u8,
+    ) -> (
+        NewOutputBalanceValidityWitness,
+        NewOutputBalanceValidityStatement,
+        IntentAndBalancePrivateSettlementWitness,
+        IntentAndBalancePrivateSettlementStatement,
+    ) {
+        // Create the private settlement witness and statement with compatible intents
+        let (mut settlement_witness, mut settlement_statement) =
+            create_private_settlement_witness_statement::<TEST_MERKLE_HEIGHT>();
+
+        // Get mutable references to the relevant fields based on the party ID
+        let (output_balance, pre_settlement_out_balance_shares) = if party_id == 0 {
+            (
+                &mut settlement_witness.output_balance0,
+                &mut settlement_witness.pre_settlement_out_balance_shares0,
+            )
+        } else {
+            (
+                &mut settlement_witness.output_balance1,
+                &mut settlement_witness.pre_settlement_out_balance_shares1,
+            )
+        };
+
+        // Create a zeroed balance matching the settlement's output balance (mint and
+        // owner)
+        let mut zeroed_balance = random_zeroed_balance();
+        zeroed_balance.mint = output_balance.mint;
+        zeroed_balance.owner = output_balance.owner;
+
+        // Create the validity witness and statement using the zeroed balance
+        let (validity_witness, validity_statement) =
+            create_new_output_balance_witness_statement_with_balance(zeroed_balance);
+
+        // Align the settlement witness with the validity witness
+        *output_balance = validity_witness.balance.clone();
+        *pre_settlement_out_balance_shares = validity_witness.post_match_balance_shares.clone();
+
+        // Update the settlement statement to reflect the settlement
+        let amt_out0 = Scalar::from(settlement_witness.settlement_obligation0.amount_out);
+        let amt_out1 = Scalar::from(settlement_witness.settlement_obligation1.amount_out);
+
+        settlement_statement.new_out_balance_public_shares0 =
+            settlement_witness.pre_settlement_out_balance_shares0.clone();
+        settlement_statement.new_out_balance_public_shares1 =
+            settlement_witness.pre_settlement_out_balance_shares1.clone();
+        settlement_statement.new_out_balance_public_shares0.amount += amt_out0;
+        settlement_statement.new_out_balance_public_shares1.amount += amt_out1;
+
+        (validity_witness, validity_statement, settlement_witness, settlement_statement)
+    }
+
     // --------------
     // | Test Cases |
     // --------------
+
+    // --- Valid Test Cases --- //
 
     /// Tests a valid link between a proof of OUTPUT BALANCE VALIDITY and a
     /// proof of INTENT AND BALANCE PUBLIC SETTLEMENT
@@ -326,6 +587,48 @@ mod test {
         )
         .unwrap();
     }
+
+    /// Tests a valid link between a proof of OUTPUT BALANCE VALIDITY and a
+    /// proof of INTENT AND BALANCE PRIVATE SETTLEMENT
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    fn test_output_balance_valid_private_link() {
+        let mut rng = thread_rng();
+        let party_id = *[0u8, 1].choose(&mut rng).unwrap();
+        let (validity_witness, validity_statement, settlement_witness, settlement_statement) =
+            build_output_balance_private_settlement_data(party_id);
+
+        test_output_balance_private_settlement_link(
+            party_id,
+            validity_witness,
+            validity_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap()
+    }
+
+    /// Tests a valid link between a proof of NEW OUTPUT BALANCE VALIDITY and a
+    /// proof of INTENT AND BALANCE PRIVATE SETTLEMENT
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    fn test_new_output_balance_valid_private_link() {
+        let mut rng = thread_rng();
+        let party_id = *[0u8, 1].choose(&mut rng).unwrap();
+        let (validity_witness, validity_statement, settlement_witness, settlement_statement) =
+            build_new_output_balance_private_settlement_data(party_id);
+
+        test_new_output_balance_private_settlement_link(
+            party_id,
+            validity_witness,
+            validity_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap()
+    }
+
+    // --- Invalid Test Cases --- //
 
     /// Tests an invalid link between a proof of OUTPUT BALANCE VALIDITY
     /// and a proof of INTENT AND BALANCE PUBLIC SETTLEMENT wherein the balance

--- a/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
+++ b/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
@@ -247,6 +247,19 @@ pub mod test_helpers {
     -> (NewOutputBalanceValidityWitness, NewOutputBalanceValidityStatement) {
         // Create a random balance
         let balance_inner = random_zeroed_balance();
+        create_witness_statement_with_balance(balance_inner)
+    }
+
+    /// Construct a witness and statement with the given balance
+    ///
+    /// The balance must be zeroed (amount = 0, fees = 0) to satisfy the circuit
+    /// constraints
+    pub fn create_witness_statement_with_balance(
+        mut balance_inner: Balance,
+    ) -> (NewOutputBalanceValidityWitness, NewOutputBalanceValidityStatement) {
+        balance_inner.amount = 0;
+        balance_inner.relayer_fee_balance = 0;
+        balance_inner.protocol_fee_balance = 0;
         let mut balance = create_state_wrapper(balance_inner);
 
         // Compute the original balance commitment


### PR DESCRIPTION
### Purpose
This PR adds helpers and tests for linking an output balance validity proof into a private settlement proof for both parties.

### Testing
- [x] All tests pass