### PR TITLE
state: storage: cursor: Re-implement using rkyv

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![deny(unsafe_code)]
 #![allow(incomplete_features)]
+#![feature(inherent_associated_types)]
 #![feature(let_chains)]
 #![feature(io_error_more)]
 

--- a/crates/state/src/storage/db.rs
+++ b/crates/state/src/storage/db.rs
@@ -105,7 +105,7 @@ impl DB {
     ) -> Result<Option<V>, StorageError> {
         let tx = self.new_raw_read_tx()?;
         let archived: Option<&V::Archived> = tx.read::<_, V>(table_name, key)?;
-        let val = archived.map(|a| V::rkyv_deserialize(a));
+        let val = archived.map(|a| V::rkyv_deserialize(a)).transpose()?;
         tx.commit()?;
 
         Ok(val)

--- a/crates/state/src/storage/mod.rs
+++ b/crates/state/src/storage/mod.rs
@@ -1,7 +1,7 @@
 //! Defines the access patterns and interface to the durable storage layer
 //! concretely implemented as an `mdbx` instance
 
-// pub mod cursor;
+pub mod cursor;
 pub mod db;
 pub mod error;
 pub mod traits;


### PR DESCRIPTION
### Purpose
This PR adds back the storage cursor to the storage module using `rkyv` as the base serialization.

### Testing
- [x] All tests pass