### PR TITLE
fix(api-server, task-driver): misc tweaks from indexer testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts#aba08226f3c4968f3ecd66547554e62989914261"
+source = "git+https://github.com/renegade-fi/renegade-contracts#84efa7110332ab4f3e001c2d19c8782271b5800e"
 dependencies = [
  "alloy",
  "ark-bn254",

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -79,7 +79,9 @@ use tokio::net::{TcpListener, TcpStream};
 use types_core::HmacKey;
 use util::get_current_time_millis;
 
-use crate::{http::external_match::processor::ExternalMatchProcessor, router::QueryParams};
+use crate::{
+    auth::AuthType, http::external_match::processor::ExternalMatchProcessor, router::QueryParams,
+};
 
 use super::{
     error::ApiServerError,
@@ -148,9 +150,10 @@ impl HttpServer {
         );
 
         // POST /v2/account/:account_id/sync
-        router.add_account_authenticated_route(
+        router.add_route(
             &Method::POST,
             SYNC_ACCOUNT_ROUTE.to_string(),
+            AuthType::AccountIfExists,
             SyncAccountHandler::new(state.clone(), task_queue.clone()),
         );
 

--- a/crates/workers/api-server/src/router.rs
+++ b/crates/workers/api-server/src/router.rs
@@ -384,6 +384,12 @@ impl Router {
                     .authenticate_account_request(account_id, path, headers, req_body)
                     .await?;
             },
+            AuthType::AccountIfExists => {
+                let account_id = parse_account_id_from_params(url_params)?;
+                self.auth_middleware
+                    .authenticate_account_request_if_exists(account_id, path, headers, req_body)
+                    .await?;
+            },
             AuthType::Admin => {
                 self.auth_middleware.authenticate_admin_request(path, headers, req_body)?;
             },

--- a/crates/workers/api-server/src/websocket/server.rs
+++ b/crates/workers/api-server/src/websocket/server.rs
@@ -318,7 +318,7 @@ impl WebsocketServer {
             AuthType::Admin => {
                 self.auth_middleware.authenticate_admin_request(topic, &headers, &body_serialized)
             },
-            AuthType::None => unreachable!(),
+            AuthType::AccountIfExists | AuthType::None => unreachable!(),
         }
     }
 

--- a/crates/workers/task-driver/src/tasks/create_order.rs
+++ b/crates/workers/task-driver/src/tasks/create_order.rs
@@ -286,7 +286,9 @@ impl CreateOrderTask {
         let order = Order::new_with_ring(order_id, state_intent, metadata, ring);
         let waiter =
             self.state().add_order_to_account(account_id, order, auth, matching_pool).await?;
+
         waiter.await?;
+        self.send_indexer_message().await;
 
         // Choose a next state based on ring
         let next_state = match ring {
@@ -372,7 +374,6 @@ impl CreateOrderTask {
             waiter.await.map_err(CreateOrderTaskError::state)?;
         }
 
-        self.send_indexer_message().await;
         Ok(())
     }
 

--- a/crates/workers/task-driver/src/tasks/refresh_account.rs
+++ b/crates/workers/task-driver/src/tasks/refresh_account.rs
@@ -284,11 +284,7 @@ impl RefreshAccountTask {
         let orders: Vec<OrderRefreshData> = public_intents
             .iter()
             .map(|intent| {
-                let intent_signature = intent
-                    .intent_signature
-                    .clone()
-                    .try_into()
-                    .map_err(RefreshAccountTaskError::conversion)?;
+                let intent_signature = intent.intent_signature.clone().into();
 
                 let auth =
                     OrderAuth::PublicOrder { permit: intent.permit.clone(), intent_signature };


### PR DESCRIPTION
In this PR, we introduce some misc tweaks stemming from testing of the indexer. Namely:
1. We send the public intent metadata update message at the end of the `create_order` step of the `CreateOrderTask`. This ensures that we don't skip sending the message if we find a pre-existing backing balance for the order in the relayer's state
2. We add an `AuthType::Sync` variant, which will pass through account sync requests if the account can't be found. This is meant to handle the case where a user is trying to sync an account that is not yet in relayer state.