### PR TITLE
ci: workflows: Prepare Claude install directory before action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,12 +31,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          path_to_claude_code_executable: /home/runner/.local/bin/claude
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,12 +30,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          path_to_claude_code_executable: /home/runner/.local/bin/claude
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
### Purpose
This PR fixes Claude Code workflow startup on GitHub-hosted runners by ensuring `$HOME/.local/bin` exists before `anthropics/claude-code-action` runs.

The previous change set `path_to_claude_code_executable` to `/home/runner/.local/bin/claude`, but that input skips automatic CLI installation and fails with `ENOENT` when the file is not already present.

This change removes that override and lets the action manage installation normally.

### Testing
- [x] Verified workflow YAML changes locally
- [x] Validation target: next GitHub Actions run for `claude-review` on PR 1403
