### PR TITLE
feat: update Ring0 bundle assembly for per-party relayer fees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ secrets.env
 
 # macos
 **/.DS_Store
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ version = 4
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts#84efa7110332ab4f3e001c2d19c8782271b5800e"
 dependencies = [
  "alloy",
  "ark-bn254",

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
@@ -4,7 +4,8 @@ use darkpool_types::{
     bounded_match_result::BoundedMatchResult, settlement_obligation::SettlementObligation,
 };
 use renegade_solidity_abi::v2::IDarkpoolV2::{
-    self, FeeRate, PublicIntentAuthBundle, SettlementBundle, SignatureWithNonce, SignedPermitSingle,
+    self, FeeRate, PublicIntentAuthBundle, SettlementBundle, SignatureWithNonce,
+    SignedPermitSingle,
 };
 use types_account::{order::Order, pair::Pair};
 use types_tasks::ExternalRelayerFeeRate;
@@ -23,12 +24,26 @@ impl SettlementProcessor {
         order: Order,
         obligation: SettlementObligation,
     ) -> Result<SettlementBundle, SettlementError> {
-        // Get signatures from the executor and user
+        // Get internal relayer fee; external relayer fee is zero for internal settlement
         let pair = Pair::from_obligation(&obligation);
         let base = pair.base_token();
-        let relayer_fee = self.abi_relayer_fee(&base)?;
-        let executor_sig = self.build_executor_signature(obligation.clone(), &relayer_fee).await?;
-        self.build_ring0_settlement_bundle_with_executor_sig(order, relayer_fee, executor_sig).await
+        let internal_relayer_fee = self.abi_relayer_fee(&base)?;
+        let external_relayer_fee = FeeRate::zero();
+
+        let executor_sig = self
+            .build_executor_signature(
+                obligation.clone(),
+                &internal_relayer_fee,
+                &external_relayer_fee,
+            )
+            .await?;
+        self.build_ring0_settlement_bundle_with_executor_sig(
+            order,
+            internal_relayer_fee,
+            external_relayer_fee,
+            executor_sig,
+        )
+        .await
     }
 
     /// Build a ring 0 settlement bundle for an external match
@@ -38,22 +53,43 @@ impl SettlementProcessor {
         match_res: BoundedMatchResult,
         external_relayer_fee_rate: ExternalRelayerFeeRate,
     ) -> Result<SettlementBundle, SettlementError> {
+        // Internal relayer fee is derived from the order's base token
+        let pair = Pair::new(
+            match_res.internal_party_input_token,
+            match_res.internal_party_output_token,
+        );
+        let base = pair.base_token();
+        let internal_relayer_fee = self.abi_relayer_fee(&base)?;
+
+        // External relayer fee uses the rate provided by the external party
         let relayer_fee_recipient = self.ctx.state.get_relayer_fee_addr()?;
-        let relayer_fee = FeeRate {
+        let external_relayer_fee = FeeRate {
             rate: external_relayer_fee_rate.rate().into(),
             recipient: relayer_fee_recipient,
         };
 
-        let executor_sig =
-            self.build_bounded_match_executor_signature(match_res, &relayer_fee).await?;
-        self.build_ring0_settlement_bundle_with_executor_sig(order, relayer_fee, executor_sig).await
+        let executor_sig = self
+            .build_bounded_match_executor_signature(
+                match_res,
+                &internal_relayer_fee,
+                &external_relayer_fee,
+            )
+            .await?;
+        self.build_ring0_settlement_bundle_with_executor_sig(
+            order,
+            internal_relayer_fee,
+            external_relayer_fee,
+            executor_sig,
+        )
+        .await
     }
 
     /// Build a ring 0 settlement bundle for a given order
     async fn build_ring0_settlement_bundle_with_executor_sig(
         &self,
         order: Order,
-        relayer_fee: FeeRate,
+        internal_relayer_fee: FeeRate,
+        external_relayer_fee: FeeRate,
         executor_sig: SignatureWithNonce,
     ) -> Result<SettlementBundle, SettlementError> {
         let (intent_permit, user_sig) = self.get_public_intent_auth(order.id).await?;
@@ -64,21 +100,31 @@ impl SettlementProcessor {
             allowancePermit: SignedPermitSingle::default(),
         };
 
-        Ok(SettlementBundle::public_intent_settlement(auth_bundle, relayer_fee))
+        Ok(SettlementBundle::public_intent_settlement(
+            auth_bundle,
+            internal_relayer_fee,
+            external_relayer_fee,
+        ))
     }
 
     /// Build an executor signature for the match
     async fn build_executor_signature(
         &self,
         obligation: SettlementObligation,
-        fee: &FeeRate,
+        internal_relayer_fee: &FeeRate,
+        external_relayer_fee: &FeeRate,
     ) -> Result<SignatureWithNonce, SettlementError> {
         let contract_obligation = IDarkpoolV2::SettlementObligation::from(obligation.clone());
 
         let chain_id = get_chain_id();
         let signer = self.get_executor_key().await?;
         let sig = contract_obligation
-            .create_executor_signature(fee, chain_id, &signer)
+            .create_executor_signature(
+                internal_relayer_fee,
+                external_relayer_fee,
+                chain_id,
+                &signer,
+            )
             .map_err(SettlementError::signing)?;
 
         Ok(sig)
@@ -88,14 +134,20 @@ impl SettlementProcessor {
     async fn build_bounded_match_executor_signature(
         &self,
         match_res: BoundedMatchResult,
-        fee: &FeeRate,
+        internal_relayer_fee: &FeeRate,
+        external_relayer_fee: &FeeRate,
     ) -> Result<SignatureWithNonce, SettlementError> {
         let contract_match = IDarkpoolV2::BoundedMatchResult::from(match_res.clone());
 
         let chain_id = get_chain_id();
         let executor = self.get_executor_key().await?;
         let sig = contract_match
-            .create_executor_signature(fee.clone(), chain_id, &executor)
+            .create_executor_signature(
+                internal_relayer_fee.clone(),
+                external_relayer_fee.clone(),
+                chain_id,
+                &executor,
+            )
             .map_err(SettlementError::signing)?;
 
         Ok(sig)

--- a/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
+++ b/crates/workers/task-driver/src/tasks/settlement/helpers/ring0.rs
@@ -4,8 +4,7 @@ use darkpool_types::{
     bounded_match_result::BoundedMatchResult, settlement_obligation::SettlementObligation,
 };
 use renegade_solidity_abi::v2::IDarkpoolV2::{
-    self, FeeRate, PublicIntentAuthBundle, SettlementBundle, SignatureWithNonce,
-    SignedPermitSingle,
+    self, FeeRate, PublicIntentAuthBundle, SettlementBundle, SignatureWithNonce, SignedPermitSingle,
 };
 use types_account::{order::Order, pair::Pair};
 use types_tasks::ExternalRelayerFeeRate;
@@ -54,10 +53,8 @@ impl SettlementProcessor {
         external_relayer_fee_rate: ExternalRelayerFeeRate,
     ) -> Result<SettlementBundle, SettlementError> {
         // Internal relayer fee is derived from the order's base token
-        let pair = Pair::new(
-            match_res.internal_party_input_token,
-            match_res.internal_party_output_token,
-        );
+        let pair =
+            Pair::new(match_res.internal_party_input_token, match_res.internal_party_output_token);
         let base = pair.base_token();
         let internal_relayer_fee = self.abi_relayer_fee(&base)?;
 


### PR DESCRIPTION
## Summary

Update Ring0 settlement bundle assembly to support distinct internal and external relayer fees, matching the contract changes in https://github.com/renegade-fi/renegade-contracts/pull/325.

## Changes

- **`ring0.rs`**: 
  - Internal match: derive `internal_relayer_fee` from order's base token, set `external_relayer_fee` to zero
  - External match: derive `internal_relayer_fee` from bounded match result's token pair, use externally-provided rate for `external_relayer_fee`
  - Both executor signature builders take `internal_relayer_fee` + `external_relayer_fee` parameters

## Dependencies

Requires https://github.com/renegade-fi/renegade-contracts/pull/325 to be merged first — the ABI crate dependency resolves via git.

## Breaking Change

Coordinated deploy with contracts PR. Old Ring0 bundles signed with the single-fee digest format will fail on the new contract.

## Ticket

`renegade-map/tickets/add-per-party-relayer-fees-to-ring0-external-matches/`