### PR TITLE
workers: gossip-server: remove duplicate util dependency

### DIFF
--- a/crates/workers/gossip-server/Cargo.toml
+++ b/crates/workers/gossip-server/Cargo.toml
@@ -19,7 +19,6 @@ circuit-types = { workspace = true }
 types-core = { workspace = true }
 types-gossip = { workspace = true }
 types-runtime = { workspace = true }
-util = { workspace = true }
 constants = { workspace = true }
 gossip-api = { workspace = true }
 job-types = { workspace = true }


### PR DESCRIPTION
In this PR, we remove the duplicate definition of the `util` dependency in the `gossip-server` crate. This prevents other projects from importing the crates defined here.