### PR TITLE
task-driver: settlement: settle-external-match: Sign bounded match result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts#6e2af32068a8cdebfa65c69b6136cffdb4215653"
+source = "git+https://github.com/renegade-fi/renegade-contracts#224fafa5456905be461b7332c148176b00f99e41"
 dependencies = [
  "alloy",
  "ark-bn254",

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
@@ -1,6 +1,8 @@
 //! Ring 0 settlement helpers
 
-use darkpool_types::settlement_obligation::SettlementObligation;
+use darkpool_types::{
+    bounded_match_result::BoundedMatchResult, settlement_obligation::SettlementObligation,
+};
 use renegade_solidity_abi::v2::IDarkpoolV2::{
     self, FeeRate, PublicIntentAuthBundle, PublicIntentPermit, SettlementBundle,
     SignatureWithNonce, SignedPermitSingle,
@@ -11,21 +13,47 @@ use util::on_chain::get_chain_id;
 use crate::tasks::settlement::helpers::{SettlementProcessor, error::SettlementError};
 
 impl SettlementProcessor {
-    /// Build a ring 0 settlement bundle for a given order
-    pub async fn build_ring0_settlement_bundle(
+    /// Build a ring 0 settlement bundle for an internal match
+    pub async fn build_ring0_internal_settlement_bundle(
         &self,
         order_id: OrderId,
         obligation: SettlementObligation,
     ) -> Result<SettlementBundle, SettlementError> {
+        // Get signatures from the executor and user
         let pair = Pair::from_obligation(&obligation);
         let base = pair.base_token();
         let relayer_fee = self.relayer_fee(base).await?;
-        let order = self.get_order(order_id).await?;
+        let executor_sig = self.build_executor_signature(obligation.clone(), &relayer_fee).await?;
+        self.build_ring0_settlement_bundle_with_executor_sig(order_id, relayer_fee, executor_sig)
+            .await
+    }
 
-        // Get signatures from the executor and user
+    /// Build a ring 0 settlement bundle for an external match
+    pub async fn build_ring0_external_settlement_bundle(
+        &self,
+        order_id: OrderId,
+        obligation: SettlementObligation,
+        match_res: BoundedMatchResult,
+    ) -> Result<SettlementBundle, SettlementError> {
+        let pair = Pair::from_obligation(&obligation);
+        let base = pair.base_token();
+        let relayer_fee = self.relayer_fee(base).await?;
+
+        let executor_sig =
+            self.build_bounded_match_executor_signature(match_res, &relayer_fee).await?;
+        self.build_ring0_settlement_bundle_with_executor_sig(order_id, relayer_fee, executor_sig)
+            .await
+    }
+
+    /// Build a ring 0 settlement bundle for a given order
+    async fn build_ring0_settlement_bundle_with_executor_sig(
+        &self,
+        order_id: OrderId,
+        relayer_fee: FeeRate,
+        executor_sig: SignatureWithNonce,
+    ) -> Result<SettlementBundle, SettlementError> {
         let executor = self.get_executor_key().await?;
-        let executor_sig = self.build_executor_signature(obligation, &relayer_fee).await?;
-        let user_sig = self.get_intent_signature(order_id).await?;
+        let order = self.get_order(order_id).await?;
 
         // Build the intent permit
         let intent_permit = PublicIntentPermit {
@@ -34,6 +62,7 @@ impl SettlementProcessor {
         };
 
         // Build the auth and settlement bundle
+        let user_sig = self.get_intent_signature(order_id).await?;
         let auth_bundle = PublicIntentAuthBundle {
             intentPermit: intent_permit,
             intentSignature: user_sig,
@@ -55,6 +84,23 @@ impl SettlementProcessor {
         let signer = self.get_executor_key().await?;
         let sig = contract_obligation
             .create_executor_signature(fee, chain_id, &signer)
+            .map_err(SettlementError::signing)?;
+
+        Ok(sig)
+    }
+
+    /// Build an executor signature for a bounded match result
+    async fn build_bounded_match_executor_signature(
+        &self,
+        match_res: BoundedMatchResult,
+        fee: &FeeRate,
+    ) -> Result<SignatureWithNonce, SettlementError> {
+        let contract_match = IDarkpoolV2::BoundedMatchResult::from(match_res);
+
+        let chain_id = get_chain_id();
+        let executor = self.get_executor_key().await?;
+        let sig = contract_match
+            .create_executor_signature(fee.clone(), chain_id, &executor)
             .map_err(SettlementError::signing)?;
 
         Ok(sig)

--- a/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
@@ -260,10 +260,14 @@ impl SettleInternalMatchTask {
         let obligation_bundle = self.processor.public_obligation_bundle(&self.match_result);
         let obligation0 = self.get_obligation(PARTY0)?.clone();
         let obligation1 = self.get_obligation(PARTY1)?.clone();
-        let settlement_bundle0 =
-            self.processor.build_ring0_settlement_bundle(self.order_id, obligation0).await?;
-        let settlement_bundle1 =
-            self.processor.build_ring0_settlement_bundle(self.other_order_id, obligation1).await?;
+        let settlement_bundle0 = self
+            .processor
+            .build_ring0_internal_settlement_bundle(self.order_id, obligation0)
+            .await?;
+        let settlement_bundle1 = self
+            .processor
+            .build_ring0_internal_settlement_bundle(self.other_order_id, obligation1)
+            .await?;
 
         // Submit the transaction
         let tx = self


### PR DESCRIPTION
### Purpose
This PR signs the `BoundedMatchResult` along with the relayer fee in the external match calldata gen path. This fixes a bug in which we were previously signing the wrong payload for external matches--that used by the internal match validation path.

### Testing
- [x] Tested settling external matches locally