### PR TITLE
Add pre-match queue guard for internal matching engine (T2)

### DIFF
--- a/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/internal_engine.rs
+++ b/crates/workers/matching-engine/matching-engine-worker/src/manager/matching/internal_engine.rs
@@ -32,6 +32,17 @@ impl MatchingEngineExecutor {
         order_id: OrderId,
     ) -> Result<(), MatchingEngineError> {
         info!("Running internal matching engine on order {order_id}");
+
+        // Skip matching if the account has tasks in flight
+        let queue_len = self.state.serial_tasks_queue_len(&account_id).await?;
+        if queue_len > 0 {
+            info!(
+                "account {account_id} has tasks in flight (queue_len={queue_len}), \
+                 skipping internal matching engine for {order_id}"
+            );
+            return Ok(());
+        }
+
         // Lookup the order, matchable amount, and matching pool
         let (order, matchable_amount) = self.fetch_order_and_matchable_amount(&order_id).await?;
         let matching_pool = self.fetch_matching_pool(&order_id).await?;
@@ -84,6 +95,16 @@ impl MatchingEngineExecutor {
         // Lookup account IDs and order rings for both orders
         let account_id = self.get_account_id_for_order(&user_order).await?;
         let other_account_id = self.get_account_id_for_order(&match_result.other_order_id).await?;
+
+        // Skip settlement if the counterparty account has tasks in flight
+        let other_queue_len = self.state.serial_tasks_queue_len(&other_account_id).await?;
+        if other_queue_len > 0 {
+            info!(
+                "counterparty account {other_account_id} has tasks in flight \
+                 (queue_len={other_queue_len}), skipping settlement for {user_order}"
+            );
+            return Ok(());
+        }
 
         let order0_ring = self.get_order_ring(&user_order).await?;
         let order1_ring = self.get_order_ring(&match_result.other_order_id).await?;
@@ -240,6 +261,7 @@ mod tests {
         order::{Order, mocks::mock_order},
         order_auth::mocks::mock_order_auth,
     };
+    use types_tasks::{RefreshAccountTaskDescriptor, TaskDescriptor};
 
     async fn mock_executor(state: State) -> MatchingEngineExecutor {
         let (_job_queue, job_receiver) = new_matching_engine_worker_queue();
@@ -286,6 +308,24 @@ mod tests {
         let matchable_amount = state.get_order_matchable_amount(&order.id).await.unwrap();
         let executor = mock_executor(state.clone()).await;
         (executor, state, account.id, order, matchable_amount)
+    }
+
+    #[tokio::test]
+    async fn test_pre_match_skips_when_own_queue_busy() {
+        let (executor, state, account_id, order, _matchable_amount) =
+            setup_executor_with_order().await;
+
+        // Enqueue a task so the serial queue is non-empty
+        let keychain = state.get_account_keychain(&account_id).await.unwrap().unwrap();
+        let descriptor =
+            TaskDescriptor::from(RefreshAccountTaskDescriptor::new(account_id, keychain));
+        let (_task_id, waiter) =
+            state.enqueue_preemptive_task(vec![account_id], descriptor, true).await.unwrap();
+        waiter.await.unwrap();
+
+        // Should return Ok(()) without attempting a match
+        let result = executor.run_internal_matching_engine(account_id, order.id).await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

After a successful internal match settlement, `RunMatchingEngineHook` fires two matching engine jobs — one for each party's residual order. Both jobs race to find the same counterparty and attempt settlement. The loser hits `"serial preemption not allowed"` because the winner already preempted the queue:

```
ME Job 1 (order A) → finds B → preempt_serial(A, B) → ✓
ME Job 2 (order B) → finds A → preempt_serial(B, A) → ✗ "serial preemption not allowed"
```

PR #1420 added a post-failure `order_still_valid` guard that catches this and stops retrying, but the matching engine still does full candidate search, match computation, and a failed settlement attempt before bailing out.

## Options

**Option 1: Guard at enqueue time (match v1 exactly)**
Add a queue-empty check inside `RunMatchingEngineHook::run()` before sending the job to the channel. Mirrors v1's `should_run_matching_engine()` which gates inside the Raft transaction that pops the settlement task.
- Pro: prevents the job from entering the channel at all
- Con: hooks don't currently have state access; would require threading `State` through the hook trait, changing the `TaskHook` interface

**Option 2: Guard at execution time (pre-match check)**
Add a queue-length check at the top of `run_internal_matching_engine()` — bail immediately if the account has tasks in flight. Also check the counterparty's queue in `try_settle_match()` before attempting settlement.
- Pro: minimal change, same file as PR #1420, no trait changes
- Con: the job still enters the channel (but exits in microseconds)

**Option 3: Rely solely on PR #1420 (no additional guard)**
The post-failure `order_still_valid` check already catches the busy-queue case.
- Pro: zero new code
- Con: every rematch does candidate search → match → failed settlement → validity check before bailing. Noisy error logs (`"serial preemption not allowed"`) on every successful partial fill.

## Rationale

**Chose Option 2.** It eliminates the wasted work and error-level log noise with a single queue-length read at the top of the matching engine — the same check `order_still_valid` already performs, just earlier. The job entering the channel is negligible cost.

This matches the **semantics** of v1's `should_run_matching_engine()` (`state/src/applicator/task_queue.rs:281`) without requiring v1's **mechanism** (Raft-atomic gating at enqueue time). In v1, the matching engine could never run unless the wallet's serial queue was confirmed empty inside the same Raft write transaction that popped the settlement task. V2's hook architecture fires unconditionally, so we add the equivalent guard at execution time instead.

## Changes

In `internal_engine.rs`:
1. **Pre-match guard** — top of `run_internal_matching_engine()`: skip if own account's `serial_tasks_queue_len > 0`
2. **Pre-settlement guard** — in `try_settle_match()`: skip if counterparty's `serial_tasks_queue_len > 0`
3. **Test** for the pre-match early-exit path

## Testing

- `cargo test -p matching-engine-worker` — 6 tests pass (5 from PR #1420 + 1 new)