### PR TITLE
task-driver: task: Add requires_refresh_on_failure method

### DIFF
--- a/workers/task-driver/src/running_task.rs
+++ b/workers/task-driver/src/running_task.rs
@@ -139,7 +139,7 @@ impl<T: Task> RunnableTask<T> {
         // code paths will clear task queues in the case of a failure.
         let failed_past_commit = !success && self.state().committed();
         should_refresh = should_refresh || failed_past_commit;
-        if should_refresh {
+        if should_refresh && self.task.requires_refresh_on_failure() {
             for wallet_id in affected_wallets {
                 let task_id = self.state.append_wallet_refresh_task(wallet_id).await?;
                 info!("enqueued wallet refresh task ({task_id}) for {wallet_id}");

--- a/workers/task-driver/src/tasks/create_new_wallet.rs
+++ b/workers/task-driver/src/tasks/create_new_wallet.rs
@@ -249,6 +249,10 @@ impl Task for NewWalletTask {
     fn name(&self) -> String {
         NEW_WALLET_TASK_NAME.to_string()
     }
+
+    fn requires_refresh_on_failure(&self) -> bool {
+        false
+    }
 }
 
 impl Descriptor for NewWalletTaskDescriptor {}

--- a/workers/task-driver/src/tasks/lookup_wallet.rs
+++ b/workers/task-driver/src/tasks/lookup_wallet.rs
@@ -205,6 +205,10 @@ impl Task for LookupWalletTask {
     fn state(&self) -> Self::State {
         self.task_state.clone()
     }
+
+    fn requires_refresh_on_failure(&self) -> bool {
+        false
+    }
 }
 
 impl Descriptor for LookupWalletTaskDescriptor {}

--- a/workers/task-driver/src/tasks/node_startup.rs
+++ b/workers/task-driver/src/tasks/node_startup.rs
@@ -274,6 +274,10 @@ impl Task for NodeStartupTask {
     fn name(&self) -> String {
         NODE_STARTUP_TASK_NAME.to_string()
     }
+
+    fn requires_refresh_on_failure(&self) -> bool {
+        false
+    }
 }
 
 impl Descriptor for NodeStartupTaskDescriptor {

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -200,6 +200,10 @@ impl Task for RefreshWalletTask {
     fn state(&self) -> Self::State {
         self.task_state.clone()
     }
+
+    fn requires_refresh_on_failure(&self) -> bool {
+        false
+    }
 }
 
 impl Descriptor for RefreshWalletTaskDescriptor {}

--- a/workers/task-driver/src/traits.rs
+++ b/workers/task-driver/src/traits.rs
@@ -66,6 +66,10 @@ pub trait Task: Send + Sized {
     async fn cleanup(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
+    /// Whether or not the task requires a refresh on failure
+    fn requires_refresh_on_failure(&self) -> bool {
+        true
+    }
 }
 
 /// A descriptor for a task, from which the task is constructable


### PR DESCRIPTION
### Purpose
This PR adds a `requires_refresh_on_failure` method to the `Task` trait. This allows a task to specify that no refresh should be enqueued when it fails.

This method returns `false` for `node-startup`, `lookup-wallet`, `create-wallet`, and `refresh-wallet`.