### PR TITLE
fix: exclude withdrawals from wallet task rate limit

### DIFF
--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -276,7 +276,6 @@ impl HttpServer {
             WithdrawBalanceHandler::new(
                 config.min_transfer_amount,
                 state.clone(),
-                wallet_rate_limiter.clone(),
                 config.price_streams.clone(),
             ),
         );

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -892,11 +892,7 @@ pub struct WithdrawBalanceHandler {
 
 impl WithdrawBalanceHandler {
     /// Constructor
-    pub fn new(
-        min_withdrawal_amount: f64,
-        state: State,
-        price_streams: PriceStreamStates,
-    ) -> Self {
+    pub fn new(min_withdrawal_amount: f64, state: State, price_streams: PriceStreamStates) -> Self {
         Self { min_withdrawal_amount, state, price_streams }
     }
 }

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -878,13 +878,14 @@ impl TypedHandler for DepositBalanceHandler {
 }
 
 /// Handler for the POST /wallet/:id/balances/:mint/withdraw route
+///
+/// Note that we do not rate limit this endpoint; withdrawals must always be
+/// allowed regardless of the wallet's task rate limit
 pub struct WithdrawBalanceHandler {
     /// The minimum withdrawal amount allowed by the relayer
     min_withdrawal_amount: f64,
     /// A copy of the relayer-global state
     state: State,
-    /// The per-wallet task rate limiter
-    rate_limiter: WalletTaskRateLimiter,
     /// The price streams from the price reporter
     price_streams: PriceStreamStates,
 }
@@ -894,10 +895,9 @@ impl WithdrawBalanceHandler {
     pub fn new(
         min_withdrawal_amount: f64,
         state: State,
-        rate_limiter: WalletTaskRateLimiter,
         price_streams: PriceStreamStates,
     ) -> Self {
-        Self { min_withdrawal_amount, state, rate_limiter, price_streams }
+        Self { min_withdrawal_amount, state, price_streams }
     }
 }
 
@@ -960,8 +960,6 @@ impl TypedHandler for WithdrawBalanceHandler {
         )
         .map_err(bad_request)?;
 
-        // Check rate limits and enqueue the task
-        self.rate_limiter.check_rate_limit(wallet_id).await?;
         let task_id = append_task_and_await(task.into(), &self.state).await?;
 
         Ok(WithdrawBalanceResponse { task_id })


### PR DESCRIPTION
Removes the per-wallet task rate limiter from the withdrawal endpoint so that withdrawals are never rate-limited. This ensures users can always withdraw their funds regardless of how many other wallet operations they've performed in the current window.

Follows the same pattern as PayFeesHandler, which is already excluded from rate limiting.