### PR TITLE
state: chain-events: Update matching engine cache before raft consensus

### DIFF
--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -65,3 +65,9 @@ impl From<ReplicationError> for StateError {
         StateError::Replication(e)
     }
 }
+
+impl From<StateApplicatorError> for StateError {
+    fn from(e: StateApplicatorError) -> Self {
+        StateError::Applicator(e)
+    }
+}


### PR DESCRIPTION
### Purpose

This PR updates the matching engine cache before raft consensus to enable low-latency matching. Every node now updates its own cache when it sees an on-chain balance event, while only the selected node (with crash recovery) proposes to raft and enqueues matching jobs.

### Testing

- [ ] Will be tested in future PR