### PR TITLE
Refactor: Rename IntentIdentifier to OrderId and add Order type with metadata

### DIFF
--- a/crates/api/external-api/src/http/admin.rs
+++ b/crates/api/external-api/src/http/admin.rs
@@ -5,7 +5,7 @@
 // ---------------
 
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_runtime::MatchingPoolName;
 
 use crate::{
@@ -59,7 +59,7 @@ pub struct IsLeaderResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenOrdersResponse {
     /// The open order IDs
-    pub orders: Vec<IntentIdentifier>,
+    pub orders: Vec<OrderId>,
 }
 
 /// The request type to add a new order to a given wallet, within a non-global
@@ -96,5 +96,5 @@ pub struct AdminGetOrderMatchingPoolResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AdminWalletMatchableOrderIdsResponse {
     /// The order IDs
-    pub order_ids: Vec<IntentIdentifier>,
+    pub order_ids: Vec<OrderId>,
 }

--- a/crates/api/external-api/src/types/api_wallet.rs
+++ b/crates/api/external-api/src/types/api_wallet.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use types_account::{
     keyed_list::KeyedList,
     wallet::{
-        IntentIdentifier, Order, Wallet, WalletIdentifier,
+        Order, OrderId, Wallet, WalletIdentifier,
         keychain::{KeyChain, PrivateKeyChain},
     },
 };
@@ -168,8 +168,8 @@ pub struct ApiOrder {
     pub allow_external_matches: bool,
 }
 
-impl From<(IntentIdentifier, Order)> for ApiOrder {
-    fn from((order_id, order): (IntentIdentifier, Order)) -> Self {
+impl From<(OrderId, Order)> for ApiOrder {
+    fn from((order_id, order): (OrderId, Order)) -> Self {
         ApiOrder {
             id: order_id,
             quote_mint: order.quote_mint,

--- a/crates/api/gossip-api/src/pubsub/cluster.rs
+++ b/crates/api/gossip-api/src/pubsub/cluster.rs
@@ -1,7 +1,7 @@
 //! Cluster communications broadcast via Pubsub
 
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_gossip::{ClusterId, WrappedPeerId};
 
 /// A message from one cluster peer to the rest indicating cluster management
@@ -23,14 +23,14 @@ pub enum ClusterManagementMessageType {
     /// Recipients should place this order pair in an invisibility window and
     /// not schedule it for handshake until the invisibility period has
     /// elapsed and either resulted in a match or an error
-    MatchInProgress(IntentIdentifier, IntentIdentifier),
+    MatchInProgress(OrderId, OrderId),
     /// A cache synchronization update wherein the sender informs its cluster
     /// peers that it has run the match computation on a given pair of
     /// orders
     ///
     /// The peers should cache this order pair as completed, and not initiate
     /// handshakes with other peers on this order
-    CacheSync(IntentIdentifier, IntentIdentifier),
+    CacheSync(OrderId, OrderId),
     /// Propose a peer expiry to the cluster
     ///
     /// Peers will check the last heartbeat they received from the expiry

--- a/crates/api/gossip-api/src/pubsub/orderbook.rs
+++ b/crates/api/gossip-api/src/pubsub/orderbook.rs
@@ -2,7 +2,7 @@
 
 use circuit_types::Nullifier;
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_gossip::ClusterId;
 
 /// The network pubsub topic to use for listening to orderbook changes
@@ -15,7 +15,7 @@ pub enum OrderBookManagementMessage {
     /// received state in their local book
     OrderReceived {
         /// The identifier of the new order
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         /// The public share nullifier of the new order's wallet
         nullifier: Nullifier,
         /// The cluster that manages this order
@@ -25,7 +25,7 @@ pub enum OrderBookManagementMessage {
     /// be placed in the `Verified` state after local peers verify the proof
     OrderProofUpdated {
         /// The identifier of the now updated order
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         /// The cluster that manages this order
         cluster: ClusterId,
         /// The new validity proof bundle for the order, containing a proof of

--- a/crates/api/gossip-api/src/request_response/handshake.rs
+++ b/crates/api/gossip-api/src/request_response/handshake.rs
@@ -1,6 +1,6 @@
 //! Groups API definitions for handshake request response
 use std::collections::HashMap;
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_core::{TimestampedPrice, Token};
 use types_gossip::WrappedPeerId;
 use uuid::Uuid;
@@ -65,9 +65,9 @@ pub struct ProposeMatchCandidate {
     /// The ID of the peer proposing a match candidate
     pub peer_id: WrappedPeerId,
     /// The recipient's order that the sender is proposing a match with
-    pub peer_order: IntentIdentifier,
+    pub peer_order: OrderId,
     /// The sender's order that it wishes to match against the receiver's
-    pub sender_order: IntentIdentifier,
+    pub sender_order: OrderId,
     /// The vector of prices that the sender is proposing to the receiver
     pub price_vector: PriceVector,
 }
@@ -84,10 +84,10 @@ pub struct RejectMatchCandidate {
     pub peer_id: WrappedPeerId,
     /// The recipient's order, i.e. the order that the proposer used from
     /// their own managed book
-    pub peer_order: IntentIdentifier,
+    pub peer_order: OrderId,
     /// The order of the sender, i.e. the peer that rejects the match
     /// proposal
-    pub sender_order: IntentIdentifier,
+    pub sender_order: OrderId,
     /// The reason that the rejecting peer is rejecting the proposal
     pub reason: MatchRejectionReason,
 }
@@ -113,7 +113,7 @@ pub struct AcceptMatchCandidate {
     /// The port that the sender can be dialed on to begin the request
     pub port: u16,
     /// The first order to attempt to match
-    pub order1: IntentIdentifier,
+    pub order1: OrderId,
     /// The second order to attempt to match
-    pub order2: IntentIdentifier,
+    pub order2: OrderId,
 }

--- a/crates/api/gossip-api/src/request_response/heartbeat.rs
+++ b/crates/api/gossip-api/src/request_response/heartbeat.rs
@@ -1,6 +1,6 @@
 //! Groups API definitions for heartbeat requests and responses
 
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_gossip::{PeerInfo, WrappedPeerId};
 
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ pub struct HeartbeatMessage {
     /// The list of peer IDs known to the sending node
     pub known_peers: Vec<WrappedPeerId>,
     /// The list of orders known to the sending node
-    pub known_orders: Vec<IntentIdentifier>,
+    pub known_orders: Vec<OrderId>,
 }
 
 /// Defines a request to bootstrap the cluster state from the recipient

--- a/crates/api/gossip-api/src/request_response/orderbook.rs
+++ b/crates/api/gossip-api/src/request_response/orderbook.rs
@@ -1,13 +1,13 @@
 //! Types for request response about order book info
 
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 
 /// The message type used to request order information from a peer
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OrderInfoRequest {
     /// The IDs of the orders
-    pub order_ids: Vec<IntentIdentifier>,
+    pub order_ids: Vec<OrderId>,
 }
 
 /// The message type used to response with order information to a peer

--- a/crates/relayer-types/types-account/src/account/mod.rs
+++ b/crates/relayer-types/types-account/src/account/mod.rs
@@ -6,6 +6,7 @@
 pub mod keychain;
 #[cfg(feature = "mocks")]
 pub mod mocks;
+pub mod order;
 pub mod pair;
 
 use std::collections::HashMap;
@@ -24,7 +25,7 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize, 
 use crate::MerkleAuthenticationPath;
 
 /// An identifier of an order used for caching
-pub type IntentIdentifier = Uuid;
+pub type OrderId = Uuid;
 /// The name of a matching pool
 pub type MatchingPoolName = String;
 
@@ -39,7 +40,7 @@ pub struct Account {
     /// The identifier used to index the wallet
     pub wallet_id: AccountId,
     /// A list of intents in this account
-    pub intents: HashMap<IntentIdentifier, Intent>,
+    pub intents: HashMap<OrderId, Intent>,
     /// A list of balances in this account
     #[cfg_attr(feature = "rkyv", rkyv(with = with::MapKV<AddressDef, with::Identity>))]
     pub balances: HashMap<Address, Balance>,

--- a/crates/relayer-types/types-account/src/account/order.rs
+++ b/crates/relayer-types/types-account/src/account/order.rs
@@ -1,0 +1,116 @@
+//! The order type for an account
+//!
+//! This type wraps an intent and adds metadata to the order that doesn't appear
+//! in the circuits (and thereby the intent) directly.
+
+use circuit_types::Amount;
+use darkpool_types::intent::Intent;
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::{OrderId, pair::Pair};
+
+/// The order type for an account
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
+pub struct Order {
+    /// The id of the order
+    pub id: OrderId,
+    /// The intent
+    pub intent: Intent,
+    /// The metadata for the order
+    pub metadata: OrderMetadata,
+}
+
+/// The metadata for an order
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
+pub struct OrderMetadata {
+    /// The minimum fill size for the order
+    pub min_fill_size: Amount,
+    /// Whether or not to allow external matches
+    pub allow_external_matches: bool,
+}
+
+impl Order {
+    /// Create a new order from the given intent and metadata
+    pub fn new(intent: Intent, metadata: OrderMetadata) -> Self {
+        let id = OrderId::new_v4();
+        Self { id, intent, metadata }
+    }
+
+    /// Get a reference to the intent
+    pub fn intent(&self) -> &Intent {
+        &self.intent
+    }
+
+    /// Get a reference to the metadata
+    pub fn metadata(&self) -> &OrderMetadata {
+        &self.metadata
+    }
+
+    /// Get the pair for the order
+    pub fn pair(&self) -> Pair {
+        Pair::new(self.intent.in_token, self.intent.out_token)
+    }
+
+    /// Get the min fill size for the order
+    pub fn min_fill_size(&self) -> Amount {
+        self.metadata.min_fill_size
+    }
+
+    /// Whether the order has external matches enabled
+    pub fn allow_external_matches(&self) -> bool {
+        self.metadata.allow_external_matches
+    }
+}
+
+impl OrderMetadata {
+    /// Create a new order metadata from the given min fill size and allow
+    /// external matches
+    pub fn new(min_fill_size: Amount, allow_external_matches: bool) -> Self {
+        Self { min_fill_size, allow_external_matches }
+    }
+}
+
+impl From<Order> for Intent {
+    fn from(order: Order) -> Self {
+        order.intent
+    }
+}
+
+impl From<Intent> for Order {
+    fn from(intent: Intent) -> Self {
+        Self::new(intent, OrderMetadata::default())
+    }
+}
+
+impl Default for OrderMetadata {
+    fn default() -> Self {
+        Self { min_fill_size: 0, allow_external_matches: true }
+    }
+}
+
+#[cfg(feature = "mocks")]
+/// Mock types for order testing
+pub mod mocks {
+    use super::{Order, OrderMetadata};
+    use crate::{account::mocks::mock_intent, pair::Pair};
+
+    /// Create a mock order for testing
+    pub fn mock_order() -> Order {
+        let intent = mock_intent();
+        Order::new(intent, OrderMetadata::default())
+    }
+
+    /// Create a mock order with the given pair
+    pub fn mock_order_with_pair(pair: Pair) -> Order {
+        let mut intent = mock_intent();
+        intent.in_token = pair.in_token;
+        intent.out_token = pair.out_token;
+        Order::new(intent, OrderMetadata::default())
+    }
+}

--- a/crates/relayer-types/types-account/src/account/pair.rs
+++ b/crates/relayer-types/types-account/src/account/pair.rs
@@ -10,9 +10,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Pair {
     /// The input token on the pair
-    in_token: Address,
+    pub in_token: Address,
     /// The output token on the pair
-    out_token: Address,
+    pub out_token: Address,
 }
 
 impl Pair {

--- a/crates/state/src/applicator/account_index.rs
+++ b/crates/state/src/applicator/account_index.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use libmdbx::RW;
 use system_bus::{ADMIN_WALLET_UPDATES_TOPIC, SystemBusMessage, account_topic};
-use types_account::account::{Account, IntentIdentifier};
+use types_account::account::{Account, OrderId};
 
 use crate::storage::tx::StateTxn;
 
@@ -98,7 +98,7 @@ impl StateApplicator {
     }
 
     /// Handle a cancelled intent
-    fn handle_cancelled_intent(&self, id: IntentIdentifier, tx: &StateTxn<RW>) -> Result<()> {
+    fn handle_cancelled_intent(&self, id: OrderId, tx: &StateTxn<RW>) -> Result<()> {
         // Remove the intent from its matching pool
         tx.remove_intent_from_matching_pool(&id)?;
 

--- a/crates/state/src/applicator/matching_pools.rs
+++ b/crates/state/src/applicator/matching_pools.rs
@@ -1,6 +1,6 @@
 //! Applicator methods for matching pools
 
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 
 use crate::storage::tx::matching_pools::MATCHING_POOL_DOES_NOT_EXIST_ERR;
 
@@ -39,7 +39,7 @@ impl StateApplicator {
     /// Assign an intent to a matching pool
     pub fn assign_intent_to_matching_pool(
         &self,
-        intent_id: &IntentIdentifier,
+        intent_id: &OrderId,
         pool_name: &str,
     ) -> Result<ApplicatorReturnType, StateApplicatorError> {
         let tx = self.db().new_write_tx()?;
@@ -52,7 +52,7 @@ impl StateApplicator {
 
 #[cfg(test)]
 mod test {
-    use types_account::account::IntentIdentifier;
+    use types_account::account::OrderId;
     use types_runtime::MatchingPoolName;
 
     use crate::applicator::test_helpers::mock_applicator;
@@ -96,7 +96,7 @@ mod test {
     fn test_assign_intent_to_matching_pool() {
         let applicator = mock_applicator();
         let pool_name: MatchingPoolName = TEST_POOL_NAME.to_string();
-        let intent_id = IntentIdentifier::new_v4();
+        let intent_id = OrderId::new_v4();
 
         // Create a matching pool, then assign the intent
         applicator.create_matching_pool(&pool_name).unwrap();
@@ -114,7 +114,7 @@ mod test {
         let applicator = mock_applicator();
         let pool_1_name: MatchingPoolName = "pool-1".to_string();
         let pool_2_name: MatchingPoolName = "pool-2".to_string();
-        let intent_id = IntentIdentifier::new_v4();
+        let intent_id = OrderId::new_v4();
 
         // Create both matching pools
         applicator.create_matching_pool(&pool_1_name).unwrap();
@@ -146,7 +146,7 @@ mod test {
     fn test_assign_intent_to_nonexistent_matching_pool() {
         let applicator = mock_applicator();
         let pool_name: MatchingPoolName = TEST_POOL_NAME.to_string();
-        let intent_id = IntentIdentifier::new_v4();
+        let intent_id = OrderId::new_v4();
 
         // Try assigning the intent to a nonexistent matching pool
         let result = applicator.assign_intent_to_matching_pool(&intent_id, &pool_name);

--- a/crates/state/src/caching/order_cache.rs
+++ b/crates/state/src/caching/order_cache.rs
@@ -4,14 +4,19 @@
 //! intents on a given asset
 
 use circuit_types::Amount;
-use darkpool_types::intent::Intent;
 use dashmap::DashSet;
 use tracing::instrument;
-use types_account::account::{IntentIdentifier, pair::Pair};
+use types_account::{
+    account::{OrderId, pair::Pair},
+    order::Order,
+};
 
-use crate::storage::{db::DB, error::StorageError};
+use crate::{
+    caching::order_metadata_index::OrderMetadataIndex,
+    storage::{db::DB, error::StorageError},
+};
 
-use super::{matchable_amount::MatchableAmountMap, order_metadata_index::IntentMetadataIndex};
+use super::matchable_amount::MatchableAmountMap;
 
 /// A filter for querying the order book cache
 #[derive(Clone, Debug)]
@@ -39,9 +44,9 @@ pub struct OrderBookCache {
     /// This may not be a subset of `matchable_intents`, some externally
     /// matchable intents may not be yet matchable, e.g. if they are waiting for
     /// validity proofs
-    externally_enabled_intents: DashSet<IntentIdentifier>,
+    externally_enabled_intents: DashSet<OrderId>,
     /// The index of intent metadata
-    intent_metadata_index: IntentMetadataIndex,
+    order_metadata_index: OrderMetadataIndex,
     /// Mapping of matchable amount at the midpoint of a pair
     matchable_amount_map: MatchableAmountMap,
 }
@@ -51,7 +56,7 @@ impl OrderBookCache {
     pub fn new() -> Self {
         Self {
             externally_enabled_intents: DashSet::new(),
-            intent_metadata_index: IntentMetadataIndex::new(),
+            order_metadata_index: OrderMetadataIndex::new(),
             matchable_amount_map: MatchableAmountMap::new(),
         }
     }
@@ -59,8 +64,8 @@ impl OrderBookCache {
     // --- Getters --- //
 
     /// Get intents matching a filter
-    pub fn get_intents(&self, filter: &OrderBookFilter) -> Vec<IntentIdentifier> {
-        let intents = self.intent_metadata_index.get_intents(&filter.pair);
+    pub fn get_intents(&self, filter: &OrderBookFilter) -> Vec<OrderId> {
+        let intents = self.order_metadata_index.get_intents(&filter.pair);
         if filter.external {
             intents.into_iter().filter(|id| self.externally_enabled_intents.contains(id)).collect()
         } else {
@@ -69,13 +74,13 @@ impl OrderBookCache {
     }
 
     /// Returns whether an intent exists in the cache
-    pub fn intent_exists(&self, id: IntentIdentifier) -> bool {
-        self.intent_metadata_index.intent_exists(&id)
+    pub fn intent_exists(&self, id: OrderId) -> bool {
+        self.order_metadata_index.intent_exists(&id)
     }
 
     /// Get all intents that match any filter
-    pub fn get_all_intents(&self) -> Vec<IntentIdentifier> {
-        self.intent_metadata_index.get_all_intents()
+    pub fn get_all_intents(&self) -> Vec<OrderId> {
+        self.order_metadata_index.get_all_intents()
     }
 
     /// Get the matchable amount for both sides of a pair
@@ -89,23 +94,21 @@ impl OrderBookCache {
     // --- Setters --- //
 
     /// Add an intent to the cache
-    pub fn add_intent(&self, id: IntentIdentifier, intent: &Intent, matchable_amount: Amount) {
-        self.intent_metadata_index.add_intent(id, intent, matchable_amount);
-        // TODO: Implement externally enabled intents
-        // if intent.allow_external_matches {
-        //     self.externally_enabled_intents.write().await.insert(id);
-        //     let pair = Pair::from_intent(intent);
-        //     self.matchable_amount_map.add_amount(pair,
-        // matchable_amount).await; }
+    pub fn add_order(&self, order: &Order, matchable_amount: Amount) {
+        self.order_metadata_index.add_intent(order.id, order.intent(), matchable_amount);
+        if order.allow_external_matches() {
+            self.externally_enabled_intents.insert(order.id);
+            self.matchable_amount_map.add_amount(order.pair(), matchable_amount);
+        }
     }
 
-    /// Update an intent in the cache
-    pub fn update_intent(&self, id: IntentIdentifier, matchable_amount: Amount) {
-        let pair = self.intent_metadata_index.get_pair(&id).unwrap();
+    /// Update an order in the cache
+    pub fn update_order(&self, id: OrderId, matchable_amount: Amount) {
+        let pair = self.order_metadata_index.get_pair(&id).unwrap();
 
         // Update the index and get the previous matchable amount
         let old_amount =
-            self.intent_metadata_index.update_matchable_amount(id, matchable_amount).unwrap_or(0);
+            self.order_metadata_index.update_matchable_amount(id, matchable_amount).unwrap_or(0);
 
         if self.externally_enabled_intents.contains(&id) {
             // Update the matchable amount map with the delta
@@ -119,34 +122,34 @@ impl OrderBookCache {
         }
     }
 
-    /// Mark an intent as externally matchable
-    pub fn mark_intent_externally_matchable(&self, intent: IntentIdentifier) {
-        self.externally_enabled_intents.insert(intent);
+    /// Mark an order as externally matchable
+    pub fn mark_order_externally_matchable(&self, order: &Order) {
+        self.externally_enabled_intents.insert(order.id);
     }
 
-    /// Remove an intent from the cache entirely
-    pub fn remove_intent(&self, intent: IntentIdentifier) {
-        let maybe_info = self.intent_metadata_index.remove_intent(&intent);
+    /// Remove an order from the cache entirely
+    pub fn remove_order(&self, id: OrderId) {
+        let maybe_info = self.order_metadata_index.remove_intent(&id);
         if maybe_info.is_none() {
             return;
         }
         let (pair, matchable_amount) = maybe_info.unwrap();
 
-        if self.externally_enabled_intents.remove(&intent).is_some() {
+        if self.externally_enabled_intents.remove(&id).is_some() {
             self.matchable_amount_map.sub_amount(pair, matchable_amount);
         }
     }
 
     /// Remove an externally enabled intent
-    pub fn remove_externally_enabled_intent(&self, intent: IntentIdentifier) {
+    pub fn remove_externally_enabled_intent(&self, intent: OrderId) {
         self.externally_enabled_intents.remove(&intent);
     }
 
     /// Backfill the intent cache from a DB
     ///
     /// This method may be used to populate the cache on startup
-    #[instrument(skip(self, db))]
-    pub fn hydrate_from_db(&self, db: &DB) -> Result<(), StorageError> {
+    #[instrument(skip(self, _db))]
+    pub fn hydrate_from_db(&self, _db: &DB) -> Result<(), StorageError> {
         // TODO: Implement intent book storage
         // let tx = db.new_read_tx()?;
         // let intents = tx.get_local_intents()?;
@@ -181,7 +184,7 @@ impl OrderBookCache {
 
 #[cfg(test)]
 mod test {
-    use types_account::mocks::mock_intent;
+    use types_account::order::mocks::{mock_order, mock_order_with_pair};
 
     use super::*;
 
@@ -189,20 +192,20 @@ mod test {
     #[test]
     fn test_get_intents_basic() {
         let cache = OrderBookCache::new();
-        let intent_id = IntentIdentifier::new_v4();
-        let intent = mock_intent();
-        let pair = Pair::from_intent(&intent);
+        let order = mock_order();
+        let order_id = order.id;
+        let pair = order.pair();
 
-        // Add an intent to the cache
-        cache.add_intent(intent_id, &intent, 100 /* matchable_amount */);
+        // Add an order to the cache
+        cache.add_order(&order, 100 /* matchable_amount */);
 
         let filter = OrderBookFilter::new(pair, false /* external */);
         let intents = cache.get_intents(&filter);
         assert_eq!(intents.len(), 1);
-        assert_eq!(intents[0], intent_id);
+        assert_eq!(intents[0], order_id);
 
         // Remove the intent from the cache
-        cache.remove_intent(intent_id);
+        cache.remove_order(order_id);
         let intents = cache.get_intents(&filter);
         assert_eq!(intents.len(), 0);
     }
@@ -211,26 +214,25 @@ mod test {
     #[test]
     fn test_get_intents_multiple() {
         let cache = OrderBookCache::new();
-        let intent_id1 = IntentIdentifier::new_v4();
-        let intent_id2 = IntentIdentifier::new_v4();
-        let intent_id3 = IntentIdentifier::new_v4();
-        let intent = mock_intent();
-        let pair = Pair::from_intent(&intent);
+        let order1 = mock_order();
+        let pair = order1.pair();
+        let order2 = mock_order_with_pair(pair);
+        let order3 = mock_order_with_pair(pair);
 
-        cache.add_intent(intent_id1, &intent, 100 /* matchable_amount */);
-        cache.add_intent(intent_id2, &intent, 300 /* matchable_amount */);
-        cache.add_intent(intent_id3, &intent, 200 /* matchable_amount */);
+        cache.add_order(&order1, 100 /* matchable_amount */);
+        cache.add_order(&order2, 300 /* matchable_amount */);
+        cache.add_order(&order3, 200 /* matchable_amount */);
 
         let filter = OrderBookFilter::new(pair, false /* external */);
         let intents = cache.get_intents(&filter);
         assert_eq!(intents.len(), 3);
-        assert_eq!(intents, vec![intent_id2, intent_id3, intent_id1]);
+        assert_eq!(intents, vec![order2.id, order3.id, order1.id]);
 
         // Remove the middle intent
-        cache.remove_intent(intent_id3);
+        cache.remove_order(order3.id);
         let intents = cache.get_intents(&filter);
         assert_eq!(intents.len(), 2);
-        assert_eq!(intents, vec![intent_id2, intent_id1]);
+        assert_eq!(intents, vec![order2.id, order1.id]);
     }
 
     // TODO: Implement external intents
@@ -238,9 +240,9 @@ mod test {
     // #[test]
     // fn test_get_intents_external() {
     //     let cache = IntentBookCache::new();
-    //     let intent_id1 = IntentIdentifier::new_v4();
-    //     let intent_id2 = IntentIdentifier::new_v4();
-    //     let intent_id3 = IntentIdentifier::new_v4();
+    //     let intent_id1 = OrderId::new_v4();
+    //     let intent_id2 = OrderId::new_v4();
+    //     let intent_id3 = OrderId::new_v4();
     //     let mut intent1 = mock_intent();
     //     let mut intent2 = intent1.clone();
     //     let mut intent3 = intent1.clone();
@@ -268,39 +270,36 @@ mod test {
     #[test]
     fn test_get_intents_different_pairs() {
         let cache = OrderBookCache::new();
-        let intent_id1 = IntentIdentifier::new_v4();
-        let intent_id2 = IntentIdentifier::new_v4();
-        let intent_id3 = IntentIdentifier::new_v4();
-        let intent1 = mock_intent();
-        let intent2 = mock_intent();
-        let intent3 = intent1.clone();
-        let pair1 = Pair::from_intent(&intent1);
-        let pair2 = Pair::from_intent(&intent2);
+        let order1 = mock_order();
+        let order2 = mock_order();
+        let pair1 = order1.pair();
+        let pair2 = order2.pair();
+        let order3 = mock_order_with_pair(pair1);
 
-        cache.add_intent(intent_id1, &intent1, 300 /* matchable_amount */);
-        cache.add_intent(intent_id2, &intent2, 100 /* matchable_amount */);
-        cache.add_intent(intent_id3, &intent3, 200 /* matchable_amount */);
+        cache.add_order(&order1, 300 /* matchable_amount */);
+        cache.add_order(&order2, 100 /* matchable_amount */);
+        cache.add_order(&order3, 200 /* matchable_amount */);
 
         // Check the first pair
         let filter1 = OrderBookFilter::new(pair1, false /* external */);
         let intents = cache.get_intents(&filter1);
         assert_eq!(intents.len(), 2);
-        assert_eq!(intents, vec![intent_id1, intent_id3]);
+        assert_eq!(intents, vec![order1.id, order3.id]);
 
         // Check the second pair
         let filter2 = OrderBookFilter::new(pair2, false /* external */);
         let intents = cache.get_intents(&filter2);
         assert_eq!(intents.len(), 1);
-        assert_eq!(intents, vec![intent_id2]);
+        assert_eq!(intents, vec![order2.id]);
 
         // Remove from the first pair
-        cache.remove_intent(intent_id1);
+        cache.remove_order(order1.id);
         let intents = cache.get_intents(&filter1);
         assert_eq!(intents.len(), 1);
-        assert_eq!(intents, vec![intent_id3]);
+        assert_eq!(intents, vec![order3.id]);
 
         // Remove from the second pair
-        cache.remove_intent(intent_id2);
+        cache.remove_order(order2.id);
         let intents = cache.get_intents(&filter2);
         assert_eq!(intents.len(), 0);
     }

--- a/crates/state/src/interface/matching_pools.rs
+++ b/crates/state/src/interface/matching_pools.rs
@@ -4,7 +4,7 @@
 // | Constants |
 // -------------
 
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_runtime::MatchingPoolName;
 
 use crate::{StateInner, StateTransition, error::StateError, notifications::ProposalWaiter};
@@ -18,7 +18,7 @@ impl StateInner {
     /// assigned to one
     pub async fn get_matching_pool_for_intent(
         &self,
-        intent_id: &IntentIdentifier,
+        intent_id: &OrderId,
     ) -> Result<MatchingPoolName, StateError> {
         let intent_id = *intent_id;
         self.with_read_tx(move |tx| {
@@ -63,7 +63,7 @@ impl StateInner {
     /// Assign an intent to a matching pool
     pub async fn assign_intent_to_matching_pool(
         &self,
-        intent_id: IntentIdentifier,
+        intent_id: OrderId,
         pool_name: MatchingPoolName,
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::AssignIntentToMatchingPool { intent_id, pool_name })

--- a/crates/state/src/interface/order_history.rs
+++ b/crates/state/src/interface/order_history.rs
@@ -1,6 +1,6 @@
 //! State interface methods for order metadata
 
-use types_account::account::{IntentIdentifier, WalletIdentifier, order_metadata::OrderMetadata};
+use types_account::account::{OrderId, WalletIdentifier, order_metadata::OrderMetadata};
 use util::res_some;
 
 use crate::{
@@ -19,7 +19,7 @@ impl StateInner {
     /// Get the metadata for an order
     pub async fn get_order_metadata(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<Option<OrderMetadata>, StateError> {
         let oid = *order_id;
         self.with_read_tx(move |tx| {
@@ -79,7 +79,7 @@ pub mod test {
         let mut rng = thread_rng();
         let data = mock_order();
         OrderMetadata {
-            id: IntentIdentifier::new_v4(),
+            id: OrderId::new_v4(),
             data,
             state: OrderState::Created,
             fills: vec![],

--- a/crates/state/src/interface/wallet_index.rs
+++ b/crates/state/src/interface/wallet_index.rs
@@ -4,8 +4,8 @@
 //! order them
 
 use circuit_types::{balance::Balance, wallet::Nullifier};
+use types_account::account::{Order, OrderId, Wallet, WalletIdentifier};
 use types_tasks::QueuedTask;
-use types_account::account::{Order, IntentIdentifier, Wallet, WalletIdentifier};
 use util::res_some;
 
 use crate::{StateInner, StateTransition, error::StateError, notifications::ProposalWaiter};
@@ -57,10 +57,7 @@ impl StateInner {
     }
 
     /// Get the plaintext order for a locally managed order ID
-    pub async fn get_managed_order(
-        &self,
-        id: &IntentIdentifier,
-    ) -> Result<Option<Order>, StateError> {
+    pub async fn get_managed_order(&self, id: &OrderId) -> Result<Option<Order>, StateError> {
         let id = *id;
         self.with_read_tx(move |tx| {
             let wallet = res_some!(tx.get_wallet_for_order(&id)?);
@@ -72,7 +69,7 @@ impl StateInner {
     /// Get the order for a given order ID and the balance that capitalizes it
     pub async fn get_managed_order_and_balance(
         &self,
-        id: &IntentIdentifier,
+        id: &OrderId,
     ) -> Result<Option<(Order, Balance)>, StateError> {
         let id = *id;
         self.with_read_tx(move |tx| {
@@ -90,7 +87,7 @@ impl StateInner {
     /// Get the wallet ID that contains the given order ID
     pub async fn get_wallet_id_for_order(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<Option<WalletIdentifier>, StateError> {
         let oid = *order_id;
         self.with_read_tx(move |tx| {
@@ -103,7 +100,7 @@ impl StateInner {
     /// Get the wallet that contains the given order ID
     pub async fn get_wallet_for_order(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<Option<Wallet>, StateError> {
         let oid = *order_id;
         self.with_read_tx(move |tx| {
@@ -162,7 +159,7 @@ mod test {
     use common::types::{
         price::TimestampedPrice,
         wallet::{
-            IntentIdentifier, WalletIdentifier,
+            OrderId, WalletIdentifier,
             order_metadata::{OrderMetadata, OrderState, PartialOrderFill},
         },
         wallet_mocks::{mock_empty_wallet, mock_order},
@@ -177,7 +174,7 @@ mod test {
         let fill = PartialOrderFill::new(1, TimestampedPrice::new(5.));
         let history = (0..n)
             .map(|_| OrderMetadata {
-                id: IntentIdentifier::new_v4(),
+                id: OrderId::new_v4(),
                 state: OrderState::Filled,
                 fills: vec![fill],
                 created: 0,
@@ -196,7 +193,7 @@ mod test {
 
         let mut wallet = mock_empty_wallet();
         let order = mock_order();
-        let order_id = IntentIdentifier::new_v4();
+        let order_id = OrderId::new_v4();
         wallet.add_order(order_id, order.clone()).unwrap();
 
         // Add the wallet to state
@@ -218,7 +215,7 @@ mod test {
         let state = mock_state().await;
         let mut wallet = mock_empty_wallet();
         let order = mock_order();
-        let order_id = IntentIdentifier::new_v4();
+        let order_id = OrderId::new_v4();
         wallet.add_order(order_id, order.clone()).unwrap();
 
         // Update the wallet
@@ -258,7 +255,7 @@ mod test {
         create_mock_historical_orders(N, wallet.wallet_id, &state);
 
         // Add an existing order
-        let order_id = IntentIdentifier::new_v4();
+        let order_id = OrderId::new_v4();
         let order = mock_order();
         wallet.add_order(order_id, order).unwrap();
 
@@ -268,7 +265,7 @@ mod test {
 
         // Now remove this order and add another
         wallet.remove_order(&order_id).unwrap();
-        let order_id2 = IntentIdentifier::new_v4();
+        let order_id2 = OrderId::new_v4();
         let order = mock_order();
         wallet.add_order(order_id2, order).unwrap();
 

--- a/crates/state/src/replication/state_machine/snapshot.rs
+++ b/crates/state/src/replication/state_machine/snapshot.rs
@@ -567,7 +567,7 @@ mod tests {
     // #[tokio::test]
     // async fn test_apply_snapshot_order_cache() {
     //     use std::sync::Arc;
-    //     use types_account::account::IntentIdentifier;
+    //     use types_account::account::OrderId;
     //     use types_account::account::mocks::mock_intent;
     //     // use crate::caching::order_cache::OrderBookFilter;
     //
@@ -579,9 +579,9 @@ mod tests {
     // is ready for match     // The second does not allow external matches,
     // but is ready for matching     // The third is neither ready for
     // matching nor allows external matches     let oid1 =
-    // IntentIdentifier::new_v4();     let oid2 =
-    // IntentIdentifier::new_v4();     let oid3 =
-    // IntentIdentifier::new_v4();     // NOTE: Order types with
+    // OrderId::new_v4();     let oid2 =
+    // OrderId::new_v4();     let oid3 =
+    // OrderId::new_v4();     // NOTE: Order types with
     // allow_external_matches are not currently used     // let mut order1 =
     // mock_order();     // let mut order2 = mock_order();
     //     // let mut order3 = mock_order();

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -5,7 +5,7 @@
 #![allow(missing_docs)]
 
 use serde::{Deserialize, Serialize};
-use types_account::{Account, account::IntentIdentifier};
+use types_account::{Account, account::OrderId};
 use types_gossip::WrappedPeerId;
 use types_runtime::MatchingPoolName;
 use types_tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey};
@@ -49,7 +49,7 @@ pub enum StateTransition {
     /// Destroy a matching pool
     DestroyMatchingPool { pool_name: MatchingPoolName },
     /// Assign an intent to a matching pool
-    AssignIntentToMatchingPool { intent_id: IntentIdentifier, pool_name: MatchingPoolName },
+    AssignIntentToMatchingPool { intent_id: OrderId, pool_name: MatchingPoolName },
 
     // --- Task Queue --- //
     /// Add a task to the task queue

--- a/crates/state/src/storage/tx/account_index.rs
+++ b/crates/state/src/storage/tx/account_index.rs
@@ -1,7 +1,7 @@
 //! Helpers for accessing account index information in the database
 
 use libmdbx::{RW, TransactionKind};
-use types_account::account::{Account, IntentIdentifier};
+use types_account::account::{Account, OrderId};
 use types_core::AccountId;
 use util::res_some;
 
@@ -30,17 +30,17 @@ impl<T: TransactionKind> StateTxn<'_, T> {
     /// Get the account ID managing a given intent
     pub fn get_account_id_for_intent(
         &self,
-        intent_id: &IntentIdentifier,
+        intent_id: &OrderId,
     ) -> Result<Option<AccountId>, StorageError> {
         self.inner()
-            .read::<_, IntentIdentifier>(INTENT_TO_WALLET_TABLE, intent_id)
+            .read::<_, OrderId>(INTENT_TO_WALLET_TABLE, intent_id)
             .map(|opt| opt.map(|archived| archived.deserialize()).transpose())?
     }
 
     /// Get the account for a given intent
     pub fn get_account_for_intent(
         &self,
-        intent_id: &IntentIdentifier,
+        intent_id: &OrderId,
     ) -> Result<Option<AccountValue<'_>>, StorageError> {
         let account_id = res_some!(self.get_account_id_for_intent(intent_id)?);
         self.get_account(&account_id)
@@ -70,7 +70,7 @@ impl StateTxn<'_, RW> {
     pub fn index_intents(
         &self,
         account_id: &AccountId,
-        intents: &[IntentIdentifier],
+        intents: &[OrderId],
     ) -> Result<(), StorageError> {
         for intent in intents.iter() {
             self.inner().write(INTENT_TO_WALLET_TABLE, intent, account_id)?;
@@ -86,7 +86,7 @@ impl StateTxn<'_, RW> {
 
 #[cfg(test)]
 mod test {
-    use types_account::account::{Account, IntentIdentifier};
+    use types_account::account::{Account, OrderId};
     use types_core::AccountId;
 
     use crate::{INTENT_TO_WALLET_TABLE, WALLETS_TABLE, test_helpers::mock_db};
@@ -120,9 +120,9 @@ mod test {
         db.create_table(INTENT_TO_WALLET_TABLE).unwrap();
 
         // Write the mapping
-        let intent_id1 = IntentIdentifier::new_v4();
-        let intent_id2 = IntentIdentifier::new_v4();
-        let intent_id3 = IntentIdentifier::new_v4();
+        let intent_id1 = OrderId::new_v4();
+        let intent_id2 = OrderId::new_v4();
+        let intent_id3 = OrderId::new_v4();
         let account_id1 = AccountId::new_v4();
         let account_id2 = AccountId::new_v4();
 

--- a/crates/system-primitives/system-bus/src/message.rs
+++ b/crates/system-primitives/system-bus/src/message.rs
@@ -2,7 +2,7 @@
 
 use darkpool_types::bounded_match_result::BoundedMatchResult;
 use external_api::{http::task::ApiTaskStatus, types::ApiHistoricalTask};
-use types_account::account::{Account, IntentIdentifier};
+use types_account::account::{Account, OrderId};
 use types_core::{AccountId, Token};
 use types_gossip::{PeerInfo, WrappedPeerId};
 use types_tasks::TaskIdentifier;
@@ -65,18 +65,18 @@ pub enum SystemBusMessage {
     /// A message indicating that a handshake with a peer has started
     HandshakeInProgress {
         /// The order_id of the local party
-        local_order_id: IntentIdentifier,
+        local_order_id: OrderId,
         /// The order_id of the remote peer
-        peer_order_id: IntentIdentifier,
+        peer_order_id: OrderId,
         /// The timestamp of the event
         timestamp: u64,
     },
     /// A message indicating that a handshake with a peer has completed
     HandshakeCompleted {
         /// The order_id of the local party
-        local_order_id: IntentIdentifier,
+        local_order_id: OrderId,
         /// The order_id of the remote peer
-        peer_order_id: IntentIdentifier,
+        peer_order_id: OrderId,
         /// The timestamp of the event
         timestamp: u64,
     },

--- a/crates/workers/api-server/benches/api-server-bench-util/src/lib.rs
+++ b/crates/workers/api-server/benches/api-server-bench-util/src/lib.rs
@@ -8,7 +8,7 @@ use circuit_types::{
 };
 use types_core::{chain::Chain, hmac::HmacKey, token::Token};
 use common::types::proof_bundles::mocks::{dummy_validity_proof_bundle, dummy_validity_witness_bundle};
-use types_account::account::{Order, IntentIdentifier, mocks::mock_empty_wallet};
+use types_account::account::{Order, OrderId, mocks::mock_empty_wallet};
 use config::{RelayerConfig, setup_token_remaps};
 use darkpool_client::conversion::address_to_biguint;
 use external_api::auth::add_expiring_auth_to_headers;
@@ -60,7 +60,7 @@ pub async fn setup_internal_order_on_token(
     mock_node: &MockNodeController,
 ) -> Result<()> {
     // Setup an internal party wallet
-    let oid = IntentIdentifier::new_v4();
+    let oid = OrderId::new_v4();
     let order = internal_party_order(&base, side);
     let bal = internal_party_balance(&base, side);
     let mut wallet = mock_empty_wallet();
@@ -103,7 +103,7 @@ fn internal_party_balance(base: &Token, side: OrderSide) -> Balance {
 /// Add a validity proof bundle to the state for the given order
 async fn add_validity_proof_bundle(
     mock_node: &MockNodeController,
-    oid: IntentIdentifier,
+    oid: OrderId,
     order: Order,
 ) -> Result<()> {
     let bundle = dummy_validity_proof_bundle();

--- a/crates/workers/api-server/integration/ctx/node_state.rs
+++ b/crates/workers/api-server/integration/ctx/node_state.rs
@@ -1,7 +1,7 @@
 //! Helpers for working with the integration node's state
 
 use types_runtime::MatchingPoolName;
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use eyre::Result;
 use state::State;
 
@@ -41,7 +41,7 @@ impl IntegrationTestCtx {
     /// Move a given order into the given matching pool
     pub async fn move_order_into_pool(
         &self,
-        oid: IntentIdentifier,
+        oid: OrderId,
         pool: MatchingPoolName,
     ) -> Result<()> {
         let state = self.state();

--- a/crates/workers/api-server/integration/ctx/wallet_setup.rs
+++ b/crates/workers/api-server/integration/ctx/wallet_setup.rs
@@ -6,7 +6,7 @@ use circuit_types::{
     Amount, balance::Balance, fixed_point::FixedPoint, max_amount, max_price, order::OrderSide,
 };
 use common::types::proof_bundles::mocks::{dummy_validity_proof_bundle, dummy_validity_witness_bundle};
-use types_account::account::{Order, IntentIdentifier, Wallet, mocks::mock_empty_wallet};
+use types_account::account::{Order, OrderId, Wallet, mocks::mock_empty_wallet};
 use external_api::http::external_match::ExternalOrder;
 use eyre::Result;
 
@@ -25,7 +25,7 @@ impl IntegrationTestCtx {
     /// Setup a well capitalized wallet with the given order
     pub async fn setup_wallet_with_order(&self, order: Order) -> Result<Wallet> {
         let mut wallet = mock_empty_wallet();
-        let oid = IntentIdentifier::new_v4();
+        let oid = OrderId::new_v4();
         wallet.add_order(oid, order.clone()).to_eyre()?;
 
         // Add a balance to capitalize the order
@@ -81,7 +81,7 @@ impl IntegrationTestCtx {
     /// Add a validity proof bundle to the state for the given order
     async fn add_validity_proof_bundle(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         order: Order,
     ) -> Result<()> {
         let bundle = dummy_validity_proof_bundle();

--- a/crates/workers/chain-events/src/listener.rs
+++ b/crates/workers/chain-events/src/listener.rs
@@ -13,7 +13,7 @@ use alloy::{
 use circuit_types::r#match::ExternalMatchResult;
 use circuit_types::wallet::Nullifier;
 use types_runtime::CancelChannel;
-use types_account::account::{IntentIdentifier, WalletIdentifier};
+use types_account::account::{OrderId, WalletIdentifier};
 use constants::in_bootstrap_mode;
 use darkpool_client::{
     DarkpoolClient, DarkpoolImplementation, conversion::u256_to_scalar, traits::DarkpoolImpl,
@@ -382,7 +382,7 @@ impl OnChainEventListenerExecutor {
         &self,
         wallet_id: WalletIdentifier,
         ext_match: &ExternalMatchResult,
-    ) -> Result<IntentIdentifier, OnChainEventListenerError> {
+    ) -> Result<OrderId, OnChainEventListenerError> {
         let wallet = self
             .state()
             .get_wallet(&wallet_id)

--- a/crates/workers/chain-events/src/post_settlement.rs
+++ b/crates/workers/chain-events/src/post_settlement.rs
@@ -8,7 +8,7 @@ use crate::error::OnChainEventListenerError;
 use crate::listener::OnChainEventListenerExecutor;
 use circuit_types::{fees::FeeTake, fixed_point::FixedPoint, r#match::ExternalMatchResult};
 use types_core::price::TimestampedPrice;
-use types_account::account::{IntentIdentifier, WalletIdentifier, order_metadata::OrderState};
+use types_account::account::{OrderId, WalletIdentifier, order_metadata::OrderState};
 use constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
 use job_types::event_manager::{ExternalFillEvent, RelayerEventType, try_send_event};
 use renegade_metrics;
@@ -55,7 +55,7 @@ impl OnChainEventListenerExecutor {
     /// Record the internal fill and update the order metadata
     pub(crate) async fn record_order_fill(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         ctx: &PostSettlementCtx,
     ) -> Result<(), OnChainEventListenerError> {
         let match_result = ctx.external_match_result.to_match_result();
@@ -87,7 +87,7 @@ impl OnChainEventListenerExecutor {
     /// Emit `ExternalFill` relayer event
     pub(crate) fn emit_event(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         ctx: &PostSettlementCtx,
     ) -> Result<(), OnChainEventListenerError> {
         let fee_take = internal_fee_take(&ctx.external_match_result);

--- a/crates/workers/gossip-server/src/orderbook.rs
+++ b/crates/workers/gossip-server/src/orderbook.rs
@@ -11,7 +11,7 @@ use circuits_core::{
 };
 use types_gossip::ClusterId;
 use common::types::{network_order::NetworkOrder, proof_bundles::OrderValidityProofBundle};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use futures::executor::block_on;
 use gossip_api::{
     pubsub::orderbook::OrderBookManagementMessage,
@@ -39,7 +39,7 @@ impl GossipProtocolExecutor {
     /// Handles a request for order information from a peer
     pub(crate) async fn handle_order_info_request(
         &self,
-        order_ids: &[IntentIdentifier],
+        order_ids: &[OrderId],
     ) -> Result<GossipResponseType, GossipError> {
         let order_info = self.state.get_orders_batch(order_ids).await?;
         let resp = OrderInfoResponse { order_info };
@@ -118,7 +118,7 @@ impl GossipProtocolExecutor {
     /// Handles a newly discovered order added to the book
     async fn handle_new_order(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         nullifier: Nullifier,
         cluster: ClusterId,
     ) -> Result<(), GossipError> {
@@ -140,7 +140,7 @@ impl GossipProtocolExecutor {
     /// contract state, e.g. merkle root, nullifiers, etc.
     async fn handle_new_validity_proof(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         cluster: ClusterId,
         proof_bundle: OrderValidityProofBundle,
     ) -> Result<(), GossipError> {

--- a/crates/workers/handshake-manager/src/manager.rs
+++ b/crates/workers/handshake-manager/src/manager.rs
@@ -16,7 +16,7 @@ use common::{
         proof_bundles::{OrderValidityProofBundle, ValidMatchSettleBundle},
         tasks::{SettleMatchTaskDescriptor, TaskDescriptor},
         token::Token,
-        wallet::IntentIdentifier,
+        wallet::OrderId,
     },
 };
 use types_gossip::handshake::ConnectionRole;
@@ -100,7 +100,7 @@ pub struct HandshakeExecutor {
     /// matches on
     pub(crate) min_fill_size: Amount,
     /// The cache used to mark order pairs as already matched
-    pub(crate) handshake_cache: SharedHandshakeCache<IntentIdentifier>,
+    pub(crate) handshake_cache: SharedHandshakeCache<OrderId>,
     /// Stores the state of existing handshake executions
     pub(crate) handshake_state_index: HandshakeStateIndex,
     /// The channel on which other workers enqueue jobs for the protocol
@@ -328,7 +328,7 @@ impl HandshakeExecutor {
     /// and casting this to a `Token`
     async fn token_pair_for_order(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<(Token, Token), HandshakeManagerError> {
         let order = self
             .state
@@ -380,7 +380,7 @@ impl HandshakeExecutor {
     }
 
     /// Chooses an order to match against a remote order
-    async fn choose_match_proposal(&self, peer_order: IntentIdentifier) -> Option<IntentIdentifier> {
+    async fn choose_match_proposal(&self, peer_order: OrderId) -> Option<OrderId> {
         let locked_handshake_cache = self.handshake_cache.read().await;
 
         // Shuffle the locally managed orders to avoid always matching the same order
@@ -432,8 +432,8 @@ impl HandshakeExecutor {
     /// that a handshake has completed
     fn publish_completion_messages(
         &self,
-        local_order_id: IntentIdentifier,
-        peer_order_id: IntentIdentifier,
+        local_order_id: OrderId,
+        peer_order_id: OrderId,
     ) -> Result<(), HandshakeManagerError> {
         // Send a message to cluster peers indicating that the local peer has completed
         // a match. Cluster peers should cache the matched order pair as

--- a/crates/workers/handshake-manager/src/manager/handshake.rs
+++ b/crates/workers/handshake-manager/src/manager/handshake.rs
@@ -4,7 +4,7 @@
 //!     2. Order selection
 //!     3. State management
 
-use common::types::wallet::IntentIdentifier;
+use types_account::account::OrderId;
 use types_gossip::handshake::ConnectionRole;
 use gossip_api::{
     pubsub::{
@@ -42,7 +42,7 @@ impl HandshakeExecutor {
     /// Perform a handshake with a peer
     pub async fn perform_handshake(
         &self,
-        peer_order_id: IntentIdentifier,
+        peer_order_id: OrderId,
     ) -> Result<(), HandshakeManagerError> {
         if let Some(local_order_id) = self.choose_match_proposal(peer_order_id).await {
             // Choose a peer to match this order with
@@ -272,8 +272,8 @@ impl HandshakeExecutor {
     fn reject_match_proposal(
         &self,
         request_id: Uuid,
-        peer_order: IntentIdentifier,
-        local_order: IntentIdentifier,
+        peer_order: OrderId,
+        local_order: OrderId,
         reason: MatchRejectionReason,
     ) -> Result<HandshakeMessage, HandshakeManagerError> {
         let message = HandshakeMessage {

--- a/crates/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/crates/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -21,7 +21,7 @@ use types_tasks::{
     SettleExternalMatchTaskDescriptor, SettleMalleableExternalMatchTaskDescriptor,
     TaskDescriptor,
 };
-use types_account::account::{Order, IntentIdentifier};
+use types_account::account::{Order, OrderId};
 use constants::Scalar;
 use system_bus::SystemBusMessage;
 use job_types::handshake_manager::ExternalMatchingEngineOptions;
@@ -167,7 +167,7 @@ impl HandshakeExecutor {
         &self,
         order: &Order,
         matching_pool: Option<MatchingPoolName>,
-    ) -> Result<HashSet<IntentIdentifier>, HandshakeManagerError> {
+    ) -> Result<HashSet<OrderId>, HandshakeManagerError> {
         let filter = matching_order_filter(order, true /* external */);
         let candidates = match matching_pool {
             Some(pool) => self.state.get_matchable_orders_in_matching_pool(pool, filter).await?,
@@ -181,7 +181,7 @@ impl HandshakeExecutor {
     /// Handle a match against an order
     async fn handle_match(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         ts_price: TimestampedPriceFp,
         match_res: MatchResult,
         response_topic: String,
@@ -199,7 +199,7 @@ impl HandshakeExecutor {
     /// Handle an exact match result on the given order
     async fn handle_exact_match(
         &self,
-        other_order_id: IntentIdentifier,
+        other_order_id: OrderId,
         ts_price: TimestampedPriceFp,
         match_res: MatchResult,
         response_topic: String,
@@ -234,7 +234,7 @@ impl HandshakeExecutor {
     /// Settle an external match
     async fn try_settle_external_match(
         &self,
-        internal_order_id: IntentIdentifier,
+        internal_order_id: OrderId,
         ts_price: TimestampedPriceFp,
         match_res: MatchResult,
         response_topic: String,
@@ -261,7 +261,7 @@ impl HandshakeExecutor {
     /// and forward the task to the task driver to create a bundle.
     async fn handle_bounded_match(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         ts_price: TimestampedPriceFp,
         match_res: MatchResult,
         response_topic: String,
@@ -294,7 +294,7 @@ impl HandshakeExecutor {
     /// Try settling a malleable match
     async fn try_settle_bounded_match(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         bounded_res: BoundedMatchResult,
         response_topic: String,
         options: &ExternalMatchingEngineOptions,
@@ -316,7 +316,7 @@ impl HandshakeExecutor {
     /// Returns a tuple containing `(min_amount, max_amount)`
     async fn derive_match_bounds(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
         price: FixedPoint,
         match_amt: Amount,
     ) -> Result<(Amount, Amount), HandshakeManagerError> {

--- a/crates/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/crates/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -7,7 +7,7 @@ use common::types::network_order::NetworkOrder;
 use types_core::price::TimestampedPriceFp;
 use common::types::proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle};
 use types_tasks::{SettleMatchInternalTaskDescriptor, TaskDescriptor};
-use types_account::account::{Order, IntentIdentifier, Wallet, WalletIdentifier};
+use types_account::account::{Order, OrderId, Wallet, WalletIdentifier};
 use tracing::{error, info, instrument};
 
 use crate::{
@@ -39,7 +39,7 @@ impl HandshakeExecutor {
     #[instrument(name = "run_internal_matching_engine", skip_all)]
     pub async fn run_internal_matching_engine(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
     ) -> Result<(), HandshakeManagerError> {
         info!("Running internal matching engine on order {order_id}");
         // Lookup the order and its wallet
@@ -103,10 +103,10 @@ impl HandshakeExecutor {
     /// Shuffles the ordering of the other orders for fairness
     async fn get_internal_match_candidates(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         order: &Order,
         wallet: &Wallet,
-    ) -> Result<HashSet<IntentIdentifier>, HandshakeManagerError> {
+    ) -> Result<HashSet<OrderId>, HandshakeManagerError> {
         // Filter by matching pool
         let my_pool_name = self.state.get_matching_pool_for_order(&order_id).await?;
         let filter = matching_order_filter(order, false /* external */);
@@ -126,8 +126,8 @@ impl HandshakeExecutor {
     /// Try a match and settle it if the two orders cross
     async fn try_settle_match(
         &self,
-        order_id1: IntentIdentifier,
-        order_id2: IntentIdentifier,
+        order_id1: OrderId,
+        order_id2: OrderId,
         price: TimestampedPriceFp,
         match_result: MatchResult,
     ) -> Result<(), HandshakeManagerError> {
@@ -165,7 +165,7 @@ impl HandshakeExecutor {
     /// Get the validity proof and witness for a given order
     async fn get_validity_proof_and_witness(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<(OrderValidityProofBundle, OrderValidityWitnessBundle), HandshakeManagerError> {
         let state = &self.state;
         let proof = state
@@ -183,7 +183,7 @@ impl HandshakeExecutor {
     /// Get the wallet for an order
     pub(crate) async fn get_wallet_id_for_order(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
     ) -> Result<WalletIdentifier, HandshakeManagerError> {
         self.state
             .get_wallet_id_for_order(order_id)
@@ -194,7 +194,7 @@ impl HandshakeExecutor {
     /// Fetch the order and wallet for the given order identifier
     async fn fetch_order_and_wallet(
         &self,
-        order: &IntentIdentifier,
+        order: &OrderId,
     ) -> Result<(NetworkOrder, Wallet), HandshakeManagerError> {
         let state = &self.state;
         let order = state

--- a/crates/workers/handshake-manager/src/manager/matching/match_helpers.rs
+++ b/crates/workers/handshake-manager/src/manager/matching/match_helpers.rs
@@ -2,13 +2,13 @@
 
 use circuit_types::{Amount, balance::Balance, fixed_point::FixedPoint, r#match::MatchResult};
 use types_core::{price::{TimestampedPrice, TimestampedPriceFp}, token::Token};
-use types_account::account::{Order, IntentIdentifier};
+use types_account::account::{Order, OrderId};
 use util::{err_str, matching_engine::match_orders_with_min_base_amount};
 
 use crate::{error::HandshakeManagerError, manager::HandshakeExecutor};
 
 /// A successful match between two orders
-pub type SuccessfulMatch = (IntentIdentifier, MatchResult);
+pub type SuccessfulMatch = (OrderId, MatchResult);
 
 impl HandshakeExecutor {
     /// Run a match between two orders
@@ -20,7 +20,7 @@ impl HandshakeExecutor {
         target_orders: I,
     ) -> Result<Option<SuccessfulMatch>, HandshakeManagerError>
     where
-        I: Iterator<Item = &'a IntentIdentifier>,
+        I: Iterator<Item = &'a OrderId>,
     {
         let min_quote = self.min_fill_size;
         self.find_match_with_min_quote_amount(order, balance, price, min_quote, target_orders).await
@@ -36,7 +36,7 @@ impl HandshakeExecutor {
         target_orders: I,
     ) -> Result<Option<SuccessfulMatch>, HandshakeManagerError>
     where
-        I: Iterator<Item = &'a IntentIdentifier>,
+        I: Iterator<Item = &'a OrderId>,
     {
         // Match against each other order in the local book
         for order_id in target_orders.into_iter() {
@@ -85,7 +85,7 @@ impl HandshakeExecutor {
     /// Get the execution price for an order
     pub(crate) async fn get_execution_price_for_order(
         &self,
-        order: &IntentIdentifier,
+        order: &OrderId,
     ) -> Result<TimestampedPriceFp, HandshakeManagerError> {
         let (base, quote) = self.token_pair_for_order(order).await?;
         self.get_execution_price(&base, &quote)

--- a/crates/workers/handshake-manager/src/manager/price_agreement.rs
+++ b/crates/workers/handshake-manager/src/manager/price_agreement.rs
@@ -7,7 +7,7 @@ use types_core::{
     price::TimestampedPrice,
     token::{Token, get_all_base_tokens},
 };
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use gossip_api::request_response::handshake::PriceVector;
 use tracing::warn;
 use util::err_str;
@@ -61,7 +61,7 @@ impl HandshakeExecutor {
     pub(super) async fn validate_price_vector(
         &self,
         proposed_prices: &PriceVector,
-        my_order_id: &IntentIdentifier,
+        my_order_id: &OrderId,
     ) -> Result<bool, HandshakeManagerError> {
         // Find the price of the asset pair that the local party's order is on in the
         // peer's proposed prices list

--- a/crates/workers/handshake-manager/src/state.rs
+++ b/crates/workers/handshake-manager/src/state.rs
@@ -6,7 +6,7 @@ use super::error::HandshakeManagerError;
 use common::types::handshake::HandshakeState;
 use types_gossip::handshake::ConnectionRole;
 use types_core::price::TimestampedPrice;
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use constants::Scalar;
 use crossbeam::channel::Sender;
 use state::State;
@@ -51,8 +51,8 @@ impl HandshakeStateIndex {
         &self,
         request_id: Uuid,
         role: ConnectionRole,
-        peer_order_id: IntentIdentifier,
-        local_order_id: IntentIdentifier,
+        peer_order_id: OrderId,
+        local_order_id: OrderId,
         execution_price: TimestampedPrice,
     ) -> Result<(), HandshakeManagerError> {
         // Lookup the public share nullifiers for the order

--- a/crates/workers/job-types/src/event_manager/event_types/external_fill.rs
+++ b/crates/workers/job-types/src/event_manager/event_types/external_fill.rs
@@ -1,6 +1,6 @@
 use darkpool_types::{bounded_match_result::BoundedMatchResult, fee::FeeTake};
 use serde::{Deserialize, Serialize};
-use types_account::IntentIdentifier;
+use types_account::OrderId;
 use types_core::{AccountId, TimestampedPrice};
 
 /// A fill event on an order, resulting from an external match
@@ -9,7 +9,7 @@ pub struct ExternalFillEvent {
     /// The ID of the internal wallet containing the filled order
     pub internal_account_id: AccountId,
     /// The ID of the internal order that received the fill
-    pub internal_order_id: IntentIdentifier,
+    pub internal_order_id: OrderId,
     /// The price at which the fill was executed
     pub execution_price: TimestampedPrice,
     /// The external match result
@@ -22,7 +22,7 @@ impl ExternalFillEvent {
     /// Creates a new external fill event
     pub fn new(
         internal_account_id: AccountId,
-        internal_order_id: IntentIdentifier,
+        internal_order_id: OrderId,
         execution_price: TimestampedPrice,
         external_match_result: BoundedMatchResult,
         internal_fee_take: FeeTake,

--- a/crates/workers/job-types/src/event_manager/event_types/fill.rs
+++ b/crates/workers/job-types/src/event_manager/event_types/fill.rs
@@ -1,6 +1,6 @@
 use darkpool_types::{fee::FeeTake, settlement_obligation::SettlementObligation};
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_core::{AccountId, TimestampedPrice};
 
 /// A fill event on an order, resulting from an internal match
@@ -9,7 +9,7 @@ pub struct FillEvent {
     /// The ID of the wallet containing the filled order
     pub account_id: AccountId,
     /// The ID of the order that received the fill
-    pub order_id: IntentIdentifier,
+    pub order_id: OrderId,
     /// The price at which the fill was executed
     pub execution_price: TimestampedPrice,
     /// The settlement obligation
@@ -22,7 +22,7 @@ impl FillEvent {
     /// Creates a new fill event
     pub fn new(
         account_id: AccountId,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         execution_price: TimestampedPrice,
         obligation: SettlementObligation,
         fee_take: FeeTake,

--- a/crates/workers/job-types/src/event_manager/event_types/intent_cancellation.rs
+++ b/crates/workers/job-types/src/event_manager/event_types/intent_cancellation.rs
@@ -1,7 +1,7 @@
 use circuit_types::Amount;
 use darkpool_types::intent::Intent;
 use serde::{Deserialize, Serialize};
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use types_core::AccountId;
 
 /// An intent cancellation event
@@ -10,7 +10,7 @@ pub struct IntentCancellationEvent {
     /// The ID of the account that cancelled the intent
     pub account_id: AccountId,
     /// The ID of the intent that was cancelled
-    pub intent_id: IntentIdentifier,
+    pub intent_id: OrderId,
     /// The cancelled intent
     pub intent: Intent,
     /// The remaining amount of the base asset in the intent
@@ -23,7 +23,7 @@ impl IntentCancellationEvent {
     /// Creates a new intent cancellation event
     pub fn new(
         account_id: AccountId,
-        intent_id: IntentIdentifier,
+        intent_id: OrderId,
         intent: Intent,
         amount_remaining: Amount,
         amount_filled: Amount,

--- a/crates/workers/job-types/src/event_manager/event_types/intent_placement.rs
+++ b/crates/workers/job-types/src/event_manager/event_types/intent_placement.rs
@@ -1,6 +1,6 @@
 use darkpool_types::intent::Intent;
 use serde::{Deserialize, Serialize};
-use types_account::{IntentIdentifier, MatchingPoolName};
+use types_account::{MatchingPoolName, OrderId};
 use types_core::AccountId;
 
 /// An intent placement event
@@ -9,7 +9,7 @@ pub struct IntentPlacementEvent {
     /// The ID of the wallet that placed the intent
     pub account_id: AccountId,
     /// The ID of the intent that was placed
-    pub intent_id: IntentIdentifier,
+    pub intent_id: OrderId,
     /// The placed intent
     pub intent: Intent,
     /// The matching pool to which the intent was assigned
@@ -20,7 +20,7 @@ impl IntentPlacementEvent {
     /// Creates a new intent placement event
     pub fn new(
         account_id: AccountId,
-        intent_id: IntentIdentifier,
+        intent_id: OrderId,
         intent: Intent,
         matching_pool: MatchingPoolName,
     ) -> Self {

--- a/crates/workers/job-types/src/event_manager/event_types/intent_update.rs
+++ b/crates/workers/job-types/src/event_manager/event_types/intent_update.rs
@@ -1,6 +1,6 @@
 use darkpool_types::intent::Intent;
 use serde::{Deserialize, Serialize};
-use types_account::{IntentIdentifier, MatchingPoolName};
+use types_account::{MatchingPoolName, OrderId};
 use types_core::AccountId;
 
 /// An intent update event
@@ -9,7 +9,7 @@ pub struct IntentUpdateEvent {
     /// The ID of the account that updated the intent
     pub account_id: AccountId,
     /// The ID of the intent that was updated
-    pub intent_id: IntentIdentifier,
+    pub intent_id: OrderId,
     /// The updated intent
     pub intent: Intent,
     /// The matching pool to which the intent was assigned
@@ -20,7 +20,7 @@ impl IntentUpdateEvent {
     /// Creates a new intent update event
     pub fn new(
         account_id: AccountId,
-        intent_id: IntentIdentifier,
+        intent_id: OrderId,
         intent: Intent,
         matching_pool: MatchingPoolName,
     ) -> Self {

--- a/crates/workers/job-types/src/handshake_manager.rs
+++ b/crates/workers/job-types/src/handshake_manager.rs
@@ -9,7 +9,7 @@ use darkpool_types::intent::Intent;
 use gossip_api::request_response::{AuthenticatedGossipResponse, handshake::HandshakeMessage};
 use libp2p::request_response::ResponseChannel;
 use system_bus::gen_atomic_match_response_topic;
-use types_account::{IntentIdentifier, MatchingPoolName};
+use types_account::{MatchingPoolName, OrderId};
 use types_core::TimestampedPrice;
 use types_gossip::WrappedPeerId;
 use util::channels::{TracedTokioReceiver, TracedTokioSender, new_traced_tokio_channel};
@@ -37,7 +37,7 @@ pub enum HandshakeManagerJob {
     /// the local peer
     InternalMatchingEngine {
         /// The order to match
-        order: IntentIdentifier,
+        order: OrderId,
     },
     /// Run the external matching engine on the given order
     ExternalMatchingEngine {
@@ -69,7 +69,7 @@ pub enum HandshakeManagerJob {
     /// A request to initiate a handshake with a scheduled peer
     PerformHandshake {
         /// The order to attempt a handshake on
-        order: IntentIdentifier,
+        order: OrderId,
     },
 
     // --- Caching --- //
@@ -77,9 +77,9 @@ pub enum HandshakeManagerJob {
     /// cluster peer has executed
     CacheEntry {
         /// The first of the orders matched
-        order1: IntentIdentifier,
+        order1: OrderId,
         /// The second of the orders matched
-        order2: IntentIdentifier,
+        order2: OrderId,
     },
     /// Indicates that the local peer should halt any MPCs active on the given
     /// nullifier
@@ -97,9 +97,9 @@ pub enum HandshakeManagerJob {
     /// match for some duration
     PeerMatchInProgress {
         /// The first of the orders in the pair
-        order1: IntentIdentifier,
+        order1: OrderId,
         /// The second of the orders in the pair
-        order2: IntentIdentifier,
+        order2: OrderId,
     },
 
     // --- Networking --- //

--- a/crates/workers/task-driver/integration/tests/update_wallet.rs
+++ b/crates/workers/task-driver/integration/tests/update_wallet.rs
@@ -9,7 +9,7 @@ use circuit_types::{
 };
 use types_tasks::{UpdateWalletTaskDescriptor, WalletUpdateType, mocks::gen_wallet_update_sig};
 use common::types::transfer_auth::ExternalTransferWithAuth;
-use types_account::account::{Order, OrderBuilder, IntentIdentifier, Wallet, mocks::{mock_empty_wallet, mock_order}};
+use types_account::account::{Order, OrderBuilder, OrderId, Wallet, mocks::{mock_empty_wallet, mock_order}};
 use constants::Scalar;
 use eyre::Result;
 use lazy_static::lazy_static;
@@ -92,7 +92,7 @@ async fn execute_wallet_update_and_verify_shares(
 ) -> Result<()> {
     let desc = WalletUpdateType::PlaceOrder {
         order: mock_order(),
-        id: IntentIdentifier::new_v4(),
+        id: OrderId::new_v4(),
         matching_pool: None,
     };
     execute_wallet_update(

--- a/crates/workers/task-driver/src/state_migration/remove_old_proofs.rs
+++ b/crates/workers/task-driver/src/state_migration/remove_old_proofs.rs
@@ -1,6 +1,6 @@
 //! Removes old proofs from the state
 
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use state::{State, storage::tx::RwTxn};
 use tracing::{info, warn};
@@ -29,7 +29,7 @@ fn remove_old_proofs_with_tx(tx: &RwTxn) -> Result<(), String> {
     for res in iter {
         let (k, _v) = res.map_err(|e| e.to_string())?;
         let oid = k.split(":").last().unwrap();
-        let oid = IntentIdentifier::parse_str(oid).map_err(|e| e.to_string())?;
+        let oid = OrderId::parse_str(oid).map_err(|e| e.to_string())?;
 
         if tx.contains_order(&oid).map_err(|e| e.to_string())? {
             continue;

--- a/crates/workers/task-driver/src/state_migration/remove_phantom_orders.rs
+++ b/crates/workers/task-driver/src/state_migration/remove_phantom_orders.rs
@@ -2,7 +2,7 @@
 //!
 //! This checks both the order book table and the local orders list
 
-use types_account::account::IntentIdentifier;
+use types_account::account::OrderId;
 use state::State;
 use tracing::{error, info};
 
@@ -19,7 +19,7 @@ pub async fn remove_phantom_orders(state: &State) -> Result<(), String> {
 // --- Find Orders --- //
 
 /// Find all phantom orders
-async fn find_phantom_orders(state: &State) -> Result<Vec<IntentIdentifier>, String> {
+async fn find_phantom_orders(state: &State) -> Result<Vec<OrderId>, String> {
     let all_orders = state.get_all_orders().await?;
     let mut phantom_orders = Vec::new();
     for order in all_orders {
@@ -33,7 +33,7 @@ async fn find_phantom_orders(state: &State) -> Result<Vec<IntentIdentifier>, Str
 }
 
 /// Check whether an order is missing from its wallet
-async fn check_order_missing(state: &State, order_id: &IntentIdentifier) -> Result<bool, String> {
+async fn check_order_missing(state: &State, order_id: &OrderId) -> Result<bool, String> {
     // Check that the order has a wallet ID mapped to it
     let maybe_wallet = state.get_wallet_for_order(order_id).await?;
     if maybe_wallet.is_none() || !maybe_wallet.unwrap().contains_order(order_id) {
@@ -48,7 +48,7 @@ async fn check_order_missing(state: &State, order_id: &IntentIdentifier) -> Resu
 /// Remove a set of orders from the order book state
 async fn remove_orders_from_order_book(
     state: &State,
-    orders: &[IntentIdentifier],
+    orders: &[OrderId],
 ) -> Result<(), String> {
     // Remove each order in a new tx to avoid blocking the db for too long
     for order_id in orders {

--- a/crates/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/crates/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -365,7 +365,7 @@ fn matchup_order_ids(
 #[cfg(test)]
 mod tests {
     use common::types::{
-        wallet::IntentIdentifier,
+        wallet::OrderId,
         wallet_mocks::{mock_empty_wallet, mock_order},
     };
 
@@ -378,8 +378,8 @@ mod tests {
         let mut existing = mock_empty_wallet();
         let mut refreshed = mock_empty_wallet();
 
-        let id1 = IntentIdentifier::new_v4();
-        let id2 = IntentIdentifier::new_v4();
+        let id1 = OrderId::new_v4();
+        let id2 = OrderId::new_v4();
         let order = mock_order();
         existing.orders.insert(id1, order.clone());
         refreshed.orders.insert(id2, order.clone());
@@ -398,10 +398,10 @@ mod tests {
         let mut existing = mock_empty_wallet();
         let mut refreshed = mock_empty_wallet();
 
-        let id1 = IntentIdentifier::new_v4();
-        let id2 = IntentIdentifier::new_v4();
-        let id3 = IntentIdentifier::new_v4();
-        let id4 = IntentIdentifier::new_v4();
+        let id1 = OrderId::new_v4();
+        let id2 = OrderId::new_v4();
+        let id3 = OrderId::new_v4();
+        let id4 = OrderId::new_v4();
 
         let order = mock_order();
 
@@ -429,9 +429,9 @@ mod tests {
         let mut existing = mock_empty_wallet();
         let mut refreshed = mock_empty_wallet();
 
-        let id1 = IntentIdentifier::new_v4();
-        let id2 = IntentIdentifier::new_v4();
-        let id3 = IntentIdentifier::new_v4();
+        let id1 = OrderId::new_v4();
+        let id2 = OrderId::new_v4();
+        let id3 = OrderId::new_v4();
 
         let order = mock_order();
 
@@ -457,10 +457,10 @@ mod tests {
         let mut existing = mock_empty_wallet();
         let mut refreshed = mock_empty_wallet();
 
-        let id1 = IntentIdentifier::new_v4();
-        let id2 = IntentIdentifier::new_v4();
-        let id3 = IntentIdentifier::new_v4();
-        let id4 = IntentIdentifier::new_v4();
+        let id1 = OrderId::new_v4();
+        let id2 = OrderId::new_v4();
+        let id3 = OrderId::new_v4();
+        let id4 = OrderId::new_v4();
 
         let order = mock_order();
         let order2 = mock_order();

--- a/crates/workers/task-driver/src/tasks/settle_malleable_external_match.rs
+++ b/crates/workers/task-driver/src/tasks/settle_malleable_external_match.rs
@@ -24,7 +24,7 @@ use common::types::proof_bundles::{
     OrderValidityProofBundle, OrderValidityWitnessBundle, ValidMalleableMatchSettleAtomicBundle,
 };
 use types_tasks::SettleMalleableExternalMatchTaskDescriptor;
-use types_account::account::{IntentIdentifier, WalletIdentifier};
+use types_account::account::{OrderId, WalletIdentifier};
 use darkpool_client::errors::DarkpoolClientError;
 use system_bus::SystemBusMessage;
 use job_types::proof_manager::ProofJob;
@@ -365,7 +365,7 @@ impl SettleMalleableExternalMatchTask {
 
     /// Fetch the internal order validity proof bundle
     async fn fetch_internal_order_validity_bundle(
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         state: &State,
     ) -> Result<(OrderValidityProofBundle, OrderValidityWitnessBundle)> {
         let validity_proofs = state

--- a/crates/workers/task-driver/src/tasks/settle_match_external.rs
+++ b/crates/workers/task-driver/src/tasks/settle_match_external.rs
@@ -19,7 +19,7 @@ use common::types::proof_bundles::{
     OrderValidityProofBundle, OrderValidityWitnessBundle, ValidMatchSettleAtomicBundle,
 };
 use types_tasks::SettleExternalMatchTaskDescriptor;
-use types_account::account::{IntentIdentifier, WalletIdentifier};
+use types_account::account::{OrderId, WalletIdentifier};
 use darkpool_client::errors::DarkpoolClientError;
 use system_bus::SystemBusMessage;
 use job_types::proof_manager::ProofJob;
@@ -360,7 +360,7 @@ impl SettleMatchExternalTask {
 
     /// Fetch the internal order validity proof bundle
     async fn fetch_internal_order_validity_bundle(
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         state: &State,
     ) -> Result<(OrderValidityProofBundle, OrderValidityWitnessBundle), SettleMatchExternalTaskError>
     {

--- a/crates/workers/task-driver/src/tasks/settle_match_internal.rs
+++ b/crates/workers/task-driver/src/tasks/settle_match_internal.rs
@@ -19,7 +19,7 @@ use circuits_core::zk_circuits::valid_match_settle::{
 use types_core::price::{TimestampedPrice, TimestampedPriceFp};
 use common::types::proof_bundles::ValidMatchSettleBundle;
 use types_tasks::SettleMatchInternalTaskDescriptor;
-use types_account::account::{IntentIdentifier, WalletIdentifier};
+use types_account::account::{OrderId, WalletIdentifier};
 use common::types::proof_bundles::{OrderValidityProofBundle, OrderValidityWitnessBundle};
 use types_account::account::Wallet;
 use constants::Scalar;
@@ -172,9 +172,9 @@ pub struct SettleMatchInternalTask {
     /// The price at which the match was executed
     execution_price: TimestampedPriceFp,
     /// The identifier of the first order
-    order_id1: IntentIdentifier,
+    order_id1: OrderId,
     /// The identifier of the second order
-    order_id2: IntentIdentifier,
+    order_id2: OrderId,
     /// The identifier of the first order's wallet
     wallet_id1: WalletIdentifier,
     /// The identifier of the second order's wallet

--- a/crates/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
+++ b/crates/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
@@ -2,7 +2,7 @@
 
 use types_runtime::MatchingPoolName;
 use types_tasks::WalletUpdateType;
-use types_account::account::{Order, IntentIdentifier};
+use types_account::account::{Order, OrderId};
 use job_types::event_manager::{
     ExternalTransferEvent, OrderCancellationEvent, OrderPlacementEvent, OrderUpdateEvent,
     RelayerEventType, try_send_event,
@@ -61,7 +61,7 @@ impl UpdateWalletTask {
     /// depending on whether the order already exists in the new wallet
     fn construct_order_placement_or_update_event(
         &self,
-        order_id: &IntentIdentifier,
+        order_id: &OrderId,
         order: &Order,
         matching_pool: &Option<MatchingPoolName>,
     ) -> RelayerEventType {
@@ -90,7 +90,7 @@ impl UpdateWalletTask {
     /// Construct an order cancellation event
     async fn construct_order_cancellation_event(
         &self,
-        order_id: IntentIdentifier,
+        order_id: OrderId,
         order: &Order,
     ) -> Result<RelayerEventType, UpdateWalletTaskError> {
         let wallet_id = self.new_wallet.wallet_id;

--- a/crates/workers/task-driver/src/utils/order_states.rs
+++ b/crates/workers/task-driver/src/utils/order_states.rs
@@ -2,7 +2,7 @@
 
 use circuit_types::r#match::MatchResult;
 use types_core::price::TimestampedPrice;
-use types_account::account::{IntentIdentifier, order_metadata::OrderState};
+use types_account::account::{OrderId, order_metadata::OrderState};
 use state::State;
 
 /// The error message emitted when metadata for an order cannot be found
@@ -10,7 +10,7 @@ const ERR_NO_ORDER_METADATA: &str = "order metadata not found";
 
 /// Update an order's state to `SettlingMatch`
 pub async fn transition_order_settling(
-    order_id: IntentIdentifier,
+    order_id: OrderId,
     state: &State,
 ) -> Result<(), String> {
     let mut metadata =
@@ -23,7 +23,7 @@ pub async fn transition_order_settling(
 
 /// Record the result of a match in the order's metadata
 pub async fn record_order_fill(
-    order_id: IntentIdentifier,
+    order_id: OrderId,
     match_res: &MatchResult,
     price: TimestampedPrice,
     state: &State,

--- a/crates/workers/task-driver/src/utils/proofs/cancellation_proofs.rs
+++ b/crates/workers/task-driver/src/utils/proofs/cancellation_proofs.rs
@@ -1,7 +1,7 @@
 //! Utils for precomputing cancellation proofs for orders
 
 use common::types::proof_bundles::ValidWalletUpdateBundle;
-use types_account::account::{IntentIdentifier, Wallet};
+use types_account::account::{OrderId, Wallet};
 use job_types::proof_manager::ProofJob;
 use tracing::{error, info};
 use util::raw_err_str;
@@ -51,10 +51,10 @@ pub(crate) async fn precompute_cancellation_proofs(
 
 /// Precompute a cancellation proof for a given order
 async fn precompute_cancellation_proof_for_order(
-    order_id: IntentIdentifier,
+    order_id: OrderId,
     old_wallet: Wallet,
     ctx: &TaskContext,
-) -> Result<(IntentIdentifier, ValidWalletUpdateBundle), String> {
+) -> Result<(OrderId, ValidWalletUpdateBundle), String> {
     info!("Precomputing cancellation proof for order: {order_id}");
     let mut new_wallet = old_wallet.clone();
     new_wallet.remove_order(&order_id);

--- a/crates/workers/task-driver/src/utils/proofs/validity_proofs.rs
+++ b/crates/workers/task-driver/src/utils/proofs/validity_proofs.rs
@@ -22,7 +22,7 @@ use common::types::proof_bundles::{
     OrderValidityProofBundle, OrderValidityWitnessBundle, ProofBundle,
 };
 use types_core::token::Token;
-use types_account::account::{IntentIdentifier, Wallet};
+use types_account::account::{OrderId, Wallet};
 use gossip_api::pubsub::PubsubMessage;
 use gossip_api::pubsub::orderbook::{ORDER_BOOK_TOPIC, OrderBookManagementMessage};
 use job_types::network_manager::NetworkManagerJob;
@@ -308,7 +308,7 @@ fn get_relayer_fee_for_order(
 /// bundle and schedule matches on the proven order
 #[instrument(skip_all)]
 async fn link_and_store_proofs(
-    order_id: &IntentIdentifier,
+    order_id: &OrderId,
     commitments_witness: &SizedValidCommitmentsWitness,
     reblind_witness: &SizedValidReblindWitness,
     commitments_bundle: ProofBundle,


### PR DESCRIPTION
### Purpose

This PR refactors the codebase to:
- Rename `IntentIdentifier` to `OrderId` for clearer naming consistency
- Introduce a new `Order` type that wraps `Intent` with metadata (`OrderMetadata`) containing:
  - `min_fill_size`: Minimum fill size for the order
  - `allow_external_matches`: Whether external matches are allowed
- Rename `IntentMetadataIndex` to `OrderMetadataIndex`
- Update all references across 53 files to use the new naming and types
- Add mock order helpers for testing

### Testing

- [x] Unit tests pass