### PR TITLE
util: on_chain: Change protocol fee from global to per-asset-pair

### DIFF
--- a/crates/darkpool-client/src/client/contract_interaction.rs
+++ b/crates/darkpool-client/src/client/contract_interaction.rs
@@ -40,13 +40,10 @@ impl<D: DarkpoolImpl> DarkpoolClientInner<D> {
         self.darkpool.get_protocol_fee(in_token, out_token).await
     }
 
-    /// Get the external match fee charged by the contract for the given mint
-    #[instrument(skip_all, err, fields(mint = %mint))]
-    pub async fn get_external_match_fee(
-        &self,
-        mint: Address,
-    ) -> Result<FixedPoint, DarkpoolClientError> {
-        self.darkpool.get_external_match_fee(mint).await
+    /// Get the default protocol fee rate
+    #[instrument(skip_all, err)]
+    pub async fn get_default_protocol_fee(&self) -> Result<FixedPoint, DarkpoolClientError> {
+        self.darkpool.get_default_protocol_fee().await
     }
 
     /// Get the protocol pubkey

--- a/crates/darkpool-client/src/solidity/mod.rs
+++ b/crates/darkpool-client/src/solidity/mod.rs
@@ -99,13 +99,9 @@ impl DarkpoolImpl for SolidityDarkpool {
             .map(|r| r.into())
     }
 
-    async fn get_external_match_fee(
-        &self,
-        mint: Address,
-    ) -> Result<FixedPoint, DarkpoolClientError> {
-        let usdc = Token::usdc().get_alloy_address();
+    async fn get_default_protocol_fee(&self) -> Result<FixedPoint, DarkpoolClientError> {
         self.darkpool
-            .getProtocolFee(mint, usdc)
+            .getDefaultProtocolFee()
             .call()
             .await
             .map_err(DarkpoolClientError::contract_interaction)

--- a/crates/darkpool-client/src/traits.rs
+++ b/crates/darkpool-client/src/traits.rs
@@ -71,11 +71,8 @@ pub trait DarkpoolImpl: Clone {
         out_token: Address,
     ) -> Result<FixedPoint, DarkpoolClientError>;
 
-    /// Get the external match fee charged by the contract for the given mint
-    async fn get_external_match_fee(
-        &self,
-        mint: Address,
-    ) -> Result<FixedPoint, DarkpoolClientError>;
+    /// Get the default protocol fee rate
+    async fn get_default_protocol_fee(&self) -> Result<FixedPoint, DarkpoolClientError>;
 
     /// Get the protocol pubkey
     async fn get_protocol_pubkey(&self) -> Result<EncryptionKey, DarkpoolClientError>;

--- a/crates/util/src/matching_engine.rs
+++ b/crates/util/src/matching_engine.rs
@@ -16,7 +16,7 @@ use constants::Scalar;
 use crypto::fields::scalar_to_u128;
 
 #[cfg(feature = "v1")]
-use crate::on_chain::get_protocol_fee;
+use crate::on_chain::get_protocol_fee_for_pair;
 
 // ------------
 // | Matching |
@@ -212,7 +212,9 @@ pub fn compute_fee_obligation(
     side: OrderSide,
     match_res: &MatchResult,
 ) -> FeeTake {
-    let protocol_fee = get_protocol_fee();
+    let asset0 = match_res.party0_obligation.input_token;
+    let asset1 = match_res.party0_obligation.output_token;
+    let protocol_fee = get_protocol_fee_for_pair(&asset0, &asset1);
     compute_fee_obligation_with_protocol_fee(relayer_fee, protocol_fee, side, match_res)
 }
 

--- a/crates/workers/api-server/src/http/external_match/processor.rs
+++ b/crates/workers/api-server/src/http/external_match/processor.rs
@@ -27,7 +27,7 @@ use state::State;
 use system_bus::{SystemBus, SystemBusMessage};
 use types_account::order::Order;
 use types_core::HmacKey;
-use util::{get_current_time_millis, on_chain::get_external_match_fee};
+use util::{get_current_time_millis, on_chain::get_protocol_fee_for_pair};
 
 use crate::error::{ApiServerError, internal_error, no_content, unauthorized};
 
@@ -287,8 +287,11 @@ impl ExternalMatchProcessor {
         order: &Order,
         relayer_fee_override: Option<FixedPoint>,
     ) -> Result<FeeRates, ApiServerError> {
-        let base = order.pair().base_token();
-        let protocol_fee = get_external_match_fee(&base.get_alloy_address());
+        let pair = order.pair();
+        let base = pair.base_token();
+        let quote = pair.quote_token();
+        let protocol_fee =
+            get_protocol_fee_for_pair(&base.get_alloy_address(), &quote.get_alloy_address());
         let relayer_fee = match relayer_fee_override {
             Some(fee) => fee,
             None => {

--- a/crates/workers/chain-events/src/post_settlement.rs
+++ b/crates/workers/chain-events/src/post_settlement.rs
@@ -12,7 +12,7 @@ use job_types::event_manager::{ExternalFillEvent, RelayerEventType};
 use renegade_metrics;
 use types_account::account::OrderId;
 use types_core::{AccountId, TimestampedPrice};
-use util::on_chain::get_external_match_fee;
+use util::on_chain::get_protocol_fee_for_pair;
 
 /// The error message emitted when metadata for an order cannot be found
 const ERR_NO_ORDER_METADATA: &str = "order metadata not found";
@@ -116,7 +116,10 @@ fn execution_price(external_match_result: &ExternalMatchResult) -> TimestampedPr
 /// Compute internal party fee take
 fn internal_fee_take(external_match_result: &ExternalMatchResult) -> FeeTake {
     let relayer_fee = FixedPoint::from_f64_round_down(DEFAULT_EXTERNAL_MATCH_RELAYER_FEE);
-    let protocol_fee = get_external_match_fee(&external_match_result.base_mint);
+    let protocol_fee = get_protocol_fee_for_pair(
+        &external_match_result.base_mint,
+        &external_match_result.quote_mint,
+    );
     let side = external_match_result.internal_party_side();
     compute_fee_obligation_with_protocol_fee(
         relayer_fee,

--- a/crates/workers/task-driver/integration/main.rs
+++ b/crates/workers/task-driver/integration/main.rs
@@ -15,7 +15,11 @@ use config::RelayerConfig;
 use mock_node::MockNodeController;
 use state::test_helpers::tmp_db_path;
 use test_helpers::{integration_test_main, types::TestVerbosity};
-use util::{on_chain::set_protocol_fee, telemetry::LevelFilter};
+use types_core::{Token, get_all_tokens};
+use util::{
+    on_chain::{set_default_protocol_fee, set_protocol_fee_for_pair},
+    telemetry::LevelFilter,
+};
 
 // -------
 // | CLI |
@@ -81,9 +85,14 @@ impl From<CliArgs> for IntegrationTestArgs {
 
 /// Setup code for the integration tests
 fn setup_integration_tests(test_args: &IntegrationTestArgs) {
-    // Set the global protocol fee
+    // Set the default and per-pair protocol fees
     let fee = FixedPoint::from_f64_round_down(0.0001);
-    set_protocol_fee(fee);
+    set_default_protocol_fee(fee);
+    let usdc = Token::usdc().get_alloy_address();
+    for token in get_all_tokens() {
+        let addr = token.get_alloy_address();
+        set_protocol_fee_for_pair(&addr, &usdc, fee);
+    }
 
     // Configure logging
     if matches!(test_args.verbosity, TestVerbosity::Full) {


### PR DESCRIPTION
### Purpose
This PR changes protocol fee storage from a single global fee with per-mint overrides to a per-asset-pair lookup. Fees are now stored as `(asset0, asset1) -> fee` and fetched from the contract during node startup via `darkpool_client.get_protocol_fee(asset, usdc)`.

### Testing
- [ ] Testing deferred