### PR TITLE
api-server: external-match: quote: Return exact-sized quote

### DIFF
--- a/crates/api/external-api/src/lib.rs
+++ b/crates/api/external-api/src/lib.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub mod auth;
 pub mod error;
 pub mod http;
+pub mod serde_helpers;
 pub mod types;
 #[cfg(feature = "websocket")]
 pub mod websocket;

--- a/crates/api/external-api/src/serde_helpers/address_as_string.rs
+++ b/crates/api/external-api/src/serde_helpers/address_as_string.rs
@@ -1,0 +1,42 @@
+//! Serialize addresses as strings
+
+use alloy::primitives::Address;
+use serde::{Deserialize, Deserializer, Serializer};
+use util::hex::{address_from_hex_string, address_to_hex_string};
+
+/// Serialize an `Address` as a string
+pub fn serialize<S>(val: &Address, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&address_to_hex_string(val))
+}
+
+/// Deserialize an `Address` from a string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let address_str = String::deserialize(deserializer)?;
+    address_from_hex_string(&address_str).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(with = "crate::serde_helpers::address_as_string")]
+        address: Address,
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let original = TestStruct { address: Address::ZERO };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/api/external-api/src/serde_helpers/amount_as_string.rs
+++ b/crates/api/external-api/src/serde_helpers/amount_as_string.rs
@@ -1,0 +1,41 @@
+//! Serialize amounts as strings
+
+use circuit_types::Amount;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize an `Amount` as a string
+pub fn serialize<S>(val: &Amount, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&val.to_string())
+}
+
+/// Deserialize an `Amount` from a string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Amount, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let amount_str = String::deserialize(deserializer)?;
+    amount_str.parse::<Amount>().map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(with = "crate::serde_helpers::amount_as_string")]
+        amount: Amount,
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let original = TestStruct { amount: 100 };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/api/external-api/src/serde_helpers/bytes_as_hex_string.rs
+++ b/crates/api/external-api/src/serde_helpers/bytes_as_hex_string.rs
@@ -1,0 +1,48 @@
+//! Serialize bytes as hex strings
+
+use serde::{Deserialize, Deserializer, Serializer};
+use util::hex::{bytes_from_hex_string, bytes_to_hex_string};
+
+/// Serialize a `Vec<u8>` as a hex string
+pub fn serialize<S>(val: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&bytes_to_hex_string(val))
+}
+
+/// Deserialize a `Vec<u8>` from a hex string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let hex_str = String::deserialize(deserializer)?;
+    bytes_from_hex_string(&hex_str).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod test {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(with = "crate::serde_helpers::bytes_as_hex_string")]
+        bytes: Vec<u8>,
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let original = TestStruct { bytes: vec![0x01, 0x02, 0x03, 0xff] };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_empty_bytes() {
+        let original = TestStruct { bytes: vec![] };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/api/external-api/src/serde_helpers/f64_as_string.rs
+++ b/crates/api/external-api/src/serde_helpers/f64_as_string.rs
@@ -1,0 +1,55 @@
+//! Serialize f64 as strings
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize an `f64` as a string
+pub fn serialize<S>(val: &f64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&val.to_string())
+}
+
+/// Deserialize an `f64` from a string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let f64_str = String::deserialize(deserializer)?;
+    f64_str.parse::<f64>().map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod test {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(with = "crate::serde_helpers::f64_as_string")]
+        value: f64,
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let original = TestStruct { value: 123.456 };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_zero() {
+        let original = TestStruct { value: 0.0 };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_negative() {
+        let original = TestStruct { value: -42.5 };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/api/external-api/src/serde_helpers/fixed_point_as_string.rs
+++ b/crates/api/external-api/src/serde_helpers/fixed_point_as_string.rs
@@ -1,0 +1,49 @@
+//! Serialize fixed points as strings
+
+use circuit_types::fixed_point::FixedPoint;
+use constants::Scalar;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize a `FixedPoint` as a string
+pub fn serialize<S>(val: &FixedPoint, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let repr_string = val.repr.to_string();
+    serializer.serialize_str(&repr_string)
+}
+
+/// Deserialize a `FixedPoint` from a string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<FixedPoint, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let repr_string = String::deserialize(deserializer)?;
+    let repr = Scalar::from_decimal_string(&repr_string).map_err(|e| {
+        serde::de::Error::custom(format!("error deserializing FixedPoint from string: {e}"))
+    })?;
+
+    Ok(FixedPoint { repr })
+}
+
+#[cfg(test)]
+mod test {
+    use serde::{Deserialize, Serialize};
+
+    use crate::serde_helpers;
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(with = "serde_helpers::fixed_point_as_string")]
+        price: circuit_types::fixed_point::FixedPoint,
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        use circuit_types::fixed_point::FixedPoint;
+        let original = TestStruct { price: FixedPoint::zero() };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: TestStruct = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/api/external-api/src/serde_helpers/mod.rs
+++ b/crates/api/external-api/src/serde_helpers/mod.rs
@@ -1,0 +1,6 @@
+//! Serde helpers for api types
+pub mod address_as_string;
+pub mod amount_as_string;
+pub mod bytes_as_hex_string;
+pub mod f64_as_string;
+pub mod fixed_point_as_string;

--- a/crates/config/src/cli.rs
+++ b/crates/config/src/cli.rs
@@ -464,7 +464,6 @@ impl RelayerConfig {
     }
 }
 
-#[cfg(any(test, feature = "mocks"))]
 impl Default for RelayerConfig {
     fn default() -> Self {
         // Set the default addresses for the config


### PR DESCRIPTION
### Purpose
This PR returns an exact-sized quote from the external matching engine's quote endpoint, rather than a bounded match result as the assembly endpoint will return. 

### Testing
- [x] Tested locally