### PR TITLE
types-tasks: create-balance: Validate `authority` point

### DIFF
--- a/crates/circuits/circuit-types/src/primitives/baby_jubjub.rs
+++ b/crates/circuits/circuit-types/src/primitives/baby_jubjub.rs
@@ -40,10 +40,25 @@ pub struct BabyJubJubPoint {
 }
 
 impl BabyJubJubPoint {
+    /// Whether the point is the additive identity
+    pub fn is_zero(&self) -> bool {
+        let affine = EmbeddedCurveGroupAffine::new_unchecked(self.x.inner(), self.y.inner());
+        affine.is_zero()
+    }
+
     /// Check that the point is on the curve
     pub fn is_on_curve(&self) -> bool {
         let affine = EmbeddedCurveGroupAffine::new_unchecked(self.x.inner(), self.y.inner());
         affine.is_on_curve()
+    }
+
+    /// Check whether the point is in the prime-order subgroup
+    ///
+    /// Returns true if the point has no small subgroup component, meaning it
+    /// is safe to use for cryptographic operations.
+    pub fn in_correct_subgroup(&self) -> bool {
+        let affine = EmbeddedCurveGroupAffine::new_unchecked(self.x.inner(), self.y.inner());
+        affine.is_in_correct_subgroup_assuming_on_curve()
     }
 }
 

--- a/crates/relayer-types/types-tasks/src/descriptors/cancel_order.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/cancel_order.rs
@@ -75,10 +75,10 @@ fn validate_cancel_signature(
     let owner = permit.intent.owner;
     let valid = cancel_signature
         .validate(&cancel_payload, chain_id, owner)
-        .map_err(TaskError::order_auth_validation)?;
+        .map_err(TaskError::validation)?;
 
     if !valid {
-        return Err(TaskError::order_auth_validation(INVALID_CANCEL_SIGNATURE));
+        return Err(TaskError::validation(INVALID_CANCEL_SIGNATURE));
     }
     Ok(())
 }

--- a/crates/relayer-types/types-tasks/src/descriptors/create_order.rs
+++ b/crates/relayer-types/types-tasks/src/descriptors/create_order.rs
@@ -41,17 +41,17 @@ pub struct CreateOrderTaskDescriptor {
 
 impl CreateOrderTaskDescriptor {
     /// Create a new create order task descriptor
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         account_id: AccountId,
         order_id: OrderId,
-        executor: Address,
         intent: Intent,
         ring: PrivacyRing,
         metadata: OrderMetadata,
         auth: OrderAuth,
         matching_pool: MatchingPoolName,
     ) -> Result<Self, TaskError> {
-        validate_order_auth(executor, &intent, &auth)?;
+        validate_order_auth(&intent, &auth)?;
         Ok(Self { account_id, order_id, intent, ring, metadata, auth, matching_pool })
     }
 }
@@ -67,14 +67,11 @@ impl From<CreateOrderTaskDescriptor> for TaskDescriptor {
 // -------------------
 
 /// Validate the order auth provided
-pub fn validate_order_auth(
-    executor: Address,
-    intent: &Intent,
-    auth: &OrderAuth,
-) -> Result<(), TaskError> {
+pub fn validate_order_auth(intent: &Intent, auth: &OrderAuth) -> Result<(), TaskError> {
+    let owner = intent.owner;
     match auth {
         OrderAuth::PublicOrder { permit, intent_signature } => {
-            validate_public_order_auth(executor, intent, intent_signature)
+            validate_public_order_auth(owner, permit, intent_signature)
         },
         _ => unimplemented!("auth validation not implemented for this order auth type"),
     }
@@ -82,18 +79,15 @@ pub fn validate_order_auth(
 
 /// Validate the public order auth provided
 fn validate_public_order_auth(
-    executor: Address,
-    intent: &Intent,
+    owner: Address,
+    permit: &PublicIntentPermit,
     auth: &SignatureWithNonce,
 ) -> Result<(), TaskError> {
     let chain_id = get_chain_id();
-
-    let addr = intent.owner;
-    let permit = PublicIntentPermit { intent: intent.clone().into(), executor };
-    let valid = permit.validate(chain_id, auth, addr).map_err(TaskError::order_auth_validation)?;
+    let valid = permit.validate(chain_id, auth, owner).map_err(TaskError::validation)?;
 
     if !valid {
-        return Err(TaskError::order_auth_validation(INVALID_PUBLIC_ORDER_AUTH));
+        return Err(TaskError::validation(INVALID_PUBLIC_ORDER_AUTH));
     }
     Ok(())
 }

--- a/crates/relayer-types/types-tasks/src/error.rs
+++ b/crates/relayer-types/types-tasks/src/error.rs
@@ -9,9 +9,9 @@ pub enum TaskError {
     /// An error related to descriptor operations
     #[error("Descriptor error: {0}")]
     Descriptor(String),
-    /// An order auth validation error
-    #[error("Order auth validation error: {0}")]
-    OrderAuthValidation(String),
+    /// A validation error
+    #[error("validation error: {0}")]
+    Validation(String),
 }
 
 impl TaskError {
@@ -21,9 +21,9 @@ impl TaskError {
         Self::Descriptor(msg.to_string())
     }
 
-    /// Create a new order auth validation error
+    /// Create a new validation error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn order_auth_validation<T: ToString>(msg: T) -> Self {
-        Self::OrderAuthValidation(msg.to_string())
+    pub fn validation<T: ToString>(msg: T) -> Self {
+        Self::Validation(msg.to_string())
     }
 }

--- a/crates/workers/api-server/src/http/admin.rs
+++ b/crates/workers/api-server/src/http/admin.rs
@@ -526,7 +526,6 @@ impl TypedHandler for AdminCreateOrderInPoolHandler {
         let descriptor = CreateOrderTaskDescriptor::new(
             account_id,
             order_id,
-            self.executor,
             intent,
             ring,
             metadata,

--- a/crates/workers/api-server/src/http/balance.rs
+++ b/crates/workers/api-server/src/http/balance.rs
@@ -186,6 +186,7 @@ impl TypedHandler for DepositBalanceHandler {
                 authority,
                 auth,
             )
+            .map_err(bad_request)?
             .into()
         } else {
             DepositTaskDescriptor::new(account_id, from_address, token, amount, auth, authority)

--- a/crates/workers/api-server/src/http/order.rs
+++ b/crates/workers/api-server/src/http/order.rs
@@ -161,7 +161,6 @@ impl TypedHandler for CreateOrderHandler {
         let descriptor = CreateOrderTaskDescriptor::new(
             account_id,
             order_id,
-            self.executor,
             intent,
             ring,
             metadata,


### PR DESCRIPTION
### Purpose
This PR adds 3 checks for the `authority` field of the balance upon creation:
1. The `authority` is not the additive identity in the curve group.
2. The `authority` satisfies the curve equation; i.e. it is a valid group element.
3. The `authority` has no small-subgroup component. 

### Testing
- [x] Tested via the API