### PR TITLE
proof-manager: external-proof-manager: Update ring 2 settlement proof API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ rustc-ice-*
 secrets.env
 /.gitattributes
 **/CLAUDE.md
+**/AGENTS.md
 
 # macos
 **/.DS_Store

--- a/crates/relayer-types/types-proofs/src/bundles.rs
+++ b/crates/relayer-types/types-proofs/src/bundles.rs
@@ -133,7 +133,7 @@ impl<Statement> std::ops::Deref for ProofAndHintBundle<Statement> {
 /// The inner settlement proof bundle type containing a proof, statement, and
 /// link proof
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SettlementProofBundleInner<Statement> {
+pub struct IntentOnlySettlementProofBundleInner<Statement> {
     /// The proof
     pub proof: PlonkProof,
     /// The statement for this proof
@@ -147,33 +147,100 @@ pub struct SettlementProofBundleInner<Statement> {
 /// This type boxes the inner proof bundle to avoid large stack allocations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SettlementProofBundle<Statement>(Box<SettlementProofBundleInner<Statement>>);
-
-impl<Statement> SettlementProofBundle<Statement> {
+pub struct IntentOnlySettlementProofBundle<Statement>(
+    Box<IntentOnlySettlementProofBundleInner<Statement>>,
+);
+impl<Statement> IntentOnlySettlementProofBundle<Statement> {
     /// Create a new settlement proof bundle from its components
     pub fn new(proof: PlonkProof, statement: Statement, link_proof: PlonkLinkProof) -> Self {
-        Self(Box::new(SettlementProofBundleInner { proof, statement, link_proof }))
+        Self(Box::new(IntentOnlySettlementProofBundleInner { proof, statement, link_proof }))
     }
 
     /// Create a new settlement proof bundle from an inner type
-    pub fn from_inner(inner: SettlementProofBundleInner<Statement>) -> Self {
+    pub fn from_inner(inner: IntentOnlySettlementProofBundleInner<Statement>) -> Self {
         Self(Box::new(inner))
     }
 
     /// Consume the bundle and return the inner data
-    pub fn into_inner(self) -> SettlementProofBundleInner<Statement> {
+    pub fn into_inner(self) -> IntentOnlySettlementProofBundleInner<Statement> {
         *self.0
     }
 }
 
-impl<Statement> AsRef<SettlementProofBundleInner<Statement>> for SettlementProofBundle<Statement> {
-    fn as_ref(&self) -> &SettlementProofBundleInner<Statement> {
+impl<Statement> AsRef<IntentOnlySettlementProofBundleInner<Statement>>
+    for IntentOnlySettlementProofBundle<Statement>
+{
+    fn as_ref(&self) -> &IntentOnlySettlementProofBundleInner<Statement> {
         &self.0
     }
 }
 
-impl<Statement> std::ops::Deref for SettlementProofBundle<Statement> {
-    type Target = SettlementProofBundleInner<Statement>;
+impl<Statement> std::ops::Deref for IntentOnlySettlementProofBundle<Statement> {
+    type Target = IntentOnlySettlementProofBundleInner<Statement>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The inner public settlement proof bundle type containing a proof,
+/// statement, and both linking proofs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicSettlementProofBundleInner<Statement> {
+    /// The proof
+    pub proof: PlonkProof,
+    /// The statement for this proof
+    pub statement: Statement,
+    /// The validity linking proof
+    pub validity_link_proof: PlonkLinkProof,
+    /// The output balance linking proof
+    pub output_balance_link_proof: PlonkLinkProof,
+}
+
+/// A heap-allocated public settlement proof bundle
+///
+/// This type boxes the inner proof bundle to avoid large stack allocations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PublicSettlementProofBundle<Statement>(Box<PublicSettlementProofBundleInner<Statement>>);
+
+impl<Statement> PublicSettlementProofBundle<Statement> {
+    /// Create a new public settlement proof bundle from its components
+    pub fn new(
+        proof: PlonkProof,
+        statement: Statement,
+        validity_link_proof: PlonkLinkProof,
+        output_balance_link_proof: PlonkLinkProof,
+    ) -> Self {
+        Self(Box::new(PublicSettlementProofBundleInner {
+            proof,
+            statement,
+            validity_link_proof,
+            output_balance_link_proof,
+        }))
+    }
+
+    /// Create a new public settlement proof bundle from an inner type
+    pub fn from_inner(inner: PublicSettlementProofBundleInner<Statement>) -> Self {
+        Self(Box::new(inner))
+    }
+
+    /// Consume the bundle and return the inner data
+    pub fn into_inner(self) -> PublicSettlementProofBundleInner<Statement> {
+        *self.0
+    }
+}
+
+impl<Statement> AsRef<PublicSettlementProofBundleInner<Statement>>
+    for PublicSettlementProofBundle<Statement>
+{
+    fn as_ref(&self) -> &PublicSettlementProofBundleInner<Statement> {
+        &self.0
+    }
+}
+
+impl<Statement> std::ops::Deref for PublicSettlementProofBundle<Statement> {
+    type Target = PublicSettlementProofBundleInner<Statement>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -301,7 +368,7 @@ pub type OutputBalanceValidityBundle = ProofAndHintBundle<OutputBalanceValidityS
 
 /// A proof bundle for `INTENT AND BALANCE BOUNDED SETTLEMENT`
 pub type IntentAndBalanceBoundedSettlementBundle =
-    SettlementProofBundle<IntentAndBalanceBoundedSettlementStatement>;
+    IntentOnlySettlementProofBundle<IntentAndBalanceBoundedSettlementStatement>;
 
 /// A proof bundle for `INTENT AND BALANCE PRIVATE SETTLEMENT`
 pub type IntentAndBalancePrivateSettlementBundle =
@@ -309,15 +376,15 @@ pub type IntentAndBalancePrivateSettlementBundle =
 
 /// A proof bundle for `INTENT AND BALANCE PUBLIC SETTLEMENT`
 pub type IntentAndBalancePublicSettlementBundle =
-    SettlementProofBundle<IntentAndBalancePublicSettlementStatement>;
+    PublicSettlementProofBundle<IntentAndBalancePublicSettlementStatement>;
 
 /// A proof bundle for `INTENT ONLY BOUNDED SETTLEMENT`
 pub type IntentOnlyBoundedSettlementBundle =
-    SettlementProofBundle<IntentOnlyBoundedSettlementStatement>;
+    IntentOnlySettlementProofBundle<IntentOnlyBoundedSettlementStatement>;
 
 /// A proof bundle for `INTENT ONLY PUBLIC SETTLEMENT`
 pub type IntentOnlyPublicSettlementBundle =
-    SettlementProofBundle<IntentOnlyPublicSettlementStatement>;
+    IntentOnlySettlementProofBundle<IntentOnlyPublicSettlementStatement>;
 
 // -----------------------
 // | Fee Circuit Bundles |

--- a/crates/workers/job-types/src/proof_manager.rs
+++ b/crates/workers/job-types/src/proof_manager.rs
@@ -415,6 +415,8 @@ pub enum ProofJob {
         party_id: PartyId,
         /// The link hint for the validity proof
         validity_link_hint: ProofLinkingHint,
+        /// The link hint for the output balance validity proof
+        output_balance_link_hint: ProofLinkingHint,
     },
     /// Prove `INTENT ONLY BOUNDED SETTLEMENT`
     IntentOnlyBoundedSettlement {

--- a/crates/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
+++ b/crates/workers/proof-manager/src/implementations/external_proof_manager/api_types.rs
@@ -122,6 +122,20 @@ pub struct PrivateSettlementProofResponse {
     pub output_balance_link_proof_1: PlonkLinkProof,
 }
 
+/// A public settlement proof response with validity and output-balance links
+///
+/// Sent by the prover service for intent-and-balance public settlement proofs
+/// that compute both linking proofs for a single party
+#[derive(Serialize, Deserialize)]
+pub struct PublicSettlementProofResponse {
+    /// The settlement proof
+    pub proof: PlonkProof,
+    /// The validity linking proof
+    pub validity_link_proof: PlonkLinkProof,
+    /// The output balance linking proof
+    pub output_balance_link_proof: PlonkLinkProof,
+}
+
 // -----------------
 // | Request Types |
 // -----------------
@@ -258,6 +272,8 @@ pub struct IntentAndBalancePublicSettlementRequest {
     pub party_id: u8,
     /// The link hint for the validity proof
     pub validity_link_hint: ProofLinkingHint,
+    /// The link hint for the output balance validity proof
+    pub output_balance_link_hint: ProofLinkingHint,
 }
 
 /// A request to prove `INTENT ONLY BOUNDED SETTLEMENT`

--- a/crates/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
+++ b/crates/workers/proof-manager/src/implementations/external_proof_manager/mod.rs
@@ -165,6 +165,7 @@ impl ExternalProofManager {
                 statement,
                 party_id,
                 validity_link_hint,
+                output_balance_link_hint,
             } => {
                 client
                     .prove_intent_and_balance_public_settlement(
@@ -172,6 +173,7 @@ impl ExternalProofManager {
                         statement,
                         party_id,
                         validity_link_hint,
+                        output_balance_link_hint,
                     )
                     .await
             },

--- a/crates/workers/proof-manager/src/mock.rs
+++ b/crates/workers/proof-manager/src/mock.rs
@@ -93,7 +93,8 @@ use tokio::runtime::Handle;
 use tracing::{error, instrument};
 use types_proofs::mocks::{dummy_link_hint, dummy_link_proof, dummy_proof};
 use types_proofs::{
-    PrivateSettlementProofBundle, ProofAndHintBundle, ProofBundle, SettlementProofBundle,
+    IntentOnlySettlementProofBundle, PrivateSettlementProofBundle, ProofAndHintBundle, ProofBundle,
+    PublicSettlementProofBundle,
 };
 use util::channels::TracedMessage;
 
@@ -377,7 +378,7 @@ impl MockProofManager {
         }
         let proof = dummy_proof();
         let link_proof = dummy_link_proof();
-        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
+        let bundle = IntentOnlySettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentAndBalanceBoundedSettlement(bundle))
     }
 
@@ -416,8 +417,12 @@ impl MockProofManager {
             )?;
         }
         let proof = dummy_proof();
-        let link_proof = dummy_link_proof();
-        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
+        let bundle = PublicSettlementProofBundle::new(
+            proof,
+            statement,
+            dummy_link_proof(),
+            dummy_link_proof(),
+        );
         Ok(ProofManagerResponse::IntentAndBalancePublicSettlement(bundle))
     }
 
@@ -432,7 +437,7 @@ impl MockProofManager {
         }
         let proof = dummy_proof();
         let link_proof = dummy_link_proof();
-        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
+        let bundle = IntentOnlySettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentOnlyBoundedSettlement(bundle))
     }
 
@@ -447,7 +452,7 @@ impl MockProofManager {
         }
         let proof = dummy_proof();
         let link_proof = dummy_link_proof();
-        let bundle = SettlementProofBundle::new(proof, statement, link_proof);
+        let bundle = IntentOnlySettlementProofBundle::new(proof, statement, link_proof);
         Ok(ProofManagerResponse::IntentOnlyPublicSettlement(bundle))
     }
 

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/mod.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/mod.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod obligation_bundle;
 pub mod ring0;
 pub mod ring1;
+pub mod ring2;
 pub mod settlement_bundle;
 
 /// A macro that branches between two parties in a settlement
@@ -84,8 +85,6 @@ impl SettlementProcessor {
             })?;
         Ok(auth.into_natively_settled_private_order())
     }
-
-    // --- Balance Retrieval --- //
 
     /// Get the input balance for a given party
     async fn get_input_balance(

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/ring2.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/ring2.rs
@@ -1,0 +1,24 @@
+//! Ring 2 settlement helpers
+
+use darkpool_types::{
+    bounded_match_result::BoundedMatchResult, settlement_obligation::SettlementObligation,
+};
+use renegade_solidity_abi::v2::IDarkpoolV2::SettlementBundle;
+use types_account::{OrderId, order::Order};
+
+use crate::tasks::settlement::helpers::{SettlementProcessor, error::SettlementError};
+
+// ----------------------
+// | Settlement Bundles |
+// ----------------------
+
+impl SettlementProcessor {
+    /// Build a Ring 2 settlement bundle for an internal match
+    pub async fn build_ring2_internal_settlement_bundle(
+        &self,
+        order: Order,
+        obligation: SettlementObligation,
+    ) -> Result<SettlementBundle, SettlementError> {
+        todo!()
+    }
+}

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/settlement_bundle.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/settlement_bundle.rs
@@ -23,6 +23,9 @@ impl SettlementProcessor {
             PrivacyRing::Ring1 => {
                 self.build_ring1_internal_settlement_bundle(order, obligation).await
             },
+            PrivacyRing::Ring2 => {
+                self.build_ring2_internal_settlement_bundle(order, obligation).await
+            },
             _ => unimplemented!("implementing settlement bundle for ring {:?}", order.ring),
         }
     }


### PR DESCRIPTION
### Purpose
This PR updates the proof manager to return a link proof for both the validity and output balance proofs in the prover service.