### PR TITLE
circuits: settlement: Add fee rate fields to all settlement statements

### DIFF
--- a/circuit-types/src/lib.rs
+++ b/circuit-types/src/lib.rs
@@ -25,7 +25,7 @@ pub use primitives::*;
 
 use ark_ff::BigInt;
 use bigdecimal::Num;
-use constants::{ADDRESS_BYTE_LENGTH, Scalar, ScalarField};
+use constants::{ADDRESS_BYTE_LENGTH, MAX_RELAYER_FEE_RATE, Scalar, ScalarField};
 use num_bigint::BigUint;
 use primitives::fixed_point::{DEFAULT_FP_PRECISION, FixedPoint};
 use renegade_crypto::fields::{biguint_to_scalar, scalar_to_biguint};
@@ -147,6 +147,11 @@ pub fn max_price() -> FixedPoint {
 /// Get the maximum representable amount
 pub fn max_amount() -> Amount {
     (1u128 << AMOUNT_BITS) - 1
+}
+
+/// The maximum fee rate allowed by the protocol
+pub fn maximum_fee() -> FixedPoint {
+    FixedPoint::from_f64_round_down(MAX_RELAYER_FEE_RATE)
 }
 
 /// Verify that an amount is within the correct bitlength

--- a/circuits/src/test_helpers/fuzzing.rs
+++ b/circuits/src/test_helpers/fuzzing.rs
@@ -11,12 +11,13 @@ use circuit_types::{
     elgamal::{DecryptionKey, EncryptionKey},
     fixed_point::FixedPoint,
     intent::Intent,
+    max_amount,
     settlement_obligation::SettlementObligation,
     state_wrapper::StateWrapper,
     traits::{BaseType, CircuitBaseType, SecretShareBaseType},
     withdrawal::Withdrawal,
 };
-use constants::Scalar;
+use constants::{MAX_RELAYER_FEE_RATE, Scalar};
 use itertools::Itertools;
 use rand::{Rng, distributions::uniform::SampleRange, thread_rng};
 use renegade_crypto::fields::scalar_to_u128;
@@ -52,11 +53,6 @@ pub fn random_amount() -> Amount {
     amt / 10
 }
 
-/// Get the maximum amount allowed
-pub fn max_amount() -> Amount {
-    (1u128 << AMOUNT_BITS) - 1u128
-}
-
 /// Generate a random address
 pub fn random_address() -> Address {
     let mut rng = thread_rng();
@@ -72,6 +68,13 @@ pub fn random_price() -> FixedPoint {
     let price_f64 = thread_rng().gen_range(min_price..max_price);
 
     FixedPoint::from_f64_round_down(price_f64)
+}
+
+/// Generate a random fee
+pub fn random_fee() -> FixedPoint {
+    let mut rng = thread_rng();
+    let fee_f64 = rng.gen_range(0.0..=MAX_RELAYER_FEE_RATE);
+    FixedPoint::from_f64_round_down(fee_f64)
 }
 
 // ---------------

--- a/circuits/src/zk_circuits/settlement/intent_and_balance_private_settlement.rs
+++ b/circuits/src/zk_circuits/settlement/intent_and_balance_private_settlement.rs
@@ -7,6 +7,7 @@ use circuit_macros::circuit_type;
 use circuit_types::{
     PlonkCircuit,
     balance::{Balance, PostMatchBalanceShare},
+    fixed_point::FixedPoint,
     intent::Intent,
     settlement_obligation::SettlementObligation,
     traits::{BaseType, CircuitBaseType, CircuitVarType},
@@ -194,6 +195,16 @@ pub struct IntentAndBalancePrivateSettlementStatement {
     pub new_in_balance_public_shares1: PostMatchBalanceShare,
     /// The updated public shares of the second party's output balance
     pub new_out_balance_public_shares1: PostMatchBalanceShare,
+
+    // --- Fees --- //
+    /// The relayer fee applied to the first party's match
+    pub relayer_fee0: FixedPoint,
+    /// The relayer fee applied to the second party's match
+    pub relayer_fee1: FixedPoint,
+    /// The protocol fee applied to the match
+    ///
+    /// This is the same for both parties
+    pub protocol_fee: FixedPoint,
 }
 
 // ---------------------
@@ -251,13 +262,14 @@ pub mod test_helpers {
         balance::{Balance, PostMatchBalanceShare},
         fixed_point::FixedPoint,
         intent::Intent,
+        max_amount,
         settlement_obligation::SettlementObligation,
     };
     use constants::Scalar;
     use rand::{Rng, thread_rng};
 
     use crate::{
-        test_helpers::{max_amount, random_address, random_amount, random_scalar},
+        test_helpers::{random_address, random_amount, random_fee, random_scalar},
         zk_circuits::settlement::intent_and_balance_private_settlement::{
             IntentAndBalancePrivateSettlementCircuit, IntentAndBalancePrivateSettlementStatement,
             IntentAndBalancePrivateSettlementWitness,
@@ -348,6 +360,9 @@ pub mod test_helpers {
             new_amount_public_share1,
             new_in_balance_public_shares1,
             new_out_balance_public_shares1,
+            relayer_fee0: random_fee(),
+            relayer_fee1: random_fee(),
+            protocol_fee: random_fee(),
         };
 
         (witness, statement)

--- a/circuits/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
+++ b/circuits/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
@@ -7,6 +7,7 @@ use circuit_macros::circuit_type;
 use circuit_types::{
     PlonkCircuit,
     balance::{Balance, PostMatchBalanceShare},
+    fixed_point::FixedPoint,
     intent::Intent,
     settlement_obligation::SettlementObligation,
     traits::{BaseType, CircuitBaseType, CircuitVarType},
@@ -135,6 +136,13 @@ pub struct IntentAndBalancePublicSettlementStatement {
     /// The updated public shares of the post-match balance fields for the
     /// output balance
     pub new_out_balance_public_shares: PostMatchBalanceShare,
+    /// The relayer fee which is charged for the settlement
+    ///
+    /// We place this field in the statement so that it is included in the
+    /// Fiat-Shamir transcript and therefore is not malleable transaction
+    /// calldata. This allows the relayer to set the fee and be sure it cannot
+    /// be modified by mempool observers.
+    pub relayer_fee: FixedPoint,
 }
 
 // ---------------------
@@ -196,7 +204,7 @@ pub mod test_helpers {
 
     use crate::{
         test_helpers::{
-            create_settlement_obligation_with_balance, random_address, random_amount,
+            create_settlement_obligation_with_balance, random_address, random_amount, random_fee,
             random_intent, random_scalar,
         },
         zk_circuits::settlement::intent_and_balance_public_settlement::{
@@ -312,6 +320,7 @@ pub mod test_helpers {
             new_amount_public_share,
             new_in_balance_public_shares,
             new_out_balance_public_shares,
+            relayer_fee: random_fee(),
         };
 
         (witness, statement)

--- a/circuits/src/zk_circuits/validity_proofs/intent_only_first_fill.rs
+++ b/circuits/src/zk_circuits/validity_proofs/intent_only_first_fill.rs
@@ -274,10 +274,12 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
-    use crate::test_helpers::{max_amount, random_address, random_intent, random_scalar};
+    use crate::test_helpers::{random_address, random_intent, random_scalar};
 
     use super::*;
-    use circuit_types::{fixed_point::FixedPoint, max_price, traits::SingleProverCircuit};
+    use circuit_types::{
+        fixed_point::FixedPoint, max_amount, max_price, traits::SingleProverCircuit,
+    };
     use rand::{Rng, thread_rng};
 
     /// A helper to print the number of constraints in the circuit


### PR DESCRIPTION
### Purpose
This PR adds relayer (and protocol where appropriate) fee rates to all settlement circuits. These are unused in public settlement circuits, but included in the statement types so that they're bound via the Fiat-Shamir transcript. This prevents these fields from being modified in the mempool to cheat the relayer.

### Testing
- [x] All unit tests pass