### PR TITLE
task-driver: Update balance validity after balance update

### DIFF
--- a/crates/relayer-types/types-account/src/account/balance.rs
+++ b/crates/relayer-types/types-account/src/account/balance.rs
@@ -34,6 +34,18 @@ pub enum BalanceLocation {
     Darkpool,
 }
 
+impl BalanceLocation {
+    /// Whether the balance location is darkpool
+    pub fn is_darkpool(&self) -> bool {
+        matches!(self, BalanceLocation::Darkpool)
+    }
+
+    /// Whether the balance location is EOA
+    pub fn is_eoa(&self) -> bool {
+        matches!(self, BalanceLocation::EOA)
+    }
+}
+
 impl Display for BalanceLocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/state/src/interface/account_index.rs
+++ b/crates/state/src/interface/account_index.rs
@@ -166,6 +166,21 @@ impl StateInner {
         .await
     }
 
+    /// Get all order IDs for an account that use the given token as output
+    pub async fn get_orders_with_output_token(
+        &self,
+        account_id: &AccountId,
+        token: &Address,
+    ) -> Result<Vec<OrderId>, StateError> {
+        let account_id = *account_id;
+        let token = *token;
+        self.with_read_tx(move |tx| {
+            let orders = tx.get_orders_with_output_token(&account_id, &token)?;
+            Ok(orders)
+        })
+        .await
+    }
+
     /// Get all orders for an account without deserializing the full account
     ///
     /// This is more efficient than calling `get_account` when only orders are

--- a/crates/workers/task-driver/src/tasks/validity_proofs/balance_update.rs
+++ b/crates/workers/task-driver/src/tasks/validity_proofs/balance_update.rs
@@ -1,0 +1,96 @@
+//! Helpers for refreshing validity proofs after balance updates.
+
+use alloy::primitives::Address;
+use circuit_types::schnorr::SchnorrSignature;
+use types_account::{OrderId, order_auth::OrderAuth};
+use types_core::AccountId;
+
+use crate::{
+    tasks::validity_proofs::{
+        error::ValidityProofsError, intent_and_balance::update_intent_and_balance_validity_proof,
+        output_balance::update_output_balance_validity_proof,
+    },
+    traits::TaskContext,
+};
+
+/// Refresh Ring 2/3 validity proofs affected by an updated balance mint.
+///
+/// When a darkpool balance changes, any private order using this mint as input
+/// may require an `INTENT AND BALANCE VALIDITY` update, and any private order
+/// using this mint as output may require an `OUTPUT BALANCE VALIDITY` update.
+pub async fn refresh_validity_proofs_for_updated_balance(
+    account_id: AccountId,
+    mint: Address,
+    ctx: &TaskContext,
+) -> Result<(), ValidityProofsError> {
+    let output_order_ids = ctx.state.get_orders_with_output_token(&account_id, &mint).await?;
+    refresh_output_balance_validity_for_orders(account_id, &output_order_ids, ctx).await?;
+
+    let input_order_ids = ctx.state.get_orders_with_input_token(&account_id, &mint).await?;
+    refresh_intent_and_balance_validity_for_orders(account_id, &input_order_ids, ctx).await?;
+
+    Ok(())
+}
+
+/// Refresh output-balance validity proofs for the given orders.
+async fn refresh_output_balance_validity_for_orders(
+    account_id: AccountId,
+    order_ids: &[OrderId],
+    ctx: &TaskContext,
+) -> Result<(), ValidityProofsError> {
+    for order_id in order_ids {
+        let Some((_, balance_sig)) = get_private_fill_auth(*order_id, ctx).await? else {
+            continue;
+        };
+
+        update_output_balance_validity_proof(
+            account_id,
+            *order_id,
+            balance_sig,
+            true, // force: balance updates should refresh output-balance proofs
+            ctx,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Refresh intent-and-balance validity proofs for the given orders.
+async fn refresh_intent_and_balance_validity_for_orders(
+    account_id: AccountId,
+    order_ids: &[OrderId],
+    ctx: &TaskContext,
+) -> Result<(), ValidityProofsError> {
+    for order_id in order_ids {
+        // Fetch private fill auth, this will naturally filter out orders in rings 0/1
+        let Some((intent_sig, _)) = get_private_fill_auth(*order_id, ctx).await? else {
+            continue;
+        };
+
+        update_intent_and_balance_validity_proof(account_id, *order_id, intent_sig, ctx).await?;
+    }
+
+    Ok(())
+}
+
+/// Fetch renegade-settled auth, returning `None` for non-private-fill orders.
+///
+/// Returns a tuple containing the intent signature and the new output balance
+/// signature.
+async fn get_private_fill_auth(
+    order_id: OrderId,
+    ctx: &TaskContext,
+) -> Result<Option<(SchnorrSignature, SchnorrSignature)>, ValidityProofsError> {
+    let order_auth =
+        ctx.state.get_order_auth(&order_id).await?.ok_or(ValidityProofsError::state(format!(
+            "order auth not found for order {order_id}"
+        )))?;
+
+    match order_auth {
+        OrderAuth::RenegadeSettledOrder { intent_signature, new_output_balance_signature } => {
+            Ok(Some((intent_signature, new_output_balance_signature)))
+        },
+        _ => Ok(None),
+    }
+}

--- a/crates/workers/task-driver/src/tasks/validity_proofs/mod.rs
+++ b/crates/workers/task-driver/src/tasks/validity_proofs/mod.rs
@@ -1,5 +1,6 @@
 //! Defines task helpers for updating validity proofs
 
+pub mod balance_update;
 pub mod error;
 pub mod intent_and_balance;
 pub mod intent_only;

--- a/crates/workers/task-driver/src/tasks/validity_proofs/output_balance.rs
+++ b/crates/workers/task-driver/src/tasks/validity_proofs/output_balance.rs
@@ -185,6 +185,10 @@ async fn update_new_output_balance_proof(
 
     let new_output_balance = create_new_output_balance(mint, &existing_balance, &mut keychain);
 
+    // Persist the updated keychain (streams were consumed when sampling seeds)
+    let waiter = ctx.state.update_account_keychain(account_id, keychain).await?;
+    waiter.await?;
+
     let (witness, statement) = generate_new_witness_statement(
         new_output_balance,
         existing_balance,


### PR DESCRIPTION
### Purpose
This PR updates balance validity in tasks that modify darkpool-allocated balances.

### Testing
- [x] Tested locally