### PR TITLE
task-driver: create-order: Check for on-chain balance after placement

### DIFF
--- a/crates/workers/api-server/src/error.rs
+++ b/crates/workers/api-server/src/error.rs
@@ -15,6 +15,8 @@ use super::router::{ResponseBody, build_500_response, build_response_from_status
 pub(crate) const ERR_RATE_LIMIT_EXCEEDED: &str = "Rate limit exceeded";
 /// The error message for account not found
 pub(crate) const ERR_ACCOUNT_NOT_FOUND: &str = "account not found";
+/// The error message for balance not found
+pub(crate) const ERR_BALANCE_NOT_FOUND: &str = "balance not found";
 
 /// The error type for errors that occur during ApiServer execution
 #[derive(Debug)]

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -192,7 +192,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_BALANCE_BY_MINT_ROUTE.to_string(),
-            GetBalanceByMintHandler::new(),
+            GetBalanceByMintHandler::new(state.clone()),
         );
 
         // POST /v2/account/:account_id/balances/:mint/deposit


### PR DESCRIPTION
### Purpose
This PR checks for an on-chain balance after creating a ring 0 order in the `create_order` task.

### Testing
- [x] Tested with a local client. Verified that the client was able to fetch a balance and order after the task completes.