### PR TITLE
feat: enforce disabled_assets across all user-facing API endpoints

### DIFF
--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -2,6 +2,7 @@
 
 mod account;
 mod admin;
+pub(super) mod asset_filter;
 mod balance;
 mod external_match;
 mod helpers;
@@ -74,12 +75,13 @@ use order::{
     CancelOrderHandler, CreateOrderHandler, GetOrderByIdHandler, GetOrdersHandler,
     UpdateOrderHandler,
 };
-use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 use task::{GetTaskByIdHandler, GetTasksHandler};
 use tokio::net::{TcpListener, TcpStream};
-use alloy::primitives::Address;
-use types_core::{HmacKey, Token};
+use types_core::HmacKey;
 use util::get_current_time_millis;
+
+use self::asset_filter::AssetFilter;
 
 use crate::{
     auth::AuthType, http::external_match::processor::ExternalMatchProcessor, router::QueryParams,
@@ -124,11 +126,7 @@ impl HttpServer {
         let task_queue = &config.task_queue;
 
         // Resolve disabled asset tickers to addresses once
-        let disabled_assets: HashSet<Address> = config
-            .disabled_assets
-            .iter()
-            .map(|ticker| Token::from_ticker(ticker).get_alloy_address())
-            .collect();
+        let asset_filter = AssetFilter::new(&config.disabled_assets);
 
         // --- Misc Routes --- //
 
@@ -182,7 +180,7 @@ impl HttpServer {
             CREATE_ORDER_ROUTE.to_string(),
             CreateOrderHandler::new(
                 executor,
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 state.clone(),
                 task_queue.clone(),
             ),
@@ -229,7 +227,7 @@ impl HttpServer {
         router.add_account_authenticated_route(
             &Method::POST,
             DEPOSIT_BALANCE_ROUTE.to_string(),
-            DepositBalanceHandler::new(disabled_assets.clone(), state.clone(), task_queue.clone()),
+            DepositBalanceHandler::new(asset_filter.clone(), state.clone(), task_queue.clone()),
         );
 
         // POST /v2/account/:account_id/balances/:mint/withdraw
@@ -261,7 +259,7 @@ impl HttpServer {
         let admin_key = config.admin_api_key.unwrap_or_else(HmacKey::random);
         let processor = ExternalMatchProcessor::new(
             admin_key,
-            disabled_assets.clone(),
+            asset_filter.clone(),
             darkpool_client.clone(),
             bus.clone(),
             matching_engine_worker_queue.clone(),
@@ -288,7 +286,7 @@ impl HttpServer {
         let market_calculator = MarketDataCalculator::new(
             state.clone(),
             config.price_streams.clone(),
-            disabled_assets.clone(),
+            asset_filter.clone(),
         );
 
         // GET /v2/markets
@@ -316,7 +314,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_MARKET_PRICE_ROUTE.to_string(),
-            GetMarketPriceHandler::new(disabled_assets.clone(), config.price_streams.clone()),
+            GetMarketPriceHandler::new(asset_filter.clone(), config.price_streams.clone()),
         );
 
         // --- Metadata Routes (v2) --- //
@@ -326,7 +324,7 @@ impl HttpServer {
             &Method::GET,
             GET_EXCHANGE_METADATA_ROUTE.to_string(),
             GetExchangeMetadataHandler::new(
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 state.clone(),
                 darkpool_client.clone(),
             ),

--- a/crates/workers/api-server/src/http.rs
+++ b/crates/workers/api-server/src/http.rs
@@ -74,10 +74,11 @@ use order::{
     CancelOrderHandler, CreateOrderHandler, GetOrderByIdHandler, GetOrdersHandler,
     UpdateOrderHandler,
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 use task::{GetTaskByIdHandler, GetTasksHandler};
 use tokio::net::{TcpListener, TcpStream};
-use types_core::HmacKey;
+use alloy::primitives::Address;
+use types_core::{HmacKey, Token};
 use util::get_current_time_millis;
 
 use crate::{
@@ -121,6 +122,13 @@ impl HttpServer {
         let bus = &config.system_bus;
         let matching_engine_worker_queue = &config.matching_engine_worker_queue;
         let task_queue = &config.task_queue;
+
+        // Resolve disabled asset tickers to addresses once
+        let disabled_assets: HashSet<Address> = config
+            .disabled_assets
+            .iter()
+            .map(|ticker| Token::from_ticker(ticker).get_alloy_address())
+            .collect();
 
         // --- Misc Routes --- //
 
@@ -172,7 +180,12 @@ impl HttpServer {
         router.add_account_authenticated_route(
             &Method::POST,
             CREATE_ORDER_ROUTE.to_string(),
-            CreateOrderHandler::new(executor, state.clone(), task_queue.clone()),
+            CreateOrderHandler::new(
+                executor,
+                disabled_assets.clone(),
+                state.clone(),
+                task_queue.clone(),
+            ),
         );
 
         // GET /v2/account/:account_id/orders/:order_id
@@ -216,7 +229,7 @@ impl HttpServer {
         router.add_account_authenticated_route(
             &Method::POST,
             DEPOSIT_BALANCE_ROUTE.to_string(),
-            DepositBalanceHandler::new(state.clone(), task_queue.clone()),
+            DepositBalanceHandler::new(disabled_assets.clone(), state.clone(), task_queue.clone()),
         );
 
         // POST /v2/account/:account_id/balances/:mint/withdraw
@@ -248,6 +261,7 @@ impl HttpServer {
         let admin_key = config.admin_api_key.unwrap_or_else(HmacKey::random);
         let processor = ExternalMatchProcessor::new(
             admin_key,
+            disabled_assets.clone(),
             darkpool_client.clone(),
             bus.clone(),
             matching_engine_worker_queue.clone(),
@@ -271,8 +285,11 @@ impl HttpServer {
 
         // --- Market Routes (v2) --- //
 
-        let market_calculator =
-            MarketDataCalculator::new(state.clone(), config.price_streams.clone());
+        let market_calculator = MarketDataCalculator::new(
+            state.clone(),
+            config.price_streams.clone(),
+            disabled_assets.clone(),
+        );
 
         // GET /v2/markets
         router.add_admin_authenticated_route(
@@ -299,7 +316,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_MARKET_PRICE_ROUTE.to_string(),
-            GetMarketPriceHandler::new(config.price_streams.clone()),
+            GetMarketPriceHandler::new(disabled_assets.clone(), config.price_streams.clone()),
         );
 
         // --- Metadata Routes (v2) --- //
@@ -308,7 +325,11 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_EXCHANGE_METADATA_ROUTE.to_string(),
-            GetExchangeMetadataHandler::new(state.clone(), darkpool_client.clone()),
+            GetExchangeMetadataHandler::new(
+                disabled_assets.clone(),
+                state.clone(),
+                darkpool_client.clone(),
+            ),
         );
 
         // --- Network Routes (v2) --- //

--- a/crates/workers/api-server/src/http/asset_filter.rs
+++ b/crates/workers/api-server/src/http/asset_filter.rs
@@ -1,0 +1,50 @@
+//! Centralizes disabled-asset policy for the API layer
+
+use std::collections::HashSet;
+
+use alloy::primitives::Address;
+use types_core::{Token, get_all_base_tokens};
+
+use crate::error::{ApiServerError, bad_request};
+
+/// Error returned when a request references a disabled token
+const ERR_TOKEN_DISABLED: &str = "token is not supported";
+
+/// Holds the resolved set of disabled asset addresses and exposes
+/// a small API for checking and filtering tokens.
+#[derive(Clone, Debug)]
+pub(crate) struct AssetFilter {
+    disabled: HashSet<Address>,
+}
+
+impl AssetFilter {
+    /// Build an `AssetFilter` by resolving ticker strings to addresses
+    pub fn new(tickers: &[String]) -> Self {
+        let disabled = tickers.iter().map(|t| Token::from_ticker(t).get_alloy_address()).collect();
+        Self { disabled }
+    }
+
+    /// Reject if `addr` is disabled
+    pub fn check_token(&self, addr: &Address) -> Result<(), ApiServerError> {
+        if self.disabled.contains(addr) {
+            return Err(bad_request(ERR_TOKEN_DISABLED));
+        }
+        Ok(())
+    }
+
+    /// Reject if either of two tokens is disabled
+    pub fn check_pair(&self, token_a: &Address, token_b: &Address) -> Result<(), ApiServerError> {
+        if self.disabled.contains(token_a) || self.disabled.contains(token_b) {
+            return Err(bad_request(ERR_TOKEN_DISABLED));
+        }
+        Ok(())
+    }
+
+    /// Return only the base tokens that are *not* disabled
+    pub fn enabled_base_tokens(&self) -> Vec<Token> {
+        get_all_base_tokens()
+            .into_iter()
+            .filter(|t| !self.disabled.contains(&t.get_alloy_address()))
+            .collect()
+    }
+}

--- a/crates/workers/api-server/src/http/balance.rs
+++ b/crates/workers/api-server/src/http/balance.rs
@@ -1,7 +1,5 @@
 //! Route handlers for balance operations
 
-use std::collections::HashSet;
-
 use alloy::{
     primitives::{Address, U256},
     sol_types::SolValue,
@@ -33,7 +31,7 @@ use crate::{
         ApiServerError, ERR_ACCOUNT_NOT_FOUND, ERR_BALANCE_NOT_FOUND, bad_request, internal_error,
         not_found,
     },
-    http::helpers::append_task,
+    http::{asset_filter::AssetFilter, helpers::append_task},
     param_parsing::{parse_account_id_from_params, parse_mint_from_params, should_block_on_task},
     router::{QueryParams, TypedHandler, UrlParams},
 };
@@ -116,8 +114,8 @@ impl TypedHandler for GetBalanceByMintHandler {
 
 /// Handler for POST /v2/account/:account_id/balances/:mint/deposit
 pub struct DepositBalanceHandler {
-    /// Assets disabled for deposits
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The global state
     state: State,
     /// The task driver queue
@@ -126,12 +124,8 @@ pub struct DepositBalanceHandler {
 
 impl DepositBalanceHandler {
     /// Constructor
-    pub fn new(
-        disabled_assets: HashSet<Address>,
-        state: State,
-        task_queue: TaskDriverQueue,
-    ) -> Self {
-        Self { disabled_assets, state, task_queue }
+    pub fn new(asset_filter: AssetFilter, state: State, task_queue: TaskDriverQueue) -> Self {
+        Self { asset_filter, state, task_queue }
     }
 }
 
@@ -152,9 +146,7 @@ impl TypedHandler for DepositBalanceHandler {
         // Parse parameters
         let account_id = parse_account_id_from_params(&params)?;
         let token = parse_mint_from_params(&params)?;
-        if self.disabled_assets.contains(&token) {
-            return Err(bad_request("token is not supported for deposits"));
-        }
+        self.asset_filter.check_token(&token)?;
         let from_address = req.from_address;
         let amount = req.amount;
         let auth = DepositAuth::from(req.permit);

--- a/crates/workers/api-server/src/http/balance.rs
+++ b/crates/workers/api-server/src/http/balance.rs
@@ -1,5 +1,7 @@
 //! Route handlers for balance operations
 
+use std::collections::HashSet;
+
 use alloy::{
     primitives::{Address, U256},
     sol_types::SolValue,
@@ -114,6 +116,8 @@ impl TypedHandler for GetBalanceByMintHandler {
 
 /// Handler for POST /v2/account/:account_id/balances/:mint/deposit
 pub struct DepositBalanceHandler {
+    /// Assets disabled for deposits
+    disabled_assets: HashSet<Address>,
     /// The global state
     state: State,
     /// The task driver queue
@@ -122,8 +126,12 @@ pub struct DepositBalanceHandler {
 
 impl DepositBalanceHandler {
     /// Constructor
-    pub fn new(state: State, task_queue: TaskDriverQueue) -> Self {
-        Self { state, task_queue }
+    pub fn new(
+        disabled_assets: HashSet<Address>,
+        state: State,
+        task_queue: TaskDriverQueue,
+    ) -> Self {
+        Self { disabled_assets, state, task_queue }
     }
 }
 
@@ -144,6 +152,9 @@ impl TypedHandler for DepositBalanceHandler {
         // Parse parameters
         let account_id = parse_account_id_from_params(&params)?;
         let token = parse_mint_from_params(&params)?;
+        if self.disabled_assets.contains(&token) {
+            return Err(bad_request("token is not supported for deposits"));
+        }
         let from_address = req.from_address;
         let amount = req.amount;
         let auth = DepositAuth::from(req.permit);

--- a/crates/workers/api-server/src/http/external_match/processor.rs
+++ b/crates/workers/api-server/src/http/external_match/processor.rs
@@ -1,11 +1,9 @@
 //! The external match processor
 
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 use alloy::{
-    network::TransactionBuilder,
-    primitives::{Address, U256},
-    rpc::types::TransactionRequest,
+    network::TransactionBuilder, primitives::U256, rpc::types::TransactionRequest,
     sol_types::SolCall,
 };
 use circuit_types::fixed_point::FixedPoint;
@@ -32,7 +30,10 @@ use types_account::{order::Order, pair::Pair};
 use types_core::{HmacKey, TimestampedPrice, TimestampedPriceFp};
 use util::{get_current_time_millis, on_chain::get_protocol_fee};
 
-use crate::error::{ApiServerError, bad_request, internal_error, no_content, unauthorized};
+use crate::{
+    error::{ApiServerError, internal_error, no_content, unauthorized},
+    http::asset_filter::AssetFilter,
+};
 
 // -------------
 // | Constants |
@@ -55,8 +56,8 @@ const ERR_NO_EXTERNAL_MATCH_FOUND: &str = "no external match found";
 pub struct ExternalMatchProcessor {
     /// The admin API key, used to sign quotes
     admin_key: HmacKey,
-    /// Assets disabled for matching
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The darkpool client
     darkpool_client: DarkpoolClient,
     /// The system bus
@@ -73,7 +74,7 @@ impl ExternalMatchProcessor {
     /// Constructor
     pub fn new(
         admin_key: HmacKey,
-        disabled_assets: HashSet<Address>,
+        asset_filter: AssetFilter,
         darkpool_client: DarkpoolClient,
         bus: SystemBus,
         matching_engine_worker_queue: MatchingEngineWorkerQueue,
@@ -82,7 +83,7 @@ impl ExternalMatchProcessor {
     ) -> Self {
         Self {
             admin_key,
-            disabled_assets,
+            asset_filter,
             darkpool_client,
             bus,
             matching_engine_worker_queue,
@@ -93,12 +94,7 @@ impl ExternalMatchProcessor {
 
     /// Validate that neither token in the pair is disabled
     fn validate_pair_not_disabled(&self, pair: &Pair) -> Result<(), ApiServerError> {
-        if self.disabled_assets.contains(&pair.in_token)
-            || self.disabled_assets.contains(&pair.out_token)
-        {
-            return Err(bad_request("token is not supported"));
-        }
-        Ok(())
+        self.asset_filter.check_pair(&pair.in_token, &pair.out_token)
     }
 
     // --- Quote --- //

--- a/crates/workers/api-server/src/http/external_match/processor.rs
+++ b/crates/workers/api-server/src/http/external_match/processor.rs
@@ -1,9 +1,11 @@
 //! The external match processor
 
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use alloy::{
-    network::TransactionBuilder, primitives::U256, rpc::types::TransactionRequest,
+    network::TransactionBuilder,
+    primitives::{Address, U256},
+    rpc::types::TransactionRequest,
     sol_types::SolCall,
 };
 use circuit_types::fixed_point::FixedPoint;
@@ -30,7 +32,7 @@ use types_account::{order::Order, pair::Pair};
 use types_core::{HmacKey, TimestampedPrice, TimestampedPriceFp};
 use util::{get_current_time_millis, on_chain::get_protocol_fee};
 
-use crate::error::{ApiServerError, internal_error, no_content, unauthorized};
+use crate::error::{ApiServerError, bad_request, internal_error, no_content, unauthorized};
 
 // -------------
 // | Constants |
@@ -53,6 +55,8 @@ const ERR_NO_EXTERNAL_MATCH_FOUND: &str = "no external match found";
 pub struct ExternalMatchProcessor {
     /// The admin API key, used to sign quotes
     admin_key: HmacKey,
+    /// Assets disabled for matching
+    disabled_assets: HashSet<Address>,
     /// The darkpool client
     darkpool_client: DarkpoolClient,
     /// The system bus
@@ -69,13 +73,32 @@ impl ExternalMatchProcessor {
     /// Constructor
     pub fn new(
         admin_key: HmacKey,
+        disabled_assets: HashSet<Address>,
         darkpool_client: DarkpoolClient,
         bus: SystemBus,
         matching_engine_worker_queue: MatchingEngineWorkerQueue,
         price_streams: PriceStreamStates,
         state: State,
     ) -> Self {
-        Self { admin_key, darkpool_client, bus, matching_engine_worker_queue, price_streams, state }
+        Self {
+            admin_key,
+            disabled_assets,
+            darkpool_client,
+            bus,
+            matching_engine_worker_queue,
+            price_streams,
+            state,
+        }
+    }
+
+    /// Validate that neither token in the pair is disabled
+    fn validate_pair_not_disabled(&self, pair: &Pair) -> Result<(), ApiServerError> {
+        if self.disabled_assets.contains(&pair.in_token)
+            || self.disabled_assets.contains(&pair.out_token)
+        {
+            return Err(bad_request("token is not supported"));
+        }
+        Ok(())
     }
 
     // --- Quote --- //
@@ -102,6 +125,7 @@ impl ExternalMatchProcessor {
         // Fetch the price for the pair; this effectively adds to the delay
         // between price sampling and settlement, but is acceptable for simplicity
         let pair = Pair::new(req.external_order.input_mint, req.external_order.output_mint);
+        self.validate_pair_not_disabled(&pair)?;
         let price_fp = self.get_price(&pair)?;
 
         // Determine fee rates before normalizing output-denominated exact orders
@@ -183,6 +207,7 @@ impl ExternalMatchProcessor {
         // normalization and matching-engine options.
         let external_order = req.order.get_external_order();
         let pair = Pair::new(external_order.input_mint, external_order.output_mint);
+        self.validate_pair_not_disabled(&pair)?;
         let price = self.assembly_price(&req, &pair)?;
         let fee_override = req.options.relayer_fee_rate.map(FixedPoint::from_f64_round_down);
         let fee_rates = self.get_fee_rates_for_pair(&pair, fee_override)?;

--- a/crates/workers/api-server/src/http/market.rs
+++ b/crates/workers/api-server/src/http/market.rs
@@ -1,8 +1,5 @@
 //! Route handlers for market operations
 
-use std::collections::HashSet;
-
-use alloy::primitives::Address;
 use async_trait::async_trait;
 use circuit_types::fixed_point::FixedPoint;
 use external_api::{
@@ -18,11 +15,12 @@ use hyper::HeaderMap;
 use price_state::PriceStreamStates;
 use state::State;
 use types_account::pair::Pair;
-use types_core::{Token, get_all_base_tokens};
+use types_core::Token;
 use util::on_chain::get_protocol_fee;
 
 use crate::{
-    error::{ApiServerError, bad_request},
+    error::ApiServerError,
+    http::asset_filter::AssetFilter,
     param_parsing::parse_token_from_params,
     router::{QueryParams, TypedHandler, UrlParams},
 };
@@ -38,26 +36,24 @@ pub(super) struct MarketDataCalculator {
     state: State,
     /// The price stream states
     price_streams: PriceStreamStates,
-    /// Assets disabled for matching
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
 }
 
 impl MarketDataCalculator {
     /// Constructor
-    pub fn new(
-        state: State,
-        price_streams: PriceStreamStates,
-        disabled_assets: HashSet<Address>,
-    ) -> Self {
-        Self { state, price_streams, disabled_assets }
+    pub fn new(state: State, price_streams: PriceStreamStates, asset_filter: AssetFilter) -> Self {
+        Self { state, price_streams, asset_filter }
     }
 
-    /// Get the list of enabled base tokens
-    fn get_enabled_base_tokens(&self) -> Vec<Token> {
-        get_all_base_tokens()
-            .into_iter()
-            .filter(|t| !self.disabled_assets.contains(&t.get_alloy_address()))
-            .collect()
+    /// Reject if a token is disabled
+    fn check_token(&self, addr: &alloy::primitives::Address) -> Result<(), ApiServerError> {
+        self.asset_filter.check_token(addr)
+    }
+
+    /// Return enabled base tokens
+    fn enabled_base_tokens(&self) -> Vec<Token> {
+        self.asset_filter.enabled_base_tokens()
     }
 
     /// Get fee rates for a token
@@ -142,7 +138,7 @@ impl TypedHandler for GetMarketsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let tokens = self.calculator.get_enabled_base_tokens();
+        let tokens = self.calculator.enabled_base_tokens();
         let markets =
             tokens.iter().filter_map(|t| self.calculator.get_market_info(t).ok()).collect();
         Ok(GetMarketsResponse { markets })
@@ -174,7 +170,7 @@ impl TypedHandler for GetMarketDepthsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let tokens = self.calculator.get_enabled_base_tokens();
+        let tokens = self.calculator.enabled_base_tokens();
         let futs = tokens
             .iter()
             .map(|t| async { self.calculator.get_market_depth(t).await })
@@ -211,9 +207,7 @@ impl TypedHandler for GetMarketDepthByMintHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let token = parse_token_from_params(&params)?;
-        if self.calculator.disabled_assets.contains(&token.get_alloy_address()) {
-            return Err(bad_request("token is not supported"));
-        }
+        self.calculator.check_token(&token.get_alloy_address())?;
         let market_depth = self.calculator.get_market_depth(&token).await?;
         Ok(GetMarketDepthByMintResponse { market_depth })
     }
@@ -221,16 +215,16 @@ impl TypedHandler for GetMarketDepthByMintHandler {
 
 /// Handler for GET /v2/markets/:mint/price
 pub struct GetMarketPriceHandler {
-    /// Assets disabled for matching
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The price stream states
     price_streams: PriceStreamStates,
 }
 
 impl GetMarketPriceHandler {
     /// Constructor
-    pub fn new(disabled_assets: HashSet<Address>, price_streams: PriceStreamStates) -> Self {
-        Self { disabled_assets, price_streams }
+    pub fn new(asset_filter: AssetFilter, price_streams: PriceStreamStates) -> Self {
+        Self { asset_filter, price_streams }
     }
 }
 
@@ -247,9 +241,7 @@ impl TypedHandler for GetMarketPriceHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let token = parse_token_from_params(&params)?;
-        if self.disabled_assets.contains(&token.get_alloy_address()) {
-            return Err(bad_request("token is not supported"));
-        }
+        self.asset_filter.check_token(&token.get_alloy_address())?;
         let price: ApiTimestampedPrice = self.price_streams.peek_timestamped_price(&token)?.into();
         Ok(price)
     }

--- a/crates/workers/api-server/src/http/market.rs
+++ b/crates/workers/api-server/src/http/market.rs
@@ -1,5 +1,8 @@
 //! Route handlers for market operations
 
+use std::collections::HashSet;
+
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use circuit_types::fixed_point::FixedPoint;
 use external_api::{
@@ -19,7 +22,7 @@ use types_core::{Token, get_all_base_tokens};
 use util::on_chain::get_protocol_fee;
 
 use crate::{
-    error::ApiServerError,
+    error::{ApiServerError, bad_request},
     param_parsing::parse_token_from_params,
     router::{QueryParams, TypedHandler, UrlParams},
 };
@@ -35,12 +38,26 @@ pub(super) struct MarketDataCalculator {
     state: State,
     /// The price stream states
     price_streams: PriceStreamStates,
+    /// Assets disabled for matching
+    disabled_assets: HashSet<Address>,
 }
 
 impl MarketDataCalculator {
     /// Constructor
-    pub fn new(state: State, price_streams: PriceStreamStates) -> Self {
-        Self { state, price_streams }
+    pub fn new(
+        state: State,
+        price_streams: PriceStreamStates,
+        disabled_assets: HashSet<Address>,
+    ) -> Self {
+        Self { state, price_streams, disabled_assets }
+    }
+
+    /// Get the list of enabled base tokens
+    fn get_enabled_base_tokens(&self) -> Vec<Token> {
+        get_all_base_tokens()
+            .into_iter()
+            .filter(|t| !self.disabled_assets.contains(&t.get_alloy_address()))
+            .collect()
     }
 
     /// Get fee rates for a token
@@ -125,7 +142,7 @@ impl TypedHandler for GetMarketsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let tokens = get_all_base_tokens();
+        let tokens = self.calculator.get_enabled_base_tokens();
         let markets =
             tokens.iter().filter_map(|t| self.calculator.get_market_info(t).ok()).collect();
         Ok(GetMarketsResponse { markets })
@@ -157,7 +174,7 @@ impl TypedHandler for GetMarketDepthsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let tokens = get_all_base_tokens();
+        let tokens = self.calculator.get_enabled_base_tokens();
         let futs = tokens
             .iter()
             .map(|t| async { self.calculator.get_market_depth(t).await })
@@ -194,6 +211,9 @@ impl TypedHandler for GetMarketDepthByMintHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let token = parse_token_from_params(&params)?;
+        if self.calculator.disabled_assets.contains(&token.get_alloy_address()) {
+            return Err(bad_request("token is not supported"));
+        }
         let market_depth = self.calculator.get_market_depth(&token).await?;
         Ok(GetMarketDepthByMintResponse { market_depth })
     }
@@ -201,14 +221,16 @@ impl TypedHandler for GetMarketDepthByMintHandler {
 
 /// Handler for GET /v2/markets/:mint/price
 pub struct GetMarketPriceHandler {
+    /// Assets disabled for matching
+    disabled_assets: HashSet<Address>,
     /// The price stream states
     price_streams: PriceStreamStates,
 }
 
 impl GetMarketPriceHandler {
     /// Constructor
-    pub fn new(price_streams: PriceStreamStates) -> Self {
-        Self { price_streams }
+    pub fn new(disabled_assets: HashSet<Address>, price_streams: PriceStreamStates) -> Self {
+        Self { disabled_assets, price_streams }
     }
 }
 
@@ -225,6 +247,9 @@ impl TypedHandler for GetMarketPriceHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let token = parse_token_from_params(&params)?;
+        if self.disabled_assets.contains(&token.get_alloy_address()) {
+            return Err(bad_request("token is not supported"));
+        }
         let price: ApiTimestampedPrice = self.price_streams.peek_timestamped_price(&token)?.into();
         Ok(price)
     }

--- a/crates/workers/api-server/src/http/metadata.rs
+++ b/crates/workers/api-server/src/http/metadata.rs
@@ -1,8 +1,5 @@
 //! Route handlers for metadata operations
 
-use std::collections::HashSet;
-
-use alloy::primitives::Address;
 use async_trait::async_trait;
 use darkpool_client::DarkpoolClient;
 use external_api::{
@@ -11,11 +8,11 @@ use external_api::{
 };
 use hyper::HeaderMap;
 use state::State;
-use types_core::get_all_base_tokens;
 use util::on_chain::get_chain_id;
 
 use crate::{
     error::{ApiServerError, internal_error},
+    http::asset_filter::AssetFilter,
     router::{QueryParams, TypedHandler, UrlParams},
 };
 
@@ -25,8 +22,8 @@ use crate::{
 
 /// Handler for GET /v2/metadata/exchange
 pub struct GetExchangeMetadataHandler {
-    /// Assets disabled for matching
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// A handle to the relayer's state
     state: State,
     /// The darkpool client
@@ -35,12 +32,8 @@ pub struct GetExchangeMetadataHandler {
 
 impl GetExchangeMetadataHandler {
     /// Constructor
-    pub fn new(
-        disabled_assets: HashSet<Address>,
-        state: State,
-        darkpool_client: DarkpoolClient,
-    ) -> Self {
-        Self { disabled_assets, state, darkpool_client }
+    pub fn new(asset_filter: AssetFilter, state: State, darkpool_client: DarkpoolClient) -> Self {
+        Self { asset_filter, state, darkpool_client }
     }
 }
 
@@ -61,9 +54,10 @@ impl TypedHandler for GetExchangeMetadataHandler {
         let executor_address = self.state.get_executor_key().map_err(internal_error)?.address();
         let relayer_fee_recipient = self.state.get_relayer_fee_addr().map_err(internal_error)?;
 
-        let supported_tokens = get_all_base_tokens()
+        let supported_tokens = self
+            .asset_filter
+            .enabled_base_tokens()
             .into_iter()
-            .filter(|t| !self.disabled_assets.contains(&t.get_alloy_address()))
             .filter_map(|t| t.get_ticker().map(|sym| ApiToken::new(t.get_alloy_address(), sym)))
             .collect();
 

--- a/crates/workers/api-server/src/http/metadata.rs
+++ b/crates/workers/api-server/src/http/metadata.rs
@@ -1,5 +1,8 @@
 //! Route handlers for metadata operations
 
+use std::collections::HashSet;
+
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use darkpool_client::DarkpoolClient;
 use external_api::{
@@ -22,6 +25,8 @@ use crate::{
 
 /// Handler for GET /v2/metadata/exchange
 pub struct GetExchangeMetadataHandler {
+    /// Assets disabled for matching
+    disabled_assets: HashSet<Address>,
     /// A handle to the relayer's state
     state: State,
     /// The darkpool client
@@ -30,8 +35,12 @@ pub struct GetExchangeMetadataHandler {
 
 impl GetExchangeMetadataHandler {
     /// Constructor
-    pub fn new(state: State, darkpool_client: DarkpoolClient) -> Self {
-        Self { state, darkpool_client }
+    pub fn new(
+        disabled_assets: HashSet<Address>,
+        state: State,
+        darkpool_client: DarkpoolClient,
+    ) -> Self {
+        Self { disabled_assets, state, darkpool_client }
     }
 }
 
@@ -54,6 +63,7 @@ impl TypedHandler for GetExchangeMetadataHandler {
 
         let supported_tokens = get_all_base_tokens()
             .into_iter()
+            .filter(|t| !self.disabled_assets.contains(&t.get_alloy_address()))
             .filter_map(|t| t.get_ticker().map(|sym| ApiToken::new(t.get_alloy_address(), sym)))
             .collect();
 

--- a/crates/workers/api-server/src/http/order.rs
+++ b/crates/workers/api-server/src/http/order.rs
@@ -1,7 +1,5 @@
 //! Route handlers for order operations
 
-use std::collections::HashSet;
-
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use constants::GLOBAL_MATCHING_POOL;
@@ -23,7 +21,10 @@ use types_tasks::CancelOrderTaskDescriptor;
 
 use crate::{
     error::{ApiServerError, bad_request, conflict, not_found},
-    http::helpers::{append_create_order_task, append_task},
+    http::{
+        asset_filter::AssetFilter,
+        helpers::{append_create_order_task, append_task},
+    },
     param_parsing::{
         parse_account_id_from_params, parse_order_id_from_params, should_block_on_task,
     },
@@ -133,8 +134,8 @@ impl TypedHandler for GetOrderByIdHandler {
 pub struct CreateOrderHandler {
     /// The local relayer's executor address
     executor: Address,
-    /// Assets disabled for order placement
-    disabled_assets: HashSet<Address>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// A handle to the relayer's state
     state: State,
     /// The task driver queue
@@ -145,11 +146,11 @@ impl CreateOrderHandler {
     /// Constructor
     pub fn new(
         executor: Address,
-        disabled_assets: HashSet<Address>,
+        asset_filter: AssetFilter,
         state: State,
         task_queue: TaskDriverQueue,
     ) -> Self {
-        Self { executor, disabled_assets, state, task_queue }
+        Self { executor, asset_filter, state, task_queue }
     }
 }
 
@@ -171,11 +172,7 @@ impl TypedHandler for CreateOrderHandler {
 
         // Check if either token in the order is disabled
         let intent = &req.order.intent;
-        if self.disabled_assets.contains(&intent.in_token)
-            || self.disabled_assets.contains(&intent.out_token)
-        {
-            return Err(bad_request("order contains a disabled token"));
-        }
+        self.asset_filter.check_pair(&intent.in_token, &intent.out_token)?;
 
         // Check if order already exists
         let order_id = OrderId::from(req.order.id);

--- a/crates/workers/api-server/src/http/order.rs
+++ b/crates/workers/api-server/src/http/order.rs
@@ -1,5 +1,7 @@
 //! Route handlers for order operations
 
+use std::collections::HashSet;
+
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use constants::GLOBAL_MATCHING_POOL;
@@ -131,6 +133,8 @@ impl TypedHandler for GetOrderByIdHandler {
 pub struct CreateOrderHandler {
     /// The local relayer's executor address
     executor: Address,
+    /// Assets disabled for order placement
+    disabled_assets: HashSet<Address>,
     /// A handle to the relayer's state
     state: State,
     /// The task driver queue
@@ -139,8 +143,13 @@ pub struct CreateOrderHandler {
 
 impl CreateOrderHandler {
     /// Constructor
-    pub fn new(executor: Address, state: State, task_queue: TaskDriverQueue) -> Self {
-        Self { executor, state, task_queue }
+    pub fn new(
+        executor: Address,
+        disabled_assets: HashSet<Address>,
+        state: State,
+        task_queue: TaskDriverQueue,
+    ) -> Self {
+        Self { executor, disabled_assets, state, task_queue }
     }
 }
 
@@ -159,6 +168,14 @@ impl TypedHandler for CreateOrderHandler {
         // Parse query and URL params
         let blocking = should_block_on_task(&query_params);
         let account_id = parse_account_id_from_params(&params)?;
+
+        // Check if either token in the order is disabled
+        let intent = &req.order.intent;
+        if self.disabled_assets.contains(&intent.in_token)
+            || self.disabled_assets.contains(&intent.out_token)
+        {
+            return Err(bad_request("order contains a disabled token"));
+        }
 
         // Check if order already exists
         let order_id = OrderId::from(req.order.id);


### PR DESCRIPTION
## Summary

The `disabled_assets` config was previously only enforced at the matching engine level. This PR extends enforcement to all user-facing API endpoints, ensuring disabled tokens are rejected or filtered before they reach any business logic.

## What changed

### New: `AssetFilter` service object (`asset_filter.rs`)

A single type that holds the resolved set of disabled token addresses and exposes three methods:
- `check_token(addr)` -- rejects requests for a single disabled token
- `check_pair(token_a, token_b)` -- rejects requests where either side of a pair is disabled
- `enabled_base_tokens()` -- returns the filtered list for listing endpoints

This replaces what would otherwise be scattered `HashSet::contains()` checks in every handler.

### Guarded endpoints

| Endpoint | Behavior |
|---|---|
| `POST .../balances/:mint/deposit` | Rejects deposit |
| `POST .../orders` | Rejects if either `in_token` or `out_token` is disabled |
| `POST /v2/external-matches/get-quote` | Rejects quote request |
| `POST /v2/external-matches/assemble-match-bundle` | Rejects assembly |
| `GET /v2/markets` | Filters disabled tokens from listing |
| `GET /v2/markets/depth` | Filters disabled tokens from aggregate depth |
| `GET /v2/markets/:mint/depth` | Rejects query for disabled token |
| `GET /v2/markets/:mint/price` | Rejects query for disabled token |
| `GET /v2/metadata/exchange` | Filters disabled tokens from `supported_tokens` |

### Intentionally unguarded

Withdrawals, balance reads, order reads/cancels, account management, task status, admin routes, and network topology. Principle: **block new activity on disabled tokens, never block exit operations or read-access to existing state.**

## v1 companion

The equivalent v1 changes (same pattern, plus a fix to the matching engine to check both `base_mint` and `quote_mint`) are in the companion PR targeting `v1`.