### PR TITLE
fix: allow v1 withdrawals without price data

### DIFF
--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -128,9 +128,13 @@ pub(crate) fn get_usdc_denominated_value(
 
     // Peek at the price report from the price reporter and compute the USDC
     // denominated value
-    let price = price_streams.peek_price(&base_token)?;
-    let value = amount_with_decimals * price;
-    Ok(Some(value))
+    match price_streams.peek_price(&base_token) {
+        Ok(price) => {
+            let value = amount_with_decimals * price;
+            Ok(Some(value))
+        },
+        Err(_) => Ok(None),
+    }
 }
 
 /// Enqueue fee payment tasks for all unpaid fees in a wallet, returning the


### PR DESCRIPTION
# Problem

v1 withdrawals are intended to remain available even when price data is unavailable. The withdrawal handler already contains this fallback comment and branch:

> If we are unable to fetch a price, do not block the withdrawal

But in practice that safeguard does not apply to all missing-price cases. Before the handler reaches that branch, it calls `get_usdc_denominated_value(...)`, which calls `price_streams.peek_price(...)` for non-USDC assets. If that lookup fails, the error is converted into a `bad_request` and the request exits early, so the withdrawal never reaches the intended fallback path.

This makes v1 withdrawals fragile when an asset is no longer present in local price state, including delist-style scenarios where the remote price reporter stops serving a token before all users have exited.

# Solution

Make `get_usdc_denominated_value(...)` treat missing price data as unavailable valuation rather than as a hard error.

With this change:
- when price data exists, the function still returns a USDC-denominated value and the minimum-withdrawal-value check behaves exactly as before
- when price data is unavailable, the function returns `None` instead of erroring

That lets `WithdrawBalanceHandler` reach and use the existing remedy that was already intended for this case: skipping the minimum-value enforcement when price data cannot be fetched, while still allowing the withdrawal to proceed.