### PR TITLE
matching-engine-core: Prevent self-matches

### DIFF
--- a/crates/state/src/applicator/account_index.rs
+++ b/crates/state/src/applicator/account_index.rs
@@ -58,7 +58,7 @@ impl StateApplicator {
 
         // Update the matching engine book
         if matchable_amount > 0 {
-            self.matching_engine().upsert_order(order, matchable_amount, matching_pool);
+            self.matching_engine().upsert_order(account_id, order, matchable_amount, matching_pool);
         }
         Ok(ApplicatorReturnType::None)
     }
@@ -120,7 +120,7 @@ impl StateApplicator {
 
         // Update the matching engine book
         if matchable_amount > 0 {
-            self.matching_engine().upsert_order(order, matchable_amount, matching_pool);
+            self.matching_engine().upsert_order(account_id, order, matchable_amount, matching_pool);
         } else {
             self.matching_engine().cancel_order(order, matching_pool);
         }
@@ -160,7 +160,7 @@ impl StateApplicator {
             let matching_pool = tx.get_matching_pool_for_order(&order_id)?;
             let matchable_amount = tx.get_order_matchable_amount(&order_id)?.unwrap_or_default();
             if matchable_amount > 0 {
-                engine.upsert_order(&order, matchable_amount, matching_pool);
+                engine.upsert_order(account_id, &order, matchable_amount, matching_pool);
             } else {
                 engine.cancel_order(&order, matching_pool);
             }

--- a/crates/workers/job-types/src/matching_engine.rs
+++ b/crates/workers/job-types/src/matching_engine.rs
@@ -3,7 +3,7 @@
 use circuit_types::{Amount, fixed_point::FixedPoint};
 use system_bus::gen_atomic_match_response_topic;
 use types_account::{MatchingPoolName, OrderId, order::Order};
-use types_core::TimestampedPrice;
+use types_core::{AccountId, TimestampedPrice};
 use util::channels::{TracedTokioReceiver, TracedTokioSender, new_traced_tokio_channel};
 
 /// The job queue for the matching engine worker
@@ -28,6 +28,8 @@ pub enum MatchingEngineWorkerJob {
     /// with a remote peer. Both orders matched are known in the clear to
     /// the local peer
     InternalMatchingEngine {
+        /// The account ID that owns the order
+        account_id: AccountId,
         /// The order to match
         order: OrderId,
     },
@@ -50,8 +52,8 @@ pub enum MatchingEngineWorkerJob {
 
 impl MatchingEngineWorkerJob {
     /// Run the internal matching engine on a given order
-    pub fn run_internal_engine(order: OrderId) -> Self {
-        Self::InternalMatchingEngine { order }
+    pub fn run_internal_engine(account_id: AccountId, order: OrderId) -> Self {
+        Self::InternalMatchingEngine { account_id, order }
     }
 
     /// Get a quote for an external order

--- a/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/executor.rs
@@ -124,8 +124,8 @@ impl MatchingEngineExecutor {
         match job.consume() {
             // An order has been updated, the executor should run the internal engine on the
             // new order to check for matches
-            MatchingEngineWorkerJob::InternalMatchingEngine { order } => {
-                self.run_internal_matching_engine(order).await
+            MatchingEngineWorkerJob::InternalMatchingEngine { account_id, order } => {
+                self.run_internal_matching_engine(account_id, order).await
             },
 
             // A request to run the external matching engine

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/internal_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/internal_engine.rs
@@ -25,6 +25,7 @@ impl MatchingEngineExecutor {
     #[instrument(name = "run_internal_matching_engine", skip_all)]
     pub async fn run_internal_matching_engine(
         &self,
+        account_id: AccountId,
         order_id: OrderId,
     ) -> Result<(), MatchingEngineError> {
         info!("Running internal matching engine on order {order_id}");
@@ -33,7 +34,7 @@ impl MatchingEngineExecutor {
         let matching_pool = self.fetch_matching_pool(&order_id).await?;
 
         // Find a match
-        let res = self.find_internal_match(&order, matchable_amount, matching_pool)?;
+        let res = self.find_internal_match(account_id, &order, matchable_amount, matching_pool)?;
         let successful_match = match res {
             Some(match_res) => match_res,
             None => {

--- a/crates/workers/task-driver/src/tasks/create_order.rs
+++ b/crates/workers/task-driver/src/tasks/create_order.rs
@@ -231,7 +231,7 @@ impl Task for CreateOrderTask {
 
     // Run the matching engine on the order after a successful creation
     fn success_hooks(&self) -> Vec<Box<dyn TaskHook>> {
-        let run_matching_engine = RunMatchingEngineHook::new(vec![self.order_id]);
+        let run_matching_engine = RunMatchingEngineHook::new(self.account_id, vec![self.order_id]);
         vec![Box::new(run_matching_engine)]
     }
 }

--- a/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
@@ -234,8 +234,11 @@ impl Task for SettleInternalMatchTask {
 
     // Re-run the matching engine on both orders for recursive fills
     fn success_hooks(&self) -> Vec<Box<dyn TaskHook>> {
-        let engine_run = RunMatchingEngineHook::new(vec![self.order_id, self.other_order_id]);
-        vec![Box::new(engine_run)]
+        // Create a hook for each order/account pair
+        let engine_run1 = RunMatchingEngineHook::new(self.account_id, vec![self.order_id]);
+        let engine_run2 =
+            RunMatchingEngineHook::new(self.other_account_id, vec![self.other_order_id]);
+        vec![Box::new(engine_run1), Box::new(engine_run2)]
     }
 
     // Refresh both accounts after a failure


### PR DESCRIPTION
### Purpose
This PR prevents self-matches in the matching engine by allowing the handlers to specify an `exclude_account_id` which filters orders from the same account.

### Testing
- [x] Unit tests pass