### PR TITLE
task-driver: settle-internal-match: Update state after match

### DIFF
--- a/crates/relayer-types/types-account/src/account/order.rs
+++ b/crates/relayer-types/types-account/src/account/order.rs
@@ -82,6 +82,18 @@ impl Order {
         self.intent.inner.amount_in
     }
 
+    /// Decrement the amount remaining for the order
+    pub fn decrement_amount_in(&mut self, amount: Amount) {
+        let new_amount = self
+            .intent
+            .inner
+            .amount_in
+            .checked_sub(amount)
+            .expect("underflow when decrementing amount_in");
+
+        self.intent.inner.amount_in = new_amount;
+    }
+
     /// Whether the order is zero'd out
     ///
     /// This can happen without an order being removed from an account because

--- a/crates/state/src/applicator/mod.rs
+++ b/crates/state/src/applicator/mod.rs
@@ -98,6 +98,7 @@ impl StateApplicator {
             StateTransition::RemoveOrderFromAccount { account_id, order_id } => {
                 self.remove_order_from_account(account_id, order_id)
             },
+            StateTransition::UpdateOrder { order } => self.update_order(&order),
             StateTransition::UpdateAccountBalance { account_id, balance } => {
                 self.update_account_balance(account_id, &balance)
             },

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -199,6 +199,11 @@ impl StateInner {
         self.send_proposal(StateTransition::RemoveOrderFromAccount { account_id, order_id }).await
     }
 
+    /// Update an existing order
+    pub async fn update_order(&self, order: Order) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::UpdateOrder { order }).await
+    }
+
     /// Update a balance in an account
     pub async fn update_account_balance(
         &self,

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -52,6 +52,8 @@ pub enum StateTransition {
     AddOrderToAccount { account_id: AccountId, order: Order, auth: OrderAuth },
     /// Remove an order from an account
     RemoveOrderFromAccount { account_id: AccountId, order_id: OrderId },
+    /// Update an existing order in an account
+    UpdateOrder { order: Order },
     /// Update a balance in an account
     UpdateAccountBalance { account_id: AccountId, balance: Balance },
 

--- a/crates/state/src/storage/tx/account_index.rs
+++ b/crates/state/src/storage/tx/account_index.rs
@@ -315,6 +315,14 @@ impl StateTxn<'_, RW> {
         self.inner().write(ACCOUNTS_TABLE, &index_key, account_id)
     }
 
+    /// Update an existing order in an account
+    ///
+    /// This only updates the order data, not the order->account index
+    pub fn update_order(&self, account_id: &AccountId, order: &Order) -> Result<(), StorageError> {
+        let key = order_key(account_id, &order.id);
+        self.inner().write(ACCOUNTS_TABLE, &key, order)
+    }
+
     /// Update (add or modify) a balance for an account
     pub fn update_balance(
         &self,


### PR DESCRIPTION
### Purpose
This PR updates order and balance state for ring 0 orders after a successful match.

### Testing
- [x] Tested locally