### PR TITLE
fix: defer external-fill metadata pruning to wallet refresh

### DIFF
--- a/state/src/applicator/mod.rs
+++ b/state/src/applicator/mod.rs
@@ -89,6 +89,9 @@ impl StateApplicator {
                 self.add_order_cancellation_proofs(&proofs)
             },
             StateTransition::UpdateOrderMetadata { meta } => self.update_order_metadata(meta),
+            StateTransition::PruneTerminalOrderMetadata { wallet_id, order_id } => {
+                self.prune_terminal_order_metadata(wallet_id, order_id)
+            },
             StateTransition::CreateMatchingPool { pool_name } => {
                 self.create_matching_pool(&pool_name)
             },

--- a/state/src/applicator/order_history.rs
+++ b/state/src/applicator/order_history.rs
@@ -4,8 +4,10 @@ use crate::storage::tx::StateTxn;
 
 use super::{StateApplicator, error::StateApplicatorError, return_type::ApplicatorReturnType};
 use common::types::wallet::order_metadata::OrderMetadata;
+use common::types::wallet::{OrderIdentifier, WalletIdentifier};
 use external_api::bus_message::{SystemBusMessage, wallet_order_history_topic};
 use libmdbx::RW;
+use tracing::warn;
 
 /// Error emitted when a wallet cannot be found for an order
 const ERR_MISSING_WALLET: &str = "wallet not found";
@@ -41,23 +43,17 @@ impl StateApplicator {
             Some(old_meta) => {
                 let became_terminal = !old_meta.state.is_terminal() && meta.state.is_terminal();
 
-                let order_history_enabled = tx.get_historical_state_enabled()?;
-
-                // Always update order metadata if order history is enabled, otherwise
-                // only update it for non-terminal orders
-                if order_history_enabled || !became_terminal {
-                    tx.update_order_metadata(&wallet, meta.clone())?;
-                }
+                // Always write the metadata update — even for terminal orders
+                // when history is disabled. This keeps the Filled/Cancelled
+                // state visible so that concurrent tasks see `is_terminal()`
+                // and skip the order cleanly. Pruning is deferred to
+                // `PruneTerminalOrderMetadata` after the wallet refresh.
+                tx.update_order_metadata(&wallet, meta.clone())?;
 
                 if became_terminal {
                     // Remove the order from the set of local open
                     // orders as it is no longer matchable
                     tx.remove_local_order(&meta.id)?;
-
-                    // Remove the order from order history if history is disabled
-                    if !order_history_enabled {
-                        tx.remove_order_from_history(&wallet, &meta.id)?;
-                    }
                 }
             },
         }
@@ -67,6 +63,42 @@ impl StateApplicator {
         self.system_bus().publish(topic, SystemBusMessage::OrderMetadataUpdated { order: meta });
 
         Ok(())
+    }
+
+    /// Remove terminal order metadata (deferred prune).
+    ///
+    /// Called by the wallet refresh task after `update_wallet` has made the
+    /// wallet consistent. Only prunes if the metadata exists and is terminal
+    /// and historical state recording is disabled.
+    pub fn prune_terminal_order_metadata(
+        &self,
+        wallet_id: WalletIdentifier,
+        order_id: OrderIdentifier,
+    ) -> Result<ApplicatorReturnType, StateApplicatorError> {
+        let tx = self.db().new_write_tx()?;
+        let order_history_enabled = tx.get_historical_state_enabled()?;
+
+        if order_history_enabled {
+            return Ok(ApplicatorReturnType::None);
+        }
+
+        let meta = tx.get_order_metadata(wallet_id, order_id)?;
+        match meta {
+            Some(m) if m.state.is_terminal() => {
+                tx.remove_order_from_history(&wallet_id, &order_id)?;
+                tx.commit()?;
+            },
+            Some(_) => {
+                warn!(
+                    "prune_terminal_order_metadata called for non-terminal order {order_id}, skipping"
+                );
+            },
+            None => {
+                // Already pruned or never existed — no-op
+            },
+        }
+
+        Ok(ApplicatorReturnType::None)
     }
 }
 

--- a/state/src/interface/order_history.rs
+++ b/state/src/interface/order_history.rs
@@ -57,6 +57,20 @@ impl StateInner {
     ) -> Result<ProposalWaiter, StateError> {
         self.send_proposal(StateTransition::UpdateOrderMetadata { meta }).await
     }
+
+    /// Remove terminal order metadata after the wallet has been refreshed.
+    ///
+    /// This is the deferred prune path: metadata is kept alive during the
+    /// external-fill race window so `is_terminal()` works, then pruned here
+    /// once the wallet state is consistent.
+    pub async fn prune_terminal_order_metadata(
+        &self,
+        wallet_id: WalletIdentifier,
+        order_id: OrderIdentifier,
+    ) -> Result<ProposalWaiter, StateError> {
+        self.send_proposal(StateTransition::PruneTerminalOrderMetadata { wallet_id, order_id })
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -21,7 +21,7 @@ use common::types::{
         OrderValidityProofBundle, OrderValidityWitnessBundle, ValidWalletUpdateBundle,
     },
     tasks::{QueuedTask, QueuedTaskState, TaskIdentifier, TaskQueueKey},
-    wallet::{OrderIdentifier, Wallet, order_metadata::OrderMetadata},
+    wallet::{OrderIdentifier, Wallet, WalletIdentifier, order_metadata::OrderMetadata},
 };
 use notifications::ProposalId;
 use replication::{NodeId, RaftNode};
@@ -153,6 +153,8 @@ pub enum StateTransition {
     // --- Order History --- //
     /// Update the metadata for a given order
     UpdateOrderMetadata { meta: OrderMetadata },
+    /// Remove terminal order metadata for a given wallet (deferred prune)
+    PruneTerminalOrderMetadata { wallet_id: WalletIdentifier, order_id: OrderIdentifier },
 
     // --- Matching Pools --- //
     /// Create a matching pool

--- a/workers/task-driver/src/tasks/refresh_wallet.rs
+++ b/workers/task-driver/src/tasks/refresh_wallet.rs
@@ -20,7 +20,7 @@ use constants::Scalar;
 use darkpool_client::errors::DarkpoolClientError;
 use serde::Serialize;
 use state::error::StateError;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::{
     task_state::StateWrapper,
@@ -249,6 +249,13 @@ impl RefreshWalletTask {
 
         let waiter = self.ctx.state.update_wallet(wallet.clone()).await?;
         waiter.await?;
+
+        // Now that the wallet is updated, prune terminal order metadata that
+        // is no longer needed. This is safe because the wallet state is
+        // consistent — orders removed by the fill are no longer in the wallet,
+        // so no concurrent task will generate proofs for them.
+        self.prune_terminal_metadata(&wallet).await?;
+
         Ok(false)
     }
 
@@ -332,6 +339,41 @@ impl RefreshWalletTask {
         }
 
         Ok(false)
+    }
+
+    /// Prune terminal order metadata for orders no longer in the wallet.
+    ///
+    /// When `record-historical-state` is disabled, terminal metadata is kept
+    /// alive until the wallet refresh completes (to avoid a race where
+    /// metadata is deleted while the wallet still references the order).
+    /// This method cleans up that deferred metadata after `update_wallet`
+    /// has made the wallet consistent.
+    async fn prune_terminal_metadata(
+        &self,
+        refreshed_wallet: &Wallet,
+    ) -> Result<(), RefreshWalletTaskError> {
+        if self.ctx.state.historical_state_enabled()? {
+            return Ok(());
+        }
+
+        let active_order_ids: HashSet<_> =
+            refreshed_wallet.get_nonzero_orders().into_keys().collect();
+
+        // Fetch all metadata for this wallet and remove terminal entries
+        // whose orders are no longer active in the wallet
+        let history = self.ctx.state.get_order_history(usize::MAX, &self.wallet_id).await?;
+
+        for meta in history {
+            if meta.state.is_terminal() && !active_order_ids.contains(&meta.id) {
+                let waiter =
+                    self.ctx.state.prune_terminal_order_metadata(self.wallet_id, meta.id).await?;
+                if let Err(e) = waiter.await {
+                    warn!("failed to prune terminal metadata for order {}: {e}", meta.id);
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
### Root cause

When an external fill settles on-chain, the chain events listener (`listener.rs`) calls `record_order_fill` (`post_settlement.rs`), which transitions order metadata to `Filled` via `update_order_metadata`. When `record-historical-state` is disabled, `update_order_metadata_with_tx` (`order_history.rs`) immediately deletes the metadata via `remove_order_from_history` in the same Raft apply.

The wallet is NOT updated in this path — the wallet reconstruction (new shares, Merkle proof, blinder chain) is deferred to a `refresh_wallet` task enqueued via `append_wallet_refresh_task`.

This creates an inconsistency window: the wallet in the DB still contains the filled order at nonzero amount, but the order's metadata no longer exists. Any concurrent task that calls `update_wallet_proofs` during this window reads the stale wallet, finds the order via `get_matchable_orders()` (which checks only amount/balance, not metadata), generates validity proofs, and proposes `AddOrderValidityBundle` to Raft. When the applicator calls `transition_order_matching`, the metadata lookup returns `None`.

PRs #1413 and #1422 made this path non-fatal by converting the `MissingEntry` error to a graceful skip. PR #1411 closed the race for internal match paths by reordering `update_wallet` before `record_order_fill` in `settle_match.rs` and `settle_match_internal.rs`. The external-fill path cannot use this reordering because the wallet data isn't available at `record_order_fill` time — it requires on-chain reconstruction that only happens in `refresh_wallet`.

### Options considered

**A. Reorder `update_wallet` before `record_order_fill` in the listener** (same pattern as #1411)

Would require inlining `refresh_wallet`'s reconstruction logic (chain queries for public shares, blinder seed derivation, Merkle path lookup) into the listener. This is the bulk of `refresh_wallet.rs:find_wallet` (~30 lines of async chain interaction). Also introduces new race conditions: concurrent `UpdateWallet` proposals from the listener and an in-flight `settle_match` task would conflict. Rejected as too invasive and risky.

**B. Keep terminal metadata alive, prune via `update_order_metadata` re-submission**

Stop deleting metadata on terminal transition. Have `refresh_wallet` re-submit the terminal metadata after `update_wallet`, using an `already_terminal` heuristic in `update_order_metadata_with_tx` to trigger the deferred prune. Rejected because the heuristic is too broad: `transition_order_matching` in `order_book.rs` also calls `update_order_metadata_with_tx` with unchanged terminal metadata, which would inadvertently trigger premature pruning during the exact race window we're trying to close.

**C. Keep terminal metadata alive, prune via dedicated `StateTransition`** (chosen)

Stop deleting metadata on terminal transition in `update_order_metadata_with_tx`. Add a new `PruneTerminalOrderMetadata` Raft transition that only `refresh_wallet` calls, after `update_wallet` has made the wallet consistent. The applicator handler validates that the metadata is terminal before deleting. Double-prune is a no-op (metadata already gone). The prune replicates via Raft so all nodes stay consistent.

### Why option C

- Closes the race: metadata stays visible during the inconsistency window, so `is_terminal()` in `transition_order_matching` works as designed
- No heuristic ambiguity: the prune is an explicit, dedicated operation — cannot be triggered accidentally by concurrent tasks
- Idempotent: the applicator checks `is_terminal()` before deleting, and treats missing metadata as a no-op
- Raft-replicated: all nodes prune consistently, unlike a `with_write_tx` approach where only the executor node would prune
- ~22 lines of boilerplate for the new transition (enum variant, dispatch, interface, applicator handler)

### Test plan

- [ ] `cargo check -p state -p task-driver`
- [ ] Existing tests pass: `cargo test -p state -p task-driver`
- [ ] Terminal metadata survives `update_order_metadata` (no immediate prune)
- [ ] `PruneTerminalOrderMetadata` deletes terminal metadata
- [ ] `PruneTerminalOrderMetadata` is a no-op for non-terminal or missing metadata
- [ ] `transition_order_matching` with terminal metadata hits `is_terminal()` guard, does not prune