### PR TITLE
circuits: zk-circuits: intent-only-bounded-settlement: Add proof linking

### DIFF
--- a/circuits/src/zk_circuits/proof_linking/intent_only.rs
+++ b/circuits/src/zk_circuits/proof_linking/intent_only.rs
@@ -10,18 +10,18 @@ use mpc_relation::proof_linking::GroupLayout;
 
 use crate::zk_circuits::{
     settlement::{
-        INTENT_ONLY_PUBLIC_SETTLEMENT_LINK,
+        INTENT_ONLY_SETTLEMENT_LINK,
         intent_only_public_settlement::IntentOnlyPublicSettlementCircuit,
     },
     validity_proofs::intent_only::IntentOnlyValidityCircuit,
 };
 
-// ----------------------------------------------------------
-// | Intent Only Validity <-> Intent Only Public Settlement |
-// ----------------------------------------------------------
+// ----------------------------------------------------------------------
+// | Intent Only Validity <-> Intent Only Settlement (Exact or Bounded) |
+// ----------------------------------------------------------------------
 
 /// Link an intent only validity proof with a proof of INTENT ONLY
-/// PUBLIC SETTLEMENT using the system wide sizing constants
+/// SETTLEMENT (exact or bounded) using the system wide sizing constants
 pub fn link_sized_intent_only_settlement(
     validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
@@ -30,13 +30,13 @@ pub fn link_sized_intent_only_settlement(
 }
 
 /// Link an intent only validity proof with a proof of INTENT ONLY
-/// PUBLIC SETTLEMENT
+/// SETTLEMENT (exact or bounded)
 pub fn link_intent_only_settlement<const MERKLE_HEIGHT: usize>(
     validity_link_hint: &ProofLinkingHint,
     settlement_link_hint: &ProofLinkingHint,
 ) -> Result<PlonkLinkProof, ProverError> {
     // Get the group layout for the first fill <-> settlement link group
-    let layout = get_intent_public_settlement_group_layout()?;
+    let layout = get_intent_only_settlement_group_layout()?;
     let pk = IntentOnlyValidityCircuit::<MERKLE_HEIGHT>::proving_key();
 
     PlonkKzgSnark::link_proofs::<SolidityTranscript>(
@@ -49,8 +49,8 @@ pub fn link_intent_only_settlement<const MERKLE_HEIGHT: usize>(
 }
 
 /// Validate a link between an intent only validity proof with a
-/// proof of INTENT ONLY PUBLIC SETTLEMENT using the system wide sizing
-/// constants
+/// proof of INTENT ONLY SETTLEMENT (exact or bounded) using the system wide
+/// sizing constants
 pub fn validate_sized_intent_only_settlement_link(
     link_proof: &PlonkLinkProof,
     validity_proof: &PlonkProof,
@@ -64,14 +64,14 @@ pub fn validate_sized_intent_only_settlement_link(
 }
 
 /// Validate a link between an intent only validity proof with a
-/// proof of INTENT ONLY PUBLIC SETTLEMENT
+/// proof of INTENT ONLY SETTLEMENT (exact or bounded)
 pub fn validate_intent_only_settlement_link<const MERKLE_HEIGHT: usize>(
     link_proof: &PlonkLinkProof,
     validity_proof: &PlonkProof,
     settlement_proof: &PlonkProof,
 ) -> Result<(), ProverError> {
     // Get the group layout for the first fill <-> settlement link group
-    let layout = get_intent_public_settlement_group_layout()?;
+    let layout = get_intent_only_settlement_group_layout()?;
     let vk = IntentOnlyValidityCircuit::<MERKLE_HEIGHT>::verifying_key();
 
     PlonkKzgSnark::verify_link_proof::<SolidityTranscript>(
@@ -84,12 +84,14 @@ pub fn validate_intent_only_settlement_link<const MERKLE_HEIGHT: usize>(
     .map_err(ProverError::Plonk)
 }
 
-/// Get the group layout for the intent only validity <-> public settlement link
-/// group
-pub fn get_intent_public_settlement_group_layout() -> Result<GroupLayout, ProverError> {
+/// Get the group layout for the intent only validity <-> intent only settlement
+/// link group
+///
+/// This layout is shared by both exact and bounded settlement circuits.
+pub fn get_intent_only_settlement_group_layout() -> Result<GroupLayout, ProverError> {
     let circuit_layout =
         IntentOnlyPublicSettlementCircuit::get_circuit_layout().map_err(ProverError::Plonk)?;
-    Ok(circuit_layout.get_group_layout(INTENT_ONLY_PUBLIC_SETTLEMENT_LINK))
+    Ok(circuit_layout.get_group_layout(INTENT_ONLY_SETTLEMENT_LINK))
 }
 
 #[cfg(test)]
@@ -97,9 +99,12 @@ mod test {
     use super::*;
     use crate::{
         singleprover_prove_with_hint,
-        zk_circuits::validity_proofs::{
-            intent_only::IntentOnlyValidityCircuit,
-            intent_only_first_fill::IntentOnlyFirstFillValidityCircuit,
+        zk_circuits::{
+            settlement::intent_only_bounded_settlement::IntentOnlyBoundedSettlementCircuit,
+            validity_proofs::{
+                intent_only::IntentOnlyValidityCircuit,
+                intent_only_first_fill::IntentOnlyFirstFillValidityCircuit,
+            },
         },
     };
     use circuit_types::traits::SingleProverCircuit;
@@ -111,13 +116,17 @@ mod test {
     /// Intent only validity with testing sizing
     type SizedIntentOnlyValidity = IntentOnlyValidityCircuit<TEST_MERKLE_HEIGHT>;
 
+    // --------------------
+    // | Exact Settlement |
+    // --------------------
+
     // -----------
     // | Helpers |
     // -----------
 
     /// Prove INTENT ONLY FIRST FILL VALIDITY and INTENT ONLY PUBLIC SETTLEMENT,
     /// then link the proofs and verify the link
-    fn test_intent_first_fill_settlement_link(
+    fn test_intent_first_fill_exact_settlement_link(
         first_fill_witness: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
         first_fill_statement: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
         settlement_witness: <IntentOnlyPublicSettlementCircuit as SingleProverCircuit>::Witness,
@@ -150,7 +159,7 @@ mod test {
     ///
     /// This involves modifying the witness and statements for each circuit to
     /// align with one another so that they may be linked
-    fn build_intent_first_fill_settlement_data() -> (
+    fn build_intent_first_fill_exact_settlement_data() -> (
         <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
         <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
         <IntentOnlyPublicSettlementCircuit as SingleProverCircuit>::Witness,
@@ -180,7 +189,7 @@ mod test {
     ///
     /// This involves modifying the witness and statements for each circuit to
     /// align with one another so that they may be linked
-    fn build_intent_validity_settlement_data() -> (
+    fn build_intent_validity_exact_settlement_data() -> (
         <SizedIntentOnlyValidity as SingleProverCircuit>::Witness,
         <SizedIntentOnlyValidity as SingleProverCircuit>::Statement,
         <IntentOnlyPublicSettlementCircuit as SingleProverCircuit>::Witness,
@@ -208,7 +217,7 @@ mod test {
 
     /// Prove INTENT ONLY VALIDITY and INTENT ONLY PUBLIC SETTLEMENT, then link
     /// the proofs and verify the link
-    fn test_intent_validity_settlement_link(
+    fn test_intent_validity_exact_settlement_link(
         validity_witness: <SizedIntentOnlyValidity as SingleProverCircuit>::Witness,
         validity_statement: <SizedIntentOnlyValidity as SingleProverCircuit>::Statement,
         settlement_witness: <IntentOnlyPublicSettlementCircuit as SingleProverCircuit>::Witness,
@@ -243,11 +252,11 @@ mod test {
     /// and a proof of INTENT ONLY PUBLIC SETTLEMENT
     #[cfg_attr(feature = "ci", ignore)]
     #[test]
-    fn test_intent_first_fill_settlement_valid_link() {
+    fn test_intent_first_fill_exact_settlement_valid_link() {
         let (first_fill_witness, first_fill_statement, settlement_witness, settlement_statement) =
-            build_intent_first_fill_settlement_data();
+            build_intent_first_fill_exact_settlement_data();
 
-        test_intent_first_fill_settlement_link(
+        test_intent_first_fill_exact_settlement_link(
             first_fill_witness,
             first_fill_statement,
             settlement_witness,
@@ -260,11 +269,11 @@ mod test {
     /// of INTENT ONLY PUBLIC SETTLEMENT
     #[cfg_attr(feature = "ci", ignore)]
     #[test]
-    fn test_intent_validity_settlement_valid_link() {
+    fn test_intent_validity_exact_settlement_valid_link() {
         let (validity_witness, validity_statement, settlement_witness, settlement_statement) =
-            build_intent_validity_settlement_data();
+            build_intent_validity_exact_settlement_data();
 
-        test_intent_validity_settlement_link(
+        test_intent_validity_exact_settlement_link(
             validity_witness,
             validity_statement,
             settlement_witness,
@@ -280,18 +289,213 @@ mod test {
     #[test]
     #[should_panic(expected = "ProofLinkVerification")]
     #[allow(non_snake_case)]
-    fn test_intent_first_fill_settlement_invalid_link__modified_intent() {
+    fn test_intent_first_fill_exact_settlement_invalid_link__modified_intent() {
         let (
             first_fill_witness,
             first_fill_statement,
             mut settlement_witness,
             settlement_statement,
-        ) = build_intent_first_fill_settlement_data();
+        ) = build_intent_first_fill_exact_settlement_data();
 
         // Modify the intent in the settlement witness to break the link
         settlement_witness.intent.amount_in += 1;
 
-        test_intent_first_fill_settlement_link(
+        test_intent_first_fill_exact_settlement_link(
+            first_fill_witness,
+            first_fill_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+
+    // ----------------------
+    // | Bounded Settlement |
+    // ----------------------
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Prove INTENT ONLY FIRST FILL VALIDITY and INTENT ONLY BOUNDED
+    /// SETTLEMENT, then link the proofs and verify the link
+    fn test_intent_first_fill_bounded_settlement_link(
+        first_fill_witness: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
+        first_fill_statement: <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
+        settlement_witness: <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Witness,
+        settlement_statement: <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Statement,
+    ) -> Result<(), ProverError> {
+        // Create a proof of INTENT ONLY FIRST FILL VALIDITY and one of INTENT ONLY
+        // BOUNDED SETTLEMENT
+        let (first_fill_proof, first_fill_hint) = singleprover_prove_with_hint::<
+            SizedIntentOnlyFirstFillValidity,
+        >(
+            &first_fill_witness, &first_fill_statement
+        )?;
+        let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
+            IntentOnlyBoundedSettlementCircuit,
+        >(
+            &settlement_witness, &settlement_statement
+        )?;
+
+        // Link the proofs and verify the link
+        let link_proof =
+            link_intent_only_settlement::<TEST_MERKLE_HEIGHT>(&first_fill_hint, &settlement_hint)?;
+        validate_intent_only_settlement_link::<TEST_MERKLE_HEIGHT>(
+            &link_proof,
+            &first_fill_proof,
+            &settlement_proof,
+        )
+    }
+
+    /// Build a first fill and bounded settlement witness and statement with
+    /// valid data
+    ///
+    /// This involves modifying the witness and statements for each circuit to
+    /// align with one another so that they may be linked
+    fn build_intent_first_fill_bounded_settlement_data() -> (
+        <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Witness,
+        <SizedIntentOnlyFirstFillValidity as SingleProverCircuit>::Statement,
+        <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Witness,
+        <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Statement,
+    ) {
+        use crate::test_helpers::random_intent;
+        use crate::zk_circuits::{
+            settlement::intent_only_bounded_settlement::test_helpers::create_witness_statement_with_intent as create_settlement_witness_statement,
+            validity_proofs::intent_only_first_fill::test_helpers::create_witness_statement_with_intent as create_first_fill_witness_statement,
+        };
+
+        // Create a random intent
+        let intent = random_intent();
+
+        // Create the first fill witness and statement
+        let (first_fill_witness, first_fill_statement) =
+            create_first_fill_witness_statement(&intent);
+
+        // Create the settlement witness and statement with the same intent
+        let (settlement_witness, settlement_statement) =
+            create_settlement_witness_statement(&intent);
+
+        (first_fill_witness, first_fill_statement, settlement_witness, settlement_statement)
+    }
+
+    /// Build a validity and bounded settlement witness and statement with valid
+    /// data
+    ///
+    /// This involves modifying the witness and statements for each circuit to
+    /// align with one another so that they may be linked
+    fn build_intent_validity_bounded_settlement_data() -> (
+        <SizedIntentOnlyValidity as SingleProverCircuit>::Witness,
+        <SizedIntentOnlyValidity as SingleProverCircuit>::Statement,
+        <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Witness,
+        <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Statement,
+    ) {
+        use crate::test_helpers::random_intent;
+        use crate::zk_circuits::{
+            settlement::intent_only_bounded_settlement::test_helpers::create_witness_statement_with_intent as create_settlement_witness_statement,
+            validity_proofs::intent_only::test_helpers::create_witness_statement_with_intent as create_validity_witness_statement,
+        };
+
+        // Create a random intent
+        let intent = random_intent();
+
+        // Create the validity witness and statement
+        let (validity_witness, validity_statement) =
+            create_validity_witness_statement::<TEST_MERKLE_HEIGHT>(intent.clone());
+
+        // Create the settlement witness and statement with the same intent
+        let (settlement_witness, settlement_statement) =
+            create_settlement_witness_statement(&intent);
+
+        (validity_witness, validity_statement, settlement_witness, settlement_statement)
+    }
+
+    /// Prove INTENT ONLY VALIDITY and INTENT ONLY BOUNDED SETTLEMENT, then link
+    /// the proofs and verify the link
+    fn test_intent_validity_bounded_settlement_link(
+        validity_witness: <SizedIntentOnlyValidity as SingleProverCircuit>::Witness,
+        validity_statement: <SizedIntentOnlyValidity as SingleProverCircuit>::Statement,
+        settlement_witness: <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Witness,
+        settlement_statement: <IntentOnlyBoundedSettlementCircuit as SingleProverCircuit>::Statement,
+    ) -> Result<(), ProverError> {
+        // Create a proof of INTENT ONLY VALIDITY and one of INTENT ONLY BOUNDED
+        // SETTLEMENT
+        let (validity_proof, validity_hint) = singleprover_prove_with_hint::<
+            SizedIntentOnlyValidity,
+        >(&validity_witness, &validity_statement)?;
+        let (settlement_proof, settlement_hint) = singleprover_prove_with_hint::<
+            IntentOnlyBoundedSettlementCircuit,
+        >(
+            &settlement_witness, &settlement_statement
+        )?;
+
+        // Link the proofs and verify the link
+        let link_proof =
+            link_intent_only_settlement::<TEST_MERKLE_HEIGHT>(&validity_hint, &settlement_hint)?;
+        validate_intent_only_settlement_link::<TEST_MERKLE_HEIGHT>(
+            &link_proof,
+            &validity_proof,
+            &settlement_proof,
+        )
+    }
+
+    // --------------
+    // | Test Cases |
+    // --------------
+
+    /// Tests a valid link between a proof of INTENT ONLY FIRST FILL VALIDITY
+    /// and a proof of INTENT ONLY BOUNDED SETTLEMENT
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    fn test_intent_first_fill_bounded_settlement_valid_link() {
+        let (first_fill_witness, first_fill_statement, settlement_witness, settlement_statement) =
+            build_intent_first_fill_bounded_settlement_data();
+
+        test_intent_first_fill_bounded_settlement_link(
+            first_fill_witness,
+            first_fill_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+
+    /// Tests a valid link between a proof of INTENT ONLY VALIDITY and a proof
+    /// of INTENT ONLY BOUNDED SETTLEMENT
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    fn test_intent_validity_bounded_settlement_valid_link() {
+        let (validity_witness, validity_statement, settlement_witness, settlement_statement) =
+            build_intent_validity_bounded_settlement_data();
+
+        test_intent_validity_bounded_settlement_link(
+            validity_witness,
+            validity_statement,
+            settlement_witness,
+            settlement_statement,
+        )
+        .unwrap();
+    }
+
+    /// Tests an invalid link between a proof of INTENT ONLY FIRST FILL VALIDITY
+    /// and a proof of INTENT ONLY BOUNDED SETTLEMENT wherein the intent is
+    /// modified between the two proofs
+    #[cfg_attr(feature = "ci", ignore)]
+    #[test]
+    #[should_panic(expected = "ProofLinkVerification")]
+    #[allow(non_snake_case)]
+    fn test_intent_first_fill_bounded_settlement_invalid_link__modified_intent() {
+        let (
+            first_fill_witness,
+            first_fill_statement,
+            mut settlement_witness,
+            settlement_statement,
+        ) = build_intent_first_fill_bounded_settlement_data();
+
+        // Modify the intent in the settlement witness to break the link
+        settlement_witness.intent.amount_in += 1;
+
+        test_intent_first_fill_bounded_settlement_link(
             first_fill_witness,
             first_fill_statement,
             settlement_witness,

--- a/circuits/src/zk_circuits/settlement/intent_only_public_settlement.rs
+++ b/circuits/src/zk_circuits/settlement/intent_only_public_settlement.rs
@@ -24,7 +24,7 @@ use mpc_relation::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::INTENT_ONLY_PUBLIC_SETTLEMENT_LINK;
+use super::INTENT_ONLY_SETTLEMENT_LINK;
 use crate::{SingleProverCircuit, zk_circuits::settlement::settlement_lib::SettlementGadget};
 
 // ----------------------
@@ -115,12 +115,12 @@ impl SingleProverCircuit for IntentOnlyPublicSettlementCircuit {
     }
 
     /// INTENT ONLY PUBLIC SETTLEMENT has one proof linking group:
-    /// - intent_only_public_settlement: The linking group between INTENT ONLY
-    ///   VALIDITY and INTENT ONLY PUBLIC SETTLEMENT. This group is placed by
-    ///   this circuit.
+    /// - intent_only_settlement: The linking group between INTENT ONLY VALIDITY
+    ///   and INTENT ONLY PUBLIC SETTLEMENT. This group is placed by this
+    ///   circuit.
     fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
         // Place the linking group (the intent validity circuit will inherit it)
-        Ok(vec![(INTENT_ONLY_PUBLIC_SETTLEMENT_LINK.to_string(), None)])
+        Ok(vec![(INTENT_ONLY_SETTLEMENT_LINK.to_string(), None)])
     }
 
     fn apply_constraints(

--- a/circuits/src/zk_circuits/settlement/mod.rs
+++ b/circuits/src/zk_circuits/settlement/mod.rs
@@ -14,8 +14,8 @@ pub mod intent_only_public_settlement;
 pub mod settlement_lib;
 
 /// The group name for the INTENT ONLY VALIDITY <-> INTENT ONLY
-/// SETTLEMENT link
-pub const INTENT_ONLY_PUBLIC_SETTLEMENT_LINK: &str = "intent_only_settlement";
+/// SETTLEMENT link for both exact and bounded settlement circuits
+pub const INTENT_ONLY_SETTLEMENT_LINK: &str = "intent_only_settlement";
 
 /// The group name for the INTENT AND BALANCE VALIDITY <-> INTENT
 /// AND BALANCE SETTLEMENT link

--- a/circuits/src/zk_circuits/validity_proofs/intent_only.rs
+++ b/circuits/src/zk_circuits/validity_proofs/intent_only.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SingleProverCircuit,
     zk_circuits::settlement::{
-        INTENT_ONLY_PUBLIC_SETTLEMENT_LINK,
+        INTENT_ONLY_SETTLEMENT_LINK,
         intent_only_public_settlement::IntentOnlyPublicSettlementCircuit,
     },
     zk_gadgets::{
@@ -155,7 +155,7 @@ pub struct IntentOnlyValidityWitness<const MERKLE_HEIGHT: usize> {
     ///
     /// This value is denormalized from the `old_intent` to enable proof linking
     /// between this circuit's witness and the `INTENT ONLY PUBLIC
-    /// SETTLEMENT` circuit's witness.
+    /// SETTLEMENT` / `INTENT ONLY BOUNDED SETTLEMENT` circuit's witness.
     #[link_groups = "intent_only_settlement"]
     pub intent: Intent,
 }
@@ -213,14 +213,15 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit for IntentOnlyValidityCircu
         format!("Intent Only Validity ({MERKLE_HEIGHT})")
     }
 
-    /// INTENT ONLY VALIDITY has a single proof linking group:
-    /// - intent_only_public_settlement: The linking group between INTENT ONLY
-    ///   VALIDITY and INTENT ONLY PUBLIC SETTLEMENT. This group is placed by
-    ///   the settlement circuit, so we inherit its layout here.
+    /// INTENT ONLY VALIDITY has one proof linking group:
+    /// - intent_only_settlement: The linking group between INTENT ONLY VALIDITY
+    ///   and both INTENT ONLY PUBLIC SETTLEMENT and INTENT ONLY BOUNDED
+    ///   SETTLEMENT. This group is placed by INTENT ONLY PUBLIC SETTLEMENT, so
+    ///   we inherit its layout here.
     fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
         let layout = IntentOnlyPublicSettlementCircuit::get_circuit_layout()?;
-        let settlement_group = layout.get_group_layout(INTENT_ONLY_PUBLIC_SETTLEMENT_LINK);
-        let group_name = INTENT_ONLY_PUBLIC_SETTLEMENT_LINK.to_string();
+        let settlement_group = layout.get_group_layout(INTENT_ONLY_SETTLEMENT_LINK);
+        let group_name = INTENT_ONLY_SETTLEMENT_LINK.to_string();
 
         Ok(vec![(group_name, Some(settlement_group))])
     }

--- a/circuits/src/zk_circuits/validity_proofs/intent_only_first_fill.rs
+++ b/circuits/src/zk_circuits/validity_proofs/intent_only_first_fill.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SingleProverCircuit,
     zk_circuits::settlement::{
-        INTENT_ONLY_PUBLIC_SETTLEMENT_LINK,
+        INTENT_ONLY_SETTLEMENT_LINK,
         intent_only_public_settlement::IntentOnlyPublicSettlementCircuit,
     },
     zk_gadgets::{
@@ -161,13 +161,14 @@ impl SingleProverCircuit for IntentOnlyFirstFillValidityCircuit {
     }
 
     /// INTENT ONLY FIRST FILL VALIDITY has one proof linking group:
-    /// - intent_only_public_settlement: The linking group between INTENT ONLY
-    ///   FIRST FILL VALIDITY and INTENT ONLY PUBLIC SETTLEMENT. This group is
-    ///   placed by the settlement circuit, so we inherit its layout here.
+    /// - intent_only_settlement: The linking group between INTENT ONLY FIRST
+    ///   FILL VALIDITY and both INTENT ONLY PUBLIC SETTLEMENT and INTENT ONLY
+    ///   BOUNDED SETTLEMENT. This group is placed by INTENT ONLY PUBLIC
+    ///   SETTLEMENT, so we inherit its layout here.
     fn proof_linking_groups() -> Result<Vec<(String, Option<GroupLayout>)>, PlonkError> {
         let layout = IntentOnlyPublicSettlementCircuit::get_circuit_layout()?;
-        let settlement_group = layout.get_group_layout(INTENT_ONLY_PUBLIC_SETTLEMENT_LINK);
-        let group_name = INTENT_ONLY_PUBLIC_SETTLEMENT_LINK.to_string();
+        let settlement_group = layout.get_group_layout(INTENT_ONLY_SETTLEMENT_LINK);
+        let group_name = INTENT_ONLY_SETTLEMENT_LINK.to_string();
 
         Ok(vec![(group_name, Some(settlement_group))])
     }


### PR DESCRIPTION
### Purpose

This PR adds proof linking helpers and tests between `INTENT ONLY VALIDITY` <-> `INTENT ONLY BOUNDED SETTLEMENT` and `INTENT ONLY FIRST FILL VALIDITY` <-> `INTENT ONLY BOUNDED SETTLEMENT`. 

The witness value being linked is the same between intent only public settlement and intent only bounded settlement, thus we share layouts by having the bounded circuit inherit the layout from the public circuit which places the link group.

### Testing

- [x] All tests pass