### PR TITLE
matching-engine: Allow external matches against all pools

### DIFF
--- a/crates/workers/job-types/src/matching_engine.rs
+++ b/crates/workers/job-types/src/matching_engine.rs
@@ -1,7 +1,6 @@
 //! Jobs consumed by the matching engine worker
 
 use circuit_types::{Amount, fixed_point::FixedPoint};
-use constants::GLOBAL_MATCHING_POOL;
 use system_bus::gen_atomic_match_response_topic;
 use types_account::{MatchingPoolName, OrderId, order::Order};
 use types_core::TimestampedPrice;
@@ -151,10 +150,5 @@ impl ExternalMatchingEngineOptions {
     pub fn with_matching_pool(mut self, pool: Option<MatchingPoolName>) -> Self {
         self.matching_pool = pool;
         self
-    }
-
-    /// Get the matching pool
-    pub fn matching_pool(&self) -> MatchingPoolName {
-        self.matching_pool.clone().unwrap_or(GLOBAL_MATCHING_POOL.to_string())
     }
 }

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
@@ -42,7 +42,7 @@ impl MatchingEngineExecutor {
         response_topic: String,
         options: ExternalMatchingEngineOptions,
     ) -> Result<(), MatchingEngineError> {
-        let matching_pool = options.matching_pool();
+        let matching_pool = options.matching_pool.clone();
         let res = self.find_external_match(&order, matching_pool)?;
         let successful_match = match res {
             Some(match_res) => match_res,


### PR DESCRIPTION
### Purpose
This PR allows external matches against all pools if no matching pool is specified. This matches the v1 behavior.

### Testing
- [x] Unit tests pass