### PR TITLE
state: applicator: Add state transition to update an account's balance

### DIFF
--- a/crates/state/src/applicator/account_index.rs
+++ b/crates/state/src/applicator/account_index.rs
@@ -1,8 +1,8 @@
 //! Applicator methods for the account index, separated out for discoverability
 
-use system_bus::{SystemBusMessage, account_topic};
 use types_account::{
     account::{Account, OrderId},
+    balance::Balance,
     order::Order,
     order_auth::OrderAuth,
 };
@@ -29,9 +29,6 @@ impl StateApplicator {
         // Write the account (new accounts are empty, so no intents to index)
         tx.new_account(account)?;
         tx.commit()?;
-
-        // Publish a message to the bus describing the account update
-        self.publish_account_update(account);
         Ok(ApplicatorReturnType::None)
     }
 
@@ -60,7 +57,9 @@ impl StateApplicator {
         tx.commit()?;
 
         // Update the matching engine
-        self.matching_engine().add_order(order, matchable_amount, matching_pool);
+        if matchable_amount > 0 {
+            self.matching_engine().add_order(order, matchable_amount, matching_pool);
+        }
         Ok(ApplicatorReturnType::None)
     }
 
@@ -96,99 +95,47 @@ impl StateApplicator {
         Ok(ApplicatorReturnType::None)
     }
 
-    // /// Update an account in the state
-    // ///
-    // /// This update may take many forms: placing/cancelling an intent,
-    // /// depositing or withdrawing a balance, etc.
-    // ///
-    // /// It is assumed that the update to the account is proven valid and posted
-    // /// on-chain before this method is called. That is, we maintain the
-    // /// invariant that the state stored by this module is valid -- but
-    // /// possibly stale -- contract state
-    // ///
-    // /// NOTE: This method is kept for reference but is no longer used.
-    // /// Use `add_local_order` instead for order updates.
-    // ///
-    // /// TODO: Delete this method
-    // #[allow(dead_code)]
-    // pub fn update_account(&self, account: &Account) ->
-    // Result<ApplicatorReturnType> {     let tx = self.db().new_write_tx()?;
+    /// Update a balance in an account
+    pub fn update_account_balance(
+        &self,
+        account_id: AccountId,
+        balance: &Balance,
+    ) -> Result<ApplicatorReturnType> {
+        // Create write transaction
+        let tx = self.db().new_write_tx()?;
+        if !tx.contains_account(&account_id)? {
+            return Err(StateApplicatorError::reject("account not found"));
+        }
+        tx.update_balance(&account_id, balance)?;
+        tx.commit()?;
 
-    //     // Index the intents in the account
-    //     self.index_intents_with_tx(account, &tx)?;
+        // Open a read transaction to get order info for matching engine updates
+        // We do this after committing to ensure the balance state is durable
+        let engine = self.matching_engine();
+        let tx = self.db().new_read_tx()?;
 
-    //     // Write the account
-    //     // tx.write_account(account)?;
-    //     tx.commit()?;
+        let affected_order_ids = tx.get_orders_with_input_token(&account_id, &balance.mint())?;
+        for order_id in affected_order_ids {
+            let order = match tx.get_order(&order_id)? {
+                Some(archived_order) => Order::from_archived(&archived_order)?,
+                None => {
+                    tracing::warn!("order {order_id} not found, skipping matchable amount update");
+                    continue;
+                },
+            };
 
-    //     // Push updates to the bus
-    //     self.publish_account_update(account);
-    //     self.system_bus().publish(
-    //         ADMIN_WALLET_UPDATES_TOPIC.to_string(),
-    //         SystemBusMessage::AdminAccountUpdate { account_id: account.id },
-    //     );
+            // Fetch the information the matching engine needs to update
+            let matching_pool = tx.get_matching_pool_for_order(&order_id)?;
+            let matchable_amount = tx.get_order_matchable_amount(&order_id)?.unwrap_or_default();
+            if matchable_amount > 0 {
+                engine.add_order(&order, matchable_amount, matching_pool);
+            } else {
+                engine.cancel_order(&order, matching_pool);
+            }
+        }
 
-    //     Ok(ApplicatorReturnType::None)
-    // }
-
-    // -----------
-    // | Helpers |
-    // -----------
-
-    /// Publish an account update message to the system bus
-    fn publish_account_update(&self, account: &Account) {
-        let account_topic = account_topic(&account.id);
-        self.system_bus().publish(
-            account_topic,
-            SystemBusMessage::AccountUpdate { account: Box::new(account.clone()) },
-        );
+        Ok(ApplicatorReturnType::None)
     }
-
-    // /// Index the intents of an account
-    // fn index_intents_with_tx(&self, account: &Account, tx: &StateTxn<RW>) ->
-    // Result<()> {     // Update the intent -> account mapping
-    //     let nonzero_intents = account.orders.keys().copied().collect_vec();
-    //     // tx.index_orders(&account.id, &nonzero_intents)?;
-
-    //     // Handle cancelled intents
-    //     self.handle_cancelled_intents(account, tx)
-    // }
-
-    // /// Handle cancelled intents
-    // fn handle_cancelled_intents(&self, account: &Account, tx: &StateTxn<RW>) ->
-    // Result<()> {     let old_account = tx.get_account(&account.id)?;
-    //     let old_intents = old_account
-    //         .map(|a|
-    // a.deserialize().unwrap().orders.keys().copied().collect_vec())
-    //         .unwrap_or_default();
-
-    //     // Handle cancelled intents
-    //     for id in old_intents {
-    //         if !account.orders.contains_key(&id) {
-    //             self.handle_cancelled_intent(id, tx)?;
-    //         }
-    //     }
-
-    //     Ok(())
-    // }
-
-    // /// Handle a cancelled intent
-    // fn handle_cancelled_intent(&self, id: OrderId, tx: &StateTxn<RW>) ->
-    // Result<()> {     // Remove the order from the matching engine
-    //     let matching_pool = tx.get_matching_pool_for_order(&id)?;
-    //     let id = tx.get_account_id_for_order(&id)?.ok_or_else(||
-    // reject_account_missing(id))?;     if let Some(order) =
-    // account.get_order_deserialized(&id) {         self.matching_engine().
-    // cancel_order(&order, matching_pool);     }
-
-    //     // Remove the intent from its matching pool
-    //     tx.remove_order_from_matching_pool(&id)?;
-
-    //     // TODO: Remove the intent from the order book table
-    //     // TODO: Delete proofs for the intent
-
-    //     Ok(())
-    // }
 }
 
 // ---------
@@ -197,9 +144,14 @@ impl StateApplicator {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use alloy_primitives::Address;
+    use circuit_types::Amount;
     use types_account::{
-        account::mocks::mock_empty_account, order::mocks::mock_order,
+        account::mocks::mock_empty_account,
+        balance::mocks::mock_balance,
+        order::mocks::{mock_order, mock_order_with_pair},
         order_auth::mocks::mock_order_auth,
+        pair::Pair,
     };
 
     use crate::applicator::test_helpers::mock_applicator;
@@ -223,7 +175,8 @@ pub(crate) mod test {
 
     /// Test adding an order to an account
     #[test]
-    fn test_add_order_to_account() {
+    #[allow(non_snake_case)]
+    fn test_add_order_to_account__no_balance() {
         let applicator = mock_applicator();
 
         // Add an account
@@ -256,24 +209,57 @@ pub(crate) mod test {
         let retrieved_auth = retrieved_auth.unwrap().deserialize().unwrap();
         assert_eq!(retrieved_auth, auth);
 
+        // Check that the order is not in the matching engine
+        let matching_pool = tx.get_matching_pool_for_order(&order.id).unwrap();
+        let contains_order = applicator.matching_engine().contains_order(&order, matching_pool);
+        assert!(!contains_order); // zero matchable amount, so not in the matching engine
+    }
+
+    /// Test adding an order to an account with a balance
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_add_order_to_account__with_balance() {
+        let applicator = mock_applicator();
+        let order = mock_order();
+        let auth = mock_order_auth();
+        let mut balance = mock_balance();
+        balance.state_wrapper.inner.mint = order.input_token();
+
+        // Add an account
+        let account = mock_empty_account();
+        applicator.create_account(&account).unwrap();
+
+        // Add a balance, then an order
+        applicator.update_account_balance(account.id, &balance).unwrap();
+        applicator.add_order_to_account(account.id, &order, &auth).unwrap();
+
+        // Check that the order is stored in the account
+        let tx = applicator.db().new_read_tx().unwrap();
+        let retrieved_account = tx.get_account(&account.id).unwrap().unwrap();
+        assert!(retrieved_account.orders.contains_key(&order.id));
+
         // Check that the order is in the matching engine
         let matching_pool = tx.get_matching_pool_for_order(&order.id).unwrap();
-        assert!(applicator.matching_engine().contains_order(&order, matching_pool));
+        let contains_order = applicator.matching_engine().contains_order(&order, matching_pool);
+        assert!(contains_order);
     }
 
     /// Test removing an order from an account
     #[test]
     fn test_remove_order_from_account() {
         let applicator = mock_applicator();
+        let order = mock_order();
+        let auth = mock_order_auth();
+        let mut balance = mock_balance();
+        balance.state_wrapper.inner.mint = order.input_token();
         let matching_engine = applicator.matching_engine().clone();
 
         // Add an account
         let account = mock_empty_account();
         applicator.create_account(&account).unwrap();
 
-        // Add an order to the account
-        let order = mock_order();
-        let auth = mock_order_auth();
+        // Add a balance, then an order
+        applicator.update_account_balance(account.id, &balance).unwrap();
         applicator.add_order_to_account(account.id, &order, &auth).unwrap();
 
         // Verify the order exists before removal
@@ -307,5 +293,86 @@ pub(crate) mod test {
         let matching_pool = tx.get_matching_pool_for_order(&order.id).unwrap();
         let contains_order = matching_engine.contains_order(&order, matching_pool.clone());
         assert!(!contains_order);
+    }
+
+    /// Test updating an account balance
+    #[test]
+    fn test_update_account_balance() {
+        let applicator = mock_applicator();
+        let matching_engine = applicator.matching_engine().clone();
+
+        // Add an account
+        let account = mock_empty_account();
+        applicator.create_account(&account).unwrap();
+
+        // Create a balance
+        let mut balance = mock_balance();
+        let mint = balance.mint();
+
+        // Create orders with different input tokens
+        let mint1 = Address::from([1u8; 20]);
+        let mint2 = Address::from([2u8; 20]);
+        let pair1 = Pair::new(mint, mint1); // Uses balance mint as input
+        let pair2 = Pair::new(mint, mint2); // Uses balance mint as input
+        let pair3 = Pair::new(mint1, mint); // Uses different mint as input
+
+        let order1 = mock_order_with_pair(pair1);
+        let order2 = mock_order_with_pair(pair2);
+        let order3 = mock_order_with_pair(pair3);
+        let auth = mock_order_auth();
+
+        // Add orders to the account
+        applicator.add_order_to_account(account.id, &order1, &auth).unwrap();
+        applicator.add_order_to_account(account.id, &order2, &auth).unwrap();
+        applicator.add_order_to_account(account.id, &order3, &auth).unwrap();
+
+        // Verify initial matchable amounts
+        let tx = applicator.db().new_read_tx().unwrap();
+        let matching_pool1 = tx.get_matching_pool_for_order(&order1.id).unwrap();
+        let matching_pool2 = tx.get_matching_pool_for_order(&order2.id).unwrap();
+        let matching_pool3 = tx.get_matching_pool_for_order(&order3.id).unwrap();
+        let initial_matchable1 = tx.get_order_matchable_amount(&order1.id).unwrap().unwrap();
+        let initial_matchable2 = tx.get_order_matchable_amount(&order2.id).unwrap().unwrap();
+        let initial_matchable3 = tx.get_order_matchable_amount(&order3.id).unwrap().unwrap();
+
+        // Verify initial matchable amounts are all zero (no balance initially)
+        assert_eq!(initial_matchable1, 0);
+        assert_eq!(initial_matchable2, 0);
+        assert_eq!(initial_matchable3, 0);
+        drop(tx);
+
+        // Update the balance (increase amount)
+        const AMOUNT_ADDED: Amount = 1000;
+        *balance.amount_mut() = AMOUNT_ADDED;
+        applicator.update_account_balance(account.id, &balance).unwrap();
+
+        // Verify balance was updated
+        let tx = applicator.db().new_read_tx().unwrap();
+        let retrieved_account = tx.get_account(&account.id).unwrap().unwrap();
+        let retrieved_balance = retrieved_account.get_balance(&mint).unwrap();
+        assert_eq!(retrieved_balance.amount(), AMOUNT_ADDED);
+
+        // Verify orders using the updated balance's mint have updated matchable amounts
+        let new_matchable1 = tx.get_order_matchable_amount(&order1.id).unwrap().unwrap();
+        let new_matchable2 = tx.get_order_matchable_amount(&order2.id).unwrap().unwrap();
+        let new_matchable3 = tx.get_order_matchable_amount(&order3.id).unwrap().unwrap();
+        assert_eq!(new_matchable1, AMOUNT_ADDED);
+        assert_eq!(new_matchable2, AMOUNT_ADDED);
+        assert_eq!(new_matchable3, 0);
+
+        // Verify matching engine matchable amounts match transaction layer values
+        let engine_matchable1_after =
+            matching_engine.get_matchable_amount(&order1, matching_pool1.clone()).unwrap();
+        let engine_matchable2_after =
+            matching_engine.get_matchable_amount(&order2, matching_pool2.clone()).unwrap();
+
+        assert_eq!(engine_matchable1_after, new_matchable1);
+        assert_eq!(engine_matchable2_after, new_matchable2);
+
+        // Verify matching engine was updated for orders 1 and 2 (using balance mint)
+        // Order 3 should not be affected since it uses a different input token
+        assert!(matching_engine.contains_order(&order1, matching_pool1));
+        assert!(matching_engine.contains_order(&order2, matching_pool2));
+        assert!(!matching_engine.contains_order(&order3, matching_pool3));
     }
 }

--- a/crates/state/src/applicator/mod.rs
+++ b/crates/state/src/applicator/mod.rs
@@ -98,6 +98,9 @@ impl StateApplicator {
             StateTransition::RemoveOrderFromAccount { account_id, order_id } => {
                 self.remove_order_from_account(account_id, order_id)
             },
+            StateTransition::UpdateAccountBalance { account_id, balance } => {
+                self.update_account_balance(account_id, &balance)
+            },
             StateTransition::AddOrderValidityProof { order_id, proof } => {
                 self.add_order_validity_proof(order_id, proof)
             },

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -139,6 +139,15 @@ impl StateInner {
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::RemoveOrderFromAccount { account_id, order_id }).await
     }
+
+    /// Update a balance in an account
+    pub async fn update_account_balance(
+        &self,
+        account_id: AccountId,
+        balance: types_account::balance::Balance,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::UpdateAccountBalance { account_id, balance }).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -8,8 +8,8 @@ use circuit_types::Nullifier;
 use darkpool_types::rkyv_remotes::ScalarDef;
 use serde::{Deserialize, Serialize};
 use types_account::{
-    Account, MatchingPoolName, MerkleAuthenticationPath, account::OrderId, order::Order,
-    order_auth::OrderAuth,
+    Account, MatchingPoolName, MerkleAuthenticationPath, account::OrderId, balance::Balance,
+    order::Order, order_auth::OrderAuth,
 };
 use types_core::AccountId;
 use types_gossip::WrappedPeerId;
@@ -52,6 +52,8 @@ pub enum StateTransition {
     AddOrderToAccount { account_id: AccountId, order: Order, auth: OrderAuth },
     /// Remove an order from an account
     RemoveOrderFromAccount { account_id: AccountId, order_id: OrderId },
+    /// Update a balance in an account
+    UpdateAccountBalance { account_id: AccountId, balance: Balance },
 
     // --- Orders --- //
     /// Add a validity proof to an order

--- a/crates/workers/matching-engine/matching-engine-core/src/book.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/book.rs
@@ -96,7 +96,6 @@ impl Book {
     }
 
     /// Get the matchable amount for an order
-    #[cfg(test)]
     pub fn get_matchable_amount(&self, order_id: OrderId) -> Option<Amount> {
         self.order_map.get(&order_id).map(|order| order.matchable_amount)
     }


### PR DESCRIPTION
### Purpose
This PR adds a state transition to update an account's balance of a given mint.

In particular, this state transition must update the matchable amount for each order in the account which is capitalized by the given balance.

### Testing
- [x] Unit tests pass