### PR TITLE
refactor(external-api): add fixed-point price to ApiExternalMatchResult

### DIFF
--- a/crates/workers/job-types/src/matching_engine.rs
+++ b/crates/workers/job-types/src/matching_engine.rs
@@ -3,7 +3,7 @@
 use circuit_types::{Amount, fixed_point::FixedPoint};
 use system_bus::gen_atomic_match_response_topic;
 use types_account::{MatchingPoolName, OrderId, order::Order};
-use types_core::{AccountId, TimestampedPrice};
+use types_core::{AccountId, TimestampedPriceFp};
 use util::channels::{TracedTokioReceiver, TracedTokioSender, new_traced_tokio_channel};
 
 /// The job queue for the matching engine worker
@@ -65,7 +65,7 @@ impl MatchingEngineWorkerJob {
     /// Get an external match bundle with a previously committed-to price
     pub fn get_external_match_bundle_with_price(
         order: Order,
-        price: TimestampedPrice,
+        price: TimestampedPriceFp,
     ) -> (Self, String) {
         let opt = ExternalMatchingEngineOptions::new().with_price(price);
         Self::new_external_match_job(order, opt)
@@ -102,7 +102,7 @@ pub struct ExternalMatchingEngineOptions {
     ///
     /// This is used to fulfill a previously committed-to quote at the
     /// api-layer
-    pub price: Option<TimestampedPrice>,
+    pub price: Option<TimestampedPriceFp>,
     /// The minimum input amount to use for a full fill
     pub min_input_amount: Option<Amount>,
     /// The matching pool to request a quote from
@@ -137,7 +137,7 @@ impl ExternalMatchingEngineOptions {
     }
 
     /// Set the price
-    pub fn with_price(mut self, price: TimestampedPrice) -> Self {
+    pub fn with_price(mut self, price: TimestampedPriceFp) -> Self {
         self.price = Some(price);
         self
     }

--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/external_engine.rs
@@ -15,7 +15,7 @@ use job_types::matching_engine::ExternalMatchingEngineOptions;
 use system_bus::SystemBusMessage;
 use tracing::{info, instrument, warn};
 use types_account::{account::OrderId, order::Order};
-use types_core::TimestampedPriceFp;
+
 use types_tasks::SettleExternalMatchTaskDescriptor;
 
 use crate::{error::MatchingEngineError, executor::MatchingEngineExecutor};
@@ -52,7 +52,7 @@ impl MatchingEngineExecutor {
         }
 
         let matching_pool = options.matching_pool.clone();
-        let price = options.price.map(TimestampedPriceFp::from);
+        let price = options.price;
         let res = self.find_external_match(&order, matching_pool, price)?;
         let successful_match = match res {
             Some(match_res) => match_res,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1346,6 +1346,7 @@ components:
         - output_mint
         - input_amount
         - output_amount
+        - price_fp
       properties:
         input_mint:
           type: string
@@ -1355,6 +1356,20 @@ components:
           type: string
         output_amount:
           type: string
+        price_fp:
+          $ref: '#/components/schemas/ApiTimestampedPriceFp'
+
+    ApiTimestampedPriceFp:
+      type: object
+      required:
+        - price
+        - timestamp
+      properties:
+        price:
+          $ref: '#/components/schemas/FixedPoint'
+        timestamp:
+          type: integer
+          format: uint64
 
     ApiTimestampedPrice:
       type: object


### PR DESCRIPTION
In this PR, we add a fixed-point price field to the `ApiExternalMatchResult` so that we can avoid a `FixedPoint` -> `f64` -> `FixedPoint` lossy roundtrip when reusing a quoted price for the matching engine. This should ensure that the exact quoted price is respected.

An accompanying change in the Rust SDK will follow.