### PR TITLE
state: applicator: Add order update state transitions

### DIFF
--- a/crates/relayer-types/types-account/src/account/order_auth.rs
+++ b/crates/relayer-types/types-account/src/account/order_auth.rs
@@ -81,3 +81,24 @@ mod rkyv_impls {
 // Re-export the rkyv remote type shims
 #[cfg(feature = "rkyv")]
 pub use rkyv_impls::*;
+
+#[cfg(feature = "mocks")]
+pub mod mocks {
+    //! Mocks for order auth
+    #![allow(missing_docs, clippy::missing_docs_in_private_items)]
+
+    use alloy::primitives::{Bytes, U256};
+    use renegade_solidity_abi::v2::IDarkpoolV2::SignatureWithNonce;
+
+    use super::OrderAuth;
+
+    /// Create a mock signature with nonce
+    pub fn mock_signature_with_nonce() -> SignatureWithNonce {
+        SignatureWithNonce { nonce: U256::from(0), signature: Bytes::from(vec![0u8; 65]) }
+    }
+
+    /// Create a mock order auth
+    pub fn mock_order_auth() -> OrderAuth {
+        OrderAuth::PublicOrder { intent_signature: mock_signature_with_nonce() }
+    }
+}

--- a/crates/state/src/applicator/matching_pools.rs
+++ b/crates/state/src/applicator/matching_pools.rs
@@ -87,6 +87,7 @@ mod test {
         MatchingPoolName,
         account::{OrderId, mocks::mock_empty_account},
         order::mocks::mock_order,
+        order_auth::mocks::mock_order_auth,
     };
 
     use crate::applicator::test_helpers::mock_applicator;
@@ -135,10 +136,11 @@ mod test {
         let account = mock_empty_account();
         let order = mock_order();
         let order_id = order.id;
+        let auth = mock_order_auth();
 
         // Add the account to the state
         applicator.create_account(&account).unwrap();
-        // applicator.add_local_order(account.id, &order, &auth).unwrap();
+        applicator.add_order_to_account(account.id, &order, &auth).unwrap();
 
         // Create a matching pool, then assign the order
         applicator.create_matching_pool(&pool_name).unwrap();
@@ -161,16 +163,11 @@ mod test {
         let account = mock_empty_account();
         let order = mock_order();
         let order_id = order.id;
-        let auth = types_account::order_auth::OrderAuth::PublicOrder {
-            intent_signature: renegade_solidity_abi::v2::IDarkpoolV2::SignatureWithNonce {
-                nonce: alloy::primitives::U256::from(0),
-                signature: alloy::primitives::Bytes::from(vec![0u8; 65]),
-            },
-        };
+        let auth = mock_order_auth();
 
         // Add the account to the state
         applicator.create_account(&account).unwrap();
-        // applicator.add_local_order(account.id, &order, &auth).unwrap();
+        applicator.add_order_to_account(account.id, &order, &auth).unwrap();
 
         // Create both matching pools
         applicator.create_matching_pool(&pool_1_name).unwrap();

--- a/crates/state/src/applicator/order_book.rs
+++ b/crates/state/src/applicator/order_book.rs
@@ -1,7 +1,7 @@
 //! Applicator methods for the network order book, separated out for
 //! discoverability
 
-use circuit_types::{Amount, Nullifier};
+use circuit_types::Nullifier;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use types_account::{OrderId, order::Order};
@@ -21,8 +21,6 @@ pub const ORDER_DEFAULT_PRIORITY: u32 = 1;
 
 /// The error message emitted when an order is missing from the message
 const ERR_ORDER_MISSING: &str = "Order missing from message";
-/// The error message emitted when a wallet cannot be found for an order
-const ERR_WALLET_MISSING: &str = "Cannot find wallet for order";
 
 // ----------------------------
 // | Orderbook Implementation |
@@ -107,7 +105,8 @@ mod test {
     use constants::Scalar;
     use rand::thread_rng;
     use types_account::{
-        account::mocks::mock_empty_account, order::mocks::mock_order, order_auth::OrderAuth,
+        account::mocks::mock_empty_account, order::mocks::mock_order,
+        order_auth::mocks::mock_order_auth,
     };
     use types_gossip::network_order::{
         ArchivedNetworkOrderState, test_helpers::dummy_network_order,
@@ -127,10 +126,11 @@ mod test {
         let account = mock_empty_account();
         let order = mock_order();
         let order_id = order.id;
+        let auth = mock_order_auth();
 
         // Add the account to the state
         applicator.create_account(&account).unwrap();
-        // applicator.add_local_order(account.id, &order, &auth).unwrap();
+        applicator.add_order_to_account(account.id, &order, &auth).unwrap();
 
         // Create a network order and add it to the order book
         // The order must exist in the order book for add_order_validity_proof to work

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -48,8 +48,10 @@ pub enum StateTransition {
     // --- Accounts --- //
     /// Create a new account
     CreateAccount { account: Account },
-    /// Update an account by adding a local order, marking it as local, and storing its auth
-    AddLocalOrder { account_id: AccountId, order: Order, auth: OrderAuth },
+    /// Update an account by adding an order, marking it as local, and storing its auth
+    AddOrderToAccount { account_id: AccountId, order: Order, auth: OrderAuth },
+    /// Remove an order from an account
+    RemoveOrderFromAccount { account_id: AccountId, order_id: OrderId },
 
     // --- Orders --- //
     /// Add a validity proof to an order

--- a/crates/state/src/storage/tx/account_index.rs
+++ b/crates/state/src/storage/tx/account_index.rs
@@ -104,6 +104,11 @@ fn order_index_key(order_id: &OrderId) -> String {
 // -----------
 
 impl<T: TransactionKind> StateTxn<'_, T> {
+    /// Whether the account exists
+    pub fn contains_account(&self, account_id: &AccountId) -> Result<bool, StorageError> {
+        self.get_account_header(account_id).map(|opt| opt.is_some())
+    }
+
     /// Get the account header for the given ID
     pub fn get_account_header(
         &self,


### PR DESCRIPTION
### Purpose
This PR adds two state transition methods to the state for adding an order to an account and removing an order from an account.

### Testing
- [x] Unit tests pass