### PR TITLE
task-driver: settle-external-match: Add block deadlines

### DIFF
--- a/crates/config/src/cli.rs
+++ b/crates/config/src/cli.rs
@@ -84,6 +84,11 @@ pub struct Cli {
     /// Mapping from ticker to fee rate
     #[clap(long, value_parser, value_parser = parse_cli_map::<f64>, default_value = "")]
     pub per_asset_fees: HashMap<String, f64>,
+    /// The number of blocks an external match bundle remains valid
+    ///
+    /// The block deadline is set to current_block + this value
+    #[clap(long, value_parser, default_value = "50")]
+    pub external_match_validity_window: u64,
     /// The address at which to collect relayer fees
     /// 
     /// This is the address at which the relayer collects match fees.
@@ -288,6 +293,8 @@ pub struct RelayerConfig {
     pub default_match_fee: FixedPoint,
     /// The per-asset match fee that the relayer will charge
     pub per_asset_fees: HashMap<String, FixedPoint>,
+    /// The number of blocks an external match bundle remains valid
+    pub external_match_validity_window: u64,
     /// The address at which the relayer collects match fees
     ///
     /// This is the address at which the relayer collects match fees.

--- a/crates/config/src/parsing/mod.rs
+++ b/crates/config/src/parsing/mod.rs
@@ -121,6 +121,7 @@ pub(crate) fn parse_config_from_args(cli_args: Cli) -> Result<RelayerConfig, Str
         max_match_fee,
         default_match_fee,
         per_asset_fees,
+        external_match_validity_window: cli_args.external_match_validity_window,
         relayer_fee_addr,
         price_reporter_url,
         chain_id: cli_args.chain_id,

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -279,6 +279,7 @@ async fn main() -> Result<(), CoordinatorError> {
     let (handshake_cancel_sender, handshake_cancel_receiver) = new_cancel_channel();
     let mut handshake_manager = MatchingEngineManager::new(MatchingEngineConfig {
         min_fill_size: args.min_fill_size,
+        external_match_validity_window: args.external_match_validity_window,
         state: global_state.clone(),
         matching_engine: matching_engine.clone(),
         price_streams: price_streams.clone(),

--- a/crates/relayer-types/types-tasks/src/descriptors/settle_external_match.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/settle_external_match.rs
@@ -23,6 +23,8 @@ pub struct SettleExternalMatchTaskDescriptor {
     pub match_result: BoundedMatchResult,
     /// The system bus topic on which to send the response
     pub response_topic: String,
+    /// The number of blocks the match remains valid from the current block
+    pub validity_window_blocks: u64,
 }
 
 impl From<SettleExternalMatchTaskDescriptor> for TaskDescriptor {

--- a/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
@@ -34,6 +34,8 @@ pub struct MatchingEngineExecutor {
     /// The minimum amount of the quote asset that the relayer should settle
     /// matches on
     pub(crate) min_fill_size: Amount,
+    /// The number of blocks an external match bundle remains valid
+    pub(crate) external_match_validity_window: u64,
     /// The channel on which other workers enqueue jobs for the protocol
     /// executor
     pub(crate) job_channel: DefaultOption<MatchingEngineWorkerReceiver>,
@@ -57,6 +59,7 @@ impl MatchingEngineExecutor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         min_fill_size: Amount,
+        external_match_validity_window: u64,
         job_channel: MatchingEngineWorkerReceiver,
         price_streams: PriceStreamStates,
         state: State,
@@ -67,6 +70,7 @@ impl MatchingEngineExecutor {
     ) -> Result<Self, MatchingEngineError> {
         Ok(Self {
             min_fill_size,
+            external_match_validity_window,
             job_channel: DefaultOption::new(Some(job_channel)),
             price_streams,
             state,

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
@@ -90,6 +90,7 @@ impl MatchingEngineExecutor {
             amount_in,
             match_result: bounded_match_result,
             response_topic,
+            validity_window_blocks: self.external_match_validity_window,
         };
 
         // Enqueue the task directly with the driver

--- a/crates/workers/matching-engine/matching-engine-worker/src/worker.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/worker.rs
@@ -30,6 +30,8 @@ pub struct MatchingEngineConfig {
     /// The minimum amount of the quote asset that the relayer should settle
     /// matches on
     pub min_fill_size: Amount,
+    /// The number of blocks an external match bundle remains valid
+    pub external_match_validity_window: u64,
     /// The relayer-global state
     pub state: State,
     /// The matching engine instance
@@ -67,6 +69,7 @@ impl Worker for MatchingEngineManager {
         // peers
         let executor = MatchingEngineExecutor::new(
             config.min_fill_size,
+            config.external_match_validity_window,
             config.job_receiver.take().unwrap(),
             config.price_streams.clone(),
             config.state.clone(),


### PR DESCRIPTION
### Purpose
This PR adds block deadlines to the external match task. These are configured via the CLI to allow different bundle validity windows depending on the chain.

### Testing
- [x] Tested locally