### PR TITLE
types-account: orders, balances: Track CSPRNG states in account

### DIFF
--- a/crates/api/external-api/src/types/balance.rs
+++ b/crates/api/external-api/src/types/balance.rs
@@ -1,6 +1,6 @@
 //! API types for balances
 
-use darkpool_types::balance::Balance;
+use darkpool_types::balance::DarkpoolBalance;
 #[cfg(feature = "full-api")]
 use renegade_solidity_abi::v2::IDarkpoolV2::DepositAuth;
 use serde::{Deserialize, Serialize};
@@ -37,8 +37,8 @@ pub struct ApiBalance {
     pub public_shares: ApiBalanceShare,
 }
 
-impl From<Balance> for ApiBalance {
-    fn from(bal: Balance) -> Self {
+impl From<DarkpoolBalance> for ApiBalance {
+    fn from(bal: DarkpoolBalance) -> Self {
         Self {
             mint: address_to_hex_string(&bal.mint),
             owner: address_to_hex_string(&bal.owner),

--- a/crates/circuits/circuits-core/src/zk_circuits/fees/valid_private_protocol_fee_payment.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/fees/valid_private_protocol_fee_payment.rs
@@ -10,7 +10,9 @@ use circuit_types::ser_embedded_scalar_field;
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
 use circuit_types::{Commitment, Nullifier, PlonkCircuit};
 use constants::{EmbeddedScalarField, MERKLE_HEIGHT, Scalar, ScalarField};
-use darkpool_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
+use darkpool_types::balance::{
+    DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+};
 use darkpool_types::note::{NOTE_CIPHERTEXT_SIZE, NoteVar};
 use mpc_plonk::errors::PlonkError;
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
@@ -113,11 +115,11 @@ impl<const MERKLE_HEIGHT: usize> ValidPrivateProtocolFeePayment<MERKLE_HEIGHT> {
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
     pub fn compute_post_payment_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         statement: &ValidPrivateProtocolFeePaymentStatementVar,
         witness: &ValidPrivateProtocolFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
@@ -230,7 +232,7 @@ pub mod test_helpers {
     use alloy_primitives::Address;
     use constants::Scalar;
     use darkpool_types::{
-        balance::{Balance, DarkpoolStateBalance},
+        balance::{DarkpoolBalance, DarkpoolStateBalance},
         note::Note,
     };
     use rand::thread_rng;
@@ -272,7 +274,7 @@ pub mod test_helpers {
         let protocol_encryption_key = random_elgamal_encryption_key();
 
         // The address to which protocol fees are paid
-        let old_balance = create_random_state_wrapper(Balance {
+        let old_balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: Address::ZERO,
             owner: random_address(),
@@ -323,7 +325,7 @@ pub mod test_helpers {
     }
 
     /// Create a note for the given balance's protocol fee payment
-    fn create_note(balance: &Balance, protocol_fee_receiver: Address) -> Note {
+    fn create_note(balance: &DarkpoolBalance, protocol_fee_receiver: Address) -> Note {
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
         Note {

--- a/crates/circuits/circuits-core/src/zk_circuits/fees/valid_private_relayer_fee_payment.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/fees/valid_private_relayer_fee_payment.rs
@@ -8,7 +8,9 @@ use circuit_types::merkle::{MerkleOpening, MerkleRoot};
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
 use circuit_types::{Commitment, Nullifier, PlonkCircuit};
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
-use darkpool_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
+use darkpool_types::balance::{
+    DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+};
 use darkpool_types::note::NoteVar;
 use mpc_plonk::errors::PlonkError;
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
@@ -103,11 +105,11 @@ impl<const MERKLE_HEIGHT: usize> ValidPrivateRelayerFeePayment<MERKLE_HEIGHT> {
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
     pub fn compute_post_payment_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         statement: &ValidPrivateRelayerFeePaymentStatementVar,
         witness: &ValidPrivateRelayerFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
@@ -215,7 +217,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 pub mod test_helpers {
     use constants::Scalar;
     use darkpool_types::{
-        balance::{Balance, DarkpoolStateBalance},
+        balance::{DarkpoolBalance, DarkpoolStateBalance},
         note::Note,
     };
     use rand::thread_rng;
@@ -252,7 +254,7 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement()
     -> (SizedValidPrivateRelayerFeePaymentWitness, ValidPrivateRelayerFeePaymentStatement) {
         // The balance from which relayer fees are paid
-        let old_balance = create_random_state_wrapper(Balance {
+        let old_balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: random_address(),
             owner: random_address(),
@@ -305,7 +307,7 @@ pub mod test_helpers {
     }
 
     /// Create a note for the given balance's relayer fee payment
-    fn create_note(balance: &Balance) -> Note {
+    fn create_note(balance: &DarkpoolBalance) -> Note {
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
         Note {
@@ -342,7 +344,7 @@ mod test {
     use super::test_helpers::create_dummy_witness_statement_with_balance;
     use super::*;
     use circuit_types::traits::SingleProverCircuit;
-    use darkpool_types::{balance::Balance, note::Note};
+    use darkpool_types::{balance::DarkpoolBalance, note::Note};
 
     /// A helper to print the number of constraints in the circuit
     ///
@@ -370,7 +372,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid__zero_relayer_fee_balance() {
-        let balance = create_random_state_wrapper(Balance {
+        let balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: random_address(),
             owner: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/fees/valid_public_protocol_fee_payment.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/fees/valid_public_protocol_fee_payment.rs
@@ -9,7 +9,9 @@ use circuit_types::merkle::{MerkleOpening, MerkleRoot};
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
 use circuit_types::{Commitment, Nullifier, PlonkCircuit};
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
-use darkpool_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
+use darkpool_types::balance::{
+    DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+};
 use darkpool_types::note::Note;
 use mpc_plonk::errors::PlonkError;
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
@@ -98,11 +100,11 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicProtocolFeePayment<MERKLE_HEIGHT> {
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
     pub fn compute_post_payment_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         statement: &ValidPublicProtocolFeePaymentStatementVar,
         witness: &ValidPublicProtocolFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
@@ -202,7 +204,7 @@ pub mod test_helpers {
     use alloy_primitives::Address;
     use constants::Scalar;
     use darkpool_types::{
-        balance::{Balance, DarkpoolStateBalance},
+        balance::{DarkpoolBalance, DarkpoolStateBalance},
         note::Note,
     };
     use rand::thread_rng;
@@ -239,7 +241,7 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement()
     -> (SizedValidPublicProtocolFeePaymentWitness, ValidPublicProtocolFeePaymentStatement) {
         // The balance from which protocol fees are paid
-        let old_balance = create_random_state_wrapper(Balance {
+        let old_balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: Address::ZERO,
             owner: random_address(),
@@ -288,7 +290,7 @@ pub mod test_helpers {
     }
 
     /// Create a note for the given balance's protocol fee payment
-    fn create_note(balance: &Balance) -> Note {
+    fn create_note(balance: &DarkpoolBalance) -> Note {
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
         Note {
@@ -325,7 +327,7 @@ mod test {
     use super::*;
     use alloy_primitives::Address;
     use circuit_types::traits::SingleProverCircuit;
-    use darkpool_types::balance::Balance;
+    use darkpool_types::balance::DarkpoolBalance;
 
     /// A helper to print the number of constraints in the circuit
     ///
@@ -353,7 +355,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid__zero_protocol_fee_balance() {
-        let balance = create_random_state_wrapper(Balance {
+        let balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: Address::ZERO,
             owner: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/fees/valid_public_relayer_fee_payment.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/fees/valid_public_relayer_fee_payment.rs
@@ -9,7 +9,9 @@ use circuit_types::merkle::{MerkleOpening, MerkleRoot};
 use circuit_types::traits::{BaseType, CircuitBaseType, CircuitVarType};
 use circuit_types::{Commitment, Nullifier, PlonkCircuit};
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
-use darkpool_types::balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar};
+use darkpool_types::balance::{
+    DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+};
 use darkpool_types::note::Note;
 use mpc_plonk::errors::PlonkError;
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
@@ -98,11 +100,11 @@ impl<const MERKLE_HEIGHT: usize> ValidPublicRelayerFeePayment<MERKLE_HEIGHT> {
     /// Returns the new balance, the new private shares, and the new public
     /// shares.
     pub fn compute_post_payment_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         statement: &ValidPublicRelayerFeePaymentStatementVar,
         witness: &ValidPublicRelayerFeePaymentWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
@@ -201,7 +203,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 pub mod test_helpers {
     use constants::Scalar;
     use darkpool_types::{
-        balance::{Balance, DarkpoolStateBalance},
+        balance::{DarkpoolBalance, DarkpoolStateBalance},
         note::Note,
     };
     use rand::thread_rng;
@@ -238,7 +240,7 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement()
     -> (SizedValidPublicRelayerFeePaymentWitness, ValidPublicRelayerFeePaymentStatement) {
         // The balance from which relayer fees are paid
-        let old_balance = create_random_state_wrapper(Balance {
+        let old_balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: random_address(),
             owner: random_address(),
@@ -286,7 +288,7 @@ pub mod test_helpers {
     }
 
     /// Create a note for the given balance's relayer fee payment
-    fn create_note(balance: &Balance) -> Note {
+    fn create_note(balance: &DarkpoolBalance) -> Note {
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
         Note {
@@ -322,7 +324,7 @@ mod test {
     use super::test_helpers::create_dummy_witness_statement_with_balance;
     use super::*;
     use circuit_types::traits::SingleProverCircuit;
-    use darkpool_types::balance::Balance;
+    use darkpool_types::balance::DarkpoolBalance;
 
     /// A helper to print the number of constraints in the circuit
     ///
@@ -350,7 +352,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_invalid__zero_relayer_fee_balance() {
-        let balance = create_random_state_wrapper(Balance {
+        let balance = create_random_state_wrapper(DarkpoolBalance {
             mint: random_address(),
             relayer_fee_recipient: random_address(),
             owner: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/proof_linking/intent_and_balance.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/proof_linking/intent_and_balance.rs
@@ -452,13 +452,13 @@ mod test {
     #[allow(non_snake_case)]
     fn test_intent_and_balance_exact_public_settlement_invalid_link__modified_balance() {
         use crate::test_helpers::{random_address, random_amount};
-        use darkpool_types::balance::Balance;
+        use darkpool_types::balance::DarkpoolBalance;
 
         let (validity_witness, validity_statement, mut settlement_witness, settlement_statement) =
             build_intent_and_balance_validity_exact_public_settlement_data();
 
         // Modify the balance in the settlement witness to break the link
-        settlement_witness.in_balance = Balance {
+        settlement_witness.in_balance = DarkpoolBalance {
             mint: random_address(),
             owner: random_address(),
             relayer_fee_recipient: random_address(),
@@ -1110,13 +1110,13 @@ mod test {
     #[allow(non_snake_case)]
     fn test_intent_and_balance_bounded_settlement_invalid_link__modified_balance() {
         use crate::test_helpers::{random_address, random_amount};
-        use darkpool_types::balance::Balance;
+        use darkpool_types::balance::DarkpoolBalance;
 
         let (validity_witness, validity_statement, mut settlement_witness, settlement_statement) =
             build_intent_and_balance_validity_bounded_settlement_data();
 
         // Modify the balance in the settlement witness to break the link
-        settlement_witness.in_balance = Balance {
+        settlement_witness.in_balance = DarkpoolBalance {
             mint: random_address(),
             owner: random_address(),
             relayer_fee_recipient: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_bounded_settlement.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_bounded_settlement.rs
@@ -17,7 +17,7 @@ use circuit_types::{
 };
 use constants::{Scalar, ScalarField};
 use darkpool_types::{
-    balance::{Balance, PostMatchBalanceShare},
+    balance::{DarkpoolBalance, PostMatchBalanceShare},
     bounded_match_result::BoundedMatchResult,
     intent::Intent,
 };
@@ -109,7 +109,7 @@ pub struct IntentAndBalanceBoundedSettlementWitness {
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
     /// circuit
     #[link_groups = "intent_and_balance_settlement_party0"]
-    pub in_balance: Balance,
+    pub in_balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     ///
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
@@ -121,7 +121,7 @@ pub struct IntentAndBalanceBoundedSettlementWitness {
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
     /// circuit
     #[link_groups = "output_balance_settlement_party0"]
-    pub out_balance: Balance,
+    pub out_balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     /// for the output balance
     ///
@@ -227,7 +227,7 @@ pub mod test_helpers {
     use alloy_primitives::Address;
     use circuit_types::max_amount;
     use darkpool_types::{
-        balance::Balance, bounded_match_result::BoundedMatchResult, intent::Intent,
+        balance::DarkpoolBalance, bounded_match_result::BoundedMatchResult, intent::Intent,
     };
     use rand::{Rng, thread_rng};
 
@@ -278,7 +278,7 @@ pub mod test_helpers {
     /// Create a witness and statement with the given intent and balance
     pub fn create_witness_statement_with_intent_and_balance(
         intent: &Intent,
-        balance: &Balance,
+        balance: &DarkpoolBalance,
     ) -> (IntentAndBalanceBoundedSettlementWitness, IntentAndBalanceBoundedSettlementStatement)
     {
         let bounded_match_result = create_bounded_match_result_with_balance(intent, balance.amount);
@@ -294,7 +294,7 @@ pub mod test_helpers {
     /// match result
     pub fn create_witness_statement_with_intent_balance_and_bounded_match_result(
         intent: &Intent,
-        balance: &Balance,
+        balance: &DarkpoolBalance,
         bounded_match_result: BoundedMatchResult,
     ) -> (IntentAndBalanceBoundedSettlementWitness, IntentAndBalanceBoundedSettlementStatement)
     {
@@ -331,14 +331,14 @@ pub mod test_helpers {
     pub fn create_receive_balance(
         owner: Address,
         bounded_match_result: &BoundedMatchResult,
-    ) -> Balance {
+    ) -> DarkpoolBalance {
         let mut rng = thread_rng();
         // Compute the maximum output amount based on price and max input amount
         let max_output = compute_max_amount_out(bounded_match_result);
         let max_existing_balance = max_amount() - max_output;
         let amount = rng.gen_range(0..=max_existing_balance);
 
-        Balance {
+        DarkpoolBalance {
             mint: bounded_match_result.internal_party_output_token,
             owner,
             relayer_fee_recipient: random_address(),
@@ -362,7 +362,7 @@ mod test {
         zk_circuits::settlement::intent_and_balance_bounded_settlement::test_helpers,
     };
     use circuit_types::{max_amount, traits::SingleProverCircuit};
-    use darkpool_types::balance::PostMatchBalanceShare;
+    use darkpool_types::balance::{DarkpoolBalance, PostMatchBalanceShare};
     use rand::{Rng, thread_rng};
 
     /// A helper to print the number of constraints in the circuit

--- a/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_private_settlement.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_private_settlement.rs
@@ -11,7 +11,7 @@ use circuit_types::{
 };
 use constants::{Scalar, ScalarField};
 use darkpool_types::{
-    balance::{Balance, PostMatchBalanceShare},
+    balance::{DarkpoolBalance, PostMatchBalanceShare},
     fee::FeeRatesVar,
     intent::Intent,
     settlement_obligation::SettlementObligation,
@@ -151,13 +151,13 @@ pub struct IntentAndBalancePrivateSettlementWitness {
     pub pre_settlement_amount_public_share0: Scalar,
     /// The first party's input balance
     #[link_groups = "intent_and_balance_settlement_party0"]
-    pub input_balance0: Balance,
+    pub input_balance0: DarkpoolBalance,
     /// The pre-update public shares of the first party's input balance
     #[link_groups = "intent_and_balance_settlement_party0"]
     pub pre_settlement_in_balance_shares0: PostMatchBalanceShare,
     /// The first party's output balance
     #[link_groups = "output_balance_settlement_party0"]
-    pub output_balance0: Balance,
+    pub output_balance0: DarkpoolBalance,
     /// The pre-update public shares of the first party's output balance
     #[link_groups = "output_balance_settlement_party0"]
     pub pre_settlement_out_balance_shares0: PostMatchBalanceShare,
@@ -173,13 +173,13 @@ pub struct IntentAndBalancePrivateSettlementWitness {
     pub pre_settlement_amount_public_share1: Scalar,
     /// The second party's input balance
     #[link_groups = "intent_and_balance_settlement_party1"]
-    pub input_balance1: Balance,
+    pub input_balance1: DarkpoolBalance,
     /// The pre-update public shares of the second party's input balance
     #[link_groups = "intent_and_balance_settlement_party1"]
     pub pre_settlement_in_balance_shares1: PostMatchBalanceShare,
     /// The second party's output balance
     #[link_groups = "output_balance_settlement_party1"]
-    pub output_balance1: Balance,
+    pub output_balance1: DarkpoolBalance,
     /// The pre-update public shares of the second party's output balance
     #[link_groups = "output_balance_settlement_party1"]
     pub pre_settlement_out_balance_shares1: PostMatchBalanceShare,
@@ -275,7 +275,7 @@ pub mod test_helpers {
     use circuit_types::max_amount;
     use constants::Scalar;
     use darkpool_types::{
-        balance::{Balance, PostMatchBalanceShare},
+        balance::{DarkpoolBalance, PostMatchBalanceShare},
         fee::FeeRates,
         intent::Intent,
         settlement_obligation::SettlementObligation,
@@ -444,10 +444,10 @@ pub mod test_helpers {
     }
 
     /// Create a send balance for a given obligation
-    fn create_send_balance(owner: Address, obligation: &SettlementObligation) -> Balance {
+    fn create_send_balance(owner: Address, obligation: &SettlementObligation) -> DarkpoolBalance {
         let mut rng = thread_rng();
         let amount = rng.gen_range(obligation.amount_in..=max_amount());
-        Balance {
+        DarkpoolBalance {
             mint: obligation.input_token,
             owner,
             relayer_fee_recipient: random_address(),
@@ -459,11 +459,14 @@ pub mod test_helpers {
     }
 
     /// Create a receive balance for a given obligation
-    fn create_receive_balance(owner: Address, obligation: &SettlementObligation) -> Balance {
+    fn create_receive_balance(
+        owner: Address,
+        obligation: &SettlementObligation,
+    ) -> DarkpoolBalance {
         let mut rng = thread_rng();
         let max_existing_balance = max_amount() - obligation.amount_out;
         let amount = rng.gen_range(0..=max_existing_balance);
-        Balance {
+        DarkpoolBalance {
             mint: obligation.output_token,
             owner,
             relayer_fee_recipient: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/settlement/intent_and_balance_public_settlement.rs
@@ -12,7 +12,7 @@ use circuit_types::{
 };
 use constants::{Scalar, ScalarField};
 use darkpool_types::{
-    balance::{Balance, PostMatchBalanceShare},
+    balance::{DarkpoolBalance, PostMatchBalanceShare},
     intent::Intent,
     settlement_obligation::SettlementObligation,
 };
@@ -109,7 +109,7 @@ pub struct IntentAndBalancePublicSettlementWitness {
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
     /// circuit
     #[link_groups = "intent_and_balance_settlement_party0"]
-    pub in_balance: Balance,
+    pub in_balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     ///
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
@@ -121,7 +121,7 @@ pub struct IntentAndBalancePublicSettlementWitness {
     /// This value is proof-linked from the `INTENT AND BALANCE VALIDITY`
     /// circuit
     #[link_groups = "output_balance_settlement_party0"]
-    pub out_balance: Balance,
+    pub out_balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     /// for the output balance
     ///
@@ -226,7 +226,7 @@ pub mod test_helpers {
     use alloy_primitives::Address;
     use circuit_types::max_amount;
     use darkpool_types::{
-        balance::Balance, intent::Intent, settlement_obligation::SettlementObligation,
+        balance::DarkpoolBalance, intent::Intent, settlement_obligation::SettlementObligation,
     };
     use rand::{Rng, thread_rng};
 
@@ -275,7 +275,7 @@ pub mod test_helpers {
     /// Create a witness and statement with the given intent and balance
     pub fn create_witness_statement_with_intent_and_balance<const MERKLE_HEIGHT: usize>(
         intent: &Intent,
-        balance: &Balance,
+        balance: &DarkpoolBalance,
     ) -> (IntentAndBalancePublicSettlementWitness, IntentAndBalancePublicSettlementStatement) {
         let settlement_obligation =
             create_settlement_obligation_with_balance(intent, balance.amount);
@@ -293,7 +293,7 @@ pub mod test_helpers {
         const MERKLE_HEIGHT: usize,
     >(
         intent: &Intent,
-        balance: &Balance,
+        balance: &DarkpoolBalance,
         settlement_obligation: SettlementObligation,
     ) -> (IntentAndBalancePublicSettlementWitness, IntentAndBalancePublicSettlementStatement) {
         // Create the intent amount public shares
@@ -326,12 +326,15 @@ pub mod test_helpers {
     }
 
     /// Create a receive balance for the given obligation
-    pub fn create_receive_balance(owner: Address, obligation: &SettlementObligation) -> Balance {
+    pub fn create_receive_balance(
+        owner: Address,
+        obligation: &SettlementObligation,
+    ) -> DarkpoolBalance {
         let mut rng = thread_rng();
         let max_existing_balance = max_amount() - obligation.amount_out;
         let amount = rng.gen_range(0..=max_existing_balance);
 
-        Balance {
+        DarkpoolBalance {
             mint: obligation.output_token,
             owner,
             relayer_fee_recipient: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/settlement/settlement_lib.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/settlement/settlement_lib.rs
@@ -4,7 +4,7 @@
 
 use circuit_types::{AMOUNT_BITS, PRICE_BITS, PlonkCircuit};
 use darkpool_types::{
-    balance::{BalanceVar, PostMatchBalanceShareVar},
+    balance::{DarkpoolBalanceVar, PostMatchBalanceShareVar},
     bounded_match_result::BoundedMatchResultVar,
     fee::FeeRatesVar,
     intent::IntentVar,
@@ -28,8 +28,8 @@ impl SettlementGadget {
     /// Verify the intent and balance constraints on a settlement obligation
     pub fn verify_intent_and_balance_obligation_constraints(
         intent: &IntentVar,
-        in_balance: &BalanceVar,
-        out_balance: &BalanceVar,
+        in_balance: &DarkpoolBalanceVar,
+        out_balance: &DarkpoolBalanceVar,
         obligation: &SettlementObligationVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -80,7 +80,7 @@ impl SettlementGadget {
     /// of the balance matches the mint of the intent, and thereby the
     /// obligation.
     fn verify_in_balance_constraints(
-        in_balance: &BalanceVar,
+        in_balance: &DarkpoolBalanceVar,
         obligation: &SettlementObligationVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -96,7 +96,7 @@ impl SettlementGadget {
     /// Verify receive balance constraints
     fn verify_out_balance_constraints(
         intent: &IntentVar,
-        out_balance: &BalanceVar,
+        out_balance: &DarkpoolBalanceVar,
         obligation: &SettlementObligationVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -197,8 +197,8 @@ impl BoundedSettlementGadget {
     /// Verify the intent and balance constraints for a bounded match result
     pub fn verify_intent_and_balance_bounded_match_result_constraints(
         intent: &IntentVar,
-        in_balance: &BalanceVar,
-        out_balance: &BalanceVar,
+        in_balance: &DarkpoolBalanceVar,
+        out_balance: &DarkpoolBalanceVar,
         bounded_match_result: &BoundedMatchResultVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -263,7 +263,7 @@ impl BoundedSettlementGadget {
     /// Note: The balance.mint == intent.in_token constraint is enforced by
     /// the INTENT AND BALANCE VALIDITY proof via proof-linking.
     fn verify_in_balance_constraints(
-        in_balance: &BalanceVar,
+        in_balance: &DarkpoolBalanceVar,
         bounded_match_result: &BoundedMatchResultVar,
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError> {
@@ -281,7 +281,7 @@ impl BoundedSettlementGadget {
     /// The contract validates that min <= max <= amount_in, so we only need to
     /// check the upper bound here.
     fn verify_out_balance_constraints(
-        out_balance: &BalanceVar,
+        out_balance: &DarkpoolBalanceVar,
         intent: &IntentVar,
         bounded_match_result: &BoundedMatchResultVar,
         cs: &mut PlonkCircuit,

--- a/crates/circuits/circuits-core/src/zk_circuits/valid_deposit.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/valid_deposit.rs
@@ -10,7 +10,7 @@ use circuit_types::{
 };
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
 use darkpool_types::{
-    balance::{BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar},
+    balance::{DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar},
     deposit::Deposit,
 };
 use mpc_plonk::errors::PlonkError;
@@ -95,11 +95,11 @@ impl<const MERKLE_HEIGHT: usize> ValidDeposit<MERKLE_HEIGHT> {
 
     /// Create a new balance from the deposit
     fn create_new_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         statement: &ValidDepositStatementVar,
         witness: &ValidDepositWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_share = old_balance_private_shares.clone();
@@ -199,7 +199,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit for ValidDeposit<MERKLE_HEI
 pub mod test_helpers {
     use alloy_primitives::Address;
     use constants::Scalar;
-    use darkpool_types::{balance::Balance, deposit::Deposit};
+    use darkpool_types::{balance::DarkpoolBalance, deposit::Deposit};
 
     use crate::{
         test_helpers::{
@@ -238,7 +238,7 @@ pub mod test_helpers {
     pub fn create_dummy_witness_statement_with_deposit(
         deposit: Deposit,
     ) -> (SizedValidDepositWitness, ValidDepositStatement) {
-        let old_balance = create_random_state_wrapper(Balance {
+        let old_balance = create_random_state_wrapper(DarkpoolBalance {
             mint: deposit.token,
             relayer_fee_recipient: Address::ZERO,
             owner: deposit.from,

--- a/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/intent_and_balance.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/intent_and_balance.rs
@@ -15,7 +15,7 @@ use circuit_types::{
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
 use darkpool_types::{
     balance::{
-        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+        DarkpoolBalance, DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
         PostMatchBalanceShare, PostMatchBalanceShareVar,
     },
     intent::{DarkpoolStateIntent, DarkpoolStateIntentVar, Intent, IntentShare, IntentShareVar},
@@ -197,10 +197,10 @@ impl<const MERKLE_HEIGHT: usize> IntentAndBalanceValidityCircuit<MERKLE_HEIGHT> 
 
     /// Build the new balance
     fn build_new_balance(
-        private_shares: &BalanceShareVar,
+        private_shares: &DarkpoolBalanceShareVar,
         witness: &IntentAndBalanceValidityWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = private_shares.clone();
 
@@ -264,7 +264,7 @@ pub struct IntentAndBalanceValidityWitness<const MERKLE_HEIGHT: usize> {
     pub old_balance_opening: MerkleOpening<MERKLE_HEIGHT>,
     /// The balance which capitalizes the intent
     #[link_groups = "intent_and_balance_settlement_party0,intent_and_balance_settlement_party1"]
-    pub balance: Balance,
+    pub balance: DarkpoolBalance,
     /// The updated public shares of the post-match balance
     #[link_groups = "intent_and_balance_settlement_party0,intent_and_balance_settlement_party1"]
     pub post_match_balance_shares: PostMatchBalanceShare,
@@ -549,7 +549,7 @@ mod test {
         let mut balance_scalars = witness.balance.to_scalars();
         let idx = rng.gen_range(0..balance_scalars.len());
         balance_scalars[idx] = random_scalar();
-        witness.balance = Balance::from_scalars(&mut balance_scalars.into_iter());
+        witness.balance = DarkpoolBalance::from_scalars(&mut balance_scalars.into_iter());
 
         assert!(!test_helpers::check_constraints::<MERKLE_HEIGHT>(&witness, &statement));
     }

--- a/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/intent_and_balance_first_fill.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/intent_and_balance_first_fill.rs
@@ -14,12 +14,12 @@ use circuit_types::{
     merkle::{MerkleOpening, MerkleRoot},
     schnorr::SchnorrSignature,
 };
-use darkpool_types::csprng::PoseidonCSPRNG;
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
+use darkpool_types::csprng::PoseidonCSPRNG;
 use darkpool_types::{
     balance::{
-        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar, PostMatchBalance,
-        PostMatchBalanceShare, PostMatchBalanceShareVar,
+        DarkpoolBalance, DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+        PostMatchBalance, PostMatchBalanceShare, PostMatchBalanceShareVar,
     },
     intent::{DarkpoolStateIntentVar, Intent, IntentShare, PreMatchIntentShare},
     state_wrapper::PartialCommitment,
@@ -51,7 +51,7 @@ use crate::{
 
 /// The size of the partial commitment to the balance
 pub const BALANCE_PARTIAL_COMMITMENT_SIZE: usize =
-    Balance::NUM_SCALARS - PostMatchBalance::NUM_SCALARS;
+    DarkpoolBalance::NUM_SCALARS - PostMatchBalance::NUM_SCALARS;
 
 // ----------------------
 // | Circuit Definition |
@@ -241,10 +241,10 @@ impl<const MERKLE_HEIGHT: usize> IntentAndBalanceFirstFillValidityCircuit<MERKLE
     ///
     /// Returns the new balance and the private shares of the new balance
     fn create_new_balance(
-        old_balance_private_shares: &BalanceShareVar,
+        old_balance_private_shares: &DarkpoolBalanceShareVar,
         witness: &IntentAndBalanceFirstFillValidityWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         // Update the balance
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = old_balance_private_shares.clone();
@@ -319,7 +319,7 @@ pub struct IntentAndBalanceFirstFillValidityWitness<const MERKLE_HEIGHT: usize> 
     /// element balance here so that it may be proof-linked into the settlement
     /// proof.
     #[link_groups = "intent_and_balance_settlement_party0,intent_and_balance_settlement_party1"]
-    pub balance: Balance,
+    pub balance: DarkpoolBalance,
     /// The updated public shares of the post-match balance
     #[link_groups = "intent_and_balance_settlement_party0,intent_and_balance_settlement_party1"]
     pub post_match_balance_shares: PostMatchBalanceShare,
@@ -421,7 +421,7 @@ impl<const MERKLE_HEIGHT: usize> SingleProverCircuit
 pub mod test_helpers {
     use circuit_types::schnorr::SchnorrPrivateKey;
     use darkpool_types::{
-        balance::{Balance, DarkpoolStateBalance, PostMatchBalance},
+        balance::{DarkpoolBalance, DarkpoolStateBalance, PostMatchBalance},
         intent::{Intent, PreMatchIntentShare},
     };
 
@@ -557,7 +557,7 @@ pub mod test_helpers {
         intent: &Intent,
     ) -> (DarkpoolStateBalance, SchnorrPrivateKey) {
         let (secret_key, authority) = random_schnorr_keypair();
-        let balance_inner = Balance {
+        let balance_inner = DarkpoolBalance {
             mint: intent.in_token,
             owner: intent.owner,
             relayer_fee_recipient: random_address(),

--- a/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/new_output_balance.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/new_output_balance.rs
@@ -19,7 +19,7 @@ use circuit_types::{
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
 use darkpool_types::{
     balance::{
-        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+        DarkpoolBalance, DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
         PostMatchBalanceShare, PreMatchBalanceShare,
     },
     state_wrapper::PartialCommitment,
@@ -53,7 +53,7 @@ use crate::{
 ///
 /// This is the set of shares that will not change after the match.
 pub const NEW_BALANCE_PARTIAL_COMMITMENT_SIZE: usize =
-    Balance::NUM_SCALARS - PostMatchBalanceShare::NUM_SCALARS;
+    DarkpoolBalance::NUM_SCALARS - PostMatchBalanceShare::NUM_SCALARS;
 
 // ----------------------
 // | Circuit Definition |
@@ -117,7 +117,7 @@ impl<const MERKLE_HEIGHT: usize> NewOutputBalanceValidityCircuit<MERKLE_HEIGHT> 
         witness: &NewOutputBalanceValidityWitnessVar<MERKLE_HEIGHT>,
         statement: &NewOutputBalanceValidityStatementVar,
         cs: &mut PlonkCircuit,
-    ) -> Result<BalanceShareVar, CircuitError> {
+    ) -> Result<DarkpoolBalanceShareVar, CircuitError> {
         let balance = &witness.balance;
         let public_share = &witness.new_balance.public_share;
 
@@ -247,7 +247,7 @@ pub struct NewOutputBalanceValidityWitness<const MERKLE_HEIGHT: usize> {
     /// We duplicate this value here to proof-link the balance into the
     /// settlement circuit.
     #[link_groups = "output_balance_settlement_party0,output_balance_settlement_party1"]
-    pub balance: Balance,
+    pub balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     ///
     /// These values are proof-linked into the settlement circuit
@@ -382,7 +382,7 @@ pub mod test_helpers {
     /// The balance must be zeroed (amount = 0, fees = 0) to satisfy the circuit
     /// constraints
     pub fn create_witness_statement_with_balance<const MERKLE_HEIGHT: usize>(
-        mut balance_inner: Balance,
+        mut balance_inner: DarkpoolBalance,
     ) -> (NewOutputBalanceValidityWitness<MERKLE_HEIGHT>, NewOutputBalanceValidityStatement) {
         let (private_key, public_key) = random_schnorr_keypair();
 

--- a/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/output_balance.rs
+++ b/crates/circuits/circuits-core/src/zk_circuits/validity_proofs/output_balance.rs
@@ -12,7 +12,7 @@ use circuit_types::{
 use constants::{MERKLE_HEIGHT, Scalar, ScalarField};
 use darkpool_types::{
     balance::{
-        Balance, BalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
+        DarkpoolBalance, DarkpoolBalanceShareVar, DarkpoolStateBalance, DarkpoolStateBalanceVar,
         PostMatchBalanceShare,
     },
     state_wrapper::PartialCommitment,
@@ -44,7 +44,7 @@ use crate::{
 
 /// The size of the partial commitment to the balance
 const BALANCE_PARTIAL_COMMITMENT_SIZE: usize =
-    Balance::NUM_SCALARS - PostMatchBalanceShare::NUM_SCALARS;
+    DarkpoolBalance::NUM_SCALARS - PostMatchBalanceShare::NUM_SCALARS;
 
 // ----------------------
 // | Circuit Definition |
@@ -101,10 +101,10 @@ impl<const MERKLE_HEIGHT: usize> OutputBalanceValidityCircuit<MERKLE_HEIGHT> {
     ///
     /// Returns the new balance and private shares.
     fn build_new_balance(
-        private_shares: &BalanceShareVar,
+        private_shares: &DarkpoolBalanceShareVar,
         witness: &OutputBalanceValidityWitnessVar<MERKLE_HEIGHT>,
         cs: &mut PlonkCircuit,
-    ) -> Result<(DarkpoolStateBalanceVar, BalanceShareVar), CircuitError> {
+    ) -> Result<(DarkpoolStateBalanceVar, DarkpoolBalanceShareVar), CircuitError> {
         let mut new_balance = witness.old_balance.clone();
         let mut new_balance_private_shares = private_shares.clone();
 
@@ -144,7 +144,7 @@ pub struct OutputBalanceValidityWitness<const MERKLE_HEIGHT: usize> {
     ///
     /// Places here to proof-link the circuit into the settlement circuit.
     #[link_groups = "output_balance_settlement_party0,output_balance_settlement_party1"]
-    pub balance: Balance,
+    pub balance: DarkpoolBalance,
     /// The balance public shares which are updated in the settlement circuit
     ///
     /// These values are proof-linked into the settlement circuit.
@@ -252,7 +252,7 @@ pub mod test_helpers {
     /// Construct a witness and statement with valid data using the provided
     /// balance
     pub fn create_witness_statement_with_balance<const MERKLE_HEIGHT: usize>(
-        balance_inner: Balance,
+        balance_inner: DarkpoolBalance,
     ) -> (OutputBalanceValidityWitness<MERKLE_HEIGHT>, OutputBalanceValidityStatement) {
         let old_balance = create_random_state_wrapper(balance_inner.clone());
 
@@ -338,7 +338,7 @@ mod test {
         let mut balance_scalars = witness.balance.to_scalars();
         let idx = rng.gen_range(0..balance_scalars.len());
         balance_scalars[idx] = random_scalar();
-        witness.balance = Balance::from_scalars(&mut balance_scalars.into_iter());
+        witness.balance = DarkpoolBalance::from_scalars(&mut balance_scalars.into_iter());
 
         assert!(!test_helpers::check_constraints::<MERKLE_HEIGHT>(&witness, &statement));
     }

--- a/crates/circuits/circuits-core/src/zk_gadgets/primitives/stream_cipher.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/primitives/stream_cipher.rs
@@ -42,7 +42,7 @@ impl StreamCipherGadget {
 mod test {
     use circuit_types::{PlonkCircuit, traits::CircuitBaseType};
     use constants::Scalar;
-    use darkpool_types::balance::Balance;
+    use darkpool_types::balance::DarkpoolBalance;
     use eyre::Result;
     use mpc_relation::Variable;
     use mpc_relation::traits::Circuit;
@@ -60,7 +60,7 @@ mod test {
     fn test_encrypt() -> Result<()> {
         // Create a state wrapper, the inner type is unimportant for this test
         let mut cs = PlonkCircuit::new_turbo_plonk();
-        let mut state = create_random_state_wrapper(Balance::default());
+        let mut state = create_random_state_wrapper(DarkpoolBalance::default());
         let mut state_var = state.create_witness(&mut cs);
 
         // Generate test data to encrypt

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/commitment.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/commitment.rs
@@ -30,7 +30,9 @@ use circuit_types::{
     PlonkCircuit,
     traits::{CircuitBaseType, CircuitVarType, SecretShareBaseType},
 };
-use darkpool_types::state_wrapper::{PartialCommitmentVar, StateWrapperVar};
+use darkpool_types::state_wrapper::{
+    PartialCommitmentVar, StateWrapperBound, StateWrapperShareBound, StateWrapperVar,
+};
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::primitives::poseidon::PoseidonHashGadget;
@@ -73,8 +75,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         // Serialize the commitment input
         let private_commitment = Self::compute_private_commitment(private_share, element, cs)?;
@@ -88,8 +90,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let mut hasher = PoseidonHashGadget::new(cs.zero());
         hasher.batch_absorb(&private_share.to_vars(), cs)?;
@@ -151,8 +153,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<PartialCommitmentVar, CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let private_commitment = Self::compute_private_commitment(private_share, element, cs)?;
         let partial_public_commitment = Self::compute_partial_public_commitment::<T>(
@@ -196,8 +198,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<(Variable, Variable), CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let (private_comm1, private_comm2) = Self::compute_private_commitments_with_shared_prefix(
             private_share1,
@@ -234,8 +236,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<(Variable, Variable), CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let prefix_length = determine_shared_prefix_length(private_share_1, private_share_2);
 
@@ -281,8 +283,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<(Variable, Variable), CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let prefix_length = determine_shared_prefix_length(public_share_1, public_share_2);
 
@@ -334,8 +336,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<(Variable, PartialCommitmentVar), CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         let (private_comm1, private_comm2) = Self::compute_private_commitments_with_shared_prefix(
             private_share_1,
@@ -376,8 +378,8 @@ impl CommitmentGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<(Variable, Variable), CircuitError>
     where
-        T: CircuitBaseType + SecretShareBaseType,
-        T::ShareType: CircuitBaseType,
+        T: StateWrapperBound,
+        T::ShareType: StateWrapperShareBound,
     {
         assert!(
             num_shares <= T::NUM_SCALARS,

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/nullifier.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/nullifier.rs
@@ -1,10 +1,7 @@
 //! Gadget for computing nullifiers of state elements
 
-use circuit_types::{
-    PlonkCircuit,
-    traits::{CircuitBaseType, SecretShareBaseType},
-};
-use darkpool_types::state_wrapper::StateWrapperVar;
+use circuit_types::PlonkCircuit;
+use darkpool_types::state_wrapper::{StateWrapperBound, StateWrapperShareBound, StateWrapperVar};
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::primitives::poseidon::PoseidonHashGadget;
@@ -25,8 +22,8 @@ impl NullifierGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         let last_idx = cs.sub(element.recovery_stream.index, cs.one())?;
         let recovery_id = CSPRNGGadget::get_ith(&element.recovery_stream, last_idx, cs)?;

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/recovery_id.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/recovery_id.rs
@@ -1,10 +1,7 @@
 //! Gadget for computing recovery identifiers of state elements
 
-use circuit_types::{
-    PlonkCircuit,
-    traits::{CircuitBaseType, SecretShareBaseType},
-};
-use darkpool_types::state_wrapper::StateWrapperVar;
+use circuit_types::PlonkCircuit;
+use darkpool_types::state_wrapper::{StateWrapperBound, StateWrapperShareBound, StateWrapperVar};
 use mpc_relation::{Variable, errors::CircuitError};
 
 use crate::zk_gadgets::state_primitives::csprng::CSPRNGGadget;
@@ -22,8 +19,8 @@ impl RecoveryIdGadget {
         cs: &mut PlonkCircuit,
     ) -> Result<Variable, CircuitError>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         CSPRNGGadget::next(&mut element.recovery_stream, cs)
     }

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/shares.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/shares.rs
@@ -6,7 +6,7 @@ use circuit_types::{
 };
 use darkpool_types::{
     balance::{
-        BalanceShareVar, BalanceVar, PostMatchBalanceShareVar, PostMatchBalanceVar,
+        DarkpoolBalanceShareVar, DarkpoolBalanceVar, PostMatchBalanceShareVar, PostMatchBalanceVar,
         PreMatchBalanceShareVar,
     },
     intent::{IntentShareVar, PreMatchIntentShareVar},
@@ -75,7 +75,7 @@ impl ShareGadget {
 
     /// Build a pre-match balance share from a balance share
     pub fn build_pre_match_balance_share(
-        balance_share: &BalanceShareVar,
+        balance_share: &DarkpoolBalanceShareVar,
     ) -> PreMatchBalanceShareVar {
         PreMatchBalanceShareVar {
             mint: balance_share.mint,
@@ -86,7 +86,7 @@ impl ShareGadget {
     }
 
     /// Build a post-match balance share from a balance
-    pub fn build_post_match_balance(pre_match_balance: &BalanceVar) -> PostMatchBalanceVar {
+    pub fn build_post_match_balance(pre_match_balance: &DarkpoolBalanceVar) -> PostMatchBalanceVar {
         PostMatchBalanceVar {
             amount: pre_match_balance.amount,
             relayer_fee_balance: pre_match_balance.relayer_fee_balance,
@@ -96,7 +96,7 @@ impl ShareGadget {
 
     /// Build a post-match balance share from a balance share
     pub fn build_post_match_balance_share(
-        balance_share: &BalanceShareVar,
+        balance_share: &DarkpoolBalanceShareVar,
     ) -> PostMatchBalanceShareVar {
         PostMatchBalanceShareVar {
             amount: balance_share.amount,
@@ -109,7 +109,7 @@ impl ShareGadget {
     ///
     /// Mutates the given balance share in place.
     pub fn update_balance_share_post_match(
-        balance_share: &mut BalanceShareVar,
+        balance_share: &mut DarkpoolBalanceShareVar,
         post_match_balance: &PostMatchBalanceShareVar,
     ) {
         balance_share.amount = post_match_balance.amount;

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/state_rotation.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/state_rotation.rs
@@ -1,11 +1,9 @@
 //! Gadgets for rotating state elements
 
-use circuit_types::{
-    PlonkCircuit,
-    merkle::MerkleOpeningVar,
-    traits::{CircuitBaseType, SecretShareBaseType},
+use circuit_types::{PlonkCircuit, merkle::MerkleOpeningVar, traits::CircuitBaseType};
+use darkpool_types::state_wrapper::{
+    PartialCommitmentVar, StateWrapperBound, StateWrapperShareBound, StateWrapperVar,
 };
-use darkpool_types::state_wrapper::{PartialCommitmentVar, StateWrapperVar};
 use mpc_relation::{Variable, errors::CircuitError, traits::Circuit};
 
 use crate::zk_gadgets::{
@@ -16,8 +14,8 @@ use crate::zk_gadgets::{
 /// The arguments to a state element rotation gadget
 pub struct StateElementRotationArgs<V, const MERKLE_HEIGHT: usize>
 where
-    V: CircuitBaseType + SecretShareBaseType,
-    V::ShareType: CircuitBaseType,
+    V: StateWrapperBound,
+    V::ShareType: StateWrapperShareBound,
 {
     // --- Old Version --- //
     /// The old version of the state element
@@ -45,8 +43,8 @@ where
 /// The arguments to a state element rotation gadget with partial commitment
 pub struct StateElementRotationArgsWithPartialCommitment<V, const MERKLE_HEIGHT: usize>
 where
-    V: CircuitBaseType + SecretShareBaseType,
-    V::ShareType: CircuitBaseType,
+    V: StateWrapperBound,
+    V::ShareType: StateWrapperShareBound,
 {
     // --- Old Version --- //
     /// The old version of the state element
@@ -87,8 +85,8 @@ impl<const MERKLE_HEIGHT: usize> StateElementRotationGadget<MERKLE_HEIGHT> {
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         // Compute the recovery identifier for the new version and constrain it to the
         // given value
@@ -135,8 +133,8 @@ impl<const MERKLE_HEIGHT: usize> StateElementRotationGadget<MERKLE_HEIGHT> {
         cs: &mut PlonkCircuit,
     ) -> Result<(), CircuitError>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         // Compute the recovery identifier for the new version and constrain it to the
         // given value
@@ -222,8 +220,8 @@ mod test {
     #[derive(Clone)]
     struct NativeStateElementRotationArgs<V, const MERKLE_HEIGHT: usize>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         /// The old version of the state element
         old_version: StateWrapper<V>,
@@ -250,8 +248,8 @@ mod test {
     #[derive(Clone)]
     struct NativeStateElementRotationArgsWithPartialCommitment<V, const MERKLE_HEIGHT: usize>
     where
-        V: CircuitBaseType + SecretShareBaseType,
-        V::ShareType: CircuitBaseType,
+        V: StateWrapperBound,
+        V::ShareType: StateWrapperShareBound,
     {
         /// The old version of the state element
         old_version: StateWrapper<V>,

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/stream_cipher.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/stream_cipher.rs
@@ -42,7 +42,7 @@ impl StreamCipherGadget {
 mod test {
     use circuit_types::{PlonkCircuit, traits::CircuitBaseType};
     use constants::Scalar;
-    use darkpool_types::balance::Balance;
+    use darkpool_types::balance::DarkpoolBalance;
     use eyre::Result;
     use mpc_relation::Variable;
     use mpc_relation::traits::Circuit;
@@ -58,7 +58,7 @@ mod test {
     fn test_encrypt() -> Result<()> {
         // Create a state wrapper, the inner type is unimportant for this test
         let mut cs = PlonkCircuit::new_turbo_plonk();
-        let mut state = create_random_state_wrapper(Balance::default());
+        let mut state = create_random_state_wrapper(DarkpoolBalance::default());
         let mut state_var = state.create_witness(&mut cs);
 
         // Generate test data to encrypt

--- a/crates/darkpool-types/src/fuzzing.rs
+++ b/crates/darkpool-types/src/fuzzing.rs
@@ -3,12 +3,12 @@
 use std::cmp;
 
 use crate::{
-    balance::{Balance, PostMatchBalanceShare},
+    balance::{DarkpoolBalance, PostMatchBalanceShare},
     bounded_match_result::BoundedMatchResult,
     deposit::Deposit,
     intent::Intent,
     settlement_obligation::SettlementObligation,
-    state_wrapper::StateWrapper,
+    state_wrapper::{StateWrapper, StateWrapperBound, StateWrapperShareBound},
     withdrawal::Withdrawal,
 };
 use alloy_primitives::Address;
@@ -18,7 +18,7 @@ use circuit_types::{
     fixed_point::FixedPoint,
     max_amount,
     schnorr::{SchnorrPrivateKey, SchnorrPublicKey},
-    traits::{BaseType, CircuitBaseType, SecretShareBaseType},
+    traits::{BaseType, SecretShareBaseType},
 };
 
 use crate::csprng::PoseidonCSPRNG;
@@ -135,8 +135,8 @@ pub fn random_bounded_intent(max_amount_in: Amount) -> Intent {
 ///
 /// The balance will have the same owner and mint as the intent's in_token,
 /// with random values for other fields.
-pub fn create_matching_balance_for_intent(intent: &Intent) -> Balance {
-    Balance {
+pub fn create_matching_balance_for_intent(intent: &Intent) -> DarkpoolBalance {
+    DarkpoolBalance {
         mint: intent.in_token,
         owner: intent.owner,
         relayer_fee_recipient: random_address(),
@@ -148,20 +148,20 @@ pub fn create_matching_balance_for_intent(intent: &Intent) -> Balance {
 }
 
 /// Create a random balance with a small initial amount
-pub fn random_small_balance() -> Balance {
+pub fn random_small_balance() -> DarkpoolBalance {
     random_bounded_balance(BOUNDED_MAX_AMT)
 }
 
 /// Create a random balance
-pub fn random_balance() -> Balance {
+pub fn random_balance() -> DarkpoolBalance {
     random_bounded_balance(max_amount())
 }
 
 /// Create a random balance with a bounded initial amount
-pub fn random_bounded_balance(max_amount: Amount) -> Balance {
+pub fn random_bounded_balance(max_amount: Amount) -> DarkpoolBalance {
     let mut rng = thread_rng();
     let amount = rng.gen_range(0..=max_amount);
-    Balance {
+    DarkpoolBalance {
         mint: random_address(),
         owner: random_address(),
         relayer_fee_recipient: random_address(),
@@ -173,8 +173,8 @@ pub fn random_bounded_balance(max_amount: Amount) -> Balance {
 }
 
 /// Create a random zero'd balance
-pub fn random_zeroed_balance() -> Balance {
-    Balance {
+pub fn random_zeroed_balance() -> DarkpoolBalance {
+    DarkpoolBalance {
         mint: random_address(),
         owner: random_address(),
         relayer_fee_recipient: random_address(),
@@ -306,8 +306,8 @@ pub fn compute_implied_price(amount_out: Amount, amount_in: Amount) -> FixedPoin
 /// Create a state wrapper and initialize the share state
 pub fn create_state_wrapper<V>(state: V) -> StateWrapper<V>
 where
-    V: SecretShareBaseType + CircuitBaseType,
-    V::ShareType: CircuitBaseType,
+    V: StateWrapperBound,
+    V::ShareType: StateWrapperShareBound,
 {
     let share_seed = random_scalar();
     let recovery_seed = random_scalar();
@@ -317,8 +317,8 @@ where
 /// Create a state wrapper for a given state element
 pub fn create_random_state_wrapper<V>(state: V) -> StateWrapper<V>
 where
-    V: SecretShareBaseType + CircuitBaseType,
-    V::ShareType: CircuitBaseType,
+    V: StateWrapperBound,
+    V::ShareType: StateWrapperShareBound,
 {
     let mut rng = thread_rng();
     let (_, public_share) = create_random_shares::<V>(&state);

--- a/crates/darkpool-types/src/lib.rs
+++ b/crates/darkpool-types/src/lib.rs
@@ -17,5 +17,5 @@ pub mod withdrawal;
 #[cfg(feature = "rkyv")]
 pub mod rkyv_remotes;
 
-#[cfg(feature = "test_helpers")]
+#[cfg(any(test, feature = "test_helpers"))]
 pub mod fuzzing;

--- a/crates/darkpool-types/src/note.rs
+++ b/crates/darkpool-types/src/note.rs
@@ -106,8 +106,8 @@ impl Note {
     }
 
     /// Get the balance associated with the note
-    pub fn as_balance(&self) -> crate::balance::Balance {
-        crate::balance::Balance {
+    pub fn as_balance(&self) -> crate::balance::DarkpoolBalance {
+        crate::balance::DarkpoolBalance {
             mint: self.mint,
             relayer_fee_recipient: Address::ZERO,
             owner: Address::ZERO,                   // Default owner

--- a/crates/darkpool-types/src/rkyv_remotes/mod.rs
+++ b/crates/darkpool-types/src/rkyv_remotes/mod.rs
@@ -10,9 +10,16 @@
 
 mod remote_types;
 
-// Re-export remote types
+// Re-export remote types (always available)
 pub use remote_types::{
     AddressDef, ArchivedAddress, ArchivedBabyJubJubPoint, ArchivedFixedPoint, ArchivedScalar,
     ArchivedSchnorrPublicKey, ArchivedU256, BabyJubJubPointDef, FixedPointDef, ScalarDef,
     SchnorrPublicKeyDef, U256Def,
+};
+
+// Re-export share type definitions (only when proof-system-types is enabled)
+#[cfg(feature = "proof-system-types")]
+pub use remote_types::{
+    ArchivedBabyJubJubPointShare, ArchivedFixedPointShare, ArchivedSchnorrPublicKeyShare,
+    BabyJubJubPointShareDef, FixedPointShareDef, SchnorrPublicKeyShareDef,
 };

--- a/crates/darkpool-types/src/rkyv_remotes/remote_types.rs
+++ b/crates/darkpool-types/src/rkyv_remotes/remote_types.rs
@@ -12,6 +12,13 @@ use circuit_types::{
     fixed_point::FixedPoint,
     primitives::{baby_jubjub::BabyJubJubPoint, schnorr::SchnorrPublicKey},
 };
+
+// Share types are only available when proof-system-types feature is enabled
+#[cfg(feature = "proof-system-types")]
+use circuit_types::{
+    fixed_point::FixedPointShare,
+    primitives::{baby_jubjub::BabyJubJubPointShare, schnorr::SchnorrPublicKeyShare},
+};
 use constants::Scalar;
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -170,6 +177,73 @@ impl PartialEq<SchnorrPublicKey> for ArchivedSchnorrPublicKey {
     }
 }
 
+// --- BabyJubJubPointShare --- //
+// Only available when proof-system-types feature is enabled
+
+/// Remote type shim for
+/// `circuit_types::primitives::baby_jubjub::BabyJubJubPointShare`
+///
+/// The share type has `x: Scalar, y: Scalar` fields.
+#[cfg(feature = "proof-system-types")]
+#[derive(Archive, Deserialize, Serialize)]
+#[rkyv(remote = BabyJubJubPointShare)]
+#[rkyv(derive(Debug))]
+#[rkyv(archived = ArchivedBabyJubJubPointShare)]
+pub struct BabyJubJubPointShareDef {
+    /// The x coordinate share
+    #[rkyv(with = ScalarDef)]
+    pub x: Scalar,
+    /// The y coordinate share
+    #[rkyv(with = ScalarDef)]
+    pub y: Scalar,
+}
+
+#[cfg(feature = "proof-system-types")]
+impl From<BabyJubJubPointShareDef> for BabyJubJubPointShare {
+    fn from(value: BabyJubJubPointShareDef) -> Self {
+        BabyJubJubPointShare { x: value.x, y: value.y }
+    }
+}
+
+#[cfg(feature = "proof-system-types")]
+impl PartialEq<BabyJubJubPointShare> for ArchivedBabyJubJubPointShare {
+    fn eq(&self, other: &BabyJubJubPointShare) -> bool {
+        self.x == other.x && self.y == other.y
+    }
+}
+
+// --- SchnorrPublicKeyShare --- //
+// Only available when proof-system-types feature is enabled
+
+/// Remote type shim for
+/// `circuit_types::primitives::schnorr::SchnorrPublicKeyShare`
+///
+/// The share type has a `point: BabyJubJubPointShare` field.
+#[cfg(feature = "proof-system-types")]
+#[derive(Archive, Deserialize, Serialize)]
+#[rkyv(remote = SchnorrPublicKeyShare)]
+#[rkyv(derive(Debug))]
+#[rkyv(archived = ArchivedSchnorrPublicKeyShare)]
+pub struct SchnorrPublicKeyShareDef {
+    /// The curve point share representing the public key
+    #[rkyv(with = BabyJubJubPointShareDef)]
+    pub point: BabyJubJubPointShare,
+}
+
+#[cfg(feature = "proof-system-types")]
+impl From<SchnorrPublicKeyShareDef> for SchnorrPublicKeyShare {
+    fn from(value: SchnorrPublicKeyShareDef) -> Self {
+        SchnorrPublicKeyShare { point: value.point }
+    }
+}
+
+#[cfg(feature = "proof-system-types")]
+impl PartialEq<SchnorrPublicKeyShare> for ArchivedSchnorrPublicKeyShare {
+    fn eq(&self, other: &SchnorrPublicKeyShare) -> bool {
+        self.point == other.point
+    }
+}
+
 // --- FixedPoint --- //
 
 /// Remote type shim for `circuit_types::fixed_point::FixedPoint`
@@ -191,6 +265,37 @@ impl From<FixedPointDef> for FixedPoint {
 
 impl PartialEq<FixedPoint> for ArchivedFixedPoint {
     fn eq(&self, other: &FixedPoint) -> bool {
+        self.repr == other.repr
+    }
+}
+
+// --- FixedPointShare --- //
+// Only available when proof-system-types feature is enabled
+
+/// Remote type shim for `circuit_types::fixed_point::FixedPointShare`
+///
+/// The share type has `repr: Scalar` field.
+#[cfg(feature = "proof-system-types")]
+#[derive(Archive, Deserialize, Serialize)]
+#[rkyv(derive(Debug))]
+#[rkyv(remote = FixedPointShare)]
+#[rkyv(archived = ArchivedFixedPointShare)]
+pub struct FixedPointShareDef {
+    /// The underlying scalar share
+    #[rkyv(with = ScalarDef)]
+    pub repr: Scalar,
+}
+
+#[cfg(feature = "proof-system-types")]
+impl From<FixedPointShareDef> for FixedPointShare {
+    fn from(value: FixedPointShareDef) -> Self {
+        FixedPointShare { repr: value.repr }
+    }
+}
+
+#[cfg(feature = "proof-system-types")]
+impl PartialEq<FixedPointShare> for ArchivedFixedPointShare {
+    fn eq(&self, other: &FixedPointShare) -> bool {
         self.repr == other.repr
     }
 }

--- a/crates/relayer-types/types-account/src/account/balance.rs
+++ b/crates/relayer-types/types-account/src/account/balance.rs
@@ -1,0 +1,135 @@
+//! The balance type for an account
+//!
+//! This type wraps a DarkpoolBalance in a StateWrapper, similar to how Order
+//! wraps Intent.
+
+use alloy::primitives::Address;
+use circuit_types::Amount;
+use darkpool_types::{balance::DarkpoolBalance, state_wrapper::StateWrapper};
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+
+/// The balance type for an account
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
+pub struct Balance {
+    /// The balance data wrapped in a state wrapper
+    pub balance: StateWrapper<DarkpoolBalance>,
+}
+
+impl Balance {
+    /// Create a new balance from a state wrapper
+    pub fn new(balance: StateWrapper<DarkpoolBalance>) -> Self {
+        Self { balance }
+    }
+
+    /// Get a reference to the inner balance
+    pub fn inner(&self) -> &DarkpoolBalance {
+        self.balance.as_ref()
+    }
+
+    /// Get the mint address
+    pub fn mint(&self) -> Address {
+        self.balance.inner.mint
+    }
+
+    /// Get the owner address
+    pub fn owner(&self) -> Address {
+        self.balance.inner.owner
+    }
+
+    /// Get the amount
+    pub fn amount(&self) -> Amount {
+        self.balance.inner.amount
+    }
+
+    /// Get the relayer fee balance
+    pub fn relayer_fee_balance(&self) -> Amount {
+        self.balance.inner.relayer_fee_balance
+    }
+
+    /// Get the protocol fee balance
+    pub fn protocol_fee_balance(&self) -> Amount {
+        self.balance.inner.protocol_fee_balance
+    }
+
+    /// Get a mutable reference to the amount
+    pub fn amount_mut(&mut self) -> &mut Amount {
+        &mut self.balance.inner.amount
+    }
+}
+
+impl From<StateWrapper<DarkpoolBalance>> for Balance {
+    fn from(balance: StateWrapper<DarkpoolBalance>) -> Self {
+        Self::new(balance)
+    }
+}
+
+impl From<Balance> for DarkpoolBalance {
+    fn from(balance: Balance) -> Self {
+        balance.balance.inner
+    }
+}
+
+impl AsRef<DarkpoolBalance> for Balance {
+    fn as_ref(&self) -> &DarkpoolBalance {
+        self.inner()
+    }
+}
+
+#[cfg(feature = "mocks")]
+/// Mock types for balance testing
+pub mod mocks {
+    use super::Balance;
+    use alloy::primitives::Address;
+    use circuit_types::primitives::schnorr::SchnorrPublicKey;
+    use constants::Scalar;
+    use darkpool_types::{balance::DarkpoolBalance, state_wrapper::StateWrapper};
+    use rand::{Rng, RngCore, thread_rng};
+
+    /// Create a mock balance for testing
+    pub fn mock_balance() -> Balance {
+        let balance = mock_darkpool_balance();
+        let mut rng = thread_rng();
+        let share_stream_seed = Scalar::random(&mut rng);
+        let recovery_stream_seed = Scalar::random(&mut rng);
+        let state_wrapper = StateWrapper::new(balance, share_stream_seed, recovery_stream_seed);
+        Balance::new(state_wrapper)
+    }
+
+    /// Create a mock balance with a specific mint
+    pub fn mock_balance_with_mint(mint: Address) -> Balance {
+        let mut balance = mock_darkpool_balance();
+        balance.mint = mint;
+        let mut rng = thread_rng();
+        let share_stream_seed = Scalar::random(&mut rng);
+        let recovery_stream_seed = Scalar::random(&mut rng);
+        let state_wrapper = StateWrapper::new(balance, share_stream_seed, recovery_stream_seed);
+        Balance::new(state_wrapper)
+    }
+
+    /// Create a mock DarkpoolBalance
+    fn mock_darkpool_balance() -> DarkpoolBalance {
+        let mut rng = thread_rng();
+        let mut addr_bytes = [0u8; 20];
+        rng.fill_bytes(&mut addr_bytes);
+        let mint = Address::from(addr_bytes);
+        rng.fill_bytes(&mut addr_bytes);
+        let owner = Address::from(addr_bytes);
+        rng.fill_bytes(&mut addr_bytes);
+        let relayer_fee_recipient = Address::from(addr_bytes);
+        let authority = SchnorrPublicKey::default();
+
+        DarkpoolBalance {
+            mint,
+            owner,
+            relayer_fee_recipient,
+            authority,
+            relayer_fee_balance: rng.r#gen(),
+            protocol_fee_balance: rng.r#gen(),
+            amount: rng.r#gen(),
+        }
+    }
+}

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -4,7 +4,7 @@
 //! order them
 
 use circuit_types::Amount;
-use darkpool_types::balance::Balance;
+use darkpool_types::balance::DarkpoolBalance;
 use types_account::{
     account::{Account, OrderId},
     order::Order,

--- a/crates/workers/matching-engine/matching-engine-core/src/book.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/book.rs
@@ -201,8 +201,8 @@ mod tests {
     /// Create a test order with the given matchable amount
     fn create_test_order(matchable_amount: Amount) -> Order {
         let mut order = mock_order();
-        order.intent.amount_in = matchable_amount * 2;
-        order.intent.min_price = FixedPoint::from_integer(1);
+        order.intent.inner.amount_in = matchable_amount * 2;
+        order.intent.inner.min_price = FixedPoint::from_integer(1);
         order
     }
 

--- a/crates/workers/matching-engine/matching-engine-core/src/engine.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/engine.rs
@@ -225,8 +225,8 @@ mod tests {
     /// Create a test order with the given matchable amount and min price
     fn create_test_order(matchable_amount: Amount, min_price: FixedPoint) -> Order {
         let mut order = mock_order_with_pair(test_pair());
-        order.intent.amount_in = matchable_amount * 2;
-        order.intent.min_price = min_price;
+        order.intent.inner.amount_in = matchable_amount * 2;
+        order.intent.inner.min_price = min_price;
         order.metadata.min_fill_size = 1;
         order
     }
@@ -236,8 +236,8 @@ mod tests {
     fn create_counterparty_order(matchable_amount: Amount, min_price: FixedPoint) -> Order {
         let pair = test_pair();
         let mut order = mock_order_with_pair(pair.reverse());
-        order.intent.amount_in = matchable_amount * 2;
-        order.intent.min_price = min_price;
+        order.intent.inner.amount_in = matchable_amount * 2;
+        order.intent.inner.min_price = min_price;
         order.metadata.min_fill_size = 1;
         order
     }

--- a/crates/workers/task-driver/src/task_state.rs
+++ b/crates/workers/task-driver/src/task_state.rs
@@ -6,7 +6,10 @@ use serde::Serialize;
 use types_tasks::QueuedTaskState;
 
 use crate::{
-    tasks::{create_new_account::CreateNewAccountTaskState, deposit::DepositTaskState, node_startup::NodeStartupTaskState},
+    tasks::{
+        create_new_account::CreateNewAccountTaskState, deposit::DepositTaskState,
+        node_startup::NodeStartupTaskState,
+    },
     traits::TaskState,
 };
 
@@ -37,9 +40,7 @@ impl StateWrapper {
             StateWrapper::NodeStartup(state) => {
                 <NodeStartupTaskState as TaskState>::committed(state)
             },
-            StateWrapper::Deposit(state) => {
-                <DepositTaskState as TaskState>::committed(state)
-            },
+            StateWrapper::Deposit(state) => <DepositTaskState as TaskState>::committed(state),
         }
     }
 
@@ -64,9 +65,7 @@ impl StateWrapper {
             StateWrapper::NodeStartup(state) => {
                 <NodeStartupTaskState as TaskState>::completed(state)
             },
-            StateWrapper::Deposit(state) => {
-                <DepositTaskState as TaskState>::completed(state)
-            },
+            StateWrapper::Deposit(state) => <DepositTaskState as TaskState>::completed(state),
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR tracks the CSPRNG states for account elements in the account by including the `StateWrapper<T>` type in the account.