### PR TITLE
state: chain-events: Add EventCursor for stale write prevention

### DIFF
--- a/crates/state/src/applicator/mod.rs
+++ b/crates/state/src/applicator/mod.rs
@@ -99,12 +99,14 @@ impl StateApplicator {
             StateTransition::AddOrderToAccount { account_id, order, auth } => {
                 self.add_order_to_account(account_id, &order, &auth)
             },
-            StateTransition::RemoveOrderFromAccount { account_id, order_id } => {
-                self.remove_order_from_account(account_id, order_id)
+            StateTransition::RemoveOrderFromAccount { account_id, order_id, cursor } => {
+                self.remove_order_from_account(account_id, order_id, cursor.as_ref())
             },
-            StateTransition::UpdateOrder { order } => self.update_order(&order),
-            StateTransition::UpdateAccountBalance { account_id, balance } => {
-                self.update_account_balance(account_id, &balance)
+            StateTransition::UpdateOrder { order, cursor } => {
+                self.update_order(&order, cursor.as_ref())
+            },
+            StateTransition::UpdateAccountBalance { account_id, balance, cursor } => {
+                self.update_account_balance(account_id, &balance, cursor.as_ref())
             },
             StateTransition::AddOrderValidityProof { order_id, proof } => {
                 self.add_order_validity_proof(order_id, proof)

--- a/crates/state/src/cursor.rs
+++ b/crates/state/src/cursor.rs
@@ -1,0 +1,50 @@
+//! Event cursor type for tracking chain event positions
+//!
+//! Used to prevent stale writes by rejecting proposals that arrive out of
+//! order. The cursor uniquely identifies a log event's position in the chain.
+
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+
+/// Uniquely identifies a log event's position in the chain.
+///
+/// Derived Ord gives lexicographic comparison: (block_number, tx_index,
+/// log_index) This provides total ordering of all events across the chain.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvDeserialize,
+    RkyvSerialize,
+)]
+#[rkyv(derive(Debug))]
+pub struct EventCursor {
+    /// The block number where the event occurred
+    pub block_number: u64,
+    /// The transaction index within the block
+    pub tx_index: u64,
+    /// The log index within the transaction
+    pub log_index: u64,
+}
+
+impl EventCursor {
+    /// Create a new event cursor
+    pub fn new(block_number: u64, tx_index: u64, log_index: u64) -> Self {
+        Self { block_number, tx_index, log_index }
+    }
+}
+
+impl std::fmt::Display for EventCursor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {}, {})", self.block_number, self.tx_index, self.log_index)
+    }
+}

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -17,12 +17,16 @@
 use crate::error::StateError;
 
 pub mod applicator;
+pub mod cursor;
 pub mod error;
 mod interface;
 pub mod notifications;
 pub mod replication;
 pub mod state_transition;
 pub mod storage;
+
+// Re-export EventCursor for convenience
+pub use cursor::EventCursor;
 
 // Re-export the state interface
 pub use interface::*;

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -17,6 +17,7 @@ use types_tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey};
 use uuid::Uuid;
 
 use crate::{
+    cursor::EventCursor,
     replication::{NodeId, RaftNode},
     storage::tx::merkle_proofs::MerkleProofType,
 };
@@ -51,11 +52,23 @@ pub enum StateTransition {
     /// Update an account by adding an order, marking it as local, and storing its auth
     AddOrderToAccount { account_id: AccountId, order: Order, auth: OrderAuth },
     /// Remove an order from an account
-    RemoveOrderFromAccount { account_id: AccountId, order_id: OrderId },
+    ///
+    /// When triggered by an on-chain event, `cursor` should be `Some` to enable
+    /// stale write prevention. When triggered by internal logic (e.g., task
+    /// driver), `cursor` should be `None`.
+    RemoveOrderFromAccount { account_id: AccountId, order_id: OrderId, cursor: Option<EventCursor> },
     /// Update an existing order in an account
-    UpdateOrder { order: Order },
+    ///
+    /// When triggered by an on-chain event, `cursor` should be `Some` to enable
+    /// stale write prevention. When triggered by internal logic (e.g., task
+    /// driver), `cursor` should be `None`.
+    UpdateOrder { order: Order, cursor: Option<EventCursor> },
     /// Update a balance in an account
-    UpdateAccountBalance { account_id: AccountId, balance: Balance },
+    ///
+    /// When triggered by an on-chain event, `cursor` should be `Some` to enable
+    /// stale write prevention. When triggered by internal logic (e.g., task
+    /// driver), `cursor` should be `None`.
+    UpdateAccountBalance { account_id: AccountId, balance: Balance, cursor: Option<EventCursor> },
 
     // --- Orders --- //
     /// Add a validity proof to an order

--- a/crates/workers/task-driver/src/tasks/create_order.rs
+++ b/crates/workers/task-driver/src/tasks/create_order.rs
@@ -291,7 +291,8 @@ impl CreateOrderTask {
         info!("Found usable balance of {amt} on chain, updating account balance");
 
         let bal = create_ring0_balance(in_token, owner, relayer_fee_addr, amt);
-        let waiter = self.state().update_account_balance(self.account_id, bal).await?;
+        // Pass None for cursor - this is an internal update, not from an on-chain event
+        let waiter = self.state().update_account_balance(self.account_id, bal, None).await?;
         waiter.await.map_err(CreateOrderTaskError::state)?;
         Ok(())
     }

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/mod.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/mod.rs
@@ -90,7 +90,8 @@ impl SettlementProcessor {
         let mut order = self.get_order(order_id).await?;
         order.decrement_amount_in(obligation.amount_in);
 
-        let waiter = self.ctx.state.update_order(order).await?;
+        // Pass None for cursor - this is an internal update, not from an on-chain event
+        let waiter = self.ctx.state.update_order(order, None).await?;
         waiter.await.map_err(SettlementError::from)?;
         Ok(())
     }
@@ -107,7 +108,8 @@ impl SettlementProcessor {
         *balance.amount_mut() -= obligation.amount_in;
 
         // Write the balance back to the state
-        let waiter = state.update_account_balance(account_id, balance).await?;
+        // Pass None for cursor - this is an internal update, not from an on-chain event
+        let waiter = state.update_account_balance(account_id, balance, None).await?;
         waiter.await.map_err(SettlementError::from)?;
         Ok(())
     }


### PR DESCRIPTION
### Purpose

Adds applicator-level guards to reject out-of-order Raft proposals using an EventCursor type that tracks `(block_number, tx_index, log_index)`. This prevents stale-write regressions where a slow node proposes older data that overwrites newer values committed by a faster node.

Key changes:
- Add `EventCursor` type with derived `Ord` for total chain ordering
- Add cursor storage methods for balances and orders
- Add cursor check in applicator (atomic within DB transaction)
- Pass cursor through state interface and listener
- Retain cursor after order removal to prevent reorg replay

### Testing

- [ ] Unit tests pass
- [ ] Integration tests pending