### PR TITLE
refactor(external-api): export separate types for server websocket message variants

### DIFF
--- a/crates/api/external-api/src/types/websocket.rs
+++ b/crates/api/external-api/src/types/websocket.rs
@@ -54,55 +54,85 @@ pub struct ServerWebsocketMessage {
     pub body: ServerWebsocketMessageBody,
 }
 
+// --- Individual message body types ---
+
+/// A subscriptions list message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubscriptionsMessage {
+    /// The list of subscribed topics
+    pub subscriptions: Vec<String>,
+}
+
+/// A balance update message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BalanceUpdateMessage {
+    /// The updated balance
+    pub balance: ApiBalance,
+}
+
+/// An order update message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OrderUpdateMessage {
+    /// The updated order
+    pub order: ApiOrder,
+    /// The type of update
+    pub update_type: ApiOrderUpdateType,
+}
+
+/// A fill message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FillMessage {
+    /// The fill details
+    pub fill: ApiPartialOrderFill,
+    /// The order that was filled
+    pub order: ApiOrderCore,
+    /// Whether the order is now fully filled
+    pub filled: bool,
+}
+
+/// A task update message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskUpdateMessage {
+    /// The updated task
+    pub task: ApiTask,
+}
+
+/// An admin balance update message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdminBalanceUpdateMessage {
+    /// The account ID
+    pub account_id: Uuid,
+    /// The updated balance
+    pub balance: ApiBalance,
+}
+
+/// An admin order update message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdminOrderUpdateMessage {
+    /// The account ID
+    pub account_id: Uuid,
+    /// The updated order
+    pub order: ApiAdminOrder,
+    /// The type of update
+    pub update_type: ApiOrderUpdateType,
+}
+
 /// The body of a server WebSocket message
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum ServerWebsocketMessageBody {
     /// List of current subscriptions
-    Subscriptions {
-        /// The list of subscribed topics
-        subscriptions: Vec<String>,
-    },
+    Subscriptions(SubscriptionsMessage),
     /// A balance update event
-    BalanceUpdate {
-        /// The updated balance
-        balance: ApiBalance,
-    },
+    BalanceUpdate(BalanceUpdateMessage),
     /// An order update event
-    OrderUpdate {
-        /// The updated order
-        order: ApiOrder,
-        /// The type of update
-        update_type: ApiOrderUpdateType,
-    },
+    OrderUpdate(OrderUpdateMessage),
     /// A fill event
-    Fill {
-        /// The fill details
-        fill: ApiPartialOrderFill,
-        /// The order that was filled
-        order: ApiOrderCore,
-        /// Whether the order is now fully filled
-        filled: bool,
-    },
+    Fill(FillMessage),
     /// A task update event
-    TaskUpdate {
-        /// The updated task
-        task: ApiTask,
-    },
+    TaskUpdate(TaskUpdateMessage),
     /// An admin balance update event
-    AdminBalanceUpdate {
-        /// The account ID
-        account_id: Uuid,
-        /// The updated balance
-        balance: ApiBalance,
-    },
+    AdminBalanceUpdate(AdminBalanceUpdateMessage),
     /// An admin order update event
-    AdminOrderUpdate {
-        /// The account ID
-        account_id: Uuid,
-        /// The updated order
-        order: ApiAdminOrder,
-        /// The type of update
-        update_type: ApiOrderUpdateType,
-    },
+    AdminOrderUpdate(AdminOrderUpdateMessage),
 }

--- a/crates/workers/api-server/src/websocket/conversion.rs
+++ b/crates/workers/api-server/src/websocket/conversion.rs
@@ -1,7 +1,8 @@
 //! Conversion from system bus messages to websocket message bodies
 
 use external_api::types::{
-    ApiAdminOrder, ApiBalance, ApiOrder, ApiOrderUpdateType, ServerWebsocketMessageBody,
+    AdminBalanceUpdateMessage, AdminOrderUpdateMessage, ApiAdminOrder, ApiBalance, ApiOrder,
+    ApiOrderUpdateType, ServerWebsocketMessageBody,
 };
 use system_bus::{AdminOrderUpdateType, SystemBusMessage};
 
@@ -46,11 +47,11 @@ fn convert_admin_order_update(
 
     // Convert the update type
     let api_update_type = convert_admin_order_update_type(update_type);
-    ServerWebsocketMessageBody::AdminOrderUpdate {
+    ServerWebsocketMessageBody::AdminOrderUpdate(AdminOrderUpdateMessage {
         account_id,
         order: admin_order,
         update_type: api_update_type,
-    }
+    })
 }
 
 /// Convert an AdminBalanceUpdate system bus message to a websocket message body
@@ -59,7 +60,10 @@ fn convert_admin_balance_update(
     balance: types_account::balance::Balance,
 ) -> ServerWebsocketMessageBody {
     let api_balance: ApiBalance = balance.into();
-    ServerWebsocketMessageBody::AdminBalanceUpdate { account_id, balance: api_balance }
+    ServerWebsocketMessageBody::AdminBalanceUpdate(AdminBalanceUpdateMessage {
+        account_id,
+        balance: api_balance,
+    })
 }
 
 /// Convert an AdminOrderUpdateType to an ApiOrderUpdateType


### PR DESCRIPTION
In this PR, we split up the variants of the `ServerWebsocketMessage` enum into separate, exported types. This significantly improves the experience of handling messages from specific topic subscriptions in client-side code.