### PR TITLE
state: storage: cursor: Change key filter to key prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8919,6 +8919,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "state"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "alloy",
  "alloy-primitives",
  "async-trait",

--- a/crates/api/external-api/src/types/order.rs
+++ b/crates/api/external-api/src/types/order.rs
@@ -6,6 +6,7 @@ use alloy::primitives::{Bytes, U256};
 use circuit_types::{Amount, fixed_point::FixedPoint, schnorr::SchnorrSignature};
 use constants::Scalar;
 use darkpool_types::intent::Intent;
+#[cfg(feature = "full-api")]
 use renegade_solidity_abi::v2::IDarkpoolV2;
 use serde::{Deserialize, Serialize};
 use types_account::{
@@ -137,6 +138,7 @@ pub struct ApiOrder {
     pub created: u64,
 }
 
+#[cfg(feature = "full-api")]
 impl From<Order> for ApiOrder {
     fn from(order: Order) -> Self {
         Self {
@@ -227,6 +229,7 @@ pub enum OrderAuth {
     },
 }
 
+#[cfg(feature = "full-api")]
 impl TryFrom<OrderAuth> for types_account::order_auth::OrderAuth {
     type Error = ApiTypeError;
 
@@ -268,6 +271,7 @@ pub struct SignatureWithNonce {
     pub signature: String,
 }
 
+#[cfg(feature = "full-api")]
 impl TryFrom<SignatureWithNonce> for renegade_solidity_abi::v2::IDarkpoolV2::SignatureWithNonce {
     type Error = ApiTypeError;
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -52,7 +52,7 @@ types-account = { workspace = true, features = ["rkyv"] }
 types-runtime = { workspace = true }
 config = { workspace = true }
 constants = { workspace = true }
-external-api = { workspace = true, features = ["task-api"] }
+external-api = { workspace = true, features = ["task-api", "full-api"] }
 gossip-api = { workspace = true }
 job-types = { workspace = true }
 matching-engine-core = { workspace = true }
@@ -85,6 +85,7 @@ eyre = "0.6"
 multiaddr = "0.17"
 num-bigint = "0.4"
 num-traits = "0.2"
+renegade-solidity-abi = { workspace = true }
 tempfile = "3.8"
 rand = { workspace = true }
 uuid = "1.4"

--- a/crates/state/src/storage/db.rs
+++ b/crates/state/src/storage/db.rs
@@ -2,6 +2,7 @@
 //!
 //! We serialize types using the `flexbuffers` format (a schema-less version of
 //! `flatbuffers`): https://flatbuffers.dev/flexbuffers.html
+#![allow(mismatched_lifetime_syntaxes)]
 
 use std::{ops::Bound, path::Path};
 

--- a/crates/state/src/storage/tx/matching_pools.rs
+++ b/crates/state/src/storage/tx/matching_pools.rs
@@ -89,7 +89,7 @@ impl StateTxn<'_, RW> {
         let cursor = self
             .inner()
             .cursor::<String, MatchingPoolName>(POOL_TABLE)?
-            .with_key_filter(|key| key.starts_with(POOL_KEY_PREFIX));
+            .with_key_prefix(POOL_KEY_PREFIX);
 
         for entry in cursor.into_iter() {
             let (key, value) = entry?;

--- a/crates/state/src/storage/tx/mod.rs
+++ b/crates/state/src/storage/tx/mod.rs
@@ -7,11 +7,13 @@
 //!
 //! Each of the files in this module are named after the high level interface
 //! they expose
+#![allow(mismatched_lifetime_syntaxes)]
 
 pub mod account_index;
 pub mod matching_pools;
 pub mod merkle_proofs;
 pub mod node_metadata;
+pub mod order_auth;
 pub mod order_book;
 pub mod peer_index;
 pub mod proofs;
@@ -170,7 +172,7 @@ impl<'db, T: TransactionKind> DbTxn<'db, T> {
     }
 
     /// Open a table if the transaction has not done so already
-    fn open_table(&self, table_name: &str) -> Result<Table, StorageError> {
+    fn open_table(&self, table_name: &str) -> Result<Table<'_>, StorageError> {
         self.txn
             .open_table(Some(table_name))
             .map_err(|e| StorageError::OpenTable(table_name.to_string(), e))

--- a/crates/state/src/storage/tx/task_assignments.rs
+++ b/crates/state/src/storage/tx/task_assignments.rs
@@ -72,7 +72,7 @@ impl<T: TransactionKind> StateTxn<'_, T> {
         let cursor = self
             .inner()
             .cursor::<String, ()>(TASK_ASSIGNMENT_TABLE)?
-            .with_key_filter(|key| key.starts_with(prefix.as_str()));
+            .with_key_prefix(&prefix);
 
         let mut tasks = Vec::new();
         for entry in cursor.into_iter() {

--- a/crates/state/src/storage/tx/task_queue/queue_type.rs
+++ b/crates/state/src/storage/tx/task_queue/queue_type.rs
@@ -21,9 +21,10 @@ pub(crate) type TaskValue<'a> = ArchivedValue<'a, QueuedTask>;
 
 /// The preemption state of a task queue
 #[derive(
-    Debug,
     Clone,
     Copy,
+    Debug,
+    Default,
     Serialize,
     Deserialize,
     PartialEq,
@@ -35,17 +36,12 @@ pub(crate) type TaskValue<'a> = ArchivedValue<'a, QueuedTask>;
 #[rkyv(derive(Debug, PartialEq, Eq))]
 pub enum TaskQueuePreemptionState {
     /// The queue is not currently preempted by any task
+    #[default]
     NotPreempted,
     /// The queue contains a serial preemptive task
     SerialPreemptionQueued,
     /// The queue contains one or more concurrent preemptive tasks
     ConcurrentPreemptionsQueued,
-}
-
-impl Default for TaskQueuePreemptionState {
-    fn default() -> Self {
-        Self::NotPreempted
-    }
 }
 
 /// The task queue type, containing the list of tasks that are queued for
@@ -270,7 +266,7 @@ impl ArchivedValue<'_, TaskQueue> {
         if is_first_serial && self.concurrent_tasks.is_empty() {
             // Only the first serial task may run, if no concurrent tasks are queued
             return true;
-        } else if self.concurrent_tasks.iter().any(|t| *t == *task) {
+        } else if self.concurrent_tasks.contains(task) {
             // A concurrent task may run iff it is in the queue
             return true;
         }


### PR DESCRIPTION
### Purpose
This PR changes the `Cursor`'s `key_filter` to a `key_prefix`; as the key filter is only used to prefix-filter in all callers. It's more efficient to use the MDBX cursor primitives at the cursor layer for prefix scans.

### Testing
- [x] Unit tests pass