### PR TITLE
fix(task-driver): include the has_been_filled field in the PublicIntentMetadataUpdateMessage

### DIFF
--- a/crates/node-support/indexer-message-sidecar/src/sqs.rs
+++ b/crates/node-support/indexer-message-sidecar/src/sqs.rs
@@ -19,7 +19,7 @@ pub async fn submit_message(
     // Set the message group ID for FIFO queue ordering
     let group_id = match &message {
         Message::RegisterMasterViewSeed(msg) => msg.account_id.to_string(),
-        Message::UpdatePublicIntentMetadata(msg) => msg.order_id.to_string(),
+        Message::UpdatePublicIntentMetadata(msg) => msg.order.id.to_string(),
     };
     request = request.message_group_id(group_id);
 

--- a/crates/workers/task-driver/src/utils/indexer_client.rs
+++ b/crates/workers/task-driver/src/utils/indexer_client.rs
@@ -3,16 +3,13 @@
 use std::time::Duration;
 
 use alloy::primitives::{Address, B256};
-use circuit_types::Amount;
 use constants::Scalar;
-use darkpool_types::intent::Intent;
 use external_api::{auth::add_expiring_auth_to_headers, types::SignatureWithNonce};
 use http::{HeaderMap, HeaderValue, header::CONTENT_TYPE};
 use renegade_solidity_abi::v2::IDarkpoolV2::PublicIntentPermit;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::info;
 use types_account::order::Order;
 use types_core::{AccountId, HmacKey};
 use url::Url;
@@ -144,20 +141,14 @@ pub struct MasterViewSeedMessage {
 pub struct PublicIntentMetadataUpdateMessage {
     /// The intent hash
     pub intent_hash: B256,
-    /// The public intent
-    pub intent: Intent,
+    /// The order
+    pub order: Order,
     /// The intent signature
     pub intent_signature: SignatureWithNonce,
     /// The permit for the intent
     pub permit: PublicIntentPermit,
-    /// The order ID
-    pub order_id: Uuid,
     /// The matching pool to which the intent is allocated
     pub matching_pool: String,
-    /// Whether the intent allows external matches
-    pub allow_external_matches: bool,
-    /// The minimum fill size allowed for the intent
-    pub min_fill_size: Amount,
 }
 
 // -----------------


### PR DESCRIPTION
This PR brings the `PublicIntentMetadataUpdateMessage` up-to-date with the new `OrderMetadata` state layout, including its `has_been_filled` field (which is expected by the indexer as of https://github.com/renegade-fi/relayer-extensions/pull/599)