### PR TITLE
fix(external-api): remove full-api flag on necessary imports

### DIFF
--- a/crates/api/external-api/src/types/balance.rs
+++ b/crates/api/external-api/src/types/balance.rs
@@ -4,9 +4,7 @@ use alloy::primitives::Address;
 #[cfg(feature = "full-api")]
 use alloy::primitives::Bytes;
 use alloy::primitives::U256;
-#[cfg(feature = "full-api")]
 use circuit_types::Amount;
-#[cfg(feature = "full-api")]
 use constants::Scalar;
 #[cfg(feature = "full-api")]
 use darkpool_types::balance::{DarkpoolBalance, DarkpoolBalanceShare, DarkpoolStateBalance};


### PR DESCRIPTION
Here, we remove the `full-api` gate around the `Amount` and `Scalar` imports, which are needed even when the flag isn't set.