### PR TITLE
state: storage: account-index: Key balances by location

### DIFF
--- a/crates/relayer-types/types-account/src/account/balance.rs
+++ b/crates/relayer-types/types-account/src/account/balance.rs
@@ -3,6 +3,8 @@
 //! This type wraps a DarkpoolBalance in a StateWrapper, similar to how Order
 //! wraps Intent.
 
+use std::fmt::{self, Display, Formatter};
+
 use alloy::primitives::Address;
 use circuit_types::Amount;
 use darkpool_types::{balance::DarkpoolBalance, state_wrapper::StateWrapper};
@@ -30,6 +32,15 @@ pub enum BalanceLocation {
     EOA,
     /// A balance in the darkpool Merkle state
     Darkpool,
+}
+
+impl Display for BalanceLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BalanceLocation::EOA => write!(f, "EOA"),
+            BalanceLocation::Darkpool => write!(f, "Darkpool"),
+        }
+    }
 }
 
 impl Balance {

--- a/crates/relayer-types/types-account/src/account/mod.rs
+++ b/crates/relayer-types/types-account/src/account/mod.rs
@@ -111,13 +111,9 @@ impl Account {
     /// by the account's balance.
     pub fn get_matchable_amount_for_order(&self, order: &Order) -> Amount {
         let token = order.input_token();
-        let bal = match order.ring {
-            PrivacyRing::Ring0 | PrivacyRing::Ring1 => self.get_eoa_balance(&token),
-            PrivacyRing::Ring2 | PrivacyRing::Ring3 => self.get_darkpool_balance(&token),
-        };
-
-        let bal_amt = bal.map(|b| b.amount()).unwrap_or_default();
-        Amount::min(bal_amt, order.intent.inner.amount_in)
+        let location = order.ring.balance_location();
+        let bal = self.get_balance(&token, location).map(|b| b.amount()).unwrap_or_default();
+        Amount::min(bal, order.intent.inner.amount_in)
     }
 
     /// Place an order into the account
@@ -166,6 +162,21 @@ impl Account {
     /// mint
     pub fn get_darkpool_balance_mut(&mut self, mint: &Address) -> Option<&mut Balance> {
         self.balances.get_mut(mint).and_then(|b| b.get_mut(&BalanceLocation::Darkpool))
+    }
+
+    /// Get the balance for an account by its mint and location
+    pub fn get_balance(&self, mint: &Address, location: BalanceLocation) -> Option<&Balance> {
+        self.balances.get(mint).and_then(|b| b.get(&location))
+    }
+
+    /// Get a mutable reference to the balance for an account by its mint and
+    /// location
+    pub fn get_balance_mut(
+        &mut self,
+        mint: &Address,
+        location: BalanceLocation,
+    ) -> Option<&mut Balance> {
+        self.balances.get_mut(mint).and_then(|b| b.get_mut(&location))
     }
 
     /// Get all balances in the account
@@ -306,25 +317,29 @@ mod rkyv_order_impls {
             self.balances.get(mint).and_then(|b| b.get(&ArchivedBalanceLocation::Darkpool))
         }
 
+        /// Get the balance for an account by its mint and location
+        pub fn get_balance(
+            &self,
+            mint: &ArchivedAddress,
+            location: &ArchivedBalanceLocation,
+        ) -> Option<&ArchivedBalance> {
+            self.balances.get(mint).and_then(|b| b.get(location))
+        }
+
         /// Get the matchable amount for an order
         pub fn get_matchable_amount_for_order(
             &self,
             order: &ArchivedOrder,
         ) -> <Amount as rkyv::Archive>::Archived {
             let in_token = &order.intent.inner.in_token;
-            let bal = match order.ring {
-                ArchivedPrivacyRing::Ring0 | ArchivedPrivacyRing::Ring1 => {
-                    self.get_eoa_balance(in_token)
-                },
-                ArchivedPrivacyRing::Ring2 | ArchivedPrivacyRing::Ring3 => {
-                    self.get_darkpool_balance(in_token)
-                },
-            };
+            let location = order.ring.balance_location();
+            let bal = self
+                .get_balance(in_token, &location)
+                .map(|b| b.amount_archived())
+                .unwrap_or_default();
 
-            let bal_amt = bal.map(|b| b.amount_archived()).unwrap_or_default();
             let intent_amt = order.intent.inner.amount_in;
-
-            min(bal_amt, intent_amt)
+            min(bal, intent_amt)
         }
     }
 }

--- a/crates/relayer-types/types-account/src/account/order.rs
+++ b/crates/relayer-types/types-account/src/account/order.rs
@@ -12,7 +12,9 @@ use darkpool_types::{intent::Intent, state_wrapper::StateWrapper};
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
-use crate::{OrderId, pair::Pair};
+#[cfg(feature = "rkyv")]
+use crate::balance::ArchivedBalanceLocation;
+use crate::{OrderId, balance::BalanceLocation, pair::Pair};
 
 /// The order type for an account
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -207,6 +209,31 @@ pub enum PrivacyRing {
     Ring2,
     /// Ring 3: Private intent, private balance (private fill)
     Ring3,
+}
+
+impl PrivacyRing {
+    /// Get the balance location from which an order in the privacy ring is
+    /// capitalized
+    pub fn balance_location(&self) -> BalanceLocation {
+        match self {
+            PrivacyRing::Ring0 | PrivacyRing::Ring1 => BalanceLocation::EOA,
+            PrivacyRing::Ring2 | PrivacyRing::Ring3 => BalanceLocation::Darkpool,
+        }
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl ArchivedPrivacyRing {
+    /// Get the balance location from which an order in the privacy ring is
+    /// capitalized
+    pub fn balance_location(&self) -> ArchivedBalanceLocation {
+        match self {
+            ArchivedPrivacyRing::Ring0 | ArchivedPrivacyRing::Ring1 => ArchivedBalanceLocation::EOA,
+            ArchivedPrivacyRing::Ring2 | ArchivedPrivacyRing::Ring3 => {
+                ArchivedBalanceLocation::Darkpool
+            },
+        }
+    }
 }
 
 #[cfg(feature = "mocks")]

--- a/crates/workers/task-driver/src/tasks/create_order.rs
+++ b/crates/workers/task-driver/src/tasks/create_order.rs
@@ -21,7 +21,7 @@ use state::{State, error::StateError};
 use tracing::{info, instrument};
 use types_account::{
     OrderId,
-    balance::Balance,
+    balance::{Balance, BalanceLocation},
     order::{Order, OrderMetadata, PrivacyRing},
     order_auth::OrderAuth,
 };
@@ -262,7 +262,8 @@ impl CreateOrderTask {
         // keep its value up to date as new permits and erc20 transfers happen
         let in_token = self.intent.in_token;
         let state = self.state();
-        let bal = state.get_account_balance_value(&self.account_id, &in_token).await?;
+        let loc = BalanceLocation::EOA;
+        let bal = state.get_account_balance_value(&self.account_id, &in_token, loc).await?;
         if bal > 0 {
             return Ok(());
         }

--- a/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/settle_internal_match.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use state::error::StateError;
 use tracing::{info, instrument};
 use types_account::OrderId;
+use types_account::balance::BalanceLocation;
 use types_core::MatchResult;
 use types_core::{AccountId, TimestampedPriceFp};
 use types_tasks::SettleInternalMatchTaskDescriptor;
@@ -300,7 +301,7 @@ impl SettleInternalMatchTask {
         let order_id = branch_party!(party_id, self.order_id, self.other_order_id);
         let obligation = self.get_obligation(party_id)?;
 
-        self.processor.update_input_balance(account_id, obligation.input_token, obligation).await?;
+        self.processor.update_input_balance(account_id, BalanceLocation::EOA, obligation).await?;
         self.processor.update_order_amount_in(order_id, obligation).await?;
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR keys balances in state by their `BalanceLocation` so that we may store an EOA balance and a darkpool balance for each user, token pair.

### Testing
- [x] Unit tests pass
- [x] Tested flows locally