### PR TITLE
task-driver: state-migration: Remove cbbtc quoter wallet

### DIFF
--- a/state/src/storage/tx/wallet_index.rs
+++ b/state/src/storage/tx/wallet_index.rs
@@ -85,6 +85,11 @@ impl<T: TransactionKind> StateTxn<'_, T> {
 // -----------
 
 impl StateTxn<'_, RW> {
+    /// Remove a wallet from the table
+    pub fn remove_wallet(&self, wallet_id: &WalletIdentifier) -> Result<(), StorageError> {
+        self.inner().delete(WALLETS_TABLE, wallet_id).map(|_| ())
+    }
+
     /// Write a wallet to the table
     pub fn write_wallet(&self, wallet: &Wallet) -> Result<(), StorageError> {
         let nullifier = wallet.get_wallet_nullifier();

--- a/workers/task-driver/Cargo.toml
+++ b/workers/task-driver/Cargo.toml
@@ -36,7 +36,7 @@ alloy = { workspace = true }
 darkpool-client = { workspace = true }
 circuits = { workspace = true }
 circuit-types = { workspace = true }
-common = { workspace = true }
+common = { workspace = true, features = ["wallet"] }
 constants = { workspace = true }
 external-api = { workspace = true }
 gossip-api = { workspace = true }

--- a/workers/task-driver/src/state_migration/remove_quoter_wallet.rs
+++ b/workers/task-driver/src/state_migration/remove_quoter_wallet.rs
@@ -1,0 +1,34 @@
+//! Removes a single wallet from the state so that it may be refreshed
+
+use common::types::wallet::WalletIdentifier;
+use state::State;
+use tracing::{info, warn};
+
+/// The ID of the quoter wallet to remove
+const QUOTER_WALLET_ID: &str = "e48509a3-6eba-9015-5cde-ac031d1e517e";
+
+/// Remove a single wallet from the state so that it may be refreshed
+pub(crate) async fn remove_quoter_wallet(state: &State) -> Result<(), String> {
+    let wid = WalletIdentifier::parse_str(QUOTER_WALLET_ID).map_err(|e| e.to_string())?;
+
+    info!("removing quoter wallet: {:?}", wid);
+    state
+        .with_write_tx(move |tx| {
+            let wallet = tx.get_wallet(&wid)?;
+            if wallet.is_none() {
+                warn!("wallet not found, skipping");
+                return Ok(());
+            }
+
+            let wallet = wallet.unwrap();
+            let wallet_json = serde_json::to_string(&wallet).expect("failed to serialize wallet");
+            info!("removed wallet: {}", wallet_json);
+
+            // Remove the wallet from the state
+            tx.remove_wallet(&wid)?;
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Purpose
This PR adds a state migration to remove a wallet from state so that it can be refreshed anew by the client.

### Testing
- [x] Unit tests pass