### PR TITLE
circuits: benches: valid-order-cancellation: Add benchmark

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -121,6 +121,12 @@ path = "benches/new_output_balance.rs"
 harness = false
 required-features = ["test_helpers"]
 
+[[bench]]
+name = "valid_order_cancellation"
+path = "benches/valid_order_cancellation.rs"
+harness = false
+required-features = ["test_helpers"]
+
 [dependencies]
 # === Cryptography + Arithmetic === #
 alloy-primitives = { workspace = true }

--- a/circuits/benches/valid_order_cancellation.rs
+++ b/circuits/benches/valid_order_cancellation.rs
@@ -1,0 +1,88 @@
+//! Tests the process of proving and verifying a `VALID ORDER CANCELLATION`
+//! circuit
+#![allow(incomplete_features)]
+#![allow(missing_docs)]
+
+use circuit_types::PlonkCircuit;
+use circuit_types::traits::{CircuitBaseType, SingleProverCircuit};
+use circuits::zk_circuits::valid_order_cancellation::SizedValidOrderCancellationCircuit;
+use circuits::zk_circuits::valid_order_cancellation::test_helpers::create_dummy_witness_statement;
+use circuits::{singleprover_prove, verify_singleprover_proof};
+use constants::MERKLE_HEIGHT;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+/// Benchmark applying constraints to a circuit
+pub fn bench_apply_constraints(c: &mut Criterion) {
+    // Build a witness and statement
+    let (witness, statement) = create_dummy_witness_statement();
+
+    // Allocate in the constraint system
+    let mut cs = PlonkCircuit::new_turbo_plonk();
+    let witness_var = witness.create_witness(&mut cs);
+    let statement_var = statement.create_public_var(&mut cs);
+
+    // Run the benchmark
+    let mut group = c.benchmark_group("valid_order_cancellation");
+    let benchmark_id = BenchmarkId::new("constraint-generation", format!("({MERKLE_HEIGHT})"));
+
+    group.bench_function(benchmark_id, |b| {
+        b.iter(|| {
+            SizedValidOrderCancellationCircuit::apply_constraints(
+                witness_var.clone(),
+                statement_var.clone(),
+                &mut cs,
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Benchmark proving a circuit
+pub fn bench_prover(c: &mut Criterion) {
+    // Build a witness and statement
+    let (witness, statement) = create_dummy_witness_statement();
+    let mut group = c.benchmark_group("valid_order_cancellation");
+    let benchmark_id = BenchmarkId::new("prover", format!("({MERKLE_HEIGHT})"));
+    group.bench_function(benchmark_id, |b| {
+        b.iter(|| {
+            singleprover_prove::<SizedValidOrderCancellationCircuit>(
+                witness.clone(),
+                statement.clone(),
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Benchmark verifying a circuit
+pub fn bench_verifier(c: &mut Criterion) {
+    // First generate a proof that will be verified multiple times
+    let (witness, statement) = create_dummy_witness_statement();
+    let proof =
+        singleprover_prove::<SizedValidOrderCancellationCircuit>(witness, statement.clone())
+            .unwrap();
+
+    // Run the benchmark
+    let mut group = c.benchmark_group("valid_order_cancellation");
+    let benchmark_id = BenchmarkId::new("verifier", format!("({MERKLE_HEIGHT})"));
+    group.bench_function(benchmark_id, |b| {
+        b.iter(|| {
+            verify_singleprover_proof::<SizedValidOrderCancellationCircuit>(
+                statement.clone(),
+                &proof,
+            )
+            .unwrap();
+        });
+    });
+}
+
+// -------------------
+// | Criterion Setup |
+// -------------------
+
+criterion_group! {
+    name = valid_order_cancellation;
+    config = Criterion::default().sample_size(10);
+    targets = bench_apply_constraints, bench_prover, bench_verifier
+}
+criterion_main!(valid_order_cancellation);


### PR DESCRIPTION
### Purpose
This PR adds a benchmark for the `VALID ORDER CANCELLATION` circuit.

### Testing
- [x] Ran benchmark locally