### PR TITLE
chain-events: Replace nullifier subscription with ERC20 Transfer events

### DIFF
--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -169,6 +169,23 @@ impl StateInner {
         .await
     }
 
+    /// Get the account ID for a given owner and token
+    ///
+    /// Used to route balance update events to the correct account
+    pub async fn get_account_for_owner(
+        &self,
+        owner: &Address,
+        token: &Address,
+    ) -> Result<Option<AccountId>, StateError> {
+        let owner = *owner;
+        let token = *token;
+        self.with_read_tx(move |tx| {
+            let account_id = tx.get_account_for_owner(&owner, &token)?;
+            Ok(account_id)
+        })
+        .await
+    }
+
     // -----------
     // | Setters |
     // -----------


### PR DESCRIPTION
### Purpose

This PR replaces the disabled nullifier event subscription with ERC20 Transfer event subscription and implements full event handling. When a Transfer event is detected:

1. Look up accounts for both `from` and `to` addresses
2. Fetch on-chain balance and update matching engine cache (all nodes, before raft)
3. Propose balance update via raft (selected node only)
4. Run matching engine on affected orders

Also adds `get_account_for_owner` to state for routing balance updates to the correct account.

### Testing

- [x] `cargo check -p chain-events` passes