### PR TITLE
task-driver: hooks: Add post-task hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9989,6 +9989,7 @@ dependencies = [
  "bimap",
  "circuit-types",
  "constants",
+ "darkpool-types",
  "hmac",
  "num-bigint",
  "rand 0.8.5",

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -182,6 +182,7 @@ async fn main() -> Result<(), CoordinatorError> {
         network_sender.clone(),
         proof_generation_worker_sender.clone(),
         event_manager_sender.clone(),
+        matching_engine_worker_sender.clone(),
         system_bus.clone(),
         global_state.clone(),
     );

--- a/crates/darkpool-types/src/settlement_obligation.rs
+++ b/crates/darkpool-types/src/settlement_obligation.rs
@@ -11,6 +11,9 @@ use circuit_types::{Amount, traits::BaseType};
 use constants::Scalar;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rkyv")]
+use crate::rkyv_remotes::AddressDef;
+
 #[cfg(feature = "proof-system-types")]
 use {
     circuit_types::traits::{
@@ -28,10 +31,14 @@ use {
 #[cfg_attr(feature = "proof-system-types", circuit_type(serde, singleprover_circuit, secret_share))]
 #[cfg_attr(not(feature = "proof-system-types"), circuit_type(serde))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub struct SettlementObligation {
     /// The input token address
+    #[cfg_attr(feature = "rkyv", rkyv(with = AddressDef))]
     pub input_token: Address,
     /// The output token address
+    #[cfg_attr(feature = "rkyv", rkyv(with = AddressDef))]
     pub output_token: Address,
     /// The amount of the input token to trade
     pub amount_in: Amount,
@@ -41,6 +48,8 @@ pub struct SettlementObligation {
 
 /// A match result is a pair of settlement obligations; one for each party
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub struct MatchResult {
     /// The settlement obligation for the first party
     pub party0_obligation: SettlementObligation,

--- a/crates/relayer-types/types-core/Cargo.toml
+++ b/crates/relayer-types/types-core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [features]
 default = []
 hmac = []
-rkyv = ["dep:rkyv"]
+rkyv = ["dep:rkyv", "dep:darkpool-types", "darkpool-types/rkyv"]
 
 [dependencies]
 # === Core Dependencies === #
@@ -19,6 +19,7 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 # === Workspace Dependencies === #
 circuit-types = { workspace = true }
 constants = { workspace = true, default-features = false }
+darkpool-types = { workspace = true, optional = true }
 util = { workspace = true, features = ["hex-core", "serde", "concurrency"] }
 
 # === HMAC Dependencies === #

--- a/crates/relayer-types/types-core/src/price.rs
+++ b/crates/relayer-types/types-core/src/price.rs
@@ -3,6 +3,8 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use circuit_types::fixed_point::FixedPoint;
+#[cfg(feature = "rkyv")]
+use darkpool_types::rkyv_remotes::FixedPointDef;
 use serde::{Deserialize, Serialize};
 
 use crate::exchange::PriceReport;
@@ -62,8 +64,11 @@ impl From<&PriceReport> for TimestampedPrice {
 
 /// A price along with the time it was sampled represented as a fixed point
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub struct TimestampedPriceFp {
     /// The price
+    #[cfg_attr(feature = "rkyv", rkyv(with = FixedPointDef))]
     pub price: FixedPoint,
     /// The time the price was sampled, in milliseconds since the epoch
     pub timestamp: u64,

--- a/crates/relayer-types/types-tasks/src/descriptors/mod.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/mod.rs
@@ -7,12 +7,14 @@ mod create_order;
 mod deposit;
 mod new_account;
 mod node_startup;
+mod settle_internal_match;
 
 pub use create_balance::*;
 pub use create_order::*;
 pub use deposit::*;
 pub use new_account::*;
 pub use node_startup::*;
+pub use settle_internal_match::*;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize, with::Skip};
@@ -141,6 +143,8 @@ pub enum TaskDescriptor {
     CreateBalance(CreateBalanceTaskDescriptor),
     /// The task descriptor for the `CreateOrder` task
     CreateOrder(CreateOrderTaskDescriptor),
+    /// The task descriptor for the `SettleInternalMatch` task
+    SettleInternalMatch(SettleInternalMatchTaskDescriptor),
 }
 
 impl TaskDescriptor {
@@ -152,6 +156,7 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(task) => task.account_id,
             TaskDescriptor::CreateBalance(task) => task.account_id,
             TaskDescriptor::CreateOrder(task) => task.account_id,
+            TaskDescriptor::SettleInternalMatch(task) => task.account_id,
         }
     }
 
@@ -163,17 +168,21 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(task) => vec![task.account_id],
             TaskDescriptor::CreateBalance(task) => vec![task.account_id],
             TaskDescriptor::CreateOrder(task) => vec![task.account_id],
+            TaskDescriptor::SettleInternalMatch(task) => {
+                vec![task.account_id, task.other_account_id]
+            },
         }
     }
 
     /// Returns whether the task is a wallet task
-    pub fn is_wallet_task(&self) -> bool {
+    pub fn is_account_task(&self) -> bool {
         match self {
             TaskDescriptor::NewAccount(_) => true,
             TaskDescriptor::NodeStartup(_) => false,
             TaskDescriptor::Deposit(_) => true,
             TaskDescriptor::CreateBalance(_) => true,
             TaskDescriptor::CreateOrder(_) => true,
+            TaskDescriptor::SettleInternalMatch(_) => true,
         }
     }
 
@@ -185,6 +194,7 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(_) => "Deposit".to_string(),
             TaskDescriptor::CreateBalance(_) => "Create Balance".to_string(),
             TaskDescriptor::CreateOrder(_) => "Create Order".to_string(),
+            TaskDescriptor::SettleInternalMatch(_) => "Settle Internal Match".to_string(),
         }
     }
 }

--- a/crates/relayer-types/types-tasks/src/descriptors/settle_internal_match.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/settle_internal_match.rs
@@ -1,0 +1,33 @@
+//! Descriptor for the settle internal match task
+
+use darkpool_types::settlement_obligation::MatchResult;
+use types_account::OrderId;
+use types_core::{AccountId, TimestampedPriceFp};
+
+use super::TaskDescriptor;
+
+/// The task descriptor containing only the parameterization of the
+/// `SettleInternalMatch` task
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
+pub struct SettleInternalMatchTaskDescriptor {
+    /// The account ID for the initiating order
+    pub account_id: AccountId,
+    /// The account ID for the counterparty order
+    pub other_account_id: AccountId,
+    /// The ID of the initiating order
+    pub order_id: OrderId,
+    /// The ID of the counterparty order
+    pub other_order_id: OrderId,
+    /// The price at which the match was executed
+    pub execution_price: TimestampedPriceFp,
+    /// The match result
+    pub match_result: MatchResult,
+}
+
+impl From<SettleInternalMatchTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: SettleInternalMatchTaskDescriptor) -> Self {
+        TaskDescriptor::SettleInternalMatch(descriptor)
+    }
+}

--- a/crates/relayer-types/types-tasks/src/history.rs
+++ b/crates/relayer-types/types-tasks/src/history.rs
@@ -103,6 +103,7 @@ impl HistoricalTaskDescription {
                 token: desc.token,
                 amount: desc.amount,
             }),
+            TaskDescriptor::SettleInternalMatch(_) => None,
             TaskDescriptor::NodeStartup(_) => None,
         }
     }

--- a/crates/state/src/applicator/task_queue.rs
+++ b/crates/state/src/applicator/task_queue.rs
@@ -286,8 +286,8 @@ impl StateApplicator {
         let this_node = tx.get_peer_id()?;
         let queue_empty = !tx.serial_tasks_active(queue_key)?;
         let is_executor = *executor == this_node;
-        let is_wallet_task = popped_task.descriptor.is_wallet_task();
-        Ok(queue_empty && is_executor && is_wallet_task)
+        let is_account_task = popped_task.descriptor.is_account_task();
+        Ok(queue_empty && is_executor && is_account_task)
     }
 
     /// Run the internal matching engine on all of an account's orders that are

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -144,6 +144,21 @@ impl StateInner {
         .await
     }
 
+    /// Get all order IDs for an account that use the given token as input
+    pub async fn get_orders_with_input_token(
+        &self,
+        account_id: &AccountId,
+        token: &Address,
+    ) -> Result<Vec<OrderId>, StateError> {
+        let account_id = *account_id;
+        let token = *token;
+        self.with_read_tx(move |tx| {
+            let orders = tx.get_orders_with_input_token(&account_id, &token)?;
+            Ok(orders)
+        })
+        .await
+    }
+
     // -----------
     // | Setters |
     // -----------

--- a/crates/testing/mock-node/src/lib.rs
+++ b/crates/testing/mock-node/src/lib.rs
@@ -378,6 +378,7 @@ impl MockNodeController {
             network_queue,
             proof_queue,
             event_queue,
+            self.matching_engine_worker_queue.0.clone(),
             bus,
             state,
         );

--- a/crates/workers/task-driver/src/hooks.rs
+++ b/crates/workers/task-driver/src/hooks.rs
@@ -1,0 +1,165 @@
+//! Defines execution hooks for the task driver
+
+use alloy::primitives::Address;
+use async_trait::async_trait;
+use itertools::Itertools;
+use job_types::matching_engine::MatchingEngineWorkerJob;
+use tracing::info;
+use types_account::OrderId;
+use types_core::AccountId;
+
+use crate::traits::TaskContext;
+
+/// A task hook is a function that is called in the task execution flow. It may
+/// operate on the task context asynchronously to perform some action
+#[async_trait]
+pub trait TaskHook: Send + Sync {
+    /// The name of the task hook
+    fn description(&self) -> String;
+    /// Run the task hook
+    async fn run(&self, ctx: &TaskContext) -> Result<(), TaskHookError>;
+}
+
+/// An error type for task hooks
+#[derive(thiserror::Error, Debug)]
+pub enum TaskHookError {
+    /// The hook failed to execute
+    #[error("Hook execution failed: {0}")]
+    ExecutionFailed(String),
+}
+
+impl TaskHookError {
+    /// Create a new task hook error
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn execution<T: ToString>(message: T) -> Self {
+        Self::ExecutionFailed(message.to_string())
+    }
+}
+
+// ------------------------
+// | Hook Implementations |
+// ------------------------
+
+// --- Matching Engine Hook --- //
+
+/// A hook to run the matching engine on the given orders
+pub struct RunMatchingEngineHook {
+    /// The orders to run the matching engine on
+    pub orders: Vec<OrderId>,
+}
+
+impl RunMatchingEngineHook {
+    /// Create a new run matching engine hook
+    pub fn new(orders: Vec<OrderId>) -> Self {
+        Self { orders }
+    }
+}
+
+#[async_trait]
+impl TaskHook for RunMatchingEngineHook {
+    fn description(&self) -> String {
+        let orders = self.orders.iter().map(|o| o.to_string()).collect_vec().join(", ");
+        format!("run matching engine on orders: {orders}")
+    }
+
+    async fn run(&self, ctx: &TaskContext) -> Result<(), TaskHookError> {
+        for order in self.orders.iter().copied() {
+            let job = MatchingEngineWorkerJob::run_internal_engine(order);
+            ctx.matching_engine_queue.clone().send(job).map_err(TaskHookError::execution)?;
+        }
+
+        Ok(())
+    }
+}
+
+// --- Matching Engine For Balance Hook --- //
+
+/// A hook to run the matching engine on orders affected by a balance update
+///
+/// This hook queries the state for orders that use the given token as input
+/// and runs the matching engine on each of them
+pub struct RunMatchingEngineForBalanceHook {
+    /// The account ID whose balance was updated
+    pub account_id: AccountId,
+    /// The token that was updated
+    pub token: Address,
+}
+
+impl RunMatchingEngineForBalanceHook {
+    /// Create a new run matching engine for balance hook
+    pub fn new(account_id: AccountId, token: Address) -> Self {
+        Self { account_id, token }
+    }
+}
+
+#[async_trait]
+impl TaskHook for RunMatchingEngineForBalanceHook {
+    fn description(&self) -> String {
+        format!(
+            "run matching engine for balance update: account={}, token={}",
+            self.account_id, self.token
+        )
+    }
+
+    async fn run(&self, ctx: &TaskContext) -> Result<(), TaskHookError> {
+        // Query orders using this token as input
+        let order_ids = ctx
+            .state
+            .get_orders_with_input_token(&self.account_id, &self.token)
+            .await
+            .map_err(TaskHookError::execution)?;
+
+        info!(
+            "running matching engine on {} orders for balance update (account={}, token={})",
+            order_ids.len(),
+            self.account_id,
+            self.token
+        );
+
+        // Queue matching jobs for each order
+        for order_id in order_ids {
+            let job = MatchingEngineWorkerJob::run_internal_engine(order_id);
+            ctx.matching_engine_queue.clone().send(job).map_err(TaskHookError::execution)?;
+        }
+
+        Ok(())
+    }
+}
+
+// --- Refresh Account Hook --- //
+
+/// A hook to refresh the given accounts after a task has failed
+pub struct RefreshAccountHook {
+    /// The accounts to refresh
+    pub account_ids: Vec<AccountId>,
+}
+
+impl RefreshAccountHook {
+    /// Create a new refresh account hook
+    pub fn new(account_ids: Vec<AccountId>) -> Self {
+        Self { account_ids }
+    }
+}
+
+#[async_trait]
+impl TaskHook for RefreshAccountHook {
+    fn description(&self) -> String {
+        let accounts = self.account_ids.iter().map(|a| a.to_string()).collect_vec().join(", ");
+        format!("refresh accounts: {accounts}")
+    }
+
+    async fn run(&self, ctx: &TaskContext) -> Result<(), TaskHookError> {
+        // Append an account refresh task for the given accounts
+        for account_id in self.account_ids.iter().copied() {
+            let task_id = ctx
+                .state
+                .append_account_refresh_task(account_id)
+                .await
+                .map_err(TaskHookError::execution)?;
+
+            info!("enqueued account refresh task ({task_id}) for {account_id}");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/workers/task-driver/src/lib.rs
+++ b/crates/workers/task-driver/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod driver;
 pub mod error;
+pub mod hooks;
 mod running_task;
 pub mod simulation;
 pub mod state_migration;

--- a/crates/workers/task-driver/src/simulation/account_tasks.rs
+++ b/crates/workers/task-driver/src/simulation/account_tasks.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 use types_account::Account;
 use types_tasks::{
     CreateBalanceTaskDescriptor, CreateOrderTaskDescriptor, DepositTaskDescriptor,
-    NewAccountTaskDescriptor, QueuedTask, TaskDescriptor,
+    NewAccountTaskDescriptor, QueuedTask, SettleInternalMatchTaskDescriptor, TaskDescriptor,
 };
 
 use super::error::TaskSimulationError;
@@ -46,70 +46,10 @@ fn should_simulate(task: &QueuedTask) -> bool {
         TaskDescriptor::CreateOrder(_) => true,
         TaskDescriptor::Deposit(_) => true,
         TaskDescriptor::CreateBalance(_) => true,
+        TaskDescriptor::SettleInternalMatch(_) => true,
         TaskDescriptor::NodeStartup(_) => false,
     }
 }
-
-// TODO: Replace task simulation logic
-// /// Determine if an update wallet task should be simulated
-// fn should_simulate_update_wallet(
-//     task_state: &QueuedTaskState,
-// ) -> Result<bool, TaskSimulationError> {
-//     match task_state {
-//         QueuedTaskState::Running { state, .. } => {
-//             let task_state = UpdateWalletTaskState::from_str(state)
-//                 .map_err(TaskSimulationError::invalid_task_state)?;
-
-//             Ok(task_state < UpdateWalletTaskState::FindingOpening)
-//         },
-//         QueuedTaskState::Completed | QueuedTaskState::Failed => Ok(false),
-//         _ => Ok(true),
-//     }
-// }
-
-// /// Determine if a match settlement task should be simulated
-// fn should_simulate_settle_match(task_state: &QueuedTaskState) -> Result<bool,
-// TaskSimulationError> {     match task_state {
-//         QueuedTaskState::Running { state, .. } => {
-//             let task_state = SettleMatchTaskState::from_str(state)
-//                 .map_err(TaskSimulationError::invalid_task_state)?;
-
-//             Ok(task_state < SettleMatchTaskState::UpdatingState)
-//         },
-//         QueuedTaskState::Completed | QueuedTaskState::Failed => Ok(false),
-//         _ => Ok(true),
-//     }
-// }
-
-// /// Determine if an internal match settlement task should be simulated
-// fn should_simulate_settle_match_internal(
-//     task_state: &QueuedTaskState,
-// ) -> Result<bool, TaskSimulationError> {
-//     match task_state {
-//         QueuedTaskState::Running { state, .. } => {
-//             let task_state = SettleMatchInternalTaskState::from_str(state)
-//                 .map_err(TaskSimulationError::invalid_task_state)?;
-
-//             Ok(task_state < SettleMatchInternalTaskState::UpdatingState)
-//         },
-//         QueuedTaskState::Completed | QueuedTaskState::Failed => Ok(false),
-//         _ => Ok(true),
-//     }
-// }
-
-// /// Determine if an offline fee payment task should be simulated
-// fn should_simulate_offline_fee(task_state: &QueuedTaskState) -> Result<bool,
-// TaskSimulationError> {     match task_state {
-//         QueuedTaskState::Running { state, .. } => {
-//             let task_state = PayOfflineFeeTaskState::from_str(state)
-//                 .map_err(TaskSimulationError::invalid_task_state)?;
-
-//             Ok(task_state < PayOfflineFeeTaskState::FindingOpening)
-//         },
-//         QueuedTaskState::Completed | QueuedTaskState::Failed => Ok(false),
-//         _ => Ok(true),
-//     }
-// }
 
 /// Simulate the effect of a single task on a wallet
 fn simulate_single_account_task(
@@ -122,6 +62,7 @@ fn simulate_single_account_task(
         TaskDescriptor::CreateOrder(t) => simulate_create_order(account, &t),
         TaskDescriptor::Deposit(t) => simulate_deposit(account, &t),
         TaskDescriptor::CreateBalance(t) => simulate_create_balance(account, &t, state),
+        TaskDescriptor::SettleInternalMatch(t) => simulate_settle_internal_match(account, &t),
         // Ignore all non-wallet tasks
         TaskDescriptor::NodeStartup(_) => Ok(()),
     }
@@ -171,112 +112,11 @@ fn simulate_create_balance(
     Ok(())
 }
 
-// /// Simulate an `UpdateWallet` task applied to a wallet
-// fn simulate_update_wallet(
-//     wallet: &mut Wallet,
-//     desc: UpdateWalletTaskDescriptor,
-// ) -> Result<(), TaskSimulationError> {
-//     if desc.new_wallet.wallet_id != wallet.wallet_id {
-//         return Err(TaskSimulationError::InvalidTask(ERR_INVALID_WALLET_ID));
-//     }
-
-//     *wallet = desc.new_wallet;
-//     Ok(())
-// }
-
-// /// Simulate a `SettleMatch` task applied to a wallet
-// fn simulate_settle_match(
-//     wallet: &mut Wallet,
-//     desc: &SettleMatchTaskDescriptor,
-// ) -> Result<(), TaskSimulationError> {
-//     if wallet.wallet_id != desc.wallet_id {
-//         return Err(TaskSimulationError::InvalidTask(ERR_INVALID_WALLET_ID));
-//     }
-
-//     let is_party0 = desc.handshake_state.role.get_party_id() == PARTY0;
-
-//     // Get the new public and private shares for the wallet
-//     wallet.reblind_wallet();
-//     let new_private = wallet.private_shares.clone();
-
-//     let statement = &desc.match_bundle.statement;
-//     let new_public = if is_party0 {
-//         &statement.party0_modified_shares
-//     } else {
-//         &statement.party1_modified_shares
-//     };
-
-//     // Update the wallet
-//     wallet.update_from_shares(&new_private, new_public);
-//     Ok(())
-// }
-
-// /// Simulate a settle internal match task applied to a wallet
-// fn simulate_settle_internal_match(
-//     wallet: &mut Wallet,
-//     desc: &SettleMatchInternalTaskDescriptor,
-// ) -> Result<(), TaskSimulationError> {
-//     let is_party0 = if desc.wallet_id1 == wallet.wallet_id {
-//         true
-//     } else if desc.wallet_id2 == wallet.wallet_id {
-//         false
-//     } else {
-//         return Err(TaskSimulationError::InvalidTask(ERR_INVALID_WALLET_ID));
-//     };
-
-//     // Compute fees
-//     let order_id = if is_party0 { desc.order_id1 } else { desc.order_id2 };
-//     let my_order = wallet
-//         .get_order(&order_id)
-//         .cloned()
-//         .ok_or(TaskSimulationError::InvalidTask(ERR_ORDER_MISSING))?;
-
-//     // Get the new public and private shares
-//     let witness =
-//         if is_party0 { &desc.order1_validity_witness } else {
-// &desc.order2_validity_witness };     let indices = if is_party0 {
-//         &desc.order1_proof.commitment_proof.statement.indices
-//     } else {
-//         &desc.order2_proof.commitment_proof.statement.indices
-//     };
-
-//     let relayer_fee = witness.commitment_witness.relayer_fee;
-//     let fees = compute_fee_obligation(relayer_fee, my_order.side,
-// &desc.match_result);
-
-//     let mut new_public =
-// witness.commitment_witness.augmented_public_shares.clone();
-//     let new_private =
-// witness.reblind_witness.reblinded_wallet_private_shares.clone();
-//     apply_match_to_shares(&mut new_public, indices, fees, &desc.match_result,
-// my_order.side);
-
-//     // Update the wallet
-//     wallet.update_from_shares(&new_private, &new_public);
-//     Ok(())
-// }
-
-// /// Simulate offline fee payment
-// fn simulate_offline_fee_payment(
-//     wallet: &mut Wallet,
-//     desc: &PayOfflineFeeTaskDescriptor,
-// ) -> Result<(), TaskSimulationError> {
-//     if desc.wallet_id != wallet.wallet_id {
-//         return Err(TaskSimulationError::InvalidTask(ERR_INVALID_WALLET_ID));
-//     }
-
-//     // Set the relevant fee to zero
-//     let balance = wallet
-//         .get_balance_mut(&desc.mint)
-//         .ok_or(TaskSimulationError::InvalidTask(ERR_BALANCE_MISSING))?;
-
-//     if desc.is_protocol_fee {
-//         balance.protocol_fee_balance = 0;
-//     } else {
-//         balance.relayer_fee_balance = 0;
-//     }
-
-//     wallet.reblind_wallet();
-
-//     Ok(())
-// }
+/// Simulate a `SettleInternalMatch` task applied to a wallet
+#[allow(clippy::needless_pass_by_ref_mut)]
+fn simulate_settle_internal_match(
+    _account: &mut Account,
+    _desc: &SettleInternalMatchTaskDescriptor,
+) -> Result<(), TaskSimulationError> {
+    todo!("Implement settle internal match simulation");
+}

--- a/crates/workers/task-driver/src/task_state.rs
+++ b/crates/workers/task-driver/src/task_state.rs
@@ -9,7 +9,7 @@ use crate::{
     tasks::{
         create_balance::CreateBalanceTaskState, create_new_account::CreateNewAccountTaskState,
         create_order::CreateOrderTaskState, deposit::DepositTaskState,
-        node_startup::NodeStartupTaskState,
+        node_startup::NodeStartupTaskState, settle_internal_match::SettleInternalMatchTaskState,
     },
     traits::TaskState,
 };
@@ -33,6 +33,8 @@ pub enum TaskStateWrapper {
     CreateBalance(CreateBalanceTaskState),
     /// The state of a create order task
     CreateOrder(CreateOrderTaskState),
+    /// The state of a settle internal match task
+    SettleInternalMatch(SettleInternalMatchTaskState),
 }
 
 impl TaskStateWrapper {
@@ -52,6 +54,9 @@ impl TaskStateWrapper {
             TaskStateWrapper::CreateOrder(state) => {
                 <CreateOrderTaskState as TaskState>::committed(state)
             },
+            TaskStateWrapper::SettleInternalMatch(state) => {
+                <SettleInternalMatchTaskState as TaskState>::committed(state)
+            },
         }
     }
 
@@ -68,6 +73,9 @@ impl TaskStateWrapper {
                 *state == CreateBalanceTaskState::commit_point()
             },
             TaskStateWrapper::CreateOrder(state) => *state == CreateOrderTaskState::commit_point(),
+            TaskStateWrapper::SettleInternalMatch(state) => {
+                *state == SettleInternalMatchTaskState::commit_point()
+            },
         }
     }
 
@@ -87,6 +95,9 @@ impl TaskStateWrapper {
             TaskStateWrapper::CreateOrder(state) => {
                 <CreateOrderTaskState as TaskState>::completed(state)
             },
+            TaskStateWrapper::SettleInternalMatch(state) => {
+                <SettleInternalMatchTaskState as TaskState>::completed(state)
+            },
         }
     }
 }
@@ -99,6 +110,7 @@ impl Display for TaskStateWrapper {
             TaskStateWrapper::Deposit(state) => write!(f, "{state}"),
             TaskStateWrapper::CreateBalance(state) => write!(f, "{state}"),
             TaskStateWrapper::CreateOrder(state) => write!(f, "{state}"),
+            TaskStateWrapper::SettleInternalMatch(state) => write!(f, "{state}"),
         }
     }
 }

--- a/crates/workers/task-driver/src/tasks/create_balance.rs
+++ b/crates/workers/task-driver/src/tasks/create_balance.rs
@@ -25,6 +25,7 @@ use types_proofs::ValidBalanceCreateBundle;
 use types_tasks::CreateBalanceTaskDescriptor;
 
 use crate::{
+    hooks::{RefreshAccountHook, RunMatchingEngineForBalanceHook, TaskHook},
     task_state::TaskStateWrapper,
     traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
     utils::{enqueue_proof_job, get_relayer_fee_addr},
@@ -210,6 +211,16 @@ impl Task for CreateBalanceTask {
 
     fn task_state(&self) -> Self::State {
         self.task_state.clone()
+    }
+
+    fn failure_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        let refresh = RefreshAccountHook::new(vec![self.account_id]);
+        vec![Box::new(refresh)]
+    }
+
+    fn success_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        let run_matching = RunMatchingEngineForBalanceHook::new(self.account_id, self.token);
+        vec![Box::new(run_matching)]
     }
 }
 

--- a/crates/workers/task-driver/src/tasks/mod.rs
+++ b/crates/workers/task-driver/src/tasks/mod.rs
@@ -16,10 +16,4 @@ pub mod create_balance;
 pub mod create_new_account;
 pub mod create_order;
 pub mod deposit;
-
-// ------------------
-// | Error Messages |
-// ------------------
-
-/// Error message emitted when an account cannot be found
-pub(crate) const ERR_ACCOUNT_NOT_FOUND: &str = "account not found";
+pub mod settle_internal_match;

--- a/crates/workers/task-driver/src/tasks/settle_internal_match.rs
+++ b/crates/workers/task-driver/src/tasks/settle_internal_match.rs
@@ -1,0 +1,189 @@
+//! Defines a task to settle an internal match
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use async_trait::async_trait;
+use darkpool_types::settlement_obligation::MatchResult;
+use serde::Serialize;
+use state::error::StateError;
+use tracing::{info, instrument};
+use types_account::OrderId;
+use types_core::{AccountId, TimestampedPriceFp};
+use types_tasks::SettleInternalMatchTaskDescriptor;
+
+use crate::{
+    hooks::{RefreshAccountHook, RunMatchingEngineHook, TaskHook},
+    task_state::TaskStateWrapper,
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
+};
+
+/// The task name for the settle internal match task
+const SETTLE_INTERNAL_MATCH_TASK_NAME: &str = "settle-internal-match";
+
+// --------------
+// | Task State |
+// --------------
+
+/// Represents the state of the task through its async execution
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SettleInternalMatchTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is submitting the transaction
+    SubmittingTx,
+    /// The task is completed
+    Completed,
+}
+
+impl TaskState for SettleInternalMatchTaskState {
+    fn commit_point() -> Self {
+        SettleInternalMatchTaskState::SubmittingTx
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, SettleInternalMatchTaskState::Completed)
+    }
+}
+
+impl Display for SettleInternalMatchTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            SettleInternalMatchTaskState::Pending => write!(f, "Pending"),
+            SettleInternalMatchTaskState::SubmittingTx => write!(f, "SubmittingTx"),
+            SettleInternalMatchTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl From<SettleInternalMatchTaskState> for TaskStateWrapper {
+    fn from(state: SettleInternalMatchTaskState) -> Self {
+        TaskStateWrapper::SettleInternalMatch(state)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type thrown by the settle internal match task
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum SettleInternalMatchTaskError {
+    /// Error interacting with global state
+    #[error("state error: {0}")]
+    State(String),
+}
+
+impl TaskError for SettleInternalMatchTaskError {
+    fn retryable(&self) -> bool {
+        matches!(self, SettleInternalMatchTaskError::State(_))
+    }
+}
+
+impl From<StateError> for SettleInternalMatchTaskError {
+    fn from(e: StateError) -> Self {
+        SettleInternalMatchTaskError::State(e.to_string())
+    }
+}
+
+/// A type alias for a result in this task
+type Result<T> = std::result::Result<T, SettleInternalMatchTaskError>;
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Represents a task to settle an internal match
+#[derive(Clone)]
+pub struct SettleInternalMatchTask {
+    /// The account ID for the initiating order
+    pub account_id: AccountId,
+    /// The account ID for the counterparty order
+    pub other_account_id: AccountId,
+    /// The ID of the initiating order
+    pub order_id: OrderId,
+    /// The ID of the counterparty order
+    pub other_order_id: OrderId,
+    /// The price at which the match was executed
+    pub execution_price: TimestampedPriceFp,
+    /// The match result
+    pub match_result: MatchResult,
+    /// The state of the task's execution
+    pub task_state: SettleInternalMatchTaskState,
+    /// The context of the task
+    pub ctx: TaskContext,
+}
+
+#[async_trait]
+impl Task for SettleInternalMatchTask {
+    type State = SettleInternalMatchTaskState;
+    type Error = SettleInternalMatchTaskError;
+    type Descriptor = SettleInternalMatchTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self> {
+        Ok(Self {
+            account_id: descriptor.account_id,
+            other_account_id: descriptor.other_account_id,
+            order_id: descriptor.order_id,
+            other_order_id: descriptor.other_order_id,
+            execution_price: descriptor.execution_price,
+            match_result: descriptor.match_result,
+            task_state: SettleInternalMatchTaskState::Pending,
+            ctx,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.task_state()))]
+    async fn step(&mut self) -> Result<()> {
+        // Dispatch based on task state
+        match self.task_state {
+            SettleInternalMatchTaskState::Pending => {
+                self.task_state = SettleInternalMatchTaskState::SubmittingTx;
+            },
+            SettleInternalMatchTaskState::SubmittingTx => {
+                self.task_state = SettleInternalMatchTaskState::Completed;
+                self.submit_tx().await?;
+            },
+            SettleInternalMatchTaskState::Completed => {
+                unreachable!("step called on task in Completed state")
+            },
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        SETTLE_INTERNAL_MATCH_TASK_NAME.to_string()
+    }
+
+    fn task_state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    // Re-run the matching engine on both orders for recursive fills
+    fn success_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        let engine_run = RunMatchingEngineHook::new(vec![self.order_id, self.other_order_id]);
+        vec![Box::new(engine_run)]
+    }
+
+    // Refresh both accounts after a failure
+    fn failure_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        let refresh = RefreshAccountHook::new(vec![self.account_id, self.other_account_id]);
+        vec![Box::new(refresh)]
+    }
+}
+
+impl Descriptor for SettleInternalMatchTaskDescriptor {}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl SettleInternalMatchTask {
+    /// Submit the transaction to the contract
+    async fn submit_tx(&self) -> Result<()> {
+        info!("Got to settlement task");
+        info!("Submitting transaction to the contract");
+        Ok(())
+    }
+}

--- a/crates/workers/task-driver/src/worker.rs
+++ b/crates/workers/task-driver/src/worker.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use darkpool_client::DarkpoolClient;
 use job_types::{
     event_manager::EventManagerQueue,
+    matching_engine::MatchingEngineWorkerQueue,
     network_manager::NetworkManagerQueue,
     proof_manager::ProofManagerQueue,
     task_driver::{TaskDriverQueue, TaskDriverReceiver},
@@ -42,6 +43,8 @@ pub struct TaskDriverConfig {
     pub proof_queue: ProofManagerQueue,
     /// A sender to the event manager's work queue
     pub event_queue: EventManagerQueue,
+    /// A sender to the matching engine worker's work queue
+    pub matching_engine_queue: MatchingEngineWorkerQueue,
     /// The system bus to publish task updates onto
     pub system_bus: SystemBus,
     /// A handle on the global state
@@ -58,6 +61,7 @@ impl TaskDriverConfig {
         network_queue: NetworkManagerQueue,
         proof_queue: ProofManagerQueue,
         event_queue: EventManagerQueue,
+        matching_engine_queue: MatchingEngineWorkerQueue,
         system_bus: SystemBus,
         state: State,
     ) -> Self {
@@ -69,6 +73,7 @@ impl TaskDriverConfig {
             network_queue,
             proof_queue,
             event_queue,
+            matching_engine_queue,
             system_bus,
             state,
         }


### PR DESCRIPTION
### Purpose
This PR adds an abstraction of a `TaskHook` which the driver will run at some point in the task's execution. The tasks currently only provide `success_hooks` and `failure_hooks` for post-task success and failure cases respectively.

We move the logic to invoke the matching engine to a success hook, and the logic to refresh an account to a failure hook.

### Testing
- [x] Unit tests pass, tested locally