### PR TITLE
state: replication: Add tests for snapshot and raft proposals back

### DIFF
--- a/crates/state/src/replication/mock_raft.rs
+++ b/crates/state/src/replication/mock_raft.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
-use types_gossip::mocks::{mock_peer, mock_peer_id};
+use types_gossip::mocks::mock_peer_id;
 use util::concurrency::{AsyncShared, new_async_shared};
 
 use crate::replication::raft::{RaftClient, RaftClientConfig};

--- a/crates/state/src/replication/state_machine/mod.rs
+++ b/crates/state/src/replication/state_machine/mod.rs
@@ -316,34 +316,33 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         replication::mock_raft::mock_state_machine,
-//         state_transition::{Proposal, StateTransition},
-//     };
-//     use openraft::{Entry, EntryPayload, LeaderId, LogId,
-// storage::RaftStateMachine};
+#[cfg(test)]
+mod test {
+    use crate::{
+        replication::mock_raft::mock_state_machine,
+        state_transition::{Proposal, StateTransition},
+    };
+    use openraft::{Entry, EntryPayload, LeaderId, LogId, storage::RaftStateMachine};
 
-//     /// Tests applying a log with a waiter on the state
-//     #[tokio::test]
-//     async fn test_await_application() {
-//         let mut sm = mock_state_machine().await;
-//         let notifs = sm.notifications.clone();
+    /// Tests applying a log with a waiter on the state
+    #[tokio::test]
+    async fn test_await_application() {
+        let mut sm = mock_state_machine().await;
+        let notifs = sm.notifications.clone();
 
-//         // Add a proposal and await its notification
-//         let transition = StateTransition::CreateMatchingPool { pool_name:
-// "test-pool".to_string() };         let prop = Proposal::from(transition);
-//         let rx = notifs.register_notification(prop.id).await;
+        // Add a proposal and await its notification
+        let transition = StateTransition::CreateMatchingPool { pool_name: "test-pool".to_string() };
+        let prop = Proposal::from(transition);
+        let rx = notifs.register_notification(prop.id).await;
 
-//         // Append a log with this proposal
-//         let leader_id = LeaderId::new(1 /* term */, 1 /* node */);
-//         let log_id = LogId::new(leader_id, 1 /* index */);
-//         let entry = Entry { log_id, payload: EntryPayload::Normal(prop) };
-//         sm.apply(vec![entry]).await.unwrap();
+        // Append a log with this proposal
+        let leader_id = LeaderId::new(1 /* term */, 1 /* node */);
+        let log_id = LogId::new(leader_id, 1 /* index */);
+        let entry = Entry { log_id, payload: EntryPayload::Normal(prop) };
+        sm.apply(vec![entry]).await.unwrap();
 
-//         // Await the notification
-//         let res = rx.await.unwrap();
-//         assert!(res.is_ok());
-//     }
-// }
+        // Await the notification
+        let res = rx.await.unwrap();
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION
### Purpose

Uncomment and update replication tests that were previously commented out:
- Update raft proposal tests in `replication/mod.rs` to use account terminology instead of wallet terminology
- Update snapshot tests in `replication/state_machine/snapshot.rs` to use account terminology and matching pools instead of validity proofs
- Add TODO comment for order cache test that remains commented out pending order cache hydration implementation

### Testing

- [x] Unit tests pass