### PR TITLE
feat(handshake-manager): add disabled_assets config option to skip matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4464,6 +4464,7 @@ dependencies = [
  "libp2p",
  "lru 0.11.1",
  "mpc-plonk",
+ "num-bigint",
  "num-traits",
  "portpicker",
  "price-state",

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -215,6 +215,9 @@ pub struct Cli {
     /// Disables exchanges for price reporting
     #[clap(long, value_parser, num_args=1.., value_delimiter=' ')]
     pub disabled_exchanges: Vec<Exchange>,
+    /// Assets for which to disable matching (by ticker)
+    #[clap(long, value_parser, num_args=1.., value_delimiter=' ')]
+    pub disabled_assets: Vec<String>,
     /// Whether or not to run the relayer in debug mode
     #[clap(short, long, value_parser)]
     pub debug: bool,
@@ -402,6 +405,8 @@ pub struct RelayerConfig {
     pub disable_price_reporter: bool,
     /// The exchanges explicitly disabled for price reports
     pub disabled_exchanges: Vec<Exchange>,
+    /// Assets for which matching is disabled (by ticker)
+    pub disabled_assets: Vec<String>,
     /// Whether or not the relayer is in debug mode
     pub debug: bool,
 

--- a/config/src/parsing/mod.rs
+++ b/config/src/parsing/mod.rs
@@ -143,6 +143,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         gossip_warmup: cli_args.gossip_warmup,
         disable_price_reporter: cli_args.disable_price_reporter,
         disabled_exchanges: cli_args.disabled_exchanges,
+        disabled_assets: cli_args.disabled_assets,
         cluster_keypair,
         cluster_symmetric_key,
         admin_api_key,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -291,6 +291,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (handshake_cancel_sender, handshake_cancel_receiver) = new_cancel_channel();
     let mut handshake_manager = HandshakeManager::new(HandshakeManagerConfig {
         min_fill_size: args.min_fill_size,
+        disabled_assets: args.disabled_assets.clone(),
         state: global_state.clone(),
         network_channel: network_sender.clone(),
         price_streams: price_streams.clone(),

--- a/mock-node/src/lib.rs
+++ b/mock-node/src/lib.rs
@@ -458,6 +458,7 @@ impl MockNodeController {
 
         let conf = HandshakeManagerConfig {
             min_fill_size: self.config.min_fill_size,
+            disabled_assets: Vec::new(),
             state,
             network_channel,
             price_streams,

--- a/workers/handshake-manager/Cargo.toml
+++ b/workers/handshake-manager/Cargo.toml
@@ -37,6 +37,7 @@ renegade-metrics = { workspace = true }
 # === Misc Dependencies === #
 ark-serialize = "0.4"
 itertools = "0.11"
+num-bigint = { workspace = true }
 lazy_static = { workspace = true }
 lru = "0.11"
 portpicker = "0.1"

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -53,10 +53,11 @@ impl HandshakeExecutor {
             .cloned()
             .ok_or_else(|| HandshakeManagerError::State(ERR_NO_ORDER.to_string()))?;
 
-        // TEMP: Disable USDT matches here until we expose a config option for disabling
-        // matches on an asset
-        if my_order.base_mint == Token::usdt().get_addr_biguint() {
-            warn!("USDT matches are disabled, skipping internal matching engine...");
+        // Check if the asset is disabled for matching
+        if self.is_asset_disabled(&my_order.base_mint) {
+            let base = Token::from_addr_biguint(&my_order.base_mint);
+            let ticker = base.get_ticker().unwrap_or(base.get_addr());
+            warn!("{ticker} is disabled for matching, skipping internal matching engine...");
             return Ok(());
         }
 


### PR DESCRIPTION
In this PR, we add a `disabled_assets` config option, which informs the `HandshakeManager` of assets for which it should skip matching engine runs.
This allows us to delist assets safely by first excluding them from the matching engine before instructing users to withdraw their balances of these assets.

### Testing
- [x] All unit tests pass
