### PR TITLE
feat(api-server, matching-engine): implement markets endpoints

### DIFF
--- a/crates/api/external-api/src/types/market.rs
+++ b/crates/api/external-api/src/types/market.rs
@@ -1,10 +1,13 @@
 //! API types for markets
 
 use alloy::primitives::Address;
+use circuit_types::Amount;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "full-api")]
+use types_core::Token;
 
 use super::external_match::{ApiTimestampedPrice, FeeTakeRate};
-use crate::serde_helpers::address_as_string;
+use crate::serde_helpers::{self, address_as_string};
 
 // ---------------
 // | Token Types |
@@ -24,6 +27,15 @@ impl ApiToken {
     /// Constructor
     pub fn new(addr: Address, sym: String) -> Self {
         Self { address: addr, symbol: sym }
+    }
+}
+
+#[cfg(feature = "full-api")]
+impl From<Token> for ApiToken {
+    fn from(token: Token) -> Self {
+        let symbol = token.get_ticker().unwrap_or_default();
+        let address = token.get_alloy_address();
+        Self::new(address, symbol)
     }
 }
 
@@ -60,8 +72,10 @@ pub struct MarketDepth {
 /// One side of the depth book
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DepthSide {
-    /// The total quantity
-    pub total_quantity: String,
+    /// The total quantity in base token units
+    #[serde(with = "serde_helpers::amount_as_string")]
+    pub total_quantity: Amount,
     /// The total quantity in USD
-    pub total_quantity_usd: String,
+    #[serde(with = "serde_helpers::f64_as_string")]
+    pub total_quantity_usd: f64,
 }

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -66,6 +66,7 @@ use hyper::{
 use hyper_util::rt::{TokioIo, TokioTimer};
 use market::{
     GetMarketDepthByMintHandler, GetMarketDepthsHandler, GetMarketPriceHandler, GetMarketsHandler,
+    MarketDataCalculator,
 };
 use metadata::GetExchangeMetadataHandler;
 use network::GetNetworkTopologyHandler;
@@ -270,32 +271,35 @@ impl HttpServer {
 
         // --- Market Routes (v2) --- //
 
+        let market_calculator =
+            MarketDataCalculator::new(state.clone(), config.price_streams.clone());
+
         // GET /v2/markets
-        router.add_unauthenticated_route(
+        router.add_admin_authenticated_route(
             &Method::GET,
             GET_MARKETS_ROUTE.to_string(),
-            GetMarketsHandler::new(),
+            GetMarketsHandler::new(market_calculator.clone()),
         );
 
         // GET /v2/markets/depth
         router.add_admin_authenticated_route(
             &Method::GET,
             GET_MARKETS_DEPTH_ROUTE.to_string(),
-            GetMarketDepthsHandler::new(),
+            GetMarketDepthsHandler::new(market_calculator.clone()),
         );
 
         // GET /v2/markets/:mint/depth
         router.add_admin_authenticated_route(
             &Method::GET,
             GET_MARKET_DEPTH_BY_MINT_ROUTE.to_string(),
-            GetMarketDepthByMintHandler::new(),
+            GetMarketDepthByMintHandler::new(market_calculator.clone()),
         );
 
         // GET /v2/markets/:mint/price
         router.add_unauthenticated_route(
             &Method::GET,
             GET_MARKET_PRICE_ROUTE.to_string(),
-            GetMarketPriceHandler::new(),
+            GetMarketPriceHandler::new(config.price_streams.clone()),
         );
 
         // --- Metadata Routes (v2) --- //

--- a/crates/workers/api-server/src/http/market.rs
+++ b/crates/workers/api-server/src/http/market.rs
@@ -1,35 +1,115 @@
 //! Route handlers for market operations
 
 use async_trait::async_trait;
+use circuit_types::fixed_point::FixedPoint;
 use external_api::{
     EmptyRequestResponse,
     http::market::{GetMarketDepthByMintResponse, GetMarketDepthsResponse, GetMarketsResponse},
+    types::{
+        ApiToken, DepthSide, MarketDepth, MarketInfo,
+        external_match::{ApiTimestampedPrice, FeeTakeRate},
+    },
 };
+use futures::future::join_all;
 use hyper::HeaderMap;
+use price_state::PriceStreamStates;
+use state::State;
+use types_account::pair::Pair;
+use types_core::{Token, get_all_base_tokens};
+use util::on_chain::get_protocol_fee;
 
 use crate::{
     error::ApiServerError,
+    param_parsing::parse_token_from_params,
     router::{QueryParams, TypedHandler, UrlParams},
 };
 
-// ------------------
-// | Error Messages |
-// ------------------
+// --------------------------
+// | MarketDataCalculator   |
+// --------------------------
 
-/// Error message for not implemented
-const ERR_NOT_IMPLEMENTED: &str = "not implemented";
+/// Helper for computing market info and depth
+#[derive(Clone)]
+pub(super) struct MarketDataCalculator {
+    /// The relayer state
+    state: State,
+    /// The price stream states
+    price_streams: PriceStreamStates,
+}
+
+impl MarketDataCalculator {
+    /// Constructor
+    pub fn new(state: State, price_streams: PriceStreamStates) -> Self {
+        Self { state, price_streams }
+    }
+
+    /// Get fee rates for a token
+    fn get_fee_rates(&self, token: &Token) -> Result<FeeTakeRate, ApiServerError> {
+        let ticker = token.get_ticker().unwrap_or_default();
+        let relayer_fee: FixedPoint = self.state.get_relayer_fee(&ticker)?;
+        let protocol_fee: FixedPoint =
+            get_protocol_fee(&token.get_alloy_address(), &Token::usdc().get_alloy_address());
+
+        Ok(FeeTakeRate { relayer_fee_rate: relayer_fee, protocol_fee_rate: protocol_fee })
+    }
+
+    /// Get market info for a token
+    fn get_market_info(&self, token: &Token) -> Result<MarketInfo, ApiServerError> {
+        let base = ApiToken::from(token.clone());
+        let quote = ApiToken::from(Token::usdc());
+        let price: ApiTimestampedPrice = self.price_streams.peek_timestamped_price(token)?.into();
+        let fees = self.get_fee_rates(token)?;
+
+        Ok(MarketInfo {
+            base,
+            quote,
+            price,
+            internal_match_fee_rates: fees.clone(),
+            // At the moment, the relayer does not differentiate between internal and external match
+            // fee rates
+            external_match_fee_rates: fees,
+        })
+    }
+
+    /// Get market depth for a token
+    async fn get_market_depth(&self, token: &Token) -> Result<MarketDepth, ApiServerError> {
+        let market = self.get_market_info(token)?;
+        let pair = Pair::new(token.get_alloy_address(), Token::usdc().get_alloy_address());
+
+        let (buy_amount_quote, sell_amount_base) = self.state.get_liquidity_for_pair(&pair).await;
+
+        // Sell side: we have base token amounts
+        let sell_usd = token.convert_to_decimal(sell_amount_base) * market.price.price;
+        let sell = DepthSide { total_quantity: sell_amount_base, total_quantity_usd: sell_usd };
+
+        // Buy side: we have quote (USDC) amounts, convert to base token units
+        let buy_usd = Token::usdc().convert_to_decimal(buy_amount_quote);
+        let buy_quantity_base = if market.price.price > 0.0 {
+            let base_decimal = buy_usd / market.price.price;
+            token.convert_from_decimal(base_decimal)
+        } else {
+            0u128
+        };
+        let buy = DepthSide { total_quantity: buy_quantity_base, total_quantity_usd: buy_usd };
+
+        Ok(MarketDepth { market, buy, sell })
+    }
+}
 
 // --------------------
 // | Market Handlers  |
 // --------------------
 
 /// Handler for GET /v2/markets
-pub struct GetMarketsHandler;
+pub struct GetMarketsHandler {
+    /// The market data calculator
+    calculator: MarketDataCalculator,
+}
 
 impl GetMarketsHandler {
     /// Constructor
-    pub fn new() -> Self {
-        Self
+    pub fn new(calculator: MarketDataCalculator) -> Self {
+        Self { calculator }
     }
 }
 
@@ -45,17 +125,23 @@ impl TypedHandler for GetMarketsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        Err(ApiServerError::not_implemented(ERR_NOT_IMPLEMENTED))
+        let tokens = get_all_base_tokens();
+        let markets =
+            tokens.iter().filter_map(|t| self.calculator.get_market_info(t).ok()).collect();
+        Ok(GetMarketsResponse { markets })
     }
 }
 
 /// Handler for GET /v2/markets/depth
-pub struct GetMarketDepthsHandler;
+pub struct GetMarketDepthsHandler {
+    /// The market data calculator
+    calculator: MarketDataCalculator,
+}
 
 impl GetMarketDepthsHandler {
     /// Constructor
-    pub fn new() -> Self {
-        Self
+    pub fn new(calculator: MarketDataCalculator) -> Self {
+        Self { calculator }
     }
 }
 
@@ -71,17 +157,27 @@ impl TypedHandler for GetMarketDepthsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        Err(ApiServerError::not_implemented(ERR_NOT_IMPLEMENTED))
+        let tokens = get_all_base_tokens();
+        let futs = tokens
+            .iter()
+            .map(|t| async { self.calculator.get_market_depth(t).await })
+            .collect::<Vec<_>>();
+        let results = join_all(futs).await;
+        let market_depths = results.into_iter().filter_map(|r| r.ok()).collect();
+        Ok(GetMarketDepthsResponse { market_depths })
     }
 }
 
 /// Handler for GET /v2/markets/:mint/depth
-pub struct GetMarketDepthByMintHandler;
+pub struct GetMarketDepthByMintHandler {
+    /// The market data calculator
+    calculator: MarketDataCalculator,
+}
 
 impl GetMarketDepthByMintHandler {
     /// Constructor
-    pub fn new() -> Self {
-        Self
+    pub fn new(calculator: MarketDataCalculator) -> Self {
+        Self { calculator }
     }
 }
 
@@ -94,36 +190,42 @@ impl TypedHandler for GetMarketDepthByMintHandler {
         &self,
         _headers: HeaderMap,
         _req: Self::Request,
-        _params: UrlParams,
+        params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        Err(ApiServerError::not_implemented(ERR_NOT_IMPLEMENTED))
+        let token = parse_token_from_params(&params)?;
+        let market_depth = self.calculator.get_market_depth(&token).await?;
+        Ok(GetMarketDepthByMintResponse { market_depth })
     }
 }
 
 /// Handler for GET /v2/markets/:mint/price
-/// Returns a plain text price string
-pub struct GetMarketPriceHandler;
+pub struct GetMarketPriceHandler {
+    /// The price stream states
+    price_streams: PriceStreamStates,
+}
 
 impl GetMarketPriceHandler {
     /// Constructor
-    pub fn new() -> Self {
-        Self
+    pub fn new(price_streams: PriceStreamStates) -> Self {
+        Self { price_streams }
     }
 }
 
 #[async_trait]
 impl TypedHandler for GetMarketPriceHandler {
     type Request = EmptyRequestResponse;
-    type Response = String;
+    type Response = ApiTimestampedPrice;
 
     async fn handle_typed(
         &self,
         _headers: HeaderMap,
         _req: Self::Request,
-        _params: UrlParams,
+        params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        Err(ApiServerError::not_implemented(ERR_NOT_IMPLEMENTED))
+        let token = parse_token_from_params(&params)?;
+        let price: ApiTimestampedPrice = self.price_streams.peek_timestamped_price(&token)?.into();
+        Ok(price)
     }
 }


### PR DESCRIPTION
## Summary
- Implement `get_liquidity_for_pair` in the matching engine to aggregate buy/sell depth across all pools
- Add `Book::total_matchable_amount()` helper to sum matchable amounts across all orders in a book
- Wire up the v2 market depth endpoints (`GET /v2/markets/depth`, `GET /v2/markets/:mint/depth`) so they return real data instead of panicking

## Test plan
- [x] `cargo build -p matching-engine-core`
- [x] `cargo test -p matching-engine-core` (47 tests pass, including new liquidity query tests)
- [x] `cargo build -p api-server`

## TODO:
- Auth server changes for updating relayer fee rates in response if necessary