### PR TITLE
fix(matching-engine): use external match price when provided

### DIFF
--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
@@ -15,6 +15,7 @@ use job_types::matching_engine::ExternalMatchingEngineOptions;
 use system_bus::SystemBusMessage;
 use tracing::{info, instrument, warn};
 use types_account::{account::OrderId, order::Order};
+use types_core::TimestampedPriceFp;
 use types_tasks::SettleExternalMatchTaskDescriptor;
 
 use crate::{error::MatchingEngineError, executor::MatchingEngineExecutor};
@@ -51,7 +52,8 @@ impl MatchingEngineExecutor {
         }
 
         let matching_pool = options.matching_pool.clone();
-        let res = self.find_external_match(&order, matching_pool)?;
+        let price = options.price.map(TimestampedPriceFp::from);
+        let res = self.find_external_match(&order, matching_pool, price)?;
         let successful_match = match res {
             Some(match_res) => match_res,
             None => {

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/match_helpers.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/match_helpers.rs
@@ -44,14 +44,18 @@ impl MatchingEngineExecutor {
         &self,
         order: &Order,
         matching_pool: Option<MatchingPoolName>,
+        price: Option<TimestampedPriceFp>,
     ) -> Result<Option<SuccessfulMatch>, MatchingEngineError> {
         // For an external match, no balance capitalizes the order, so the matchable
         // amount is the same as the intent amount
         let matchable_amount = order.intent().amount_in;
 
-        // Sample a price to execute the match at
+        // Use the provided price or sample a new one
         let pair = order.pair();
-        let price = self.get_execution_price(&pair)?;
+        let price = match price {
+            Some(p) => p,
+            None => self.get_execution_price(&pair)?,
+        };
 
         // Sanity check the input range
         let input_range = order.min_fill_size()..=matchable_amount;


### PR DESCRIPTION
In this PR, we ensure that the matching engine uses the price set in the `ExternalMatchingEngineOptions`, if it is set.

All matching engine tests pass.
