### PR TITLE
api-server: admin: Add `/account/:id/orders` route

### DIFF
--- a/crates/api/external-api/src/http/admin.rs
+++ b/crates/api/external-api/src/http/admin.rs
@@ -18,6 +18,8 @@ pub const ADMIN_REFRESH_MATCH_FEES_ROUTE: &str = "/v2/admin/refresh-match-fees";
 pub const ADMIN_GET_ORDERS_ROUTE: &str = "/v2/relayer-admin/orders";
 /// Route to get an order by ID as an admin
 pub const ADMIN_GET_ORDER_BY_ID_ROUTE: &str = "/v2/relayer-admin/orders/:order_id";
+/// Route to get orders for an account as an admin
+pub const ADMIN_GET_ACCOUNT_ORDERS_ROUTE: &str = "/v2/relayer-admin/account/:account_id/orders";
 
 /// Route to create a matching pool
 pub const ADMIN_MATCHING_POOL_CREATE_ROUTE: &str = "/v2/admin/matching-pools/:matching_pool";

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -169,6 +169,24 @@ impl StateInner {
         .await
     }
 
+    /// Get all orders for an account with their matching pool
+    pub async fn get_account_orders_with_matching_pool(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Vec<(Order, MatchingPoolName)>, StateError> {
+        let account_id = *account_id;
+        self.with_read_tx(move |tx| {
+            let orders = tx.get_account_orders(&account_id)?;
+            let mut result = Vec::with_capacity(orders.len());
+            for order in orders {
+                let matching_pool = tx.get_matching_pool_for_order(&order.id)?;
+                result.push((order, matching_pool));
+            }
+            Ok(result)
+        })
+        .await
+    }
+
     /// Get all orders across all accounts with their matching pool
     ///
     /// Returns a vector of tuples containing (AccountId, Order,

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -16,9 +16,9 @@ use account::{
     CreateAccountHandler, GetAccountByIdHandler, GetAccountSeedsHandler, SyncAccountHandler,
 };
 use admin::{
-    AdminCreateMatchingPoolHandler, AdminDestroyMatchingPoolHandler, AdminGetOrderByIdHandler,
-    AdminGetOrdersHandler, AdminRefreshMatchFeesHandler, AdminRefreshTokenMappingHandler,
-    AdminTriggerSnapshotHandler, IsLeaderHandler,
+    AdminCreateMatchingPoolHandler, AdminDestroyMatchingPoolHandler, AdminGetAccountOrdersHandler,
+    AdminGetOrderByIdHandler, AdminGetOrdersHandler, AdminRefreshMatchFeesHandler,
+    AdminRefreshTokenMappingHandler, AdminTriggerSnapshotHandler, IsLeaderHandler,
 };
 use async_trait::async_trait;
 use balance::{
@@ -33,9 +33,10 @@ use external_api::{
             SYNC_ACCOUNT_ROUTE,
         },
         admin::{
-            ADMIN_GET_ORDER_BY_ID_ROUTE, ADMIN_GET_ORDERS_ROUTE, ADMIN_MATCHING_POOL_CREATE_ROUTE,
-            ADMIN_MATCHING_POOL_DESTROY_ROUTE, ADMIN_REFRESH_MATCH_FEES_ROUTE,
-            ADMIN_REFRESH_TOKEN_MAPPING_ROUTE, ADMIN_TRIGGER_SNAPSHOT_ROUTE, IS_LEADER_ROUTE,
+            ADMIN_GET_ACCOUNT_ORDERS_ROUTE, ADMIN_GET_ORDER_BY_ID_ROUTE, ADMIN_GET_ORDERS_ROUTE,
+            ADMIN_MATCHING_POOL_CREATE_ROUTE, ADMIN_MATCHING_POOL_DESTROY_ROUTE,
+            ADMIN_REFRESH_MATCH_FEES_ROUTE, ADMIN_REFRESH_TOKEN_MAPPING_ROUTE,
+            ADMIN_TRIGGER_SNAPSHOT_ROUTE, IS_LEADER_ROUTE,
         },
         balance::{
             DEPOSIT_BALANCE_ROUTE, GET_BALANCE_BY_MINT_ROUTE, GET_BALANCES_ROUTE,
@@ -350,6 +351,13 @@ impl HttpServer {
             &Method::GET,
             ADMIN_GET_ORDER_BY_ID_ROUTE.to_string(),
             AdminGetOrderByIdHandler::new(state.clone()),
+        );
+
+        // GET /v2/relayer-admin/account/:account_id/orders
+        router.add_admin_authenticated_route(
+            &Method::GET,
+            ADMIN_GET_ACCOUNT_ORDERS_ROUTE.to_string(),
+            AdminGetAccountOrdersHandler::new(state.clone()),
         );
 
         // --- Matching Pool Routes (v2) --- //

--- a/crates/workers/api-server/src/websocket/server.rs
+++ b/crates/workers/api-server/src/websocket/server.rs
@@ -43,22 +43,6 @@ const ERR_HEADER_PARSE: &str = "error parsing headers";
 // | Topics |
 // ----------
 
-/// The handshake topic, events include when a handshake beings and ends
-const HANDSHAKE_ROUTE: &str = "/v2/handshake";
-/// The wallet topic, events about wallet updates are streamed here
-const WALLET_ROUTE: &str = "/v2/wallet/:wallet_id";
-/// The wallet order status topic, streams events about wallet's orders
-const WALLET_ORDERS_ROUTE: &str = "/v2/wallet/:wallet_id/order-status";
-/// The price report topic, events about price updates are streamed
-const PRICE_REPORT_ROUTE: &str = "/v2/price_report/:source/:base/:quote";
-/// The order book topic, streams events about known network orders
-const ORDER_BOOK_ROUTE: &str = "/v2/order_book";
-/// The network topic, streams events about network peers
-const NETWORK_INFO_ROUTE: &str = "/v2/network";
-/// The task status topic, streams information about task statuses
-const TASK_STATUS_ROUTE: &str = "/v2/tasks/:task_id";
-/// The task history topic, streams information about historical tasks
-const TASK_HISTORY_ROUTE: &str = "/v2/wallet/:wallet_id/task-history";
 /// The admin order updates topic, streams granular order updates for all
 /// accounts
 const ADMIN_ORDER_UPDATES_ROUTE: &str = "/v2/admin/orders";


### PR DESCRIPTION
### Purpose
This PR adds a method to get all account orders via the admin API.

### Testing
- [x] Tested locally