### PR TITLE
matching-engine: match-helpers: Fix pricing bug for quote-input orders

### DIFF
--- a/crates/config/src/cli.rs
+++ b/crates/config/src/cli.rs
@@ -242,11 +242,7 @@ pub struct Cli {
     )]
     pub private_key: String,
     /// The executor private key used for order execution
-    #[clap(
-        value_parser,
-        long = "executor-private-key",
-        default_value = "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659",
-    )]
+    #[clap( value_parser, long = "executor-private-key")]
     pub executor_private_key: String,
 
     // -------------

--- a/crates/relayer-types/types-account/src/account/pair.rs
+++ b/crates/relayer-types/types-account/src/account/pair.rs
@@ -47,6 +47,11 @@ impl Pair {
         Token::from_alloy_address(&self.out_token)
     }
 
+    /// Whether the input token is the quote token
+    pub fn is_input_quote(&self) -> bool {
+        self.in_token == Token::usdc().get_alloy_address()
+    }
+
     /// Get the base token for the pair
     pub fn base_token(&self) -> Token {
         let usdc = Token::usdc().get_alloy_address();

--- a/crates/relayer-types/types-core/src/match_result.rs
+++ b/crates/relayer-types/types-core/src/match_result.rs
@@ -4,6 +4,7 @@
 
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
+use circuit_types::Amount;
 use darkpool_types::settlement_obligation::SettlementObligation;
 use serde::{Deserialize, Serialize};
 
@@ -51,5 +52,12 @@ impl MatchResult {
         };
 
         Token::from_alloy_address(&addr)
+    }
+
+    /// Get the quote token volume of the match
+    pub fn quote_token_volume(&self) -> Amount {
+        let usdc = Token::usdc().get_alloy_address();
+        let obligation = &self.party0_obligation;
+        if obligation.input_token == usdc { obligation.amount_in } else { obligation.amount_out }
     }
 }

--- a/crates/relayer-types/types-core/src/price.rs
+++ b/crates/relayer-types/types-core/src/price.rs
@@ -54,6 +54,11 @@ impl TimestampedPrice {
 
         Ok(TimestampedPrice { price: corrected_price, timestamp })
     }
+
+    /// Invert the price
+    pub fn invert(self) -> Self {
+        Self { price: 1.0 / self.price, timestamp: self.timestamp }
+    }
 }
 
 impl From<&PriceReport> for TimestampedPrice {

--- a/crates/workers/matching-engine/matching-engine-core/src/engine.rs
+++ b/crates/workers/matching-engine/matching-engine-core/src/engine.rs
@@ -2,6 +2,7 @@
 
 use std::{ops::RangeInclusive, sync::Arc};
 
+use circuit_types::validate_price_bitlength;
 use circuit_types::{Amount, fixed_point::FixedPoint};
 use crypto::fields::scalar_to_u128;
 use darkpool_types::settlement_obligation::SettlementObligation;


### PR DESCRIPTION
### Purpose
This PR fixes two bugs:
- A pricing bug where the price needs to be inverted in a quote-input order.
- A bug wherein the matching engine's global min fill size was not applied.

### Testing
- [x] Tested locally