### PR TITLE
feat(task-driver): implement account refresh task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9180,6 +9180,7 @@ dependencies = [
  "flate2",
  "futures",
  "gossip-api",
+ "http 1.4.0",
  "inventory",
  "itertools 0.11.0",
  "job-types",
@@ -9192,6 +9193,7 @@ dependencies = [
  "proof-manager",
  "rand 0.8.5",
  "renegade-metrics",
+ "reqwest",
  "serde",
  "serde_json",
  "state",
@@ -9206,6 +9208,7 @@ dependencies = [
  "types-proofs",
  "types-runtime",
  "types-tasks",
+ "url",
  "util",
  "uuid",
 ]

--- a/crates/config/src/cli.rs
+++ b/crates/config/src/cli.rs
@@ -60,6 +60,12 @@ pub struct Cli {
     /// The password for the prover service
     #[clap(long, value_parser, env = "PROVER_SERVICE_PASSWORD", requires = "prover_service_url")]
     pub prover_service_password: Option<String>,
+    /// The URL of the darkpool indexer service
+    #[clap(long, value_parser, env = "INDEXER_URL")]
+    pub indexer_url: String,
+    /// The HMAC key for authenticating requests to the indexer service (base64-encoded)
+    #[clap(long, value_parser, env = "INDEXER_HMAC_KEY")]
+    pub indexer_hmac_key: String,
 
     // -----------------------------
     // | Application Level Configs |
@@ -319,6 +325,10 @@ pub struct RelayerConfig {
     pub prover_service_url: Option<Url>,
     /// The password for the prover service
     pub prover_service_password: Option<String>,
+    /// The URL of the darkpool indexer service
+    pub indexer_url: Url,
+    /// The HMAC key for authenticating requests to the indexer service
+    pub indexer_hmac_key: HmacKey,
 
     // -----------------------
     // | Environment Configs |
@@ -470,6 +480,7 @@ impl Default for RelayerConfig {
     fn default() -> Self {
         // Set the default addresses for the config
         let zero_addr = "0x0000000000000000000000000000000000000000".to_string();
+        let hmac_key = HmacKey::random().to_base64_string();
         let args_string = [
             "relayer".to_string(),
             "--contract-address".to_string(),
@@ -478,6 +489,10 @@ impl Default for RelayerConfig {
             zero_addr.clone(),
             "--permit2-address".to_string(),
             zero_addr.clone(),
+            "--indexer-url".to_string(),
+            "http://localhost:8080".to_string(),
+            "--indexer-hmac-key".to_string(),
+            hmac_key,
         ];
 
         // Parse a dummy set of command line args and convert this to a config

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -39,7 +39,10 @@ use util::default_option;
 
 use error::CoordinatorError;
 use system_clock::SystemClock;
-use task_driver::worker::{TaskDriver, TaskDriverConfig};
+use task_driver::{
+    indexer_client::IndexerClient,
+    worker::{TaskDriver, TaskDriverConfig},
+};
 use tokio::select;
 use tracing::info;
 
@@ -185,6 +188,8 @@ async fn main() -> Result<(), CoordinatorError> {
         matching_engine_worker_sender.clone(),
         system_bus.clone(),
         global_state.clone(),
+        args.indexer_url.clone(),
+        args.indexer_hmac_key,
     );
     let mut task_driver =
         TaskDriver::new(task_driver_config).await.expect("failed to build task driver");

--- a/crates/relayer-types/types-tasks/src/descriptors/mod.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/mod.rs
@@ -7,6 +7,7 @@ mod create_order;
 mod deposit;
 mod new_account;
 mod node_startup;
+mod refresh_account;
 mod settle_external_match;
 mod settle_internal_match;
 mod withdraw;
@@ -16,6 +17,7 @@ pub use create_order::*;
 pub use deposit::*;
 pub use new_account::*;
 pub use node_startup::*;
+pub use refresh_account::*;
 pub use settle_external_match::*;
 pub use settle_internal_match::*;
 pub use withdraw::*;
@@ -147,6 +149,8 @@ pub enum TaskDescriptor {
     CreateBalance(CreateBalanceTaskDescriptor),
     /// The task descriptor for the `CreateOrder` task
     CreateOrder(CreateOrderTaskDescriptor),
+    /// The task descriptor for the `RefreshAccount` task
+    RefreshAccount(RefreshAccountTaskDescriptor),
     /// The task descriptor for the `SettleInternalMatch` task
     SettleInternalMatch(SettleInternalMatchTaskDescriptor),
     /// The task descriptor for the `SettleExternalMatch` task
@@ -164,13 +168,14 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(task) => task.account_id,
             TaskDescriptor::CreateBalance(task) => task.account_id,
             TaskDescriptor::CreateOrder(task) => task.account_id,
+            TaskDescriptor::RefreshAccount(task) => task.account_id,
             TaskDescriptor::SettleInternalMatch(task) => task.account_id,
             TaskDescriptor::SettleExternalMatch(task) => task.account_id,
             TaskDescriptor::Withdraw(task) => task.account_id,
         }
     }
 
-    /// Returns the IDs of the wallets affected by the task
+    /// Returns the IDs of the accounts affected by the task
     pub fn affected_accounts(&self) -> Vec<AccountId> {
         match self {
             TaskDescriptor::NewAccount(task) => vec![task.account_id],
@@ -178,6 +183,7 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(task) => vec![task.account_id],
             TaskDescriptor::CreateBalance(task) => vec![task.account_id],
             TaskDescriptor::CreateOrder(task) => vec![task.account_id],
+            TaskDescriptor::RefreshAccount(task) => vec![task.account_id],
             TaskDescriptor::SettleInternalMatch(task) => {
                 vec![task.account_id, task.other_account_id]
             },
@@ -186,7 +192,7 @@ impl TaskDescriptor {
         }
     }
 
-    /// Returns whether the task is a wallet task
+    /// Returns whether the task is an account task
     pub fn is_account_task(&self) -> bool {
         match self {
             TaskDescriptor::NewAccount(_) => true,
@@ -194,6 +200,7 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(_) => true,
             TaskDescriptor::CreateBalance(_) => true,
             TaskDescriptor::CreateOrder(_) => true,
+            TaskDescriptor::RefreshAccount(_) => true,
             TaskDescriptor::SettleInternalMatch(_) => true,
             TaskDescriptor::SettleExternalMatch(_) => true,
             TaskDescriptor::Withdraw(_) => true,
@@ -208,6 +215,7 @@ impl TaskDescriptor {
             TaskDescriptor::Deposit(_) => "Deposit".to_string(),
             TaskDescriptor::CreateBalance(_) => "Create Balance".to_string(),
             TaskDescriptor::CreateOrder(_) => "Create Order".to_string(),
+            TaskDescriptor::RefreshAccount(_) => "Refresh Account".to_string(),
             TaskDescriptor::SettleInternalMatch(_) => "Settle Internal Match".to_string(),
             TaskDescriptor::SettleExternalMatch(_) => "Settle External Match".to_string(),
             TaskDescriptor::Withdraw(_) => "Withdraw".to_string(),

--- a/crates/relayer-types/types-tasks/src/descriptors/refresh_account.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/refresh_account.rs
@@ -1,0 +1,33 @@
+//! Descriptor for the refresh account task
+
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+use types_account::keychain::KeyChain;
+use types_core::AccountId;
+
+use super::TaskDescriptor;
+
+/// The task descriptor for the `RefreshAccount` task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvSerialize, RkyvDeserialize))]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
+pub struct RefreshAccountTaskDescriptor {
+    /// The account ID to refresh
+    pub account_id: AccountId,
+    /// The keychain for the account
+    pub keychain: KeyChain,
+}
+
+impl RefreshAccountTaskDescriptor {
+    /// Create a new refresh account task descriptor
+    pub fn new(account_id: AccountId, keychain: KeyChain) -> Self {
+        Self { account_id, keychain }
+    }
+}
+
+impl From<RefreshAccountTaskDescriptor> for TaskDescriptor {
+    fn from(descriptor: RefreshAccountTaskDescriptor) -> Self {
+        TaskDescriptor::RefreshAccount(descriptor)
+    }
+}

--- a/crates/relayer-types/types-tasks/src/history.rs
+++ b/crates/relayer-types/types-tasks/src/history.rs
@@ -81,6 +81,11 @@ pub enum HistoricalTaskDescription {
         /// The input amount for the order
         amount: Amount,
     },
+    /// An account was refreshed
+    RefreshAccount {
+        /// The account ID that was refreshed
+        account_id: AccountId,
+    },
 }
 
 impl HistoricalTaskDescription {
@@ -103,6 +108,9 @@ impl HistoricalTaskDescription {
                 token: desc.token,
                 amount: desc.amount,
             }),
+            TaskDescriptor::RefreshAccount(desc) => {
+                Some(Self::RefreshAccount { account_id: desc.account_id })
+            },
             TaskDescriptor::SettleInternalMatch(_) => None,
             TaskDescriptor::SettleExternalMatch(_) => None,
             TaskDescriptor::NodeStartup(_) => None,

--- a/crates/state/src/applicator/mod.rs
+++ b/crates/state/src/applicator/mod.rs
@@ -102,6 +102,9 @@ impl StateApplicator {
             StateTransition::UpdateAccountBalance { account_id, balance } => {
                 self.update_account_balance(account_id, &balance)
             },
+            StateTransition::RefreshAccount { account_id, orders, balances } => {
+                self.refresh_account(account_id, orders, &balances)
+            },
             StateTransition::AddOrderValidityProof { order_id, proof } => {
                 self.add_order_validity_proof(order_id, proof)
             },

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -309,6 +309,16 @@ impl StateInner {
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::UpdateAccountBalance { account_id, balance }).await
     }
+
+    /// Refresh an account's state with updated orders and balances
+    pub async fn refresh_account(
+        &self,
+        account_id: AccountId,
+        orders: Vec<(Order, MatchingPoolName)>,
+        balances: Vec<Balance>,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::RefreshAccount { account_id, orders, balances }).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/state/src/state_transition.rs
+++ b/crates/state/src/state_transition.rs
@@ -56,6 +56,15 @@ pub enum StateTransition {
     UpdateOrder { order: Order },
     /// Update a balance in an account
     UpdateAccountBalance { account_id: AccountId, balance: Balance },
+    /// Refresh an account's state
+    RefreshAccount {
+        /// The account ID to refresh
+        account_id: AccountId,
+        /// The up-to-date ring 0 orders with their matching pool assignments
+        orders: Vec<(Order, MatchingPoolName)>,
+        /// The up-to-date balances
+        balances: Vec<Balance>,
+    },
 
     // --- Orders --- //
     /// Add a validity proof to an order

--- a/crates/state/src/storage/tx/account_index.rs
+++ b/crates/state/src/storage/tx/account_index.rs
@@ -373,6 +373,20 @@ impl StateTxn<'_, RW> {
         self.inner().delete(ACCOUNTS_TABLE, &index_key)?;
         Ok(())
     }
+
+    /// Remove all storage artifacts for an order
+    ///
+    /// This removes the order data, auth, and matching pool assignment.
+    pub fn remove_order_with_auth(
+        &self,
+        account_id: &AccountId,
+        order_id: &OrderId,
+    ) -> Result<(), StorageError> {
+        self.remove_order(account_id, order_id)?;
+        self.delete_order_auth(order_id)?;
+        self.remove_order_from_matching_pool(order_id)?;
+        Ok(())
+    }
 }
 
 // ---------

--- a/crates/testing/mock-node/src/lib.rs
+++ b/crates/testing/mock-node/src/lib.rs
@@ -53,7 +53,10 @@ use serde::{Serialize, de::DeserializeOwned};
 use state::{State, create_global_state};
 use system_bus::SystemBus;
 use system_clock::SystemClock;
-use task_driver::worker::{TaskDriver, TaskDriverConfig};
+use task_driver::{
+    indexer_client::IndexerClient,
+    worker::{TaskDriver, TaskDriverConfig},
+};
 use test_helpers::mocks::mock_cancel;
 use tokio::runtime::Handle;
 use types_core::Price;
@@ -371,6 +374,8 @@ impl MockNodeController {
         let event_queue = self.event_queue.0.clone();
         let bus = self.bus.clone();
         let state = self.state.clone().expect("State not initialized");
+        let indexer_client =
+            IndexerClient::new(self.config.indexer_url.clone(), self.config.indexer_hmac_key);
 
         let conf = TaskDriverConfig::new(
             task_queue,
@@ -382,6 +387,7 @@ impl MockNodeController {
             self.matching_engine_worker_queue.0.clone(),
             bus,
             state,
+            indexer_client,
         );
         let mut driver = run_fut(TaskDriver::new(conf)).expect("Failed to create task driver");
         driver.start().expect("Failed to start task driver");

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -142,7 +142,7 @@ impl HttpServer {
         router.add_account_authenticated_route(
             &Method::POST,
             SYNC_ACCOUNT_ROUTE.to_string(),
-            SyncAccountHandler::new(),
+            SyncAccountHandler::new(state.clone()),
         );
 
         // --- Order Routes (v2) --- //

--- a/crates/workers/api-server/src/http/account.rs
+++ b/crates/workers/api-server/src/http/account.rs
@@ -12,7 +12,7 @@ use hyper::HeaderMap;
 use state::State;
 use types_account::keychain::{KeyChain, PrivateKeyChain};
 use types_core::HmacKey;
-use types_tasks::NewAccountTaskDescriptor;
+use types_tasks::{NewAccountTaskDescriptor, RefreshAccountTaskDescriptor};
 
 use crate::{
     error::{ApiServerError, bad_request, not_found},
@@ -140,12 +140,15 @@ impl TypedHandler for GetAccountSeedsHandler {
 }
 
 /// Handler for POST /v2/account/:account_id/sync
-pub struct SyncAccountHandler;
+pub struct SyncAccountHandler {
+    /// A handle to the state
+    state: State,
+}
 
 impl SyncAccountHandler {
     /// Constructor
-    pub fn new() -> Self {
-        Self
+    pub fn new(state: State) -> Self {
+        Self { state }
     }
 }
 
@@ -157,10 +160,22 @@ impl TypedHandler for SyncAccountHandler {
     async fn handle_typed(
         &self,
         _headers: HeaderMap,
-        _req: Self::Request,
-        _params: UrlParams,
+        req: Self::Request,
+        params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        Err(ApiServerError::not_implemented(ERR_NOT_IMPLEMENTED))
+        // Parse account_id from URL params
+        let account_id = parse_account_id_from_params(&params)?;
+
+        // Build keychain from request
+        let auth_key = HmacKey::from_base64_string(&req.auth_hmac_key).map_err(bad_request)?;
+        let master_view_seed = parse_scalar_from_string(&req.master_view_seed)?;
+        let keychain = KeyChain::new(PrivateKeyChain::new(auth_key, master_view_seed));
+
+        // Create and append the task
+        let descriptor = RefreshAccountTaskDescriptor::new(account_id, keychain);
+        let task_id = append_task(descriptor.into(), &self.state).await?;
+
+        Ok(SyncAccountResponse { task_id, completed: false })
     }
 }

--- a/crates/workers/task-driver/Cargo.toml
+++ b/crates/workers/task-driver/Cargo.toml
@@ -45,7 +45,7 @@ types-account = { workspace = true }
 types-proofs = { workspace = true }
 types-runtime = { workspace = true }
 constants = { workspace = true }
-external-api = { workspace = true }
+external-api = { workspace = true, features = ["auth"] }
 gossip-api = { workspace = true }
 job-types = { workspace = true }
 matching-engine-core = { workspace = true }
@@ -56,8 +56,14 @@ util = { workspace = true }
 renegade-metrics = { workspace = true }
 renegade-solidity-abi = { workspace = true }
 
+# === HTTP === #
+http = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+url = "2"
+
 # === Misc Dependencies === #
 itertools = "0.11"
+eyre = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/workers/task-driver/src/simulation/account_tasks.rs
+++ b/crates/workers/task-driver/src/simulation/account_tasks.rs
@@ -52,6 +52,7 @@ fn should_simulate(task: &QueuedTask) -> bool {
         // External matches bypass the task queue and are not simulated
         TaskDescriptor::SettleExternalMatch(_) => false,
         TaskDescriptor::NodeStartup(_) => false,
+        TaskDescriptor::RefreshAccount(_) => false,
     }
 }
 
@@ -71,6 +72,7 @@ fn simulate_single_account_task(
         // Ignore all non-wallet tasks
         TaskDescriptor::SettleExternalMatch(_) => Ok(()),
         TaskDescriptor::NodeStartup(_) => Ok(()),
+        TaskDescriptor::RefreshAccount(_) => Ok(()),
     }
 }
 

--- a/crates/workers/task-driver/src/task_state.rs
+++ b/crates/workers/task-driver/src/task_state.rs
@@ -9,7 +9,7 @@ use crate::{
     tasks::{
         create_balance::CreateBalanceTaskState, create_new_account::CreateNewAccountTaskState,
         create_order::CreateOrderTaskState, deposit::DepositTaskState,
-        node_startup::NodeStartupTaskState,
+        node_startup::NodeStartupTaskState, refresh_account::RefreshAccountTaskState,
         settlement::settle_external_match::SettleExternalMatchTaskState,
         settlement::settle_internal_match::SettleInternalMatchTaskState,
         withdraw::WithdrawTaskState,
@@ -36,6 +36,8 @@ pub enum TaskStateWrapper {
     CreateBalance(CreateBalanceTaskState),
     /// The state of a create order task
     CreateOrder(CreateOrderTaskState),
+    /// The state of a refresh account task
+    RefreshAccount(RefreshAccountTaskState),
     /// The state of a settle internal match task
     SettleInternalMatch(SettleInternalMatchTaskState),
     /// The state of a settle external match task
@@ -61,6 +63,9 @@ impl TaskStateWrapper {
             TaskStateWrapper::CreateOrder(state) => {
                 <CreateOrderTaskState as TaskState>::committed(state)
             },
+            TaskStateWrapper::RefreshAccount(state) => {
+                <RefreshAccountTaskState as TaskState>::committed(state)
+            },
             TaskStateWrapper::SettleInternalMatch(state) => {
                 <SettleInternalMatchTaskState as TaskState>::committed(state)
             },
@@ -84,6 +89,9 @@ impl TaskStateWrapper {
                 *state == CreateBalanceTaskState::commit_point()
             },
             TaskStateWrapper::CreateOrder(state) => *state == CreateOrderTaskState::commit_point(),
+            TaskStateWrapper::RefreshAccount(state) => {
+                *state == RefreshAccountTaskState::commit_point()
+            },
             TaskStateWrapper::SettleInternalMatch(state) => {
                 *state == SettleInternalMatchTaskState::commit_point()
             },
@@ -110,6 +118,9 @@ impl TaskStateWrapper {
             TaskStateWrapper::CreateOrder(state) => {
                 <CreateOrderTaskState as TaskState>::completed(state)
             },
+            TaskStateWrapper::RefreshAccount(state) => {
+                <RefreshAccountTaskState as TaskState>::completed(state)
+            },
             TaskStateWrapper::SettleInternalMatch(state) => {
                 <SettleInternalMatchTaskState as TaskState>::completed(state)
             },
@@ -129,6 +140,7 @@ impl Display for TaskStateWrapper {
             TaskStateWrapper::Deposit(state) => write!(f, "{state}"),
             TaskStateWrapper::CreateBalance(state) => write!(f, "{state}"),
             TaskStateWrapper::CreateOrder(state) => write!(f, "{state}"),
+            TaskStateWrapper::RefreshAccount(state) => write!(f, "{state}"),
             TaskStateWrapper::SettleInternalMatch(state) => write!(f, "{state}"),
             TaskStateWrapper::SettleExternalMatch(state) => write!(f, "{state}"),
             TaskStateWrapper::Withdraw(state) => write!(f, "{state}"),

--- a/crates/workers/task-driver/src/tasks/mod.rs
+++ b/crates/workers/task-driver/src/tasks/mod.rs
@@ -5,5 +5,6 @@ pub mod create_new_account;
 pub mod create_order;
 pub mod deposit;
 pub mod node_startup;
+pub mod refresh_account;
 pub mod settlement;
 pub mod withdraw;

--- a/crates/workers/task-driver/src/tasks/node_startup.rs
+++ b/crates/workers/task-driver/src/tasks/node_startup.rs
@@ -388,9 +388,13 @@ impl NodeStartupTask {
     // | Helpers |
     // -----------
 
-    /// Enqueue a account lookup task to refresh an account
-    async fn refresh_account(&self, _account_id: AccountId) -> Result<(), NodeStartupTaskError> {
-        // TODO(@akirillo): Re-implement this
+    /// Enqueue an account refresh task
+    async fn refresh_account(&self, account_id: AccountId) -> Result<(), NodeStartupTaskError> {
+        self.state
+            .append_account_refresh_task(account_id)
+            .await
+            .map_err(|e| NodeStartupTaskError::State(e.to_string()))?;
+
         Ok(())
     }
 

--- a/crates/workers/task-driver/src/tasks/refresh_account.rs
+++ b/crates/workers/task-driver/src/tasks/refresh_account.rs
@@ -1,0 +1,290 @@
+//! Defines a task to refresh an account's state from the indexer
+
+use std::{
+    collections::HashSet,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+use alloy::primitives::Address;
+use async_trait::async_trait;
+use darkpool_client::errors::DarkpoolClientError;
+use serde::Serialize;
+use state::error::StateError;
+use tracing::{info, instrument};
+use types_account::{Account, OrderId, keychain::KeyChain, order::Order};
+use types_core::AccountId;
+use types_tasks::RefreshAccountTaskDescriptor;
+
+use crate::{
+    hooks::{RunMatchingEngineHook, TaskHook},
+    task_state::TaskStateWrapper,
+    traits::{Descriptor, Task, TaskContext, TaskError, TaskState},
+    utils::fetch_ring0_balance,
+    utils::indexer_client::{ApiPublicIntent, ApiStateObject, IndexerClientError},
+};
+
+/// The task name for the refresh account task
+const REFRESH_ACCOUNT_TASK_NAME: &str = "refresh-account";
+
+// --------------
+// | Task State |
+// --------------
+
+/// Represents the state of the task through its async execution
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RefreshAccountTaskState {
+    /// The task is awaiting scheduling
+    Pending,
+    /// The task is ensuring the account exists
+    EnsureAccountExists,
+    /// The task is refreshing the account state from the indexer
+    RefreshingState,
+    /// The task is completed
+    Completed,
+}
+
+impl TaskState for RefreshAccountTaskState {
+    fn commit_point() -> Self {
+        RefreshAccountTaskState::RefreshingState
+    }
+
+    fn completed(&self) -> bool {
+        matches!(self, RefreshAccountTaskState::Completed)
+    }
+}
+
+impl Display for RefreshAccountTaskState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            RefreshAccountTaskState::Pending => write!(f, "Pending"),
+            RefreshAccountTaskState::EnsureAccountExists => write!(f, "EnsureAccountExists"),
+            RefreshAccountTaskState::RefreshingState => write!(f, "RefreshingState"),
+            RefreshAccountTaskState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl From<RefreshAccountTaskState> for TaskStateWrapper {
+    fn from(state: RefreshAccountTaskState) -> Self {
+        TaskStateWrapper::RefreshAccount(state)
+    }
+}
+
+// ---------------
+// | Task Errors |
+// ---------------
+
+/// The error type thrown by the refresh account task
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshAccountTaskError {
+    /// An error interacting with the darkpool client
+    #[error("darkpool client error: {0}")]
+    DarkpoolClient(String),
+    /// An error interacting with the indexer
+    #[error("indexer error: {0}")]
+    Indexer(#[from] IndexerClientError),
+    /// Error interacting with global state
+    #[error("state error: {0}")]
+    State(#[from] StateError),
+    /// Error getting relayer fee address
+    #[error("{0}")]
+    Setup(String),
+}
+
+impl RefreshAccountTaskError {
+    /// Create a new setup error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn setup<T: ToString>(msg: T) -> Self {
+        Self::Setup(msg.to_string())
+    }
+
+    /// Create a new darkpool client error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn darkpool_client<T: ToString>(msg: T) -> Self {
+        Self::DarkpoolClient(msg.to_string())
+    }
+}
+
+impl From<DarkpoolClientError> for RefreshAccountTaskError {
+    fn from(e: DarkpoolClientError) -> Self {
+        RefreshAccountTaskError::darkpool_client(e)
+    }
+}
+
+impl TaskError for RefreshAccountTaskError {
+    fn retryable(&self) -> bool {
+        matches!(
+            self,
+            RefreshAccountTaskError::Indexer(_) | RefreshAccountTaskError::DarkpoolClient(_)
+        )
+    }
+}
+
+/// A type alias for a result in this task
+type Result<T> = std::result::Result<T, RefreshAccountTaskError>;
+
+// -------------------
+// | Task Definition |
+// -------------------
+
+/// Represents a task to refresh an account's state from the indexer
+pub struct RefreshAccountTask {
+    /// The account ID to refresh
+    pub account_id: AccountId,
+    /// The keychain for the account
+    pub keychain: KeyChain,
+    /// The order IDs that were refreshed (for success hook)
+    pub refreshed_order_ids: Vec<OrderId>,
+    /// The state of the task's execution
+    pub task_state: RefreshAccountTaskState,
+    /// The context of the task
+    pub ctx: TaskContext,
+}
+
+#[async_trait]
+impl Task for RefreshAccountTask {
+    type State = RefreshAccountTaskState;
+    type Error = RefreshAccountTaskError;
+    type Descriptor = RefreshAccountTaskDescriptor;
+
+    async fn new(descriptor: Self::Descriptor, ctx: TaskContext) -> Result<Self> {
+        Ok(Self {
+            account_id: descriptor.account_id,
+            keychain: descriptor.keychain,
+            refreshed_order_ids: Vec::new(),
+            task_state: RefreshAccountTaskState::Pending,
+            ctx,
+        })
+    }
+
+    #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err, fields(task = %self.name(), state = %self.task_state()))]
+    async fn step(&mut self) -> Result<()> {
+        // Dispatch based on task state
+        match self.task_state {
+            RefreshAccountTaskState::Pending => {
+                self.task_state = RefreshAccountTaskState::EnsureAccountExists;
+            },
+            RefreshAccountTaskState::EnsureAccountExists => {
+                self.ensure_account_exists().await?;
+                self.task_state = RefreshAccountTaskState::RefreshingState;
+            },
+            RefreshAccountTaskState::RefreshingState => {
+                self.refresh_state().await?;
+                self.task_state = RefreshAccountTaskState::Completed;
+            },
+            RefreshAccountTaskState::Completed => {
+                unreachable!("step called on task in Completed state")
+            },
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        REFRESH_ACCOUNT_TASK_NAME.to_string()
+    }
+
+    fn task_state(&self) -> Self::State {
+        self.task_state.clone()
+    }
+
+    // Explicitly NOT using RefreshAccountHook as a failure hook
+    fn failure_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        vec![]
+    }
+
+    // Run the matching engine on all refreshed orders
+    fn success_hooks(&self) -> Vec<Box<dyn TaskHook>> {
+        if self.refreshed_order_ids.is_empty() {
+            return vec![];
+        }
+
+        let hook = RunMatchingEngineHook::new(self.account_id, self.refreshed_order_ids.clone());
+        vec![Box::new(hook)]
+    }
+}
+
+impl Descriptor for RefreshAccountTaskDescriptor {}
+
+// -----------------------
+// | Task Implementation |
+// -----------------------
+
+impl RefreshAccountTask {
+    /// Ensure the account exists, creating it if necessary
+    async fn ensure_account_exists(&self) -> Result<()> {
+        let state = &self.ctx.state;
+        let exists = state.contains_account(&self.account_id).await?;
+
+        if exists {
+            info!("Account {} already exists", self.account_id);
+            return Ok(());
+        }
+
+        // Create the account
+        info!("Creating account {}", self.account_id);
+        let account = Account::new_empty_account(self.account_id, self.keychain.clone());
+        let waiter = state.new_account(account).await?;
+        waiter.await?;
+
+        Ok(())
+    }
+
+    /// Refresh the account state from the indexer
+    async fn refresh_state(&mut self) -> Result<()> {
+        // Query the indexer for the user's state
+        let response = self.ctx.indexer_client.get_user_state(self.account_id).await?;
+
+        // Filter to only public intents (ring 0 orders)
+        let public_intents: Vec<ApiPublicIntent> = response
+            .active_state_objects
+            .into_iter()
+            .filter_map(|obj| match obj {
+                ApiStateObject::PublicIntent(intent) => Some(intent),
+                _ => None,
+            })
+            .collect();
+
+        if public_intents.is_empty() {
+            info!("No public intents found for account {}", self.account_id);
+            return Ok(());
+        }
+
+        info!("Found {} public intents for account {}", public_intents.len(), self.account_id);
+
+        // Collect unique input tokens from the intents
+        let input_tokens: HashSet<Address> =
+            public_intents.iter().map(|intent| intent.order.input_token()).collect();
+
+        // Refresh ring 0 balances for each input token
+        let owner = public_intents.first().unwrap().order.intent.inner.owner;
+        let mut balances = Vec::new();
+        for token in input_tokens {
+            if let Some(balance) = fetch_ring0_balance(&self.ctx, token, owner)
+                .await
+                .map_err(RefreshAccountTaskError::darkpool_client)?
+            {
+                balances.push(balance);
+            }
+        }
+
+        // Convert public intents to orders with matching pool assignments
+        let orders: Vec<(Order, String)> = public_intents
+            .iter()
+            .map(|intent| (intent.order.clone(), intent.matching_pool.clone()))
+            .collect();
+
+        // Collect order IDs for the success hook
+        self.refreshed_order_ids = orders.iter().map(|(order, _)| order.id).collect();
+
+        // Propose the state transition
+        info!("Proposing refresh with {} orders and {} balances", orders.len(), balances.len());
+
+        let waiter = self.ctx.state.refresh_account(self.account_id, orders, balances).await?;
+
+        waiter.await?;
+
+        Ok(())
+    }
+}

--- a/crates/workers/task-driver/src/traits.rs
+++ b/crates/workers/task-driver/src/traits.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use state::State;
 use system_bus::SystemBus;
 
-use crate::{hooks::TaskHook, task_state::TaskStateWrapper};
+use crate::{hooks::TaskHook, task_state::TaskStateWrapper, utils::indexer_client::IndexerClient};
 
 // ------------------
 // | Task and State |
@@ -144,4 +144,6 @@ pub struct TaskContext {
     pub task_queue: TaskDriverQueue,
     /// A handle on the system bus
     pub bus: SystemBus,
+    /// A client for the darkpool indexer API
+    pub indexer_client: IndexerClient,
 }

--- a/crates/workers/task-driver/src/utils/indexer_client.rs
+++ b/crates/workers/task-driver/src/utils/indexer_client.rs
@@ -1,0 +1,153 @@
+//! HTTP client for the darkpool indexer API
+
+use std::time::Duration;
+
+use external_api::auth::add_expiring_auth_to_headers;
+use http::HeaderMap;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use types_account::order::Order;
+use types_core::{AccountId, HmacKey};
+use url::Url;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The path for the get user state endpoint
+const GET_USER_STATE_PATH: &str = "/user-state";
+/// The expiration duration for auth signatures
+const AUTH_EXPIRATION: Duration = Duration::from_secs(30);
+
+// ----------
+// | Errors |
+// ----------
+
+/// Error type for the indexer client
+#[derive(Debug, Error)]
+pub enum IndexerClientError {
+    /// Error building the request URL
+    #[error("error building request URL: {0}")]
+    UrlBuild(String),
+    /// Error sending HTTP request
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    /// Serialization/deserialization error
+    #[error("serde error: {0}")]
+    Serde(String),
+    /// Non-success status code
+    #[error("request failed with status {0}: {1}")]
+    StatusCode(u16, String),
+}
+
+impl IndexerClientError {
+    /// Create a new URL build error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn url_build<T: ToString>(msg: T) -> Self {
+        Self::UrlBuild(msg.to_string())
+    }
+
+    /// Create a new serde error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn serde<T: ToString>(msg: T) -> Self {
+        Self::Serde(msg.to_string())
+    }
+}
+
+// -----------------------
+// | Duplicated API Types |
+// -----------------------
+
+/// A state object returned by the indexer API
+#[derive(Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum ApiStateObject {
+    /// A balance state object
+    Balance(ApiBalance),
+    /// An intent state object
+    Intent(ApiIntent),
+    /// A public intent state object
+    PublicIntent(ApiPublicIntent),
+}
+
+/// A balance state object returned by the API
+#[derive(Serialize, Deserialize)]
+pub struct ApiBalance {
+    // Note: We don't need to fully deserialize this for now
+    // as we only care about public intents
+}
+
+/// An intent state object returned by the API
+#[derive(Serialize, Deserialize)]
+pub struct ApiIntent {
+    // Note: We don't need to fully deserialize this for now
+    // as we only care about public intents
+}
+
+/// A public intent state object returned by the API
+#[derive(Serialize, Deserialize)]
+pub struct ApiPublicIntent {
+    /// The underlying order type
+    pub order: Order,
+    /// The matching pool to which the intent is allocated
+    pub matching_pool: String,
+}
+
+/// A response containing a user's active state objects
+#[derive(Serialize, Deserialize)]
+pub struct GetUserStateResponse {
+    /// The list of active state objects
+    pub active_state_objects: Vec<ApiStateObject>,
+}
+
+// -----------------
+// | IndexerClient |
+// -----------------
+
+/// HTTP client for the darkpool indexer API
+#[derive(Clone)]
+pub struct IndexerClient {
+    /// The underlying HTTP client
+    client: Client,
+    /// The base URL of the indexer API
+    base_url: Url,
+    /// The HMAC key for request authentication
+    hmac_key: HmacKey,
+}
+
+impl IndexerClient {
+    /// Create a new indexer client
+    pub fn new(base_url: Url, hmac_key: HmacKey) -> Self {
+        let client = Client::new();
+        Self { client, base_url, hmac_key }
+    }
+
+    /// Get the user state for an account
+    pub async fn get_user_state(
+        &self,
+        account_id: AccountId,
+    ) -> Result<GetUserStateResponse, IndexerClientError> {
+        // Build the request URL
+        let path = format!("{}/{}", GET_USER_STATE_PATH, account_id);
+        let url = self.base_url.join(&path).map_err(IndexerClientError::url_build)?;
+
+        // Build and sign the request headers
+        let mut headers = HeaderMap::new();
+        add_expiring_auth_to_headers(&path, &mut headers, &[], &self.hmac_key, AUTH_EXPIRATION);
+
+        // Send the request
+        let response = self.client.get(url).headers(headers).send().await?;
+
+        // Check for errors
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(IndexerClientError::StatusCode(status.as_u16(), body));
+        }
+
+        // Deserialize the response
+        let body = response.text().await?;
+        serde_json::from_str(&body).map_err(IndexerClientError::serde)
+    }
+}

--- a/crates/workers/task-driver/src/utils/mod.rs
+++ b/crates/workers/task-driver/src/utils/mod.rs
@@ -1,11 +1,20 @@
 //! Helpers for the task driver
 
-use alloy::primitives::Address;
+use std::cmp;
+
+use alloy::primitives::{Address, U256};
+use circuit_types::{Amount, schnorr::SchnorrPublicKey};
+use constants::Scalar;
+use darkpool_types::{balance::DarkpoolBalance, state_wrapper::StateWrapper};
 use job_types::proof_manager::{ProofJob, ProofManagerJob, ProofManagerResponse};
+use renegade_solidity_abi::v2::relayer_types::u256_to_u128;
 use tokio::sync::oneshot::{self, Receiver as TokioReceiver};
+use tracing::info;
+use types_account::balance::Balance;
 
 use crate::traits::TaskContext;
 
+pub(crate) mod indexer_client;
 pub(crate) mod merkle_path;
 
 /// Error message emitted when enqueuing a job with the proof manager fails
@@ -14,8 +23,8 @@ const ERR_ENQUEUING_JOB: &str = "error enqueuing job with proof manager";
 /// Get the relayer fee address from state
 ///
 /// Returns an error if the relayer fee address is not configured
-pub(crate) fn get_relayer_fee_addr(ctx: &TaskContext) -> Result<Address, String> {
-    ctx.state.get_relayer_fee_addr().map_err(|e| e.to_string())
+pub(crate) fn get_relayer_fee_addr(ctx: &TaskContext) -> eyre::Result<Address> {
+    ctx.state.get_relayer_fee_addr().map_err(|e| eyre::eyre!(e))
 }
 
 /// Enqueue a job with the proof manager
@@ -31,4 +40,52 @@ pub(crate) fn enqueue_proof_job(
         .map_err(|_| ERR_ENQUEUING_JOB.to_string())?;
 
     Ok(response_receiver)
+}
+
+/// Fetch a ring 0 balance from on-chain data
+///
+/// Queries the ERC20 balance and permit2 allowance for the given token and
+/// owner, returning a Balance if there is usable liquidity.
+pub(crate) async fn fetch_ring0_balance(
+    ctx: &TaskContext,
+    token: Address,
+    owner: Address,
+) -> eyre::Result<Option<Balance>> {
+    info!("Checking for balance of {token} for owner {owner}");
+    let darkpool_client = &ctx.darkpool_client;
+    let erc20_bal = darkpool_client.get_erc20_balance(token, owner).await?;
+    let permit_allowance = darkpool_client.get_darkpool_allowance(owner, token).await?;
+    let usable_balance = cmp::min(erc20_bal, permit_allowance);
+    if usable_balance == U256::ZERO {
+        info!(
+            "No usable balance found for token {token} [balance = {}, permit = {}]",
+            erc20_bal, permit_allowance
+        );
+        return Ok(None);
+    }
+
+    let amt = u256_to_u128(usable_balance);
+    info!("Found usable balance of {amt} for token {token}");
+
+    let relayer_fee_addr = get_relayer_fee_addr(ctx)?;
+    let balance = create_ring0_balance(token, owner, relayer_fee_addr, amt);
+    Ok(Some(balance))
+}
+
+/// Create a ring 0 balance from the given parameters
+pub(crate) fn create_ring0_balance(
+    mint: Address,
+    owner: Address,
+    relayer_fee_recipient: Address,
+    amount: Amount,
+) -> Balance {
+    let mock_authority = SchnorrPublicKey::default();
+    let bal = DarkpoolBalance::new(mint, owner, relayer_fee_recipient, mock_authority)
+        .with_amount(amount);
+
+    // Ring 0 balances don't have share or recovery streams, so we mock them
+    let share_stream_seed = Scalar::zero();
+    let recovery_stream_seed = Scalar::zero();
+    let state_wrapper = StateWrapper::new(bal, share_stream_seed, recovery_stream_seed);
+    Balance::new_eoa(state_wrapper)
 }

--- a/crates/workers/task-driver/src/worker.rs
+++ b/crates/workers/task-driver/src/worker.rs
@@ -13,7 +13,9 @@ use job_types::{
 };
 use state::State;
 use system_bus::SystemBus;
+use types_core::HmacKey;
 use types_runtime::Worker;
+use url::Url;
 use util::DefaultOption;
 
 use crate::{
@@ -49,6 +51,10 @@ pub struct TaskDriverConfig {
     pub system_bus: SystemBus,
     /// A handle on the global state
     pub state: State,
+    /// The indexer URL to use for the darkpool indexer API
+    pub indexer_url: Url,
+    /// The HMAC key for authenticating requests to the indexer API
+    pub indexer_hmac_key: HmacKey,
 }
 
 impl TaskDriverConfig {
@@ -64,6 +70,8 @@ impl TaskDriverConfig {
         matching_engine_queue: MatchingEngineWorkerQueue,
         system_bus: SystemBus,
         state: State,
+        indexer_url: Url,
+        indexer_hmac_key: HmacKey,
     ) -> Self {
         Self {
             runtime_config: Default::default(),
@@ -76,6 +84,8 @@ impl TaskDriverConfig {
             matching_engine_queue,
             system_bus,
             state,
+            indexer_url,
+            indexer_hmac_key,
         }
     }
 }


### PR DESCRIPTION
In this PR, we implement the account refresh task. A brief overview:
- We create the account if necessary
- We fetch the account's state objects (currently, ring 0 intents) from the indexer
- We fetch up-to-date views of the backing ERC20 balances
- We write all of this through to state in a single new state transition

In a subsequent PR, we'll ensure that order auth is also refreshed. This is blocked on the implementation of order auth tracking in the indexer.
