### PR TITLE
fix: enforce disabled_assets in v1 request-external-match

### DIFF
--- a/workers/api-server/src/http/external_match/processor.rs
+++ b/workers/api-server/src/http/external_match/processor.rs
@@ -262,6 +262,7 @@ impl ExternalMatchProcessor {
         matching_pool: Option<MatchingPoolName>,
         external_order: ExternalOrder,
     ) -> Result<AtomicMatchApiBundle, ApiServerError> {
+        self.validate_pair_not_disabled(&external_order)?;
         let opt = ExternalMatchingEngineOptions::new()
             .with_bundle_duration(DIRECT_MATCH_BUNDLE_TIMEOUT)
             .with_matching_pool(matching_pool)


### PR DESCRIPTION
## Summary

Fixes the remaining v1 disabled-assets gap in `POST /v0/matching-engine/request-external-match`.

## Problem

PR #1427 deployed most of the v1 disabled-asset protections successfully, but live validation showed that direct external-match requests could still proceed for disabled pairs. In production, a disabled `AAVE/USDC` request returned `204 No Content` instead of `400 token is not supported`.

## Root cause

`ExternalMatchProcessor::request_match_bundle(...)` did not call the shared disabled-pair guard, even though the sibling quote / assemble / malleable-match paths already did.

## Fix

Add the missing:

`self.validate_pair_not_disabled(&external_order)?;`

to:

- `workers/api-server/src/http/external_match/processor.rs`

## Validation

Live deploy validation before this patch showed:

- `GET /v0/supported-tokens` filtered disabled assets correctly
- depth endpoints rejected / omitted disabled assets correctly
- quote endpoints rejected disabled assets correctly
- `request-malleable-external-match` rejected disabled assets correctly
- only `request-external-match` still bypassed the guard

This patch makes `request-external-match` consistent with the rest of the rollout.