### PR TITLE
handshake-manager: disable USDT matches in matching engines

### DIFF
--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -70,6 +70,14 @@ impl HandshakeExecutor {
         response_topic: String,
         mut options: ExternalMatchingEngineOptions,
     ) -> Result<(), HandshakeManagerError> {
+        // TEMP: Disable USDT matches here until we expose a config option for disabling
+        // matches on an asset
+        if order.base_mint == Token::usdt().get_addr_biguint() {
+            warn!("USDT matches are disabled, skipping external matching engine...");
+            self.handle_no_match(response_topic);
+            return Ok(());
+        }
+
         // Sample an execution price if one is not provided
         let ts_price = match options.price {
             Some(price) => price.into(),


### PR DESCRIPTION
In this PR, we "soft-delist" USDT by skipping internal & external matching engine runs for it.
We prefer this hotfix over fully delisting it via removal from the token mapping, as that would prevent management of USDT balances (e.g., deposits & withdrawals).
In the future, we'll add a config option for disabling matching on given assets to make this process cleaner.

