### PR TITLE
chain-events: standardize usable balance flow and add removal logs

### DIFF
--- a/crates/workers/chain-events/src/handlers/darkpool.rs
+++ b/crates/workers/chain-events/src/handlers/darkpool.rs
@@ -112,6 +112,9 @@ impl OnChainEventListenerExecutor {
         // Update or remove order based on remaining amount
         if amount_remaining == 0 {
             self.state().remove_order_from_account(account_id, order_id).await?.await?;
+            info!(
+                "Removed order {order_id} from account {account_id} via PublicIntentUpdated (amount_remaining=0)"
+            );
         } else {
             let Some(mut order) = self.state().get_account_order(&order_id).await? else {
                 return Ok(());
@@ -165,6 +168,7 @@ impl OnChainEventListenerExecutor {
 
         // Remove the cancelled order
         self.state().remove_order_from_account(account_id, order_id).await?.await?;
+        info!("Removed order {order_id} from account {account_id} via PublicIntentCancelled");
 
         // TODO: Emit cancellation event to notify clients
 

--- a/crates/workers/task-driver/src/utils/mod.rs
+++ b/crates/workers/task-driver/src/utils/mod.rs
@@ -1,7 +1,5 @@
 //! Helpers for the task driver
 
-use std::cmp;
-
 use alloy::primitives::{Address, U256};
 use circuit_types::{Amount, schnorr::SchnorrPublicKey};
 use constants::Scalar;
@@ -53,14 +51,9 @@ pub(crate) async fn fetch_ring0_balance(
 ) -> eyre::Result<Option<Balance>> {
     info!("Checking for balance of {token} for owner {owner}");
     let darkpool_client = &ctx.darkpool_client;
-    let erc20_bal = darkpool_client.get_erc20_balance(token, owner).await?;
-    let permit_allowance = darkpool_client.get_darkpool_allowance(owner, token).await?;
-    let usable_balance = cmp::min(erc20_bal, permit_allowance);
+    let usable_balance = darkpool_client.get_erc20_usable_balance(token, owner).await?;
     if usable_balance == U256::ZERO {
-        info!(
-            "No usable balance found for token {token} [balance = {}, permit = {}]",
-            erc20_bal, permit_allowance
-        );
+        info!("No usable balance found for token {token}");
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary
Standardizes Ring0 usable-balance reads via get_erc20_usable_balance(...) and adds explicit logs when chain-events removes orders on PublicIntentUpdated(amount_remaining=0) and PublicIntentCancelled.

## Validation
- cargo check -p chain-events passed.

## Commit
- 12edfeb6
