### PR TITLE
circuits: zk-circuits: new-output-balance: Add output balance optimizations

### DIFF
--- a/circuit-types/src/primitives/schnorr.rs
+++ b/circuit-types/src/primitives/schnorr.rs
@@ -77,7 +77,7 @@ impl From<SchnorrSignatureVar> for SignatureVar {
 
 /// A Schnorr private key
 #[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct SchnorrPrivateKey {
     /// The underlying scalar field element
     pub inner: EmbeddedScalarField,

--- a/circuits/src/zk_circuits/fees/valid_private_relayer_fee_payment.rs
+++ b/circuits/src/zk_circuits/fees/valid_private_relayer_fee_payment.rs
@@ -213,7 +213,6 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    use alloy_primitives::Address;
     use circuit_types::{
         balance::{Balance, DarkpoolStateBalance},
         note::Note,
@@ -342,7 +341,6 @@ mod test {
 
     use super::test_helpers::create_dummy_witness_statement_with_balance;
     use super::*;
-    use alloy_primitives::Address;
     use circuit_types::{balance::Balance, note::Note, traits::SingleProverCircuit};
 
     /// A helper to print the number of constraints in the circuit

--- a/circuits/src/zk_circuits/fees/valid_public_relayer_fee_payment.rs
+++ b/circuits/src/zk_circuits/fees/valid_public_relayer_fee_payment.rs
@@ -199,7 +199,6 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
-    use alloy_primitives::Address;
     use circuit_types::{
         balance::{Balance, DarkpoolStateBalance},
         note::Note,
@@ -322,7 +321,6 @@ mod test {
 
     use super::test_helpers::create_dummy_witness_statement_with_balance;
     use super::*;
-    use alloy_primitives::Address;
     use circuit_types::{balance::Balance, traits::SingleProverCircuit};
 
     /// A helper to print the number of constraints in the circuit

--- a/circuits/src/zk_circuits/proof_linking/output_balance.rs
+++ b/circuits/src/zk_circuits/proof_linking/output_balance.rs
@@ -13,7 +13,10 @@ use crate::zk_circuits::{
         OUTPUT_BALANCE_SETTLEMENT_PARTY0_LINK, OUTPUT_BALANCE_SETTLEMENT_PARTY1_LINK,
         intent_and_balance_private_settlement::IntentAndBalancePrivateSettlementCircuit,
     },
-    validity_proofs::output_balance::OutputBalanceValidityCircuit,
+    validity_proofs::{
+        new_output_balance::NewOutputBalanceValidityCircuit,
+        output_balance::OutputBalanceValidityCircuit,
+    },
 };
 
 // --------------------------------------------------------------------
@@ -56,7 +59,7 @@ pub fn link_output_balance_settlement_with_party<const MERKLE_HEIGHT: usize>(
 ) -> Result<PlonkLinkProof, ProverError> {
     // Get the group layout for the validity <-> settlement link group
     let layout = get_group_layout(party_id)?;
-    let pk = OutputBalanceValidityCircuit::<MERKLE_HEIGHT>::proving_key();
+    let pk = NewOutputBalanceValidityCircuit::<MERKLE_HEIGHT>::proving_key();
 
     PlonkKzgSnark::link_proofs::<SolidityTranscript>(
         validity_link_hint,
@@ -259,6 +262,8 @@ mod test {
 
         // Align the settlement witness with the validity witness
         settlement_witness.out_balance = validity_witness.balance.clone();
+        settlement_statement.relayer_fee_recipient =
+            settlement_witness.out_balance.relayer_fee_recipient;
         let out_shares = validity_witness.post_match_balance_shares.clone();
         settlement_witness.pre_settlement_out_balance_shares = out_shares.clone();
         settlement_statement.out_balance_public_shares = out_shares;
@@ -336,6 +341,8 @@ mod test {
 
         // Align the settlement witness with the validity witness
         settlement_witness.out_balance = validity_witness.balance.clone();
+        settlement_statement.relayer_fee_recipient =
+            settlement_witness.out_balance.relayer_fee_recipient;
         let out_shares = validity_witness.post_match_balance_shares.clone();
         settlement_witness.pre_settlement_out_balance_shares = out_shares.clone();
         settlement_statement.out_balance_public_shares = out_shares;

--- a/circuits/src/zk_circuits/settlement/settlement_lib.rs
+++ b/circuits/src/zk_circuits/settlement/settlement_lib.rs
@@ -262,7 +262,7 @@ impl BoundedSettlementGadget {
     ///
     /// Note: The balance.mint == intent.in_token constraint is enforced by
     /// the INTENT AND BALANCE VALIDITY proof via proof-linking.
-    pub fn verify_in_balance_constraints(
+    fn verify_in_balance_constraints(
         in_balance: &BalanceVar,
         bounded_match_result: &BoundedMatchResultVar,
         cs: &mut PlonkCircuit,
@@ -280,7 +280,7 @@ impl BoundedSettlementGadget {
     ///
     /// The contract validates that min <= max <= amount_in, so we only need to
     /// check the upper bound here.
-    pub fn verify_out_balance_constraints(
+    fn verify_out_balance_constraints(
         out_balance: &BalanceVar,
         intent: &IntentVar,
         bounded_match_result: &BoundedMatchResultVar,


### PR DESCRIPTION
### Purpose
This PR makes the following optimizations/changes to the `NEW OUTPUT BALANCE VALIDITY` circuit:
1. Uses the shared commitment gadget to share commitment prefixes between the initial balance commitment and the partial commitment that is output in the statement. These commitments overlap in all shares, so this greatly reduces the redundant hashing.
2. Remove the in-circuit stream cipher encryption. Instead, we treat the user's signature over the new balance as an authorization of the stream states and shares.
3. Add a nullifier for the existing balance from which we bootstrap. On-chain we'll check that this nullifier hasn't been spent. This prevents bootstrapping from old, outdated balances. This isn't strictly necessary for safety, but prevents corner cases where e.g. a key leaks and old balances may be allocated under the old key.

### Todo
- Update contract handlers for this circuit.

### Testing
- [x] Unit tests pass