### PR TITLE
fix(external match processor): re-invert to external party price when returning quote

### DIFF
--- a/crates/workers/api-server/src/http/external_match/processor.rs
+++ b/crates/workers/api-server/src/http/external_match/processor.rs
@@ -113,7 +113,11 @@ impl ExternalMatchProcessor {
 
         // Send the job to the matching engine
         let match_res = self.forward_quote_request(job, topic).await?;
-        let price = match_res.price;
+
+        // The bounded match result returned by the matching engine is constructed from
+        // the internal party's perspective. Thus we must invert the price to
+        // have it in terms of the external party's output/input price.
+        let price = match_res.price.inverse().expect("match price is zero");
 
         // Build an API response
         let fee_override = req.options.relayer_fee_rate.map(FixedPoint::from_f64_round_down);


### PR DESCRIPTION
## Summary

The bounded match result returned by the matching engine stores the price from the internal party's perspective. When constructing the `ApiExternalQuote`, we now invert the price back to the external party's output/input denomination. This is critical for the quote-then-assemble flow, where the quoted price is fed back to the matching engine as the execution price.

Bug was introduced in commit 39516bc7 when `forward_quote` in `external_engine.rs` was refactored to store the internal-party perspective price, but the API layer in `processor.rs` was not updated to compensate.

## Test plan

- [x] Verify external match quote returns price in external party denomination (output/input)
- [x] Verify quote-then-assemble flow uses correct execution price
- [x] Run existing test suite for matching engine and API server packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)