### PR TITLE
feat(proof-manager): use new link+prove API

### DIFF
--- a/crates/workers/job-types/src/proof_manager.rs
+++ b/crates/workers/job-types/src/proof_manager.rs
@@ -4,6 +4,8 @@
 //! See the whitepaper https://renegade.fi/whitepaper.pdf for a formal specification
 //! of the types defined here
 
+use ark_mpc::network::PartyId;
+use circuit_types::ProofLinkingHint;
 use circuits_core::zk_circuits::{
     fees::{
         valid_note_redemption::{SizedValidNoteRedemptionWitness, ValidNoteRedemptionStatement},
@@ -389,26 +391,44 @@ pub enum ProofJob {
     IntentAndBalanceBoundedSettlement {
         witness: IntentAndBalanceBoundedSettlementWitness,
         statement: IntentAndBalanceBoundedSettlementStatement,
+        /// The link hint for the validity proof
+        validity_link_hint: ProofLinkingHint,
     },
     /// Prove `INTENT AND BALANCE PRIVATE SETTLEMENT`
     IntentAndBalancePrivateSettlement {
         witness: IntentAndBalancePrivateSettlementWitness,
         statement: IntentAndBalancePrivateSettlementStatement,
+        /// The link hint for party 0's validity proof
+        validity_link_hint_0: ProofLinkingHint,
+        /// The link hint for party 1's validity proof
+        validity_link_hint_1: ProofLinkingHint,
+        /// The link hint for party 0's output balance validity proof
+        output_balance_link_hint_0: ProofLinkingHint,
+        /// The link hint for party 1's output balance validity proof
+        output_balance_link_hint_1: ProofLinkingHint,
     },
     /// Prove `INTENT AND BALANCE PUBLIC SETTLEMENT`
     IntentAndBalancePublicSettlement {
         witness: IntentAndBalancePublicSettlementWitness,
         statement: IntentAndBalancePublicSettlementStatement,
+        /// The party ID (0 or 1) for two-party settlements
+        party_id: PartyId,
+        /// The link hint for the validity proof
+        validity_link_hint: ProofLinkingHint,
     },
     /// Prove `INTENT ONLY BOUNDED SETTLEMENT`
     IntentOnlyBoundedSettlement {
         witness: IntentOnlyBoundedSettlementWitness,
         statement: IntentOnlyBoundedSettlementStatement,
+        /// The link hint for the validity proof
+        validity_link_hint: ProofLinkingHint,
     },
     /// Prove `INTENT ONLY PUBLIC SETTLEMENT`
     IntentOnlyPublicSettlement {
         witness: IntentOnlyPublicSettlementWitness,
         statement: IntentOnlyPublicSettlementStatement,
+        /// The link hint for the validity proof
+        validity_link_hint: ProofLinkingHint,
     },
     // Fee proofs
     /// Prove `VALID NOTE REDEMPTION`

--- a/crates/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
+++ b/crates/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
@@ -92,25 +92,34 @@ pub struct ProofAndHintResponse {
     pub link_hint: ProofLinkingHint,
 }
 
-/// A proof-link response
+/// A settlement proof response with a linking proof
 ///
-/// Sent by the prover service when only a linking proof has been requested
+/// Sent by the prover service for settlement proofs that compute a single
+/// linking proof
 #[derive(Serialize, Deserialize)]
-pub struct ProofLinkResponse {
-    /// The proof-linking proof
+pub struct SettlementProofResponse {
+    /// The settlement proof
+    pub proof: PlonkProof,
+    /// The linking proof
     pub link_proof: PlonkLinkProof,
 }
 
-/// A response including a plonk proof and a proof-linking proof
+/// A private settlement proof response with multiple linking proofs
 ///
-/// This type is returned in response to requests which themselves include a
-/// link hint for the prover service to link against
+/// Sent by the prover service for private settlement proofs that compute
+/// multiple linking proofs
 #[derive(Serialize, Deserialize)]
-pub struct ProofAndLinkResponse {
-    /// The plonk proof
-    pub plonk_proof: PlonkProof,
-    /// The proof-linking proof
-    pub link_proof: PlonkLinkProof,
+pub struct PrivateSettlementProofResponse {
+    /// The settlement proof
+    pub proof: PlonkProof,
+    /// Party 0's validity linking proof
+    pub validity_link_proof_0: PlonkLinkProof,
+    /// Party 1's validity linking proof
+    pub validity_link_proof_1: PlonkLinkProof,
+    /// Party 0's output balance linking proof
+    pub output_balance_link_proof_0: PlonkLinkProof,
+    /// Party 1's output balance linking proof
+    pub output_balance_link_proof_1: PlonkLinkProof,
 }
 
 // -----------------
@@ -217,6 +226,8 @@ pub struct IntentAndBalanceBoundedSettlementRequest {
     pub statement: IntentAndBalanceBoundedSettlementStatement,
     /// The witness
     pub witness: IntentAndBalanceBoundedSettlementWitness,
+    /// The link hint for the validity proof
+    pub validity_link_hint: ProofLinkingHint,
 }
 
 /// A request to prove `INTENT AND BALANCE PRIVATE SETTLEMENT`
@@ -226,6 +237,14 @@ pub struct IntentAndBalancePrivateSettlementRequest {
     pub statement: IntentAndBalancePrivateSettlementStatement,
     /// The witness
     pub witness: IntentAndBalancePrivateSettlementWitness,
+    /// The link hint for party 0's validity proof
+    pub validity_link_hint_0: ProofLinkingHint,
+    /// The link hint for party 1's validity proof
+    pub validity_link_hint_1: ProofLinkingHint,
+    /// The link hint for party 0's output balance validity proof
+    pub output_balance_link_hint_0: ProofLinkingHint,
+    /// The link hint for party 1's output balance validity proof
+    pub output_balance_link_hint_1: ProofLinkingHint,
 }
 
 /// A request to prove `INTENT AND BALANCE PUBLIC SETTLEMENT`
@@ -235,6 +254,10 @@ pub struct IntentAndBalancePublicSettlementRequest {
     pub statement: IntentAndBalancePublicSettlementStatement,
     /// The witness
     pub witness: IntentAndBalancePublicSettlementWitness,
+    /// The party ID (0 or 1) for two-party settlements
+    pub party_id: u8,
+    /// The link hint for the validity proof
+    pub validity_link_hint: ProofLinkingHint,
 }
 
 /// A request to prove `INTENT ONLY BOUNDED SETTLEMENT`
@@ -244,6 +267,8 @@ pub struct IntentOnlyBoundedSettlementRequest {
     pub statement: IntentOnlyBoundedSettlementStatement,
     /// The witness
     pub witness: IntentOnlyBoundedSettlementWitness,
+    /// The link hint for the validity proof
+    pub validity_link_hint: ProofLinkingHint,
 }
 
 /// A request to prove `INTENT ONLY PUBLIC SETTLEMENT`
@@ -253,6 +278,8 @@ pub struct IntentOnlyPublicSettlementRequest {
     pub statement: IntentOnlyPublicSettlementStatement,
     /// The witness
     pub witness: IntentOnlyPublicSettlementWitness,
+    /// The link hint for the validity proof
+    pub validity_link_hint: ProofLinkingHint,
 }
 
 // Fee proofs

--- a/crates/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/crates/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -128,20 +128,62 @@ impl ExternalProofManager {
                 client.prove_output_balance_validity(witness, statement).await
             },
             // Settlement proofs
-            ProofJob::IntentAndBalanceBoundedSettlement { witness, statement } => {
-                client.prove_intent_and_balance_bounded_settlement(witness, statement).await
+            ProofJob::IntentAndBalanceBoundedSettlement {
+                witness,
+                statement,
+                validity_link_hint,
+            } => {
+                client
+                    .prove_intent_and_balance_bounded_settlement(
+                        witness,
+                        statement,
+                        validity_link_hint,
+                    )
+                    .await
             },
-            ProofJob::IntentAndBalancePrivateSettlement { witness, statement } => {
-                client.prove_intent_and_balance_private_settlement(witness, statement).await
+            ProofJob::IntentAndBalancePrivateSettlement {
+                witness,
+                statement,
+                validity_link_hint_0,
+                validity_link_hint_1,
+                output_balance_link_hint_0,
+                output_balance_link_hint_1,
+            } => {
+                client
+                    .prove_intent_and_balance_private_settlement(
+                        witness,
+                        statement,
+                        validity_link_hint_0,
+                        validity_link_hint_1,
+                        output_balance_link_hint_0,
+                        output_balance_link_hint_1,
+                    )
+                    .await
             },
-            ProofJob::IntentAndBalancePublicSettlement { witness, statement } => {
-                client.prove_intent_and_balance_public_settlement(witness, statement).await
+            ProofJob::IntentAndBalancePublicSettlement {
+                witness,
+                statement,
+                party_id,
+                validity_link_hint,
+            } => {
+                client
+                    .prove_intent_and_balance_public_settlement(
+                        witness,
+                        statement,
+                        party_id,
+                        validity_link_hint,
+                    )
+                    .await
             },
-            ProofJob::IntentOnlyBoundedSettlement { witness, statement } => {
-                client.prove_intent_only_bounded_settlement(witness, statement).await
+            ProofJob::IntentOnlyBoundedSettlement { witness, statement, validity_link_hint } => {
+                client
+                    .prove_intent_only_bounded_settlement(witness, statement, validity_link_hint)
+                    .await
             },
-            ProofJob::IntentOnlyPublicSettlement { witness, statement } => {
-                client.prove_intent_only_public_settlement(witness, statement).await
+            ProofJob::IntentOnlyPublicSettlement { witness, statement, validity_link_hint } => {
+                client
+                    .prove_intent_only_public_settlement(witness, statement, validity_link_hint)
+                    .await
             },
             // Fee proofs
             ProofJob::ValidNoteRedemption { witness, statement } => {

--- a/crates/workers/proof-manager/src/mock.rs
+++ b/crates/workers/proof-manager/src/mock.rs
@@ -91,8 +91,10 @@ use job_types::proof_manager::{
 };
 use tokio::runtime::Handle;
 use tracing::{error, instrument};
-use types_proofs::mocks::{dummy_link_hint, dummy_proof};
-use types_proofs::{ProofAndHintBundle, ProofBundle};
+use types_proofs::mocks::{dummy_link_hint, dummy_link_proof, dummy_proof};
+use types_proofs::{
+    PrivateSettlementProofBundle, ProofAndHintBundle, ProofBundle, SettlementProofBundle,
+};
 use util::channels::TracedMessage;
 
 use crate::error::ProofManagerError;
@@ -174,19 +176,19 @@ impl MockProofManager {
                 Self::output_balance_validity(witness, statement, skip_constraints)
             },
             // Settlement proofs
-            ProofJob::IntentAndBalanceBoundedSettlement { witness, statement } => {
+            ProofJob::IntentAndBalanceBoundedSettlement { witness, statement, .. } => {
                 Self::intent_and_balance_bounded_settlement(witness, statement, skip_constraints)
             },
-            ProofJob::IntentAndBalancePrivateSettlement { witness, statement } => {
+            ProofJob::IntentAndBalancePrivateSettlement { witness, statement, .. } => {
                 Self::intent_and_balance_private_settlement(witness, statement, skip_constraints)
             },
-            ProofJob::IntentAndBalancePublicSettlement { witness, statement } => {
+            ProofJob::IntentAndBalancePublicSettlement { witness, statement, .. } => {
                 Self::intent_and_balance_public_settlement(witness, statement, skip_constraints)
             },
-            ProofJob::IntentOnlyBoundedSettlement { witness, statement } => {
+            ProofJob::IntentOnlyBoundedSettlement { witness, statement, .. } => {
                 Self::intent_only_bounded_settlement(witness, statement, skip_constraints)
             },
-            ProofJob::IntentOnlyPublicSettlement { witness, statement } => {
+            ProofJob::IntentOnlyPublicSettlement { witness, statement, .. } => {
                 Self::intent_only_public_settlement(witness, statement, skip_constraints)
             },
             // Fee proofs
@@ -374,8 +376,8 @@ impl MockProofManager {
             )?;
         }
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofAndHintBundle::new(proof, statement, link_hint);
+        let link_proof = dummy_link_proof();
+        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentAndBalanceBoundedSettlement(bundle))
     }
 
@@ -391,8 +393,14 @@ impl MockProofManager {
             )?;
         }
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofAndHintBundle::new(proof, statement, link_hint);
+        let bundle = PrivateSettlementProofBundle::new(
+            proof,
+            statement,
+            dummy_link_proof(),
+            dummy_link_proof(),
+            dummy_link_proof(),
+            dummy_link_proof(),
+        );
         Ok(ProofManagerResponse::IntentAndBalancePrivateSettlement(bundle))
     }
 
@@ -408,8 +416,8 @@ impl MockProofManager {
             )?;
         }
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofAndHintBundle::new(proof, statement, link_hint);
+        let link_proof = dummy_link_proof();
+        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentAndBalancePublicSettlement(bundle))
     }
 
@@ -423,8 +431,8 @@ impl MockProofManager {
             Self::check_constraints::<IntentOnlyBoundedSettlementCircuit>(&witness, &statement)?;
         }
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofAndHintBundle::new(proof, statement, link_hint);
+        let link_proof = dummy_link_proof();
+        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentOnlyBoundedSettlement(bundle))
     }
 
@@ -438,8 +446,8 @@ impl MockProofManager {
             Self::check_constraints::<IntentOnlyPublicSettlementCircuit>(&witness, &statement)?;
         }
         let proof = dummy_proof();
-        let link_hint = dummy_link_hint();
-        let bundle = ProofAndHintBundle::new(proof, statement, link_hint);
+        let link_proof = dummy_link_proof();
+        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentOnlyPublicSettlement(bundle))
     }
 


### PR DESCRIPTION
In this PR, we update the proof manager to use the new link + prove API exposed by the prover service.

We fit the native proof manager to this pattern as well by having it compute link proofs alongside the settlement proofs, in parallel where necessary.
