### PR TITLE
circuit-types: Add helpers for integration

### DIFF
--- a/circuit-types/src/primitives/fixed_point.rs
+++ b/circuit-types/src/primitives/fixed_point.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::Ordering,
-    ops::{Add, Mul, Neg, Sub},
+    ops::{Add, Div, Mul, Neg, Sub},
 };
 
 use ark_ff::{BigInteger, Field, PrimeField};
@@ -323,6 +323,17 @@ impl Mul<Scalar> for FixedPoint {
     type Output = FixedPoint;
     fn mul(self, rhs: Scalar) -> Self::Output {
         Self { repr: self.repr * rhs }
+    }
+}
+
+impl<T: Into<Scalar>> Div<T> for FixedPoint {
+    type Output = FixedPoint;
+    fn div(self, rhs: T) -> Self::Output {
+        let rhs = scalar_to_biguint(&rhs.into());
+        let repr_biguint = scalar_to_biguint(&self.repr);
+        let new_repr = repr_biguint / rhs;
+
+        Self { repr: biguint_to_scalar(&new_repr) }
     }
 }
 

--- a/circuit-types/src/traits.rs
+++ b/circuit-types/src/traits.rs
@@ -916,8 +916,8 @@ pub trait SingleProverCircuit: Sized {
     ///
     /// Returns both the commitment to the inputs, as well as the proof itself
     fn prove(
-        witness: Self::Witness,
-        statement: Self::Statement,
+        witness: &Self::Witness,
+        statement: &Self::Statement,
     ) -> Result<Proof<SystemCurve>, ProverError> {
         let (proof, _hint) = Self::prove_with_link_hint(witness, statement)?;
         Ok(proof)
@@ -926,8 +926,8 @@ pub trait SingleProverCircuit: Sized {
     /// Generate a proof of the statement represented by the circuit and return
     /// a link hint with the proof
     fn prove_with_link_hint(
-        witness: Self::Witness,
-        statement: Self::Statement,
+        witness: &Self::Witness,
+        statement: &Self::Statement,
     ) -> Result<(PlonkProof, ProofLinkingHint), ProverError> {
         let mut circuit = PlonkCircuit::new_turbo_plonk();
 
@@ -956,7 +956,10 @@ pub trait SingleProverCircuit: Sized {
     /// Verify a proof of the statement represented by the circuit
     ///
     /// The verifier has access to the statement variables, but not the witness
-    fn verify(statement: Self::Statement, proof: &Proof<SystemCurve>) -> Result<(), VerifierError> {
+    fn verify(
+        statement: &Self::Statement,
+        proof: &Proof<SystemCurve>,
+    ) -> Result<(), VerifierError> {
         // Allocate the statement in the constraint system
         let statement_vals = statement.to_scalars().iter().map(Scalar::inner).collect_vec();
 
@@ -1102,7 +1105,7 @@ pub trait MultiProverCircuit {
         statement: <Self::Statement as MultiproverCircuitBaseType>::BaseType,
         proof: &Proof<SystemCurve>,
     ) -> Result<(), VerifierError> {
-        Self::BaseCircuit::verify(statement, proof)
+        Self::BaseCircuit::verify(&statement, proof)
     }
 }
 

--- a/circuits/benches/intent_and_balance.rs
+++ b/circuits/benches/intent_and_balance.rs
@@ -53,11 +53,8 @@ pub fn bench_prover(c: &mut Criterion) {
     let benchmark_id = BenchmarkId::new("prover", "");
     group.bench_function(benchmark_id, |b| {
         b.iter(|| {
-            singleprover_prove::<SizedIntentAndBalanceValidityCircuit>(
-                witness.clone(),
-                statement.clone(),
-            )
-            .unwrap();
+            singleprover_prove::<SizedIntentAndBalanceValidityCircuit>(&witness, &statement)
+                .unwrap();
         });
     });
 }
@@ -67,19 +64,15 @@ pub fn bench_verifier(c: &mut Criterion) {
     // First generate a proof that will be verified multiple times
     let (witness, statement) = create_witness_statement::<MERKLE_HEIGHT>();
     let proof =
-        singleprover_prove::<SizedIntentAndBalanceValidityCircuit>(witness, statement.clone())
-            .unwrap();
+        singleprover_prove::<SizedIntentAndBalanceValidityCircuit>(&witness, &statement).unwrap();
 
     // Run the benchmark
     let mut group = c.benchmark_group("intent_and_balance_validity");
     let benchmark_id = BenchmarkId::new("verifier", "");
     group.bench_function(benchmark_id, |b| {
         b.iter(|| {
-            verify_singleprover_proof::<SizedIntentAndBalanceValidityCircuit>(
-                statement.clone(),
-                &proof,
-            )
-            .unwrap();
+            verify_singleprover_proof::<SizedIntentAndBalanceValidityCircuit>(&statement, &proof)
+                .unwrap();
         });
     });
 }

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -110,23 +110,23 @@ pub fn scalar_2_to_m(m: u64) -> Scalar {
 
 /// Construct a proof of a given circuit
 pub fn singleprover_prove<C: SingleProverCircuit>(
-    witness: C::Witness,
-    statement: C::Statement,
+    witness: &C::Witness,
+    statement: &C::Statement,
 ) -> Result<PlonkProof, ProverError> {
     C::prove(witness, statement)
 }
 
 /// Construct a proof of a given circuit and return a link hint with it
 pub fn singleprover_prove_with_hint<C: SingleProverCircuit>(
-    witness: C::Witness,
-    statement: C::Statement,
+    witness: &C::Witness,
+    statement: &C::Statement,
 ) -> Result<(PlonkProof, ProofLinkingHint), ProverError> {
     C::prove_with_link_hint(witness, statement)
 }
 
 /// Verify a proof of a given circuit
 pub fn verify_singleprover_proof<C: SingleProverCircuit>(
-    statement: C::Statement,
+    statement: &C::Statement,
     proof: &PlonkProof,
 ) -> Result<(), VerifierError> {
     C::verify(statement, proof)
@@ -134,10 +134,10 @@ pub fn verify_singleprover_proof<C: SingleProverCircuit>(
 
 /// Generate a proof of a circuit and verify it
 pub fn singleprover_prove_and_verify<C: SingleProverCircuit>(
-    witness: C::Witness,
-    statement: C::Statement,
+    witness: &C::Witness,
+    statement: &C::Statement,
 ) -> Result<(), ProverError> {
-    let proof = C::prove(witness, statement.clone())?;
+    let proof = C::prove(witness, statement)?;
     C::verify(statement, &proof).map_err(ProverError::Verification)
 }
 

--- a/circuits/src/test_helpers/fuzzing.rs
+++ b/circuits/src/test_helpers/fuzzing.rs
@@ -22,6 +22,9 @@ use itertools::Itertools;
 use rand::{Rng, distributions::uniform::SampleRange, thread_rng};
 use renegade_crypto::fields::scalar_to_u128;
 
+/// The bounded maximum amount to prevent `Amount` overflow in tests
+pub const BOUNDED_MAX_AMT: Amount = 2u128.pow((AMOUNT_BITS / 2) as u32);
+
 // -------------------
 // | Primitive Types |
 // -------------------

--- a/circuits/src/zk_circuits/proof_linking/intent_and_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/intent_and_balance.rs
@@ -213,11 +213,11 @@ mod test {
         // PUBLIC SETTLEMENT
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedIntentAndBalanceValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePublicSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link
@@ -295,11 +295,11 @@ mod test {
         // AND BALANCE PUBLIC SETTLEMENT
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedIntentAndBalanceFirstFillValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePublicSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         let link_proof = link_intent_and_balance_settlement_with_party::<TEST_MERKLE_HEIGHT>(
@@ -373,13 +373,13 @@ mod test {
         // Create proofs of INTENT AND BALANCE VALIDITY for both parties
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedIntentAndBalanceValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
 
         // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePrivateSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link
@@ -475,13 +475,13 @@ mod test {
         // Create a proof of INTENT AND BALANCE FIRST FILL VALIDITY
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedIntentAndBalanceFirstFillValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
 
         // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePrivateSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link

--- a/circuits/src/zk_circuits/proof_linking/intent_only.rs
+++ b/circuits/src/zk_circuits/proof_linking/intent_only.rs
@@ -23,16 +23,16 @@ use crate::zk_circuits::{
 /// Link an intent only validity proof with a proof of INTENT ONLY
 /// PUBLIC SETTLEMENT using the system wide sizing constants
 pub fn link_sized_intent_only_settlement(
-    first_fill_link_hint: &ProofLinkingHint,
+    validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
 ) -> Result<PlonkLinkProof, ProverError> {
-    link_intent_only_settlement::<MERKLE_HEIGHT>(first_fill_link_hint, settlement_link_hint)
+    link_intent_only_settlement::<MERKLE_HEIGHT>(validity_link_hint, settlement_link_hint)
 }
 
 /// Link an intent only validity proof with a proof of INTENT ONLY
 /// PUBLIC SETTLEMENT
 pub fn link_intent_only_settlement<const MERKLE_HEIGHT: usize>(
-    first_fill_link_hint: &ProofLinkingHint,
+    validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
 ) -> Result<PlonkLinkProof, ProverError> {
     // Get the group layout for the first fill <-> settlement link group
@@ -40,7 +40,7 @@ pub fn link_intent_only_settlement<const MERKLE_HEIGHT: usize>(
     let pk = IntentOnlyValidityCircuit::<MERKLE_HEIGHT>::proving_key();
 
     PlonkKzgSnark::link_proofs::<SolidityTranscript>(
-        first_fill_link_hint,
+        validity_link_hint,
         settlement_link_hint,
         &layout,
         &pk.commit_key,
@@ -53,12 +53,12 @@ pub fn link_intent_only_settlement<const MERKLE_HEIGHT: usize>(
 /// constants
 pub fn validate_sized_intent_only_settlement_link(
     link_proof: &PlonkLinkProof,
-    first_fill_proof: &PlonkProof,
+    validity_proof: &PlonkProof,
     settlement_proof: &PlonkProof,
 ) -> Result<(), ProverError> {
     validate_intent_only_settlement_link::<MERKLE_HEIGHT>(
         link_proof,
-        first_fill_proof,
+        validity_proof,
         settlement_proof,
     )
 }
@@ -67,7 +67,7 @@ pub fn validate_sized_intent_only_settlement_link(
 /// proof of INTENT ONLY PUBLIC SETTLEMENT
 pub fn validate_intent_only_settlement_link<const MERKLE_HEIGHT: usize>(
     link_proof: &PlonkLinkProof,
-    first_fill_proof: &PlonkProof,
+    validity_proof: &PlonkProof,
     settlement_proof: &PlonkProof,
 ) -> Result<(), ProverError> {
     // Get the group layout for the first fill <-> settlement link group
@@ -75,7 +75,7 @@ pub fn validate_intent_only_settlement_link<const MERKLE_HEIGHT: usize>(
     let vk = IntentOnlyValidityCircuit::<MERKLE_HEIGHT>::verifying_key();
 
     PlonkKzgSnark::verify_link_proof::<SolidityTranscript>(
-        first_fill_proof,
+        validity_proof,
         settlement_proof,
         link_proof,
         &layout,
@@ -131,12 +131,12 @@ mod test {
         let (first_fill_proof, first_fill_hint) = singleprover_prove_with_hint::<
             SizedIntentOnlyFirstFillValidity,
         >(
-            first_fill_witness, first_fill_statement
+            &first_fill_witness, &first_fill_statement
         )?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             SizedIntentOnlyPublicSettlement,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link
@@ -221,11 +221,11 @@ mod test {
         // SETTLEMENT
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedIntentOnlyValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             SizedIntentOnlyPublicSettlement,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link

--- a/circuits/src/zk_circuits/proof_linking/output_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/output_balance.rs
@@ -208,11 +208,11 @@ mod test {
         // PUBLIC SETTLEMENT
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedOutputBalanceValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePublicSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link
@@ -285,11 +285,11 @@ mod test {
         // PUBLIC SETTLEMENT
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             NewOutputBalanceValidityCircuit,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePublicSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link using the existing sized methods
@@ -361,13 +361,13 @@ mod test {
         // Create a proof of OUTPUT BALANCE VALIDITY
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             SizedOutputBalanceValidity,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
 
         // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePrivateSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link
@@ -468,13 +468,13 @@ mod test {
         // Create a proof of NEW OUTPUT BALANCE VALIDITY
         let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
             NewOutputBalanceValidityCircuit,
-        >(validity_witness, validity_statement)?;
+        >(&validity_witness, &validity_statement)?;
 
         // Create a proof of INTENT AND BALANCE PRIVATE SETTLEMENT
         let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
             IntentAndBalancePrivateSettlementCircuit,
         >(
-            settlement_witness, settlement_statement
+            &settlement_witness, &settlement_statement
         )?;
 
         // Link the proofs and verify the link

--- a/circuits/src/zk_circuits/settlement/intent_only_public_settlement.rs
+++ b/circuits/src/zk_circuits/settlement/intent_only_public_settlement.rs
@@ -31,6 +31,9 @@ use crate::{SingleProverCircuit, zk_circuits::settlement::settlement_lib::Settle
 // | Circuit Definition |
 // ----------------------
 
+/// The `INTENT ONLY PUBLIC SETTLEMENT` circuit with default const generic
+/// sizing parameters
+pub type SizedIntentOnlyPublicSettlementCircuit = IntentOnlyPublicSettlementCircuit<MERKLE_HEIGHT>;
 /// The `INTENT ONLY PUBLIC SETTLEMENT` circuit
 pub struct IntentOnlyPublicSettlementCircuit<const MERKLE_HEIGHT: usize>;
 
@@ -144,7 +147,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    use circuit_types::intent::Intent;
+    use circuit_types::{intent::Intent, settlement_obligation::SettlementObligation};
 
     use crate::{
         test_helpers::{
@@ -185,9 +188,21 @@ pub mod test_helpers {
     ) -> (IntentOnlyPublicSettlementWitness<MERKLE_HEIGHT>, IntentOnlyPublicSettlementStatement)
     {
         let settlement_obligation = create_settlement_obligation(intent);
+        create_witness_statement_with_intent_and_obligation::<MERKLE_HEIGHT>(
+            intent,
+            &settlement_obligation,
+        )
+    }
+
+    /// Create a witness and statement with the given intent and obligation
+    pub fn create_witness_statement_with_intent_and_obligation<const MERKLE_HEIGHT: usize>(
+        intent: &Intent,
+        obligation: &SettlementObligation,
+    ) -> (IntentOnlyPublicSettlementWitness<MERKLE_HEIGHT>, IntentOnlyPublicSettlementStatement)
+    {
         let witness = IntentOnlyPublicSettlementWitness { intent: intent.clone() };
         let statement = IntentOnlyPublicSettlementStatement {
-            settlement_obligation,
+            settlement_obligation: obligation.clone(),
             relayer_fee: random_fee(),
             relayer_fee_recipient: random_address(),
         };

--- a/circuits/src/zk_circuits/validity_proofs/intent_and_balance.rs
+++ b/circuits/src/zk_circuits/validity_proofs/intent_and_balance.rs
@@ -10,7 +10,7 @@ use circuit_macros::circuit_type;
 use circuit_types::{
     Nullifier, PlonkCircuit,
     balance::{
-        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar, PostMatchBalance,
+        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
         PostMatchBalanceShare, PostMatchBalanceShareVar,
     },
     intent::{DarkpoolStateIntent, DarkpoolStateIntentVar, Intent, IntentShare, IntentShareVar},
@@ -30,9 +30,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     SingleProverCircuit,
-    zk_circuits::settlement::{
-        INTENT_AND_BALANCE_SETTLEMENT_PARTY0_LINK, INTENT_AND_BALANCE_SETTLEMENT_PARTY1_LINK,
-        intent_and_balance_private_settlement::IntentAndBalancePrivateSettlementCircuit,
+    zk_circuits::{
+        settlement::{
+            INTENT_AND_BALANCE_SETTLEMENT_PARTY0_LINK, INTENT_AND_BALANCE_SETTLEMENT_PARTY1_LINK,
+            intent_and_balance_private_settlement::IntentAndBalancePrivateSettlementCircuit,
+        },
+        validity_proofs::intent_and_balance_first_fill::BALANCE_PARTIAL_COMMITMENT_SIZE,
     },
     zk_gadgets::{
         comparators::EqGadget,
@@ -48,11 +51,7 @@ use crate::{
 ///
 /// We omit the `amount_in` share (last share of the `Intent` type) as this will
 /// be updated in the match settlement.
-const INTENT_PARTIAL_COMMITMENT_SIZE: usize = IntentShare::NUM_SCALARS - 1;
-
-/// The size of the partial commitment to the balance
-pub const BALANCE_PARTIAL_COMMITMENT_SIZE: usize =
-    Balance::NUM_SCALARS - PostMatchBalance::NUM_SCALARS;
+pub const INTENT_PARTIAL_COMMITMENT_SIZE: usize = IntentShare::NUM_SCALARS - 1;
 
 // ----------------------
 // | Circuit Definition |
@@ -364,13 +363,14 @@ pub mod test_helpers {
             check_constraints_satisfied, create_merkle_opening, create_random_state_wrapper,
             random_intent,
         },
-        zk_circuits::{
-            validity_proofs::intent_and_balance::{
-                BALANCE_PARTIAL_COMMITMENT_SIZE, INTENT_PARTIAL_COMMITMENT_SIZE,
-                IntentAndBalanceValidityCircuit, IntentAndBalanceValidityStatement,
-                IntentAndBalanceValidityWitness,
+        zk_circuits::validity_proofs::{
+            intent_and_balance::{
+                INTENT_PARTIAL_COMMITMENT_SIZE, IntentAndBalanceValidityCircuit,
+                IntentAndBalanceValidityStatement, IntentAndBalanceValidityWitness,
             },
-            validity_proofs::intent_and_balance_first_fill::test_helpers::create_matching_balance_for_intent,
+            intent_and_balance_first_fill::{
+                BALANCE_PARTIAL_COMMITMENT_SIZE, test_helpers::create_matching_balance_for_intent,
+            },
         },
     };
 

--- a/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
+++ b/circuits/src/zk_circuits/validity_proofs/new_output_balance.rs
@@ -67,11 +67,7 @@ impl NewOutputBalanceValidityCircuit {
         // 3. Compute a commitment to the original balance
         let original_balance_commitment =
             CommitmentGadget::compute_commitment(&balance, &private_shares, cs)?;
-        EqGadget::constrain_eq(
-            &original_balance_commitment,
-            &statement.original_balance_commitment,
-            cs,
-        )?;
+        // TODO: Check signature here
 
         // 4. Compute the recovery identifier for the new balance
         let recovery_id = RecoveryIdGadget::compute_recovery_id(&mut balance, cs)?;
@@ -172,8 +168,6 @@ pub struct NewOutputBalanceValidityWitness {
 #[circuit_type(singleprover_circuit)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NewOutputBalanceValidityStatement {
-    /// A commitment to the original balance before update
-    pub original_balance_commitment: Commitment,
     /// A partial commitment to the new output balance
     pub new_balance_partial_commitment: PartialCommitment,
     /// The recovery identifier of the new output balance
@@ -262,9 +256,6 @@ pub mod test_helpers {
         balance_inner.protocol_fee_balance = 0;
         let mut balance = create_state_wrapper(balance_inner);
 
-        // Compute the original balance commitment
-        let original_balance_commitment = balance.compute_commitment();
-
         // Compute the recovery identifier (mutates recovery_stream)
         let recovery_id = balance.compute_recovery_id();
         let new_balance_partial_commitment =
@@ -284,11 +275,8 @@ pub mod test_helpers {
         };
 
         // Build the statement
-        let statement = NewOutputBalanceValidityStatement {
-            original_balance_commitment,
-            new_balance_partial_commitment,
-            recovery_id,
-        };
+        let statement =
+            NewOutputBalanceValidityStatement { new_balance_partial_commitment, recovery_id };
 
         (witness, statement)
     }

--- a/circuits/src/zk_gadgets/state_primitives/state_rotation.rs
+++ b/circuits/src/zk_gadgets/state_primitives/state_rotation.rs
@@ -9,8 +9,7 @@ use circuit_types::{
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::{
-    primitives::comparators::EqGadget,
-    primitives::merkle::PoseidonMerkleHashGadget,
+    primitives::{comparators::EqGadget, merkle::PoseidonMerkleHashGadget},
     state_primitives::{CommitmentGadget, NullifierGadget, RecoveryIdGadget},
 };
 


### PR DESCRIPTION
### Purpose
This PR adds helpers for integration between the circuits and the contracts. In specific, we add helpers for updating state elements for and after transactions.

### Testing
- [x] All tests pass