### PR TITLE
state: storage: traits: Refactor `RkyvValue` trait to be `With` compatible

### DIFF
--- a/crates/state/src/applicator/task_queue.rs
+++ b/crates/state/src/applicator/task_queue.rs
@@ -136,7 +136,7 @@ impl StateApplicator {
 
         tx.transition_task(&task_id, state)?;
         let updated_task = tx.get_task(&task_id)?.expect("task should exist");
-        let task = QueuedTask::rkyv_deserialize(&updated_task)?;
+        let task = QueuedTask::from_archived(&updated_task)?;
         tx.commit()?;
 
         self.publish_task_updates_multiple(&keys, &task);
@@ -263,7 +263,7 @@ impl StateApplicator {
             .ok_or_else(|| StateApplicatorError::MissingEntry(ERR_UNASSIGNED_TASK))?;
 
         if *executor == my_peer_id {
-            let task = QueuedTask::rkyv_deserialize(task)?;
+            let task = QueuedTask::from_archived(task)?;
             let job = TaskDriverJob::run(task);
             self.config.task_queue.send(job).map_err(StateApplicatorError::enqueue_task)?;
         }

--- a/crates/state/src/replication/log_store.rs
+++ b/crates/state/src/replication/log_store.rs
@@ -142,7 +142,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         self.with_read_tx(move |tx| {
             let last_purged_log_id = tx
                 .get_last_purged_log_id()?
-                .map(|v| WrappedLogId::rkyv_deserialize(&v))
+                .map(|v| WrappedLogId::from_archived(&v))
                 .transpose()?
                 .map(|v| v.into());
 
@@ -173,7 +173,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
     async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, RaftStorageError<NodeId>> {
         self.with_read_tx(move |tx| {
             let archived_vote = res_some!(tx.get_last_vote()?);
-            let vote = WrappedVote::rkyv_deserialize(&archived_vote)?.into();
+            let vote = WrappedVote::from_archived(&archived_vote)?.into();
 
             Ok(Some(vote))
         })

--- a/crates/state/src/storage/archived_value.rs
+++ b/crates/state/src/storage/archived_value.rs
@@ -34,7 +34,7 @@ impl<'a, V: Value> ArchivedValue<'a, V> {
 
     /// Deserialize to an owned value
     pub fn deserialize(&self) -> Result<V, StorageError> {
-        V::rkyv_deserialize(&**self)
+        V::rkyv_deserialize_from_bytes(&self.backing)
     }
 
     /// Get the raw bytes
@@ -44,7 +44,7 @@ impl<'a, V: Value> ArchivedValue<'a, V> {
 }
 
 impl<V: Value> Deref for ArchivedValue<'_, V> {
-    type Target = V::Archived;
+    type Target = V::ArchivedType;
 
     #[allow(unsafe_code)]
     fn deref(&self) -> &Self::Target {

--- a/crates/state/src/storage/cursor.rs
+++ b/crates/state/src/storage/cursor.rs
@@ -28,7 +28,7 @@ pub struct DbCursor<'txn, Tx: TransactionKind, K: Key, V: Value> {
     ///
     /// This is a boxed closure to allow capturing borrowed data (e.g. a prefix)
     #[allow(clippy::type_complexity)]
-    key_filter: Option<Box<dyn Fn(&K::Archived) -> bool + 'txn>>,
+    key_filter: Option<Box<dyn Fn(&K::ArchivedType) -> bool + 'txn>>,
     /// A phantom data field to hold the deserialized type of
     /// the table
     _phantom: PhantomData<(K, V)>,
@@ -57,7 +57,7 @@ impl<'txn, Tx: TransactionKind, K: Key, V: Value> DbCursor<'txn, Tx, K, V> {
     ///
     /// Consumes the cursor to provide a builder-like pattern.
     /// Accepts any closure, including those that capture borrowed data.
-    pub fn with_key_filter(mut self, filter: impl Fn(&K::Archived) -> bool + 'txn) -> Self {
+    pub fn with_key_filter(mut self, filter: impl Fn(&K::ArchivedType) -> bool + 'txn) -> Self {
         self.key_filter = Some(Box::new(filter));
         self
     }

--- a/crates/state/src/storage/traits.rs
+++ b/crates/state/src/storage/traits.rs
@@ -1,18 +1,23 @@
 //! Defines traits for storage access
 
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 use rkyv::{
-    Archive, Deserialize, Portable, Serialize as RkyvSerialize,
+    Archive, Deserialize, Portable, Serialize,
     api::high::{HighSerializer, HighValidator},
     bytecheck::CheckBytes,
     de::Pool,
     rancor::{self, Strategy},
     ser::allocator::ArenaHandle,
     util::AlignedVec,
+    with::{ArchiveWith, DeserializeWith, SerializeWith, With},
 };
 
 use crate::storage::error::StorageError;
+
+// ---------------------
+// | Key Value Markers |
+// ---------------------
 
 /// A trait encapsulating the bounds on a key type
 pub trait Key: RkyvValue + Debug + Clone {}
@@ -26,37 +31,25 @@ impl<T: RkyvValue> Value for T {}
 // | Rkyv Wrappers |
 // -----------------
 
-/// A wrapper trait around rkyv compatible types
+/// A trait encapsulating the behavior of a (de)serializable value
 ///
-/// Pushing functionality into this trait allows us to operate generically at
-/// the storage layer without excessive trait bounds.
-pub trait RkyvValue: Archive<Archived = Self::ArchivedType> + RkyvSerializable + Sized {
+/// We structure the trait in generic terms without requiring bounds on the
+/// types or the trait itself. This is done to allow both native rkyv-capable
+/// types and non-rkyv types wrapped in `With` (below) to be used
+/// interchangeably.
+pub trait RkyvValue: Sized {
     /// The archived type of the value
-    type ArchivedType: Portable
-        + Debug
-        + for<'a> CheckBytes<HighValidator<'a, rancor::Error>>
-        + Deserialize<Self, Strategy<Pool, rancor::Error>>;
+    ///
+    /// This is the type that we may view in a zero-copy manner, without fully
+    /// deserializing.
+    type ArchivedType;
 
-    /// Deserialize the value from an archived type
-    fn rkyv_deserialize(archived: &Self::ArchivedType) -> Result<Self, StorageError> {
-        rkyv::deserialize::<_, rancor::Error>(archived).map_err(StorageError::serialization)
-    }
-
+    /// Deserialize the value from its archived type
+    fn from_archived(archived: &Self::ArchivedType) -> Result<Self, StorageError>;
     /// Deserialize the value from bytes
-    fn rkyv_deserialize_from_bytes(bytes: &[u8]) -> Result<Self, StorageError> {
-        rkyv::from_bytes::<_, rancor::Error>(bytes).map_err(StorageError::serialization)
-    }
-
-    /// Serialize the value to a byte vector
-    fn rkyv_serialize(&self) -> Result<Vec<u8>, StorageError>
-    where
-        Self: Sized,
-    {
-        rkyv::to_bytes::<rancor::Error>(self)
-            .map_err(StorageError::serialization)
-            .map(|v| v.into_vec())
-    }
-
+    fn rkyv_deserialize_from_bytes(bytes: &[u8]) -> Result<Self, StorageError>;
+    /// Serialize the value to bytes
+    fn rkyv_serialize(&self) -> Result<Vec<u8>, StorageError>;
     /// Access the value without deserializing it
     ///
     /// This method is zero-copy
@@ -67,32 +60,161 @@ pub trait RkyvValue: Archive<Archived = Self::ArchivedType> + RkyvSerializable +
     /// the type. The bytes must have been produced by rkyv serialization
     /// and must be valid for the lifetime of the returned reference.
     #[allow(unsafe_code)]
-    unsafe fn rkyv_access(value_bytes: &[u8]) -> &Self::Archived {
-        unsafe { rkyv::access_unchecked::<Self::Archived>(value_bytes) }
+    unsafe fn rkyv_access(value_bytes: &[u8]) -> &Self::ArchivedType;
+    /// Access the value and validate the bytes
+    fn rkyv_access_validated(value_bytes: &[u8]) -> Result<&Self::ArchivedType, StorageError>;
+}
+
+/// An implementation of the `RkyvValue` trait for rkyv-compatible types
+impl<A, T> RkyvValue for T
+where
+    T: Archive<Archived = A>,
+    T: RkyvSerializable2,
+    A: ArchivedValue,
+    A: RkyvDeserializable2<T>,
+{
+    type ArchivedType = A;
+
+    #[inline]
+    fn from_archived(archived: &Self::ArchivedType) -> Result<Self, StorageError> {
+        rkyv::deserialize::<_, rancor::Error>(archived).map_err(StorageError::serialization)
     }
 
-    /// Access the value and validate the bytes
-    fn rkyv_access_validated(value_bytes: &[u8]) -> Result<&Self::Archived, StorageError> {
-        rkyv::access::<Self::Archived, rancor::Error>(value_bytes)
+    #[inline]
+    fn rkyv_deserialize_from_bytes(bytes: &[u8]) -> Result<Self, StorageError> {
+        rkyv::from_bytes::<_, rancor::Error>(bytes).map_err(StorageError::serialization)
+    }
+
+    #[inline]
+    fn rkyv_serialize(&self) -> Result<Vec<u8>, StorageError> {
+        rkyv::to_bytes::<rancor::Error>(self)
+            .map_err(StorageError::serialization)
+            .map(|v| v.into_vec())
+    }
+
+    #[inline]
+    #[allow(unsafe_code)]
+    unsafe fn rkyv_access(value_bytes: &[u8]) -> &Self::ArchivedType {
+        unsafe { rkyv::access_unchecked::<Self::ArchivedType>(value_bytes) }
+    }
+
+    #[inline]
+    fn rkyv_access_validated(value_bytes: &[u8]) -> Result<&Self::ArchivedType, StorageError> {
+        rkyv::access::<Self::ArchivedType, rancor::Error>(value_bytes)
             .map_err(StorageError::serialization)
     }
 }
-impl<T: Archive + RkyvSerializable> RkyvValue for T
-where
-    T::Archived: Portable
-        + Debug
-        + for<'a> CheckBytes<HighValidator<'a, rancor::Error>>
-        + Deserialize<T, Strategy<Pool, rancor::Error>>,
-{
-    type ArchivedType = T::Archived;
+
+/// A type that wraps a remote (non-rkyv) type and implements the `RkyvValue`
+/// trait
+///
+/// This is a clone of the `rkyv::With` wrapper; but we localize the type to
+/// this crate to prevent foreign implementation conflicts from the rkyv crate.
+///
+/// `T` is the wrapped type and `W` is the remote type shim that implements the
+/// `rkyv::with` traits for `T`
+pub struct RkyvWith<T: Sized, W> {
+    /// The wrapped value
+    inner: T,
+    /// Phantom
+    _phantom: PhantomData<W>,
 }
 
-/// A trait encapsulating the serialization behavior of a type
-pub trait RkyvSerializable:
-    for<'a> RkyvSerialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>
+impl<T: Sized, W> RkyvWith<T, W> {
+    /// Create a new RkyvWith
+    pub fn new(inner: T) -> Self {
+        Self { inner, _phantom: PhantomData }
+    }
+
+    /// Get the wrapped value
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T, W, A> RkyvValue for RkyvWith<T, W>
+where
+    T: Sized,
+    A: ArchivedValue,
+    W: ArchiveWith<T, Archived = A>,
+    W: RkyvSerializableWith<T>,
+    W: RkyvDeserializableWith<A, T>,
+{
+    type ArchivedType = A;
+
+    #[inline]
+    fn from_archived(archived: &Self::ArchivedType) -> Result<Self, StorageError> {
+        // Use the rkyv `With` type to broker this implementation
+        let with: &With<A, W> = With::cast(archived);
+        let inner: T =
+            rkyv::deserialize::<_, rancor::Error>(with).map_err(StorageError::serialization)?;
+
+        Ok(Self { inner, _phantom: PhantomData })
+    }
+
+    #[inline]
+    #[allow(unsafe_code)]
+    fn rkyv_deserialize_from_bytes(bytes: &[u8]) -> Result<Self, StorageError> {
+        let archived = unsafe { Self::rkyv_access(bytes) };
+        Self::from_archived(archived)
+    }
+
+    #[inline]
+    fn rkyv_serialize(&self) -> Result<Vec<u8>, StorageError> {
+        let with = With::<T, W>::cast(&self.inner);
+        rkyv::to_bytes::<rancor::Error>(with)
+            .map_err(StorageError::serialization)
+            .map(|v| v.into_vec())
+    }
+
+    #[inline]
+    #[allow(unsafe_code)]
+    unsafe fn rkyv_access(value_bytes: &[u8]) -> &Self::ArchivedType {
+        unsafe { rkyv::access_unchecked::<A>(value_bytes) }
+    }
+
+    #[inline]
+    fn rkyv_access_validated(value_bytes: &[u8]) -> Result<&Self::ArchivedType, StorageError> {
+        rkyv::access::<A, rancor::Error>(value_bytes).map_err(StorageError::serialization)
+    }
+}
+
+// --- Bound Traits --- //
+
+/// Bound trait for the bounds on an archived value
+trait ArchivedValue: Portable + for<'a> CheckBytes<HighValidator<'a, rancor::Error>> {}
+impl<A> ArchivedValue for A where A: Portable + for<'a> CheckBytes<HighValidator<'a, rancor::Error>> {}
+
+/// Bound trait for the bounds on a serializable type
+trait RkyvSerializable2:
+    for<'a> Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>
 {
 }
-impl<T: for<'a> RkyvSerialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>>
-    RkyvSerializable for T
+impl<T: for<'a> Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>>
+    RkyvSerializable2 for T
+{
+}
+
+/// Bound trait for a serializable with type
+trait RkyvSerializableWith<T>:
+    for<'a> SerializeWith<T, HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>
+{
+}
+impl<T, S: for<'a> SerializeWith<T, HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>>
+    RkyvSerializableWith<T> for S
+{
+}
+
+/// Bound trait for the bounds on a deserializable type
+trait RkyvDeserializable2<T>: for<'a> Deserialize<T, Strategy<Pool, rancor::Error>> {}
+impl<T, D: for<'a> Deserialize<T, Strategy<Pool, rancor::Error>>> RkyvDeserializable2<T> for D {}
+
+/// Bound trait for a deserializable with type
+trait RkyvDeserializableWith<A, T>:
+    for<'a> DeserializeWith<A, T, Strategy<Pool, rancor::Error>>
+{
+}
+impl<A, T, D: for<'a> DeserializeWith<A, T, Strategy<Pool, rancor::Error>>>
+    RkyvDeserializableWith<A, T> for D
 {
 }

--- a/crates/state/src/storage/tx/task_queue/storage.rs
+++ b/crates/state/src/storage/tx/task_queue/storage.rs
@@ -178,7 +178,7 @@ impl<T: TransactionKind> StateTxn<'_, T> {
         let mut can_preempt = queue.can_preempt_serial();
         if let Some(t) = queue.serial_tasks.first() {
             let task = self.get_task(t)?.ok_or(StorageError::reject(ERR_TASK_NOT_FOUND))?;
-            let state = QueuedTaskState::rkyv_deserialize(&task.state)?;
+            let state = QueuedTaskState::from_archived(&task.state)?;
             can_preempt = can_preempt && !state.is_committed();
         }
 


### PR DESCRIPTION
### Purpose

Refactor the `RkyvValue` trait to be compatible with rkyv's `With` pattern. This allows both native rkyv-capable types and non-rkyv types wrapped in `With` to be used interchangeably at the storage layer.

### Testing

- [x] Unit tests pass