### PR TITLE
feat: enforce disabled_assets across all user-facing API endpoints (v1)

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -335,6 +335,7 @@ async fn main() -> Result<(), CoordinatorError> {
         chain: args.chain_id,
         compliance_service_url: args.compliance_service_url.clone(),
         wallet_task_rate_limit: args.wallet_task_rate_limit,
+        disabled_assets: args.disabled_assets.clone(),
         darkpool_client: darkpool_client.clone(),
         network_sender: network_sender.clone(),
         state: global_state.clone(),

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -60,9 +60,11 @@ use hyper::{
 use hyper_util::rt::{TokioIo, TokioTimer};
 use order_book::{GetDepthByMintHandler, GetExternalMatchFeesHandler};
 use price_report::{GetSupportedTokensHandler, TokenPricesHandler};
+use common::types::token::Token;
+use num_bigint::BigUint;
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 use task::GetTaskQueuePausedHandler;
 use tokio::net::{TcpListener, TcpStream};
 use util::get_current_time_millis;
@@ -129,6 +131,13 @@ impl HttpServer {
         let mut router = Router::new(config.admin_api_key, state.clone());
         let wallet_rate_limiter = WalletTaskRateLimiter::new_hourly(config.wallet_task_rate_limit);
         let handshake_queue = config.handshake_manager_work_queue.clone();
+
+        // Resolve disabled asset tickers to addresses once
+        let disabled_assets: HashSet<BigUint> = config
+            .disabled_assets
+            .iter()
+            .map(|ticker| Token::from_ticker(ticker).get_addr_biguint())
+            .collect();
 
         // --- Misc Routes --- //
 
@@ -218,7 +227,11 @@ impl HttpServer {
         router.add_wallet_authenticated_route(
             &Method::POST,
             WALLET_ORDERS_ROUTE.to_string(),
-            CreateOrderHandler::new(state.clone(), wallet_rate_limiter.clone()),
+            CreateOrderHandler::new(
+                disabled_assets.clone(),
+                state.clone(),
+                wallet_rate_limiter.clone(),
+            ),
         );
 
         // The "/wallet/:id/orders/:id" route
@@ -262,6 +275,7 @@ impl HttpServer {
             DEPOSIT_BALANCE_ROUTE.to_string(),
             DepositBalanceHandler::new(
                 config.min_transfer_amount,
+                disabled_assets.clone(),
                 config.compliance_service_url.clone(),
                 state.clone(),
                 wallet_rate_limiter.clone(),
@@ -309,6 +323,7 @@ impl HttpServer {
         let processor = ExternalMatchProcessor::new(
             config.min_order_size,
             admin_key,
+            disabled_assets.clone(),
             handshake_queue,
             config.darkpool_client.clone(),
             config.system_bus.clone(),
@@ -377,7 +392,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_SUPPORTED_TOKENS_ROUTE.to_string(),
-            GetSupportedTokensHandler,
+            GetSupportedTokensHandler::new(disabled_assets.clone()),
         );
 
         // The "/token-prices" route
@@ -398,14 +413,22 @@ impl HttpServer {
         router.add_admin_authenticated_route(
             &Method::GET,
             GET_DEPTH_BY_MINT_ROUTE.to_string(),
-            GetDepthByMintHandler::new(state.clone(), config.price_streams.clone())?,
+            GetDepthByMintHandler::new(
+                disabled_assets.clone(),
+                state.clone(),
+                config.price_streams.clone(),
+            )?,
         );
 
         // The "/order_book/depth" route
         router.add_admin_authenticated_route(
             &Method::GET,
             GET_DEPTH_FOR_ALL_PAIRS_ROUTE.to_string(),
-            GetDepthForAllPairsHandler::new(state.clone(), config.price_streams.clone())?,
+            GetDepthForAllPairsHandler::new(
+                disabled_assets.clone(),
+                state.clone(),
+                config.price_streams.clone(),
+            )?,
         );
 
         // --- Network Routes --- //

--- a/workers/api-server/src/http.rs
+++ b/workers/api-server/src/http.rs
@@ -1,6 +1,7 @@
 //! Groups handlers for the HTTP API
 
 mod admin;
+pub(super) mod asset_filter;
 mod external_match;
 mod network;
 mod order_book;
@@ -60,11 +61,11 @@ use hyper::{
 use hyper_util::rt::{TokioIo, TokioTimer};
 use order_book::{GetDepthByMintHandler, GetExternalMatchFeesHandler};
 use price_report::{GetSupportedTokensHandler, TokenPricesHandler};
-use common::types::token::Token;
-use num_bigint::BigUint;
 use rate_limit::WalletTaskRateLimiter;
 use state::State;
-use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
+
+use self::asset_filter::AssetFilter;
 use task::GetTaskQueuePausedHandler;
 use tokio::net::{TcpListener, TcpStream};
 use util::get_current_time_millis;
@@ -133,11 +134,7 @@ impl HttpServer {
         let handshake_queue = config.handshake_manager_work_queue.clone();
 
         // Resolve disabled asset tickers to addresses once
-        let disabled_assets: HashSet<BigUint> = config
-            .disabled_assets
-            .iter()
-            .map(|ticker| Token::from_ticker(ticker).get_addr_biguint())
-            .collect();
+        let asset_filter = AssetFilter::new(&config.disabled_assets);
 
         // --- Misc Routes --- //
 
@@ -228,7 +225,7 @@ impl HttpServer {
             &Method::POST,
             WALLET_ORDERS_ROUTE.to_string(),
             CreateOrderHandler::new(
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 state.clone(),
                 wallet_rate_limiter.clone(),
             ),
@@ -275,7 +272,7 @@ impl HttpServer {
             DEPOSIT_BALANCE_ROUTE.to_string(),
             DepositBalanceHandler::new(
                 config.min_transfer_amount,
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 config.compliance_service_url.clone(),
                 state.clone(),
                 wallet_rate_limiter.clone(),
@@ -323,7 +320,7 @@ impl HttpServer {
         let processor = ExternalMatchProcessor::new(
             config.min_order_size,
             admin_key,
-            disabled_assets.clone(),
+            asset_filter.clone(),
             handshake_queue,
             config.darkpool_client.clone(),
             config.system_bus.clone(),
@@ -392,7 +389,7 @@ impl HttpServer {
         router.add_unauthenticated_route(
             &Method::GET,
             GET_SUPPORTED_TOKENS_ROUTE.to_string(),
-            GetSupportedTokensHandler::new(disabled_assets.clone()),
+            GetSupportedTokensHandler::new(asset_filter.clone()),
         );
 
         // The "/token-prices" route
@@ -414,7 +411,7 @@ impl HttpServer {
             &Method::GET,
             GET_DEPTH_BY_MINT_ROUTE.to_string(),
             GetDepthByMintHandler::new(
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 state.clone(),
                 config.price_streams.clone(),
             )?,
@@ -425,7 +422,7 @@ impl HttpServer {
             &Method::GET,
             GET_DEPTH_FOR_ALL_PAIRS_ROUTE.to_string(),
             GetDepthForAllPairsHandler::new(
-                disabled_assets.clone(),
+                asset_filter.clone(),
                 state.clone(),
                 config.price_streams.clone(),
             )?,

--- a/workers/api-server/src/http/asset_filter.rs
+++ b/workers/api-server/src/http/asset_filter.rs
@@ -1,0 +1,50 @@
+//! Centralizes disabled-asset policy for the API layer
+
+use std::collections::HashSet;
+
+use common::types::token::{Token, get_all_base_tokens};
+use num_bigint::BigUint;
+
+use crate::error::{ApiServerError, bad_request};
+
+/// Error returned when a request references a disabled token
+const ERR_TOKEN_DISABLED: &str = "token is not supported";
+
+/// Holds the resolved set of disabled asset addresses and exposes
+/// a small API for checking and filtering tokens.
+#[derive(Clone, Debug)]
+pub(crate) struct AssetFilter {
+    disabled: HashSet<BigUint>,
+}
+
+impl AssetFilter {
+    /// Build an `AssetFilter` by resolving ticker strings to addresses
+    pub fn new(tickers: &[String]) -> Self {
+        let disabled = tickers.iter().map(|t| Token::from_ticker(t).get_addr_biguint()).collect();
+        Self { disabled }
+    }
+
+    /// Reject if `addr` is disabled
+    pub fn check_token(&self, addr: &BigUint) -> Result<(), ApiServerError> {
+        if self.disabled.contains(addr) {
+            return Err(bad_request(ERR_TOKEN_DISABLED));
+        }
+        Ok(())
+    }
+
+    /// Reject if either of two tokens is disabled
+    pub fn check_pair(&self, token_a: &BigUint, token_b: &BigUint) -> Result<(), ApiServerError> {
+        if self.disabled.contains(token_a) || self.disabled.contains(token_b) {
+            return Err(bad_request(ERR_TOKEN_DISABLED));
+        }
+        Ok(())
+    }
+
+    /// Return only the base tokens that are *not* disabled
+    pub fn enabled_base_tokens(&self) -> Vec<Token> {
+        get_all_base_tokens()
+            .into_iter()
+            .filter(|t| !self.disabled.contains(&t.get_addr_biguint()))
+            .collect()
+    }
+}

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -1,6 +1,6 @@
 //! The external match processor
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy::{
     primitives::{Address, U256},
@@ -111,6 +111,8 @@ pub struct ExternalMatchProcessor {
     min_order_size: f64,
     /// The admin key, used to sign and validate quotes
     admin_key: HmacKey,
+    /// Assets disabled for matching
+    disabled_assets: HashSet<BigUint>,
     /// The handshake manager's queue
     handshake_queue: HandshakeManagerQueue,
     /// A handle on the darkpool RPC client
@@ -126,12 +128,34 @@ impl ExternalMatchProcessor {
     pub fn new(
         min_order_size: f64,
         admin_key: HmacKey,
+        disabled_assets: HashSet<BigUint>,
         handshake_queue: HandshakeManagerQueue,
         darkpool_client: DarkpoolClient,
         bus: SystemBus<SystemBusMessage>,
         price_streams: PriceStreamStates,
     ) -> Self {
-        Self { min_order_size, admin_key, handshake_queue, darkpool_client, bus, price_streams }
+        Self {
+            min_order_size,
+            admin_key,
+            disabled_assets,
+            handshake_queue,
+            darkpool_client,
+            bus,
+            price_streams,
+        }
+    }
+
+    /// Validate that neither token in the order is disabled
+    fn validate_order_not_disabled(
+        &self,
+        order: &ExternalOrder,
+    ) -> Result<(), ApiServerError> {
+        if self.disabled_assets.contains(&order.base_mint)
+            || self.disabled_assets.contains(&order.quote_mint)
+        {
+            return Err(bad_request("token is not supported"));
+        }
+        Ok(())
     }
 
     /// Await the next bus message on a topic
@@ -153,6 +177,7 @@ impl ExternalMatchProcessor {
         relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
     ) -> Result<ExternalMatchResult, ApiServerError> {
+        self.validate_order_not_disabled(&external_order)?;
         let opt = ExternalMatchingEngineOptions::only_quote()
             .with_matching_pool(matching_pool)
             .with_relayer_fee_rate(relayer_fee_rate);
@@ -176,6 +201,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
+        self.validate_order_not_disabled(&order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_price(price)
@@ -210,6 +236,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
+        self.validate_order_not_disabled(&order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_bounded_match(true)
@@ -274,6 +301,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
+        self.validate_order_not_disabled(&external_order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
             .with_bounded_match(true)

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -1,6 +1,6 @@
 //! The external match processor
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use alloy::{
     primitives::{Address, U256},
@@ -40,7 +40,7 @@ use util::{
 
 use crate::{
     error::{ApiServerError, bad_request, internal_error, no_content},
-    http::wallet::get_usdc_denominated_value,
+    http::{asset_filter::AssetFilter, wallet::get_usdc_denominated_value},
 };
 
 // -------------
@@ -111,8 +111,8 @@ pub struct ExternalMatchProcessor {
     min_order_size: f64,
     /// The admin key, used to sign and validate quotes
     admin_key: HmacKey,
-    /// Assets disabled for matching
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The handshake manager's queue
     handshake_queue: HandshakeManagerQueue,
     /// A handle on the darkpool RPC client
@@ -128,7 +128,7 @@ impl ExternalMatchProcessor {
     pub fn new(
         min_order_size: f64,
         admin_key: HmacKey,
-        disabled_assets: HashSet<BigUint>,
+        asset_filter: AssetFilter,
         handshake_queue: HandshakeManagerQueue,
         darkpool_client: DarkpoolClient,
         bus: SystemBus<SystemBusMessage>,
@@ -137,7 +137,7 @@ impl ExternalMatchProcessor {
         Self {
             min_order_size,
             admin_key,
-            disabled_assets,
+            asset_filter,
             handshake_queue,
             darkpool_client,
             bus,
@@ -146,16 +146,8 @@ impl ExternalMatchProcessor {
     }
 
     /// Validate that neither token in the order is disabled
-    fn validate_order_not_disabled(
-        &self,
-        order: &ExternalOrder,
-    ) -> Result<(), ApiServerError> {
-        if self.disabled_assets.contains(&order.base_mint)
-            || self.disabled_assets.contains(&order.quote_mint)
-        {
-            return Err(bad_request("token is not supported"));
-        }
-        Ok(())
+    fn validate_order_not_disabled(&self, order: &ExternalOrder) -> Result<(), ApiServerError> {
+        self.asset_filter.check_pair(&order.base_mint, &order.quote_mint)
     }
 
     /// Await the next bus message on a topic

--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -145,8 +145,8 @@ impl ExternalMatchProcessor {
         }
     }
 
-    /// Validate that neither token in the order is disabled
-    fn validate_order_not_disabled(&self, order: &ExternalOrder) -> Result<(), ApiServerError> {
+    /// Validate that neither token in the pair is disabled
+    fn validate_pair_not_disabled(&self, order: &ExternalOrder) -> Result<(), ApiServerError> {
         self.asset_filter.check_pair(&order.base_mint, &order.quote_mint)
     }
 
@@ -169,7 +169,7 @@ impl ExternalMatchProcessor {
         relayer_fee_rate: FixedPoint,
         matching_pool: Option<MatchingPoolName>,
     ) -> Result<ExternalMatchResult, ApiServerError> {
-        self.validate_order_not_disabled(&external_order)?;
+        self.validate_pair_not_disabled(&external_order)?;
         let opt = ExternalMatchingEngineOptions::only_quote()
             .with_matching_pool(matching_pool)
             .with_relayer_fee_rate(relayer_fee_rate);
@@ -193,7 +193,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
-        self.validate_order_not_disabled(&order)?;
+        self.validate_pair_not_disabled(&order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_price(price)
@@ -228,7 +228,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
-        self.validate_order_not_disabled(&order)?;
+        self.validate_pair_not_disabled(&order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(ASSEMBLE_BUNDLE_TIMEOUT)
             .with_bounded_match(true)
@@ -293,7 +293,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<MalleableAtomicMatchApiBundle, ApiServerError> {
-        self.validate_order_not_disabled(&external_order)?;
+        self.validate_pair_not_disabled(&external_order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
             .with_bounded_match(true)

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -1,6 +1,6 @@
 //! Groups routes and handlers for order book API operations
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::{HashMap, HashSet}, sync::Arc};
 
 use async_trait::async_trait;
 use common::types::{
@@ -8,6 +8,7 @@ use common::types::{
     token::{Token, get_all_base_tokens},
     wallet::pair_from_mints,
 };
+use num_bigint::BigUint;
 use constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
 use external_api::{
     EmptyRequestResponse,
@@ -263,15 +264,21 @@ impl DepthCalculator {
 /// Handler for the GET /order_book/depth/:mint route
 #[derive(Clone)]
 pub struct GetDepthByMintHandler {
+    /// Assets disabled for matching
+    disabled_assets: HashSet<BigUint>,
     /// The depth calculator for fetching price and depth data
     depth_calculator: DepthCalculator,
 }
 
 impl GetDepthByMintHandler {
     /// Constructor
-    pub fn new(state: State, price_streams: PriceStreamStates) -> Result<Self, ApiServerError> {
+    pub fn new(
+        disabled_assets: HashSet<BigUint>,
+        state: State,
+        price_streams: PriceStreamStates,
+    ) -> Result<Self, ApiServerError> {
         let depth_calculator = DepthCalculator::new(state, price_streams)?;
-        Ok(Self { depth_calculator })
+        Ok(Self { disabled_assets, depth_calculator })
     }
 }
 
@@ -288,6 +295,9 @@ impl TypedHandler for GetDepthByMintHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let mint = parse_mint_from_params(&params)?;
+        if self.disabled_assets.contains(&mint) {
+            return Err(bad_request("token is not supported"));
+        }
         let base_token = Token::from_addr_biguint(&mint);
         let depth = self.depth_calculator.get_price_and_depth(base_token).await?;
         Ok(GetDepthByMintResponse { depth })
@@ -297,15 +307,21 @@ impl TypedHandler for GetDepthByMintHandler {
 /// Handler for the GET /order_book/depth route
 #[derive(Clone)]
 pub struct GetDepthForAllPairsHandler {
+    /// Assets disabled for matching
+    disabled_assets: HashSet<BigUint>,
     /// The depth calculator for fetching price and depth data
     depth_calculator: DepthCalculator,
 }
 
 impl GetDepthForAllPairsHandler {
     /// Constructor
-    pub fn new(state: State, price_streams: PriceStreamStates) -> Result<Self, ApiServerError> {
+    pub fn new(
+        disabled_assets: HashSet<BigUint>,
+        state: State,
+        price_streams: PriceStreamStates,
+    ) -> Result<Self, ApiServerError> {
         let depth_calculator = DepthCalculator::new(state, price_streams)?;
-        Ok(Self { depth_calculator })
+        Ok(Self { disabled_assets, depth_calculator })
     }
 }
 
@@ -321,9 +337,11 @@ impl TypedHandler for GetDepthForAllPairsHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        // Get all tokens for which we support price data
-        // Practically, this is all non-stablecoin tokens
-        let supported_tokens = get_all_base_tokens();
+        // Get all tokens for which we support price data, excluding disabled
+        let supported_tokens: Vec<Token> = get_all_base_tokens()
+            .into_iter()
+            .filter(|t| !self.disabled_assets.contains(&t.get_addr_biguint()))
+            .collect();
         let quote_token = Token::usdc();
 
         let mut pairs = Vec::new();

--- a/workers/api-server/src/http/order_book.rs
+++ b/workers/api-server/src/http/order_book.rs
@@ -1,6 +1,6 @@
 //! Groups routes and handlers for order book API operations
 
-use std::{collections::{HashMap, HashSet}, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use common::types::{
@@ -8,7 +8,6 @@ use common::types::{
     token::{Token, get_all_base_tokens},
     wallet::pair_from_mints,
 };
-use num_bigint::BigUint;
 use constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
 use external_api::{
     EmptyRequestResponse,
@@ -28,6 +27,7 @@ use util::on_chain::get_external_match_fee;
 
 use crate::{
     error::{ApiServerError, bad_request, not_found},
+    http::asset_filter::AssetFilter,
     param_parsing::{
         parse_mint_from_params, parse_order_id_from_params, parse_tickers_from_query_params,
     },
@@ -264,8 +264,8 @@ impl DepthCalculator {
 /// Handler for the GET /order_book/depth/:mint route
 #[derive(Clone)]
 pub struct GetDepthByMintHandler {
-    /// Assets disabled for matching
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The depth calculator for fetching price and depth data
     depth_calculator: DepthCalculator,
 }
@@ -273,12 +273,12 @@ pub struct GetDepthByMintHandler {
 impl GetDepthByMintHandler {
     /// Constructor
     pub fn new(
-        disabled_assets: HashSet<BigUint>,
+        asset_filter: AssetFilter,
         state: State,
         price_streams: PriceStreamStates,
     ) -> Result<Self, ApiServerError> {
         let depth_calculator = DepthCalculator::new(state, price_streams)?;
-        Ok(Self { disabled_assets, depth_calculator })
+        Ok(Self { asset_filter, depth_calculator })
     }
 }
 
@@ -295,9 +295,7 @@ impl TypedHandler for GetDepthByMintHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let mint = parse_mint_from_params(&params)?;
-        if self.disabled_assets.contains(&mint) {
-            return Err(bad_request("token is not supported"));
-        }
+        self.asset_filter.check_token(&mint)?;
         let base_token = Token::from_addr_biguint(&mint);
         let depth = self.depth_calculator.get_price_and_depth(base_token).await?;
         Ok(GetDepthByMintResponse { depth })
@@ -307,8 +305,8 @@ impl TypedHandler for GetDepthByMintHandler {
 /// Handler for the GET /order_book/depth route
 #[derive(Clone)]
 pub struct GetDepthForAllPairsHandler {
-    /// Assets disabled for matching
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The depth calculator for fetching price and depth data
     depth_calculator: DepthCalculator,
 }
@@ -316,12 +314,12 @@ pub struct GetDepthForAllPairsHandler {
 impl GetDepthForAllPairsHandler {
     /// Constructor
     pub fn new(
-        disabled_assets: HashSet<BigUint>,
+        asset_filter: AssetFilter,
         state: State,
         price_streams: PriceStreamStates,
     ) -> Result<Self, ApiServerError> {
         let depth_calculator = DepthCalculator::new(state, price_streams)?;
-        Ok(Self { disabled_assets, depth_calculator })
+        Ok(Self { asset_filter, depth_calculator })
     }
 }
 
@@ -338,10 +336,7 @@ impl TypedHandler for GetDepthForAllPairsHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Get all tokens for which we support price data, excluding disabled
-        let supported_tokens: Vec<Token> = get_all_base_tokens()
-            .into_iter()
-            .filter(|t| !self.disabled_assets.contains(&t.get_addr_biguint()))
-            .collect();
+        let supported_tokens = self.asset_filter.enabled_base_tokens();
         let quote_token = Token::usdc();
 
         let mut pairs = Vec::new();

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -1,10 +1,9 @@
 //! Groups price reporting API handlers and types
 
-use std::{collections::HashSet, iter};
+use std::iter;
 
 use async_trait::async_trait;
 use common::types::token::{Token, get_all_base_tokens};
-use num_bigint::BigUint;
 use external_api::{
     EmptyRequestResponse,
     http::price_report::{
@@ -18,6 +17,7 @@ use price_state::PriceStreamStates;
 
 use crate::{
     error::ApiServerError,
+    http::asset_filter::AssetFilter,
     param_parsing::parse_token_from_params,
     router::{QueryParams, TypedHandler, UrlParams},
 };
@@ -63,14 +63,14 @@ impl TypedHandler for PriceReportHandler {
 /// Handler for the GET /supported-tokens route
 #[derive(Clone)]
 pub struct GetSupportedTokensHandler {
-    /// Assets disabled for matching
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
 }
 
 impl GetSupportedTokensHandler {
     /// Constructor
-    pub fn new(disabled_assets: HashSet<BigUint>) -> Self {
-        Self { disabled_assets }
+    pub fn new(asset_filter: AssetFilter) -> Self {
+        Self { asset_filter }
     }
 }
 
@@ -86,10 +86,11 @@ impl TypedHandler for GetSupportedTokensHandler {
         _params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
-        let tokens = get_all_base_tokens()
+        let tokens = self
+            .asset_filter
+            .enabled_base_tokens()
             .into_iter()
             .chain(iter::once(Token::usdc()))
-            .filter(|t| !self.disabled_assets.contains(&t.get_addr_biguint()))
             .map(|token| ApiToken::new(token.get_addr(), token.get_ticker().unwrap()))
             .collect_vec();
 

--- a/workers/api-server/src/http/price_report.rs
+++ b/workers/api-server/src/http/price_report.rs
@@ -1,9 +1,10 @@
 //! Groups price reporting API handlers and types
 
-use std::iter;
+use std::{collections::HashSet, iter};
 
 use async_trait::async_trait;
 use common::types::token::{Token, get_all_base_tokens};
+use num_bigint::BigUint;
 use external_api::{
     EmptyRequestResponse,
     http::price_report::{
@@ -61,7 +62,17 @@ impl TypedHandler for PriceReportHandler {
 
 /// Handler for the GET /supported-tokens route
 #[derive(Clone)]
-pub struct GetSupportedTokensHandler;
+pub struct GetSupportedTokensHandler {
+    /// Assets disabled for matching
+    disabled_assets: HashSet<BigUint>,
+}
+
+impl GetSupportedTokensHandler {
+    /// Constructor
+    pub fn new(disabled_assets: HashSet<BigUint>) -> Self {
+        Self { disabled_assets }
+    }
+}
 
 #[async_trait]
 impl TypedHandler for GetSupportedTokensHandler {
@@ -78,6 +89,7 @@ impl TypedHandler for GetSupportedTokensHandler {
         let tokens = get_all_base_tokens()
             .into_iter()
             .chain(iter::once(Token::usdc()))
+            .filter(|t| !self.disabled_assets.contains(&t.get_addr_biguint()))
             .map(|token| ApiToken::new(token.get_addr(), token.get_ticker().unwrap()))
             .collect_vec();
 

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -1,7 +1,5 @@
 //! Groups wallet API handlers and definitions
 
-use std::collections::HashSet;
-
 use async_trait::async_trait;
 use circuit_types::{
     Amount, SizedWallet as SizedCircuitWallet, balance::Balance,
@@ -45,6 +43,7 @@ use util::{
 use crate::{
     compliance::ComplianceServerClient,
     error::{ApiServerError, bad_request, internal_error, not_found},
+    http::asset_filter::AssetFilter,
     param_parsing::{
         parse_mint_from_params, parse_order_id_from_params, parse_wallet_id_from_params,
     },
@@ -517,8 +516,8 @@ impl TypedHandler for GetOrderByIdHandler {
 
 /// Handler for the POST /wallet/:id/orders route
 pub struct CreateOrderHandler {
-    /// Assets disabled for order placement
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// A copy of the relayer-global state
     state: State,
     /// The per-wallet task rate limiter
@@ -528,11 +527,11 @@ pub struct CreateOrderHandler {
 impl CreateOrderHandler {
     /// Constructor
     pub fn new(
-        disabled_assets: HashSet<BigUint>,
+        asset_filter: AssetFilter,
         state: State,
         rate_limiter: WalletTaskRateLimiter,
     ) -> Self {
-        Self { disabled_assets, state, rate_limiter }
+        Self { asset_filter, state, rate_limiter }
     }
 }
 
@@ -551,11 +550,7 @@ impl TypedHandler for CreateOrderHandler {
         let wallet_id = parse_wallet_id_from_params(&params)?;
 
         // Check if either token in the order is disabled
-        if self.disabled_assets.contains(&req.order.base_mint)
-            || self.disabled_assets.contains(&req.order.quote_mint)
-        {
-            return Err(bad_request("order contains a disabled token"));
-        }
+        self.asset_filter.check_pair(&req.order.base_mint, &req.order.quote_mint)?;
 
         // Check that the order does not already exist
         let oid = req.order.id;
@@ -797,8 +792,8 @@ impl TypedHandler for GetBalanceByMintHandler {
 pub struct DepositBalanceHandler {
     /// The minimum deposit amount allowed by the relayer
     min_deposit_amount: f64,
-    /// Assets disabled for deposits
-    disabled_assets: HashSet<BigUint>,
+    /// Asset filter for checking disabled tokens
+    asset_filter: AssetFilter,
     /// The URL of the compliance service to use for wallet screening
     compliance_client: ComplianceServerClient,
     /// A copy of the relayer-global state
@@ -813,7 +808,7 @@ impl DepositBalanceHandler {
     /// Constructor
     pub fn new(
         min_deposit_amount: f64,
-        disabled_assets: HashSet<BigUint>,
+        asset_filter: AssetFilter,
         compliance_url: Option<Url>,
         state: State,
         rate_limiter: WalletTaskRateLimiter,
@@ -822,7 +817,7 @@ impl DepositBalanceHandler {
         let compliance_client = ComplianceServerClient::new(compliance_url);
         Self {
             min_deposit_amount,
-            disabled_assets,
+            asset_filter,
             compliance_client,
             state,
             rate_limiter,
@@ -844,9 +839,7 @@ impl TypedHandler for DepositBalanceHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         // Check if the token is disabled for deposits
-        if self.disabled_assets.contains(&req.mint) {
-            return Err(bad_request("token is not supported for deposits"));
-        }
+        self.asset_filter.check_token(&req.mint)?;
 
         // Screen the wallet for compliance
         let addr = biguint_to_hex_addr(&req.from_addr);

--- a/workers/api-server/src/http/wallet.rs
+++ b/workers/api-server/src/http/wallet.rs
@@ -1,5 +1,7 @@
 //! Groups wallet API handlers and definitions
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use circuit_types::{
     Amount, SizedWallet as SizedCircuitWallet, balance::Balance,
@@ -515,6 +517,8 @@ impl TypedHandler for GetOrderByIdHandler {
 
 /// Handler for the POST /wallet/:id/orders route
 pub struct CreateOrderHandler {
+    /// Assets disabled for order placement
+    disabled_assets: HashSet<BigUint>,
     /// A copy of the relayer-global state
     state: State,
     /// The per-wallet task rate limiter
@@ -523,8 +527,12 @@ pub struct CreateOrderHandler {
 
 impl CreateOrderHandler {
     /// Constructor
-    pub fn new(state: State, rate_limiter: WalletTaskRateLimiter) -> Self {
-        Self { state, rate_limiter }
+    pub fn new(
+        disabled_assets: HashSet<BigUint>,
+        state: State,
+        rate_limiter: WalletTaskRateLimiter,
+    ) -> Self {
+        Self { disabled_assets, state, rate_limiter }
     }
 }
 
@@ -541,6 +549,13 @@ impl TypedHandler for CreateOrderHandler {
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
         let wallet_id = parse_wallet_id_from_params(&params)?;
+
+        // Check if either token in the order is disabled
+        if self.disabled_assets.contains(&req.order.base_mint)
+            || self.disabled_assets.contains(&req.order.quote_mint)
+        {
+            return Err(bad_request("order contains a disabled token"));
+        }
 
         // Check that the order does not already exist
         let oid = req.order.id;
@@ -782,6 +797,8 @@ impl TypedHandler for GetBalanceByMintHandler {
 pub struct DepositBalanceHandler {
     /// The minimum deposit amount allowed by the relayer
     min_deposit_amount: f64,
+    /// Assets disabled for deposits
+    disabled_assets: HashSet<BigUint>,
     /// The URL of the compliance service to use for wallet screening
     compliance_client: ComplianceServerClient,
     /// A copy of the relayer-global state
@@ -796,13 +813,21 @@ impl DepositBalanceHandler {
     /// Constructor
     pub fn new(
         min_deposit_amount: f64,
+        disabled_assets: HashSet<BigUint>,
         compliance_url: Option<Url>,
         state: State,
         rate_limiter: WalletTaskRateLimiter,
         price_streams: PriceStreamStates,
     ) -> Self {
         let compliance_client = ComplianceServerClient::new(compliance_url);
-        Self { min_deposit_amount, compliance_client, state, rate_limiter, price_streams }
+        Self {
+            min_deposit_amount,
+            disabled_assets,
+            compliance_client,
+            state,
+            rate_limiter,
+            price_streams,
+        }
     }
 }
 
@@ -818,6 +843,11 @@ impl TypedHandler for DepositBalanceHandler {
         params: UrlParams,
         _query_params: QueryParams,
     ) -> Result<Self::Response, ApiServerError> {
+        // Check if the token is disabled for deposits
+        if self.disabled_assets.contains(&req.mint) {
+            return Err(bad_request("token is not supported for deposits"));
+        }
+
         // Screen the wallet for compliance
         let addr = biguint_to_hex_addr(&req.from_addr);
         if !self.compliance_client.check_address(&addr).await? {

--- a/workers/api-server/src/worker.rs
+++ b/workers/api-server/src/worker.rs
@@ -64,6 +64,8 @@ pub struct ApiServerConfig {
     ///
     /// Compliance screening is disabled if this is not set
     pub compliance_service_url: Option<Url>,
+    /// Assets for which matching is disabled (by ticker)
+    pub disabled_assets: Vec<String>,
     /// A handle on the darkpool RPC client
     pub darkpool_client: DarkpoolClient,
     /// A sender to the network manager's work queue

--- a/workers/handshake-manager/src/manager/matching/external_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/external_engine.rs
@@ -72,10 +72,10 @@ impl HandshakeExecutor {
     ) -> Result<(), HandshakeManagerError> {
         let base = Token::from_addr_biguint(&order.base_mint);
 
-        // Check if the asset is disabled for matching
-        if self.is_asset_disabled(&order.base_mint) {
+        // Check if either asset in the pair is disabled for matching
+        if self.is_asset_disabled(&order.base_mint) || self.is_asset_disabled(&order.quote_mint) {
             let ticker = base.get_ticker().unwrap_or(base.get_addr());
-            warn!("{ticker} is disabled for matching, skipping external matching engine...");
+            warn!("{ticker} pair is disabled for matching, skipping external matching engine...");
             self.handle_no_match(response_topic);
             return Ok(());
         }

--- a/workers/handshake-manager/src/manager/matching/internal_engine.rs
+++ b/workers/handshake-manager/src/manager/matching/internal_engine.rs
@@ -53,11 +53,13 @@ impl HandshakeExecutor {
             .cloned()
             .ok_or_else(|| HandshakeManagerError::State(ERR_NO_ORDER.to_string()))?;
 
-        // Check if the asset is disabled for matching
-        if self.is_asset_disabled(&my_order.base_mint) {
+        // Check if either asset in the pair is disabled for matching
+        if self.is_asset_disabled(&my_order.base_mint)
+            || self.is_asset_disabled(&my_order.quote_mint)
+        {
             let base = Token::from_addr_biguint(&my_order.base_mint);
             let ticker = base.get_ticker().unwrap_or(base.get_addr());
-            warn!("{ticker} is disabled for matching, skipping internal matching engine...");
+            warn!("{ticker} pair is disabled for matching, skipping internal matching engine...");
             return Ok(());
         }
 


### PR DESCRIPTION
v1 companion to https://github.com/renegade-fi/renegade/pull/1426

Same `AssetFilter` pattern applied to v1 handlers. Additionally fixes the matching engine to check both `base_mint` and `quote_mint` (previously only checked `base_mint`).