### PR TITLE
circuits-core: state-primitives: nullifier: Constraint index != 0

### DIFF
--- a/crates/circuits/circuits-core/src/zk_gadgets/primitives/comparators.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/primitives/comparators.rs
@@ -178,6 +178,16 @@ impl NotEqualGadget {
         let eq = EqGadget::eq(&a, &b, cs)?;
         cs.logic_neg(eq)
     }
+
+    /// Enforce that two variable assignments are not equal
+    pub fn constrain_not_equal<V>(a: &V, b: &V, cs: &mut PlonkCircuit) -> Result<(), CircuitError>
+    where
+        V: CircuitVarType,
+    {
+        let eq = EqGadget::eq(a, b, cs)?;
+        let res = cs.logic_neg(eq)?;
+        cs.enforce_true(res)
+    }
 }
 
 /// A gadget that enforces a value of a given bitlength is positive

--- a/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/nullifier.rs
+++ b/crates/circuits/circuits-core/src/zk_gadgets/state_primitives/nullifier.rs
@@ -27,7 +27,7 @@ impl NullifierGadget {
         V::ShareType: StateWrapperShareBound,
     {
         // The recovery stream index cannot underflow
-        NotEqualGadget::not_equal(element.recovery_stream.index, cs.zero(), cs)?;
+        NotEqualGadget::constrain_not_equal(&element.recovery_stream.index, &cs.zero(), cs)?;
 
         // Get the recovery identifier for the last update of the element
         let last_idx = cs.sub(element.recovery_stream.index, cs.one())?;


### PR DESCRIPTION
### Purpose
This PR constrains the index to not be zero in the recovery stream when computing the nullifier.