### PR TITLE
feat(external-api): include OrderAuth in single order getter endpoints

### DIFF
--- a/crates/api/external-api/src/error.rs
+++ b/crates/api/external-api/src/error.rs
@@ -5,6 +5,8 @@
 pub enum ApiTypeError {
     /// Error parsing or converting a value
     Parsing(String),
+    /// Error validating a value
+    Validation(String),
 }
 
 impl ApiTypeError {
@@ -12,12 +14,19 @@ impl ApiTypeError {
     pub fn parsing<T: ToString>(err: T) -> Self {
         Self::Parsing(err.to_string())
     }
+
+    /// Create a validation error from any type that can be converted to a
+    /// string
+    pub fn validation<T: ToString>(err: T) -> Self {
+        Self::Validation(err.to_string())
+    }
 }
 
 impl std::fmt::Display for ApiTypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ApiTypeError::Parsing(msg) => write!(f, "parsing error: {msg}"),
+            ApiTypeError::Validation(msg) => write!(f, "validation error: {msg}"),
         }
     }
 }

--- a/crates/api/external-api/src/types/admin.rs
+++ b/crates/api/external-api/src/types/admin.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::order::ApiOrder;
+use super::order::{ApiOrder, OrderAuth};
 
 // -------------------
 // | v2 Admin Types  |
@@ -35,6 +35,8 @@ pub struct GetOrdersAdminResponse {
 pub struct GetOrderAdminResponse {
     /// The order
     pub order: ApiAdminOrder,
+    /// The order authentication
+    pub auth: OrderAuth,
 }
 
 /// Response for checking if an account's task queue is paused


### PR DESCRIPTION
In this PR, we add the `OrderAuth` to the account & admin order getter endpoints. This brings with it some slight changes:
1. The `OrderAuth::PublicOrder` variant in `external-api` now contains the public intent permit, which we wrapped in an new `ApiPublicIntent` permit type. This is to maintain a consistent serialization format, for example its `U256` fields would otherwise be serialized as hex strings when our API standard is decimal.
2. As a result of the above, we created an `ApiIntent` type, which we now nest into `ApiOrderCore`. We can't `#[serde(flatten)]` this struct due to https://github.com/serde-rs/json/issues/625. We do this to reduce indirection in the API types.
3. Another result of the above: since `OrderAuth::PublicOrder` now contains the `permit`, the client must provide it directly. The client has to construct this type anyway, so this is fine. Since it no longer needs to be constructed server-side, we replace that logic with validation logic to ensure the fields match those which would have been constructed by the relayer. This allows us catch potential mismatches earlier on in the API layer.