### PR TITLE
fix(external-api): use STANDARD_NO_PAD b64 encoding consistently throughout API

### DIFF
--- a/crates/api/external-api/src/serde_helpers/bytes_as_base64_string.rs
+++ b/crates/api/external-api/src/serde_helpers/bytes_as_base64_string.rs
@@ -1,6 +1,6 @@
 //! Serialize bytes as base64 strings
 
-use base64::{Engine, engine::general_purpose::STANDARD};
+use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD as BASE64_ENGINE};
 use serde::{Deserialize, Deserializer, Serializer};
 
 /// Serialize a `Vec<u8>` as a base64 string
@@ -8,7 +8,7 @@ pub fn serialize<S>(val: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    serializer.serialize_str(&STANDARD.encode(val))
+    serializer.serialize_str(&BASE64_ENGINE.encode(val))
 }
 
 /// Deserialize a `Vec<u8>` from a base64 string
@@ -17,7 +17,7 @@ where
     D: Deserializer<'de>,
 {
     let base64_str = String::deserialize(deserializer)?;
-    STANDARD.decode(&base64_str).map_err(serde::de::Error::custom)
+    BASE64_ENGINE.decode(&base64_str).map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]

--- a/crates/api/external-api/src/types/balance.rs
+++ b/crates/api/external-api/src/types/balance.rs
@@ -113,7 +113,7 @@ impl TryFrom<ApiDepositPermit> for DepositAuth {
         use std::str::FromStr;
 
         use alloy::primitives::{Bytes, U256};
-        use base64::{Engine, engine::general_purpose::STANDARD as BASE64_ENGINE};
+        use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD as BASE64_ENGINE};
 
         let permit_signature_bytes = BASE64_ENGINE
             .decode(&permit.signature)


### PR DESCRIPTION
In this PR, we ensure that the API consistently uses `STANDARD_NO_PAD` base64 serialization. Previously, `SignatureWithNonce` was deserialized using `STANDARD_NO_PAD`, while `WithdrawalRequest` used `STANDARD`.
