### PR TITLE
matching-engine-worker: Re-implement internal & external matching engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4985,6 +4985,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash 2.1.1",
  "types-account",
+ "types-core",
  "util",
 ]
 
@@ -5002,6 +5003,7 @@ dependencies = [
  "crossbeam",
  "crypto",
  "darkpool-client",
+ "darkpool-types",
  "eyre",
  "futures",
  "inventory",
@@ -8890,6 +8892,7 @@ dependencies = [
  "alloy",
  "base64 0.22.1",
  "bimap",
+ "circuit-types",
  "constants",
  "hmac",
  "num-bigint",

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -133,3 +133,6 @@ pub const NATIVE_ASSET_ADDRESS: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEE
 
 /// The ticker of the native asset's wrapper token
 pub const NATIVE_ASSET_WRAPPER_TICKER: &str = "WETH";
+
+/// The name of the global matching pool
+pub const GLOBAL_MATCHING_POOL: &str = "global";

--- a/crates/relayer-types/types-account/src/account/pair.rs
+++ b/crates/relayer-types/types-account/src/account/pair.rs
@@ -3,6 +3,7 @@
 use alloy::primitives::Address;
 use darkpool_types::intent::Intent;
 use serde::{Deserialize, Serialize};
+use types_core::Token;
 
 /// The pair of an order
 ///
@@ -29,5 +30,30 @@ impl Pair {
     /// Get the pair of an intent
     pub fn from_intent(intent: &Intent) -> Self {
         Self { in_token: intent.in_token, out_token: intent.out_token }
+    }
+
+    /// Get the input token for the pair
+    pub fn in_token(&self) -> Token {
+        Token::from_alloy_address(&self.in_token)
+    }
+
+    /// Get the output token for the pair
+    pub fn out_token(&self) -> Token {
+        Token::from_alloy_address(&self.out_token)
+    }
+
+    /// Get a usdc quoted pair wherein input token is the base and output token
+    /// is the USDC quote
+    pub fn to_usdc_quoted(&self) -> Result<Self, String> {
+        let usdc = Token::usdc().get_alloy_address();
+        let new_pair = if self.in_token == usdc {
+            self.reverse()
+        } else if self.out_token == usdc {
+            *self
+        } else {
+            return Err("Pair does not contain USDC".to_string());
+        };
+
+        Ok(new_pair)
     }
 }

--- a/crates/relayer-types/types-core/Cargo.toml
+++ b/crates/relayer-types/types-core/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 # === Workspace Dependencies === #
+circuit-types = { workspace = true }
 constants = { workspace = true, default-features = false }
 util = { workspace = true, features = ["hex-core", "serde", "concurrency"] }
 

--- a/crates/state/src/storage/tx/matching_pools.rs
+++ b/crates/state/src/storage/tx/matching_pools.rs
@@ -1,5 +1,6 @@
 //! Helpers for accessing information about matching pools in the database
 
+use constants::GLOBAL_MATCHING_POOL;
 use libmdbx::{RW, TransactionKind};
 use types_account::MatchingPoolName;
 use types_account::account::OrderId;
@@ -7,9 +8,6 @@ use types_account::account::OrderId;
 use crate::{POOL_TABLE, storage::error::StorageError};
 
 use super::StateTxn;
-
-/// The name of the global matching pool
-pub const GLOBAL_MATCHING_POOL: &str = "global";
 
 /// The prefix of all matching pool keys
 pub const POOL_KEY_PREFIX: &str = "matching-pool/";

--- a/crates/workers/api-server/integration/ctx/external_match.rs
+++ b/crates/workers/api-server/integration/ctx/external_match.rs
@@ -1,5 +1,6 @@
 //! Helpers for interacting with the external match API
 
+use constants::GLOBAL_MATCHING_POOL;
 use external_api::http::external_match::{
     ASSEMBLE_EXTERNAL_MATCH_ROUTE, AssembleExternalMatchRequest, ExternalMatchResponse,
     ExternalOrder, ExternalQuoteRequest, ExternalQuoteResponse, REQUEST_EXTERNAL_QUOTE_ROUTE,
@@ -8,7 +9,6 @@ use external_api::http::external_match::{
 use eyre::Result;
 use hyper::StatusCode;
 use reqwest::{Method, Response, header::HeaderMap};
-use state::storage::tx::matching_pools::GLOBAL_MATCHING_POOL;
 use types_runtime::MatchingPoolName;
 
 use crate::ctx::IntegrationTestCtx;

--- a/crates/workers/api-server/integration/external_match/matching_pool.rs
+++ b/crates/workers/api-server/integration/external_match/matching_pool.rs
@@ -1,10 +1,10 @@
 //! Integration tests for external matching in a matching pool
 
 use circuit_types::order::OrderSide;
+use constants::GLOBAL_MATCHING_POOL;
 use external_api::http::external_match::ExternalOrder;
 use eyre::Result;
 use hyper::StatusCode;
-use state::storage::tx::matching_pools::GLOBAL_MATCHING_POOL;
 use test_helpers::{assert_eq_result, integration_test_async};
 
 use crate::ctx::IntegrationTestCtx;

--- a/crates/workers/job-types/src/matching_engine.rs
+++ b/crates/workers/job-types/src/matching_engine.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use circuit_types::{Amount, fixed_point::FixedPoint};
+use constants::GLOBAL_MATCHING_POOL;
 use system_bus::gen_atomic_match_response_topic;
 use types_account::{MatchingPoolName, OrderId, order::Order};
 use types_core::TimestampedPrice;
@@ -182,5 +183,10 @@ impl ExternalMatchingEngineOptions {
     pub fn with_matching_pool(mut self, pool: Option<MatchingPoolName>) -> Self {
         self.matching_pool = pool;
         self
+    }
+
+    /// Get the matching pool
+    pub fn matching_pool(&self) -> MatchingPoolName {
+        self.matching_pool.clone().unwrap_or(GLOBAL_MATCHING_POOL.to_string())
     }
 }

--- a/crates/workers/matching-engine/matching-engine-core/Cargo.toml
+++ b/crates/workers/matching-engine/matching-engine-core/Cargo.toml
@@ -10,6 +10,7 @@ circuit-types = { workspace = true }
 crypto = { workspace = true }
 darkpool-types = { workspace = true }
 types-account = { workspace = true }
+types-core = { workspace = true }
 util = { workspace = true, features = ["blockchain"] }
 
 # === Misc Dependencies === #

--- a/crates/workers/matching-engine/matching-engine-core/src/book.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/book.rs
@@ -131,12 +131,15 @@ impl Book {
     /// If `require_externally_matchable` is `true`, only matches against
     /// orders that have `externally_matchable` set to `true`. If `false`, does
     /// not filter on externally matchable status.
+    ///
+    /// Returns the order id, the match amount, and the matchable amount bounds
+    /// (min and max) of the counterparty.
     pub fn find_match(
         &self,
         price: FixedPoint,
         amount_range: RangeInclusive<Amount>,
         require_externally_matchable: bool,
-    ) -> Option<(OrderId, Amount)> {
+    ) -> Option<(OrderId, Amount, RangeInclusive<Amount>)> {
         // Build an iterator over orders sorted by descending matchable amount
         let orders = self.iter();
         for (oid, order) in orders {
@@ -154,7 +157,8 @@ impl Book {
 
             // Compute the match amount
             let match_amount = Amount::min(order.matchable_amount, *amount_range.end());
-            return Some((*oid, match_amount));
+            let matchable_amount_bounds = order.min_fill_size..=order.matchable_amount;
+            return Some((*oid, match_amount, matchable_amount_bounds));
         }
 
         None

--- a/crates/workers/matching-engine/matching-engine-core/src/lib.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/lib.rs
@@ -7,4 +7,22 @@
 
 pub(crate) mod book;
 pub(crate) mod engine;
+use std::ops::RangeInclusive;
+
+use circuit_types::Amount;
+use darkpool_types::settlement_obligation::MatchResult;
 pub use engine::MatchingEngine;
+use types_account::OrderId;
+use types_core::TimestampedPriceFp;
+
+/// A successful match between two orders
+pub struct SuccessfulMatch {
+    /// The ID of the other order that matched
+    pub other_order_id: OrderId,
+    /// The price at which the match was executed
+    pub price: TimestampedPriceFp,
+    /// The match result
+    pub match_result: MatchResult,
+    /// The matchable amount bounds (min and max) for the counterparty order
+    pub matchable_amount_bounds: RangeInclusive<Amount>,
+}

--- a/crates/workers/matching-engine/matching-engine-worker/Cargo.toml
+++ b/crates/workers/matching-engine/matching-engine-worker/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { workspace = true }
 
 #=== Workspace Dependencies === #
 darkpool-client = { workspace = true }
+darkpool-types = { workspace = true }
 circuit-types = { workspace = true }
 types-core = { workspace = true }
 types-tasks = { workspace = true }

--- a/crates/workers/matching-engine/matching-engine-worker/src/error.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/error.rs
@@ -11,6 +11,9 @@ pub enum MatchingEngineError {
     /// Necessary price data was not available for a token pair
     #[error("no price data: {0}")]
     NoPriceData(String),
+    /// No valid bounds could be crated for a bounded match
+    #[error("no valid bounds could be created for a bounded match")]
+    NoValidBounds,
     /// Error interacting with the price reporter
     #[error("price reporter error: {0}")]
     PriceReporter(String),

--- a/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
@@ -122,12 +122,15 @@ impl MatchingEngineExecutor {
             // An order has been updated, the executor should run the internal engine on the
             // new order to check for matches
             MatchingEngineWorkerJob::InternalMatchingEngine { order } => {
-                self.run_internal_matching_engine(order).await
+                todo!()
+                // self.run_internal_matching_engine(order).await
             },
 
             // A request to run the external matching engine
             MatchingEngineWorkerJob::ExternalMatchingEngine { order, response_topic, options } => {
-                self.run_external_matching_engine(order, response_topic, options).await
+                todo!()
+                // self.run_external_matching_engine(order, response_topic,
+                // options).await
             },
         }
     }

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
@@ -7,38 +7,19 @@
 //! The external matching engine is responsible for matching an external order
 //! against all known internal order
 
-use std::collections::HashSet;
+use std::ops::RangeInclusive;
 
-use circuit_types::{
-    Amount,
-    balance::Balance,
-    fixed_point::FixedPoint,
-    r#match::{BoundedMatchResult, ExternalMatchResult, MatchResult},
-};
-use constants::Scalar;
+use circuit_types::{Amount, fixed_point::FixedPoint};
 use crypto::fields::scalar_to_u128;
-use job_types::matching_engine_worker::ExternalMatchingEngineOptions;
-use matching_engine_core::compute_max_amount;
+use darkpool_types::settlement_obligation::MatchResult;
+use job_types::matching_engine::ExternalMatchingEngineOptions;
 use system_bus::SystemBusMessage;
-use tracing::{info, instrument, warn};
-use types_account::account::{Order, OrderId};
-use types_core::{price::TimestampedPriceFp, token::Token};
-use types_runtime::MatchingPoolName;
-use types_tasks::{
-    SettleExternalMatchTaskDescriptor, SettleMalleableExternalMatchTaskDescriptor, TaskDescriptor,
-};
-use util::telemetry::helpers::backfill_trace_field;
+use tracing::{info, instrument};
+use types_account::{account::OrderId, order::Order};
 
-use crate::executor::MatchingEngineExecutor;
+use crate::{error::MatchingEngineError, executor::MatchingEngineExecutor};
+use matching_engine_core::SuccessfulMatch;
 
-use super::matching_order_filter;
-
-/// The maximum difference between the matched quote amount and the requested
-/// exact amount that allows the quote amount to be overridden
-///
-/// This is intentionally very low, as the quote amount should only be
-/// overridden for very small differences that amount to rounding
-const MAX_PRICE_OVERRIDE_DIFF: f64 = 0.000001;
 /// The maximum one-sided range to allow on a malleable match
 ///
 /// That is, when emitting a bounded match, the range of the match is:
@@ -57,171 +38,27 @@ impl MatchingEngineExecutor {
     #[instrument(name = "run_external_matching_engine", skip_all)]
     pub async fn run_external_matching_engine(
         &self,
-        mut order: Order,
-        response_topic: String,
-        mut options: ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        // Sample an execution price if one is not provided
-        let ts_price = match options.price {
-            Some(price) => price.into(),
-            None => {
-                let base = Token::from_addr_biguint(&order.base_mint);
-                let quote = Token::from_addr_biguint(&order.quote_mint);
-                self.get_execution_price(&base, &quote)?
-            },
-        };
-
-        let ts_price = match self.setup_exact_quote_amount(ts_price, &mut order, &mut options)? {
-            Some(price) => price,
-            None => {
-                self.handle_no_match(response_topic);
-                return Ok(());
-            },
-        };
-
-        // Run the matching engine
-        match self
-            .run_external_matching_engine_inner(order, response_topic.clone(), ts_price, &options)
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                self.handle_no_match(response_topic);
-                Err(e)
-            },
-        }
-    }
-
-    /// Execute an external match
-    async fn run_external_matching_engine_inner(
-        &self,
         order: Order,
         response_topic: String,
-        ts_price: TimestampedPriceFp,
-        options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        let base = Token::from_addr_biguint(&order.base_mint);
-        let quote = Token::from_addr_biguint(&order.quote_mint);
-        info!(
-            "Running external matching engine for {} {}/{} with size {}",
-            order.side,
-            base.get_ticker().unwrap_or_default(),
-            quote.get_ticker().unwrap_or_default(),
-            order.amount
-        );
-
-        // Get all orders that consent to external matching
-        let pool = options.matching_pool.clone();
-        let mut matchable_orders = self.get_external_match_candidates(&order, pool).await?;
-        let price = ts_price.price;
-        let min_quote = options.min_quote_amount.unwrap_or_default();
-
-        // Mock a balance for the external order, assuming it's fully capitalized
-        let balance = self.mock_balance_for_external_order(&order, price);
-
-        // Try to find a match iteratively, we wrap this in a retry loop in case
-        // settlement fails on a match
-        while !matchable_orders.is_empty() {
-            let res = self
-                .find_match_with_min_quote_amount(
-                    &order,
-                    &balance,
-                    price,
-                    min_quote,
-                    matchable_orders.iter(),
-                )
-                .await?;
-            if res.is_none() {
+        options: ExternalMatchingEngineOptions,
+    ) -> Result<(), MatchingEngineError> {
+        let matching_pool = options.matching_pool();
+        let res = self.find_external_match(&order, matching_pool)?;
+        let successful_match = match res {
+            Some(match_res) => match_res,
+            None => {
                 self.handle_no_match(response_topic);
                 return Ok(());
-            }
-
-            // For an external match, the direction of the match should always equal the
-            // internal order's direction, make sure this is the case. The core engine logic
-            // may match the external order as the first party
-            let (other_order_id, mut match_res) = res.unwrap();
-            match_res.direction = order.side.opposite().match_direction();
-            let id = other_order_id;
-            let topic = response_topic.clone();
-            if self.handle_match(id, ts_price, match_res, topic, options).await.is_ok() {
-                return Ok(());
-            }
-
-            // If matching failed, remove the other order from the candidate set
-            matchable_orders.remove(&other_order_id);
-        }
-
-        self.handle_no_match(response_topic);
-        Ok(())
-    }
-
-    /// Get the match candidates for an external order
-    #[instrument(name = "get_external_match_candidates", skip(self, order), fields(num_candidates))]
-    async fn get_external_match_candidates(
-        &self,
-        order: &Order,
-        matching_pool: Option<MatchingPoolName>,
-    ) -> Result<HashSet<OrderId>, HandshakeManagerError> {
-        let filter = matching_order_filter(order, true /* external */);
-        let candidates = match matching_pool {
-            Some(pool) => self.state.get_matchable_orders_in_matching_pool(pool, filter).await?,
-            None => self.state.get_matchable_orders(filter).await?,
+            },
         };
 
-        backfill_trace_field("num_candidates", candidates.len());
-        Ok(HashSet::from_iter(candidates))
-    }
-
-    /// Handle a match against an order
-    async fn handle_match(
-        &self,
-        order_id: OrderId,
-        ts_price: TimestampedPriceFp,
-        match_res: MatchResult,
-        response_topic: String,
-        options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        if options.bounded_match {
-            self.handle_bounded_match(order_id, ts_price, match_res, response_topic, options).await
-        } else {
-            self.handle_exact_match(order_id, ts_price, match_res, response_topic, options).await
-        }
-    }
-
-    // --- Exact Match Handler -- //
-
-    /// Handle an exact match result on the given order
-    async fn handle_exact_match(
-        &self,
-        other_order_id: OrderId,
-        ts_price: TimestampedPriceFp,
-        match_res: MatchResult,
-        response_topic: String,
-        options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        // If the request only requires a quote, we can stop here
+        // Handle a successful match
         if options.only_quote {
-            self.forward_quote(response_topic.clone(), match_res);
-            return Ok(());
-        }
-
-        // Otherwise, settle the match by building an atomic match bundle
-        let settle_res = self
-            .try_settle_external_match(
-                other_order_id,
-                ts_price,
-                match_res,
-                response_topic.clone(),
-                options,
-            )
-            .await;
-
-        match settle_res {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                warn!("external match settlement failed on internal order {other_order_id}: {e}");
-                Err(e)
-            },
+            self.forward_quote(response_topic.clone(), successful_match.match_result);
+            Ok(())
+        } else {
+            self.try_settle_external_match(order.id, successful_match, response_topic, &options)
+                .await
         }
     }
 
@@ -229,191 +66,50 @@ impl MatchingEngineExecutor {
     async fn try_settle_external_match(
         &self,
         internal_order_id: OrderId,
-        ts_price: TimestampedPriceFp,
-        match_res: MatchResult,
+        match_result: SuccessfulMatch,
         response_topic: String,
         options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        let wallet_id = self.get_wallet_id_for_order(&internal_order_id).await?;
-        let task = SettleExternalMatchTaskDescriptor::new(
-            options.bundle_duration,
-            internal_order_id,
-            wallet_id,
-            ts_price,
-            options.relayer_fee_rate,
-            match_res,
-            response_topic,
-        );
-        self.enqueue_settlement_task(task).await
+    ) -> Result<(), MatchingEngineError> {
+        todo!("Settle external match")
     }
 
     // --- Bounded Match Handler --- //
 
-    /// Handle a bounded match result on the given order
-    ///
-    /// The matching engine will sample appropriate bounds for the `base_amount`
-    /// and forward the task to the task driver to create a bundle.
-    async fn handle_bounded_match(
-        &self,
-        order_id: OrderId,
-        ts_price: TimestampedPriceFp,
-        match_res: MatchResult,
-        response_topic: String,
-        options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        // Build a bounded match result
-        let price_fp = ts_price.price();
-        let (min_amount, max_amount) =
-            self.derive_match_bounds(&order_id, price_fp, match_res.base_amount).await?;
-        let bounded_res = BoundedMatchResult {
-            quote_mint: match_res.quote_mint,
-            base_mint: match_res.base_mint,
-            price: price_fp,
-            min_base_amount: min_amount,
-            max_base_amount: max_amount,
-            direction: match_res.direction,
-        };
-
-        let settle_res =
-            self.try_settle_bounded_match(order_id, bounded_res, response_topic, options).await;
-        match settle_res {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                warn!("bounded match settlement failed on internal order {order_id}: {e}");
-                Err(e)
-            },
-        }
-    }
-
-    /// Try settling a malleable match
-    async fn try_settle_bounded_match(
-        &self,
-        order_id: OrderId,
-        bounded_res: BoundedMatchResult,
-        response_topic: String,
-        options: &ExternalMatchingEngineOptions,
-    ) -> Result<(), HandshakeManagerError> {
-        let wallet_id = self.get_wallet_id_for_order(&order_id).await?;
-        let task = SettleMalleableExternalMatchTaskDescriptor::new(
-            options.bundle_duration,
-            order_id,
-            wallet_id,
-            options.relayer_fee_rate,
-            bounded_res,
-            response_topic,
-        );
-        self.enqueue_settlement_task(task).await
-    }
-
     /// Derive the bounds for a match
     ///
-    /// Returns a tuple containing `(min_amount, max_amount)`
+    /// Returns a tuple containing the minimum and maximum input amounts for the
+    /// external party.
     async fn derive_match_bounds(
         &self,
-        order_id: &OrderId,
         price: FixedPoint,
         match_amt: Amount,
-    ) -> Result<(Amount, Amount), HandshakeManagerError> {
-        let wallet = self
-            .state
-            .get_wallet_for_order(order_id)
-            .await?
-            .ok_or_else(|| HandshakeManagerError::state(ERR_NO_WALLET))?;
-        let order = wallet
-            .get_order(order_id)
-            .ok_or_else(|| HandshakeManagerError::state(ERR_NO_ORDER))?
-            .clone();
-
-        let capitalizing_balance = wallet.get_balance_for_order(&order).unwrap_or_default();
-        let order_min = order.min_fill_size;
-        let order_max = compute_max_amount(&price, &order.into(), &capitalizing_balance);
+        matchable_amount_bounds: RangeInclusive<Amount>,
+    ) -> Result<(Amount, Amount), MatchingEngineError> {
+        let counterparty_min = *matchable_amount_bounds.start();
+        let counterparty_max = *matchable_amount_bounds.end();
+        let min_input = price.ceil_div_int(counterparty_min);
+        let max_input = price.floor_div_int(counterparty_max);
 
         let min_amount = mul_amount_f64(match_amt, 1.0 - MAX_MALLEABLE_RANGE);
         let max_amount = mul_amount_f64(match_amt, 1.0 + MAX_MALLEABLE_RANGE);
 
         // Clamp the amounts to the order's min and max
-        let min_amount = u128::max(min_amount, order_min);
-        let max_amount = u128::min(max_amount, order_max);
+        let min_amount = u128::max(min_amount, scalar_to_u128(&min_input));
+        let max_amount = u128::min(max_amount, scalar_to_u128(&max_input));
+        if min_amount > max_amount {
+            return Err(MatchingEngineError::NoValidBounds);
+        }
 
         Ok((min_amount, max_amount))
     }
 
     // --- Helper Functions --- //
 
-    /// Setup an exact quote amount
-    ///
-    /// This requires tweaking the order's base amount and the price at which
-    /// the order executes. We verify that the tweaks do not move the price a
-    /// material amount. If this is not possible, we return `None` to indicate
-    /// that an exact match cannot be found
-    ///
-    /// The price returned is the price at which the match should execute in
-    /// order to fulfill the quote amount constraints
-    fn setup_exact_quote_amount(
-        &self,
-        original_price: TimestampedPriceFp,
-        order: &mut Order,
-        options: &mut ExternalMatchingEngineOptions,
-    ) -> Result<Option<TimestampedPriceFp>, HandshakeManagerError> {
-        // If no exact quote is configured, the original price will be used
-        let quote_amount = match options.exact_quote_amount {
-            Some(amount) => amount,
-            None => return Ok(Some(original_price)),
-        };
-        let price_fp = original_price.price();
-
-        // Compute a base amount that we will use to derive the modified price
-        let base_amount_scalar = price_fp.ceil_div_int(quote_amount);
-        let base_amount = scalar_to_u128(&base_amount_scalar);
-
-        // Update the order and options to reflect the new amounts
-        order.amount = base_amount;
-        options.min_quote_amount = Some(quote_amount);
-
-        // Compute the implied price for the new amounts
-        let price_fp = compute_implied_price(base_amount, quote_amount);
-        let new_price = TimestampedPriceFp::new(price_fp);
-        if check_price_override_tolerance(new_price.price.to_f64(), original_price.price.to_f64()) {
-            Ok(Some(new_price))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Enqueue a settlement task
-    async fn enqueue_settlement_task<T: Into<TaskDescriptor>>(
-        &self,
-        descriptor: T,
-    ) -> Result<(), HandshakeManagerError> {
-        let descriptor = descriptor.into();
-        self.forward_bypassing_task(descriptor).await
-    }
-
     /// Forward a quote to the client
+    #[allow(clippy::needless_pass_by_value)]
     fn forward_quote(&self, response_topic: String, quote: MatchResult) {
         info!("forwarding quote to client");
-        let external_res = ExternalMatchResult::from(quote);
-        let response = SystemBusMessage::ExternalOrderQuote { quote: external_res };
-        self.system_bus.publish(response_topic, response);
-    }
-
-    /// Mock a balance for an external order
-    ///
-    /// We cannot know the external party's balance here so we mock it for the
-    /// matching engine. We assume the external order is fully capitalized and
-    /// so we mock a full balance
-    fn mock_balance_for_external_order(&self, order: &Order, price: FixedPoint) -> Balance {
-        let base_amount = Scalar::from(order.amount);
-        let quote_amount_fp = price * base_amount + Scalar::one();
-        let quote_amount = quote_amount_fp.floor();
-
-        let (mint, amount) = if order.side.is_buy() {
-            (order.quote_mint.clone(), quote_amount)
-        } else {
-            (order.base_mint.clone(), base_amount)
-        };
-
-        Balance::new_from_mint_and_amount(mint, scalar_to_u128(&amount))
+        todo!("Forward quote")
     }
 
     /// Send a message on the response topic indicating that no match was found
@@ -431,21 +127,4 @@ fn mul_amount_f64(amount: Amount, multiplier: f64) -> Amount {
     let amount_f64 = amount as f64;
     let product = amount_f64 * multiplier;
     product.floor() as Amount
-}
-
-/// Compute the implied price for a given base and quote amount
-///
-/// We ceil div here because the `quote_amount` is constrained to equal the
-/// floor div of the price times the `base_amount` in the matching engine
-/// constraints. So we need `price * base_amount >= quote_amount` to hold.
-fn compute_implied_price(base_amount: Amount, quote_amount: Amount) -> FixedPoint {
-    let base_amount_fp = FixedPoint::from(base_amount);
-    let quote_amount_fp = FixedPoint::from(quote_amount);
-    quote_amount_fp.ceil_div(&base_amount_fp)
-}
-
-/// Check that two prices are within the price override tolerance
-fn check_price_override_tolerance(new_price: f64, old_price: f64) -> bool {
-    let override_diff = (new_price - old_price) / old_price;
-    override_diff.abs() < MAX_PRICE_OVERRIDE_DIFF
 }

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/match_helpers.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/match_helpers.rs
@@ -1,102 +1,75 @@
 //! Helpers for matching orders
 
-use circuit_types::{Amount, fixed_point::FixedPoint};
-use types_account::account::{OrderId, order::Order};
-use types_core::{TimestampedPrice, Token};
+use circuit_types::Amount;
+use matching_engine_core::SuccessfulMatch;
+use types_account::{MatchingPoolName, account::order::Order, pair::Pair};
+use types_core::{TimestampedPrice, TimestampedPriceFp};
 
 use crate::{error::MatchingEngineError, executor::MatchingEngineExecutor};
 
-/// A successful match between two orders
-pub type SuccessfulMatch = (OrderId, MatchResult);
-
+// TODO: Global min fill size
 impl MatchingEngineExecutor {
-    /// Run a match between two orders
-    pub async fn find_match<'a, I>(
+    /// Find an internal match for an order
+    pub fn find_internal_match(
         &self,
         order: &Order,
-        balance: &Balance,
-        price: FixedPoint,
-        target_orders: I,
-    ) -> Result<Option<SuccessfulMatch>, MatchingEngineError>
-    where
-        I: Iterator<Item = &'a OrderId>,
-    {
-        let min_quote = self.min_fill_size;
-        self.find_match_with_min_quote_amount(order, balance, price, min_quote, target_orders).await
+        matchable_amount: Amount,
+        matching_pool: MatchingPoolName,
+    ) -> Result<Option<SuccessfulMatch>, MatchingEngineError> {
+        self.find_match(order, matchable_amount, matching_pool, false /* external_match */)
     }
 
-    /// Try a match with a minimum quote amount specified
-    pub async fn find_match_with_min_quote_amount<'a, I>(
+    /// Find an external match for an order
+    pub fn find_external_match(
         &self,
         order: &Order,
-        balance: &Balance,
-        price: FixedPoint,
-        min_quote_amount: Amount,
-        target_orders: I,
-    ) -> Result<Option<SuccessfulMatch>, MatchingEngineError>
-    where
-        I: Iterator<Item = &'a OrderId>,
-    {
-        // Match against each other order in the local book
-        for order_id in target_orders.into_iter() {
-            // Lookup the other order and attempt to match with it
-            let (order2, balance2) =
-                match self.state.get_managed_order_and_balance(order_id).await? {
-                    Some((order, balance)) => (order, balance),
-                    None => continue,
-                };
+        matching_pool: MatchingPoolName,
+    ) -> Result<Option<SuccessfulMatch>, MatchingEngineError> {
+        // For an external match, no balance capitalizes the order, so the matchable
+        // amount is the same as the intent amount
+        let matchable_amount = order.intent.amount_in;
+        self.find_match(order, matchable_amount, matching_pool, true /* external_match */)
+    }
 
-            // If a match is successful, return the result
-            let res = self.try_match(order, &order2, balance, &balance2, price, min_quote_amount);
-            if let Some(match_result) = res {
-                return Ok(Some((*order_id, match_result)));
-            }
+    /// Run a match between two orders
+    fn find_match(
+        &self,
+        order: &Order,
+        matchable_amount: Amount,
+        matching_pool: MatchingPoolName,
+        external_match: bool,
+    ) -> Result<Option<SuccessfulMatch>, MatchingEngineError> {
+        // Sample a price to execute the match at
+        let pair = order.pair();
+        let price = self.get_execution_price(&pair)?;
+
+        // Sanity check the input range
+        let input_range = order.min_fill_size()..=matchable_amount;
+        if input_range.is_empty() {
+            return Ok(None);
         }
 
-        Ok(None)
-    }
+        // Forward to the matching engine
+        let res = if external_match {
+            self.matching_engine.find_match_external(pair, input_range, matching_pool, price)
+        } else {
+            self.matching_engine.find_match(pair, input_range, matching_pool, price)
+        };
 
-    /// Try to match two orders, return the `MatchResult` if a match is found
-    fn try_match(
-        &self,
-        o1: &Order,
-        o2: &Order,
-        b1: &Balance,
-        b2: &Balance,
-        price: FixedPoint,
-        min_quote_amount: Amount,
-    ) -> Option<MatchResult> {
-        // Match the orders
-        let min_base_amount = Amount::max(o1.min_fill_size, o2.min_fill_size);
-        let min_quote_amount = u128::max(min_quote_amount, self.min_fill_size);
-
-        match_orders_with_min_base_amount(
-            &o1.clone().into(),
-            &o2.clone().into(),
-            b1,
-            b2,
-            min_quote_amount,
-            min_base_amount,
-            price,
-        )
-    }
-
-    /// Get the execution price for an order
-    pub(crate) async fn get_execution_price_for_order(
-        &self,
-        order: &OrderId,
-    ) -> Result<TimestampedPriceFp, MatchingEngineError> {
-        let (base, quote) = self.token_pair_for_order(order).await?;
-        self.get_execution_price(&base, &quote)
+        Ok(res)
     }
 
     /// Fetch the execution price for an order
     pub(crate) fn get_execution_price(
         &self,
-        base: &Token,
-        quote: &Token,
+        pair: &Pair,
     ) -> Result<TimestampedPriceFp, MatchingEngineError> {
-        let state = self.price_streams.get_state(base, quote);
+        // Convert the pair to a canonically quoted pair
+        let usdc_quoted_pair = pair.to_usdc_quoted().map_err(MatchingEngineError::no_price)?;
+        let (base, quote) = (usdc_quoted_pair.in_token(), usdc_quoted_pair.out_token());
+
+        // Fetch the price state for the pair
+        let state = self.price_streams.get_state(&base, &quote);
         let state = &state.into_nominal().ok_or_else(|| {
             MatchingEngineError::price_reporter(format!("No price data for {base} / {quote}"))
         })?;
@@ -104,7 +77,7 @@ impl MatchingEngineExecutor {
 
         // Correct the price for decimals
         let corrected_price = price
-            .get_decimal_corrected_price(base, quote)
+            .get_decimal_corrected_price(&base, &quote)
             .map_err(MatchingEngineError::no_price)?;
         Ok(corrected_price.into())
     }

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/mod.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/mod.rs
@@ -1,5 +1,5 @@
 //! Matching engine implementations for the handshake manager
 
-// pub mod external_engine;
-// pub mod internal_engine;
+pub mod external_engine;
+pub mod internal_engine;
 mod match_helpers;

--- a/crates/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
+++ b/crates/workers/task-driver/src/tasks/update_wallet/helpers/events.rs
@@ -1,13 +1,13 @@
 //! Helpers for emitting events after a wallet update
 
-use types_runtime::MatchingPoolName;
-use types_tasks::WalletUpdateType;
-use types_account::account::{Order, OrderId};
+use constants::GLOBAL_MATCHING_POOL;
 use job_types::event_manager::{
     ExternalTransferEvent, OrderCancellationEvent, OrderPlacementEvent, OrderUpdateEvent,
     RelayerEventType, try_send_event,
 };
-use state::storage::tx::matching_pools::GLOBAL_MATCHING_POOL;
+use types_account::account::{Order, OrderId};
+use types_runtime::MatchingPoolName;
+use types_tasks::WalletUpdateType;
 use util::err_str;
 
 use crate::tasks::update_wallet::{UpdateWalletTask, UpdateWalletTaskError};


### PR DESCRIPTION
### Purpose
This PR re-implements the logic for the internal and external matching engines over the new matching engine primitive.

### Testing
- [x] Unit tests pass