### PR TITLE
docker: Add indexer-message-sidecar and update deploy config

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -38,6 +38,9 @@ RUN cargo build --release --package snapshot-sidecar
 # Build the event export sidecar
 RUN cargo build --release --package event-export-sidecar
 
+# Build the indexer message sidecar
+RUN cargo build --release --package indexer-message-sidecar
+
 # Build the relayer
 RUN cargo build --release --bin renegade-relayer --features "$CARGO_FEATURES"
 
@@ -53,6 +56,7 @@ RUN apt-get update && \
 COPY --from=builder /build/target/release/bootloader /bin/bootloader
 COPY --from=builder /build/target/release/snapshot-sidecar /bin/snapshot-sidecar
 COPY --from=builder /build/target/release/event-export-sidecar /bin/event-export-sidecar
+COPY --from=builder /build/target/release/indexer-message-sidecar /bin/indexer-message-sidecar
 COPY --from=builder /build/target/release/renegade-relayer /bin/renegade-relayer
 
 # Set the bootloader as the entrypoint

--- a/renegade-deploy-config.toml
+++ b/renegade-deploy-config.toml
@@ -10,10 +10,10 @@ ecr_repo = "relayer-arbitrum-sepolia-v2"
 cargo_features = "default"
 
 [services.arbitrum-sepolia-relayer.deploy]
-environment = "arbitrum-sepolia"
+environment = "arbitrum-sepolia-v2"
 resource = "relayer"
-cluster_name_override = "arbitrum-sepolia-relayer-v2"
-service_name_override = "arbitrum-sepolia-relayer-v2-service"
+cluster_name_override = "arbitrum-sepolia-v2-relayer"
+service_name_override = "arbitrum-sepolia-v2-relayer-service"
 
 [services.arbitrum-one-relayer]
 [services.arbitrum-one-relayer.build]
@@ -34,7 +34,7 @@ ecr_repo = "relayer-base-sepolia-v2"
 cargo_features = "default"
 
 [services.base-sepolia-relayer.deploy]
-environment = "base-sepolia"
+environment = "base-sepolia-v2"
 resource = "relayer"
 cluster_name_override = "base-sepolia-v2-relayer"
 service_name_override = "base-sepolia-v2-relayer-service"


### PR DESCRIPTION
## Summary
- Build and include `indexer-message-sidecar` in the release Dockerfile
- Update deploy config to use v2 environment names and correct cluster/service naming for arbitrum-sepolia

## Test plan
- [x] Verify Docker image builds successfully with the new sidecar
- [x] Confirm deploy config targets the correct v2 clusters